### PR TITLE
feat(backend): DB schema, RLS policies, seed 15 modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,16 @@ Key architectural decisions:
 - **Level 3 (Advanced, 100h):** M08-M12 — Advanced stats/epi, health programming, data viz
 - **Level 4 (Expert, 70h):** M13-M15 — Policy, health systems strengthening, research capstone
 
+## CRITICAL — Do NOT Re-scaffold
+
+The monorepo is fully scaffolded. **DO NOT** recreate, overwrite, or restructure:
+- `backend/` — FastAPI with uv (NOT Poetry), directory structure in `.claude/skills/fastapi-service/SKILL.md`
+- `frontend/` — Next.js 15 with npm, Tailwind + shadcn/ui, next-intl (FR/EN)
+- `docker-compose.yml`, `Makefile`, `.github/workflows/ci.yml`
+- Alembic migrations in `backend/migrations/` (NOT `backend/alembic/`)
+
+When implementing an issue, **build on top of what exists**. Read the existing code first. If a file already exists, edit it — do not create a parallel version.
+
 ## Regulatory Compliance
 
 Must align with: GDPR, Senegal Loi 2008-12, Ghana Data Protection Act 2012, Nigeria NDPR 2019, Côte d'Ivoire Loi n°2013-450. Claude API keys must remain server-side only.

--- a/backend/app/domain/models/__init__.py
+++ b/backend/app/domain/models/__init__.py
@@ -1,0 +1,19 @@
+from app.domain.models.base import Base
+from app.domain.models.content import GeneratedContent
+from app.domain.models.conversation import TutorConversation
+from app.domain.models.flashcard import FlashcardReview
+from app.domain.models.module import Module
+from app.domain.models.progress import UserModuleProgress
+from app.domain.models.quiz import QuizAttempt
+from app.domain.models.user import User
+
+__all__ = [
+    "Base",
+    "GeneratedContent",
+    "TutorConversation",
+    "FlashcardReview",
+    "Module",
+    "UserModuleProgress",
+    "QuizAttempt",
+    "User",
+]

--- a/backend/app/domain/models/content.py
+++ b/backend/app/domain/models/content.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, ForeignKey, Integer, String, func
+from sqlalchemy.dialects.postgresql import JSON
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.domain.models.base import Base
+
+if TYPE_CHECKING:
+    from app.domain.models.flashcard import FlashcardReview
+    from app.domain.models.module import Module
+    from app.domain.models.quiz import QuizAttempt
+
+
+class GeneratedContent(Base):
+    __tablename__ = "generated_content"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    module_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("modules.id"), index=True)
+    content_type: Mapped[str] = mapped_column(String, index=True)  # lesson|quiz|flashcard|case
+    language: Mapped[str] = mapped_column(String(2), index=True)  # fr|en
+    level: Mapped[int] = mapped_column(Integer)
+    content: Mapped[dict] = mapped_column(JSON)
+    sources_cited: Mapped[list | None] = mapped_column(JSON)
+    country_context: Mapped[str | None] = mapped_column(String)
+    generated_at: Mapped[datetime] = mapped_column(server_default=func.now())
+    validated: Mapped[bool] = mapped_column(Boolean, server_default="false")
+
+    module: Mapped[Module] = relationship(back_populates="generated_content")
+    quiz_attempts: Mapped[list[QuizAttempt]] = relationship(back_populates="quiz")
+    flashcard_reviews: Mapped[list[FlashcardReview]] = relationship(back_populates="card")

--- a/backend/app/domain/models/conversation.py
+++ b/backend/app/domain/models/conversation.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, func
+from sqlalchemy.dialects.postgresql import JSON
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.domain.models.base import Base
+
+if TYPE_CHECKING:
+    from app.domain.models.module import Module
+    from app.domain.models.user import User
+
+
+class TutorConversation(Base):
+    __tablename__ = "tutor_conversations"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), index=True)
+    module_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("modules.id"))
+    messages: Mapped[list] = mapped_column(JSON)
+    created_at: Mapped[datetime] = mapped_column(server_default=func.now())
+
+    user: Mapped[User] = relationship(back_populates="tutor_conversations")
+    module: Mapped[Module] = relationship(back_populates="tutor_conversations")

--- a/backend/app/domain/models/flashcard.py
+++ b/backend/app/domain/models/flashcard.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.domain.models.base import Base
+
+if TYPE_CHECKING:
+    from app.domain.models.content import GeneratedContent
+    from app.domain.models.user import User
+
+
+class FlashcardReview(Base):
+    __tablename__ = "flashcard_reviews"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), index=True)
+    card_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("generated_content.id"), index=True)
+    rating: Mapped[str] = mapped_column(String)  # again|hard|good|easy
+    next_review: Mapped[datetime] = mapped_column(index=True)
+    stability: Mapped[float] = mapped_column(server_default="1.0")
+    difficulty: Mapped[float] = mapped_column(server_default="5.0")
+    reviewed_at: Mapped[datetime] = mapped_column(server_default=func.now())
+
+    user: Mapped[User] = relationship(back_populates="flashcard_reviews")
+    card: Mapped[GeneratedContent] = relationship(back_populates="flashcard_reviews")

--- a/backend/app/domain/models/module.py
+++ b/backend/app/domain/models/module.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ARRAY, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSON, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.domain.models.base import Base
+
+if TYPE_CHECKING:
+    from app.domain.models.content import GeneratedContent
+    from app.domain.models.conversation import TutorConversation
+    from app.domain.models.progress import UserModuleProgress
+
+
+class Module(Base):
+    __tablename__ = "modules"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    module_number: Mapped[int] = mapped_column(Integer, unique=True, index=True)
+    level: Mapped[int] = mapped_column(Integer, index=True)
+    title_fr: Mapped[str] = mapped_column(Text)
+    title_en: Mapped[str] = mapped_column(Text)
+    description_fr: Mapped[str | None] = mapped_column(Text)
+    description_en: Mapped[str | None] = mapped_column(Text)
+    estimated_hours: Mapped[int] = mapped_column(server_default="20")
+    bloom_level: Mapped[str | None] = mapped_column(String)
+    prereq_modules: Mapped[list | None] = mapped_column(
+        ARRAY(UUID(as_uuid=True)), server_default="{}"
+    )
+    books_sources: Mapped[dict | None] = mapped_column(JSON)
+
+    user_progress: Mapped[list[UserModuleProgress]] = relationship(back_populates="module")
+    generated_content: Mapped[list[GeneratedContent]] = relationship(back_populates="module")
+    tutor_conversations: Mapped[list[TutorConversation]] = relationship(back_populates="module")

--- a/backend/app/domain/models/progress.py
+++ b/backend/app/domain/models/progress.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.domain.models.base import Base
+
+if TYPE_CHECKING:
+    from app.domain.models.module import Module
+    from app.domain.models.user import User
+
+
+class UserModuleProgress(Base):
+    __tablename__ = "user_module_progress"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), primary_key=True)
+    module_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("modules.id"), primary_key=True)
+    status: Mapped[str] = mapped_column(String, server_default="locked")
+    completion_pct: Mapped[float] = mapped_column(server_default="0.0")
+    quiz_score_avg: Mapped[float | None]
+    time_spent_minutes: Mapped[int] = mapped_column(server_default="0")
+    last_accessed: Mapped[datetime | None]
+
+    user: Mapped[User] = relationship(back_populates="module_progress")
+    module: Mapped[Module] = relationship(back_populates="user_progress")

--- a/backend/app/domain/models/quiz.py
+++ b/backend/app/domain/models/quiz.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, Integer, func
+from sqlalchemy.dialects.postgresql import JSON
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.domain.models.base import Base
+
+if TYPE_CHECKING:
+    from app.domain.models.content import GeneratedContent
+    from app.domain.models.user import User
+
+
+class QuizAttempt(Base):
+    __tablename__ = "quiz_attempts"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), index=True)
+    quiz_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("generated_content.id"), index=True)
+    answers: Mapped[dict] = mapped_column(JSON)
+    score: Mapped[float | None]
+    time_taken_sec: Mapped[int | None] = mapped_column(Integer)
+    attempted_at: Mapped[datetime] = mapped_column(server_default=func.now())
+
+    user: Mapped[User] = relationship(back_populates="quiz_attempts")
+    quiz: Mapped[GeneratedContent] = relationship(back_populates="quiz_attempts")

--- a/backend/app/domain/models/user.py
+++ b/backend/app/domain/models/user.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.domain.models.base import Base
+
+if TYPE_CHECKING:
+    from app.domain.models.conversation import TutorConversation
+    from app.domain.models.flashcard import FlashcardReview
+    from app.domain.models.progress import UserModuleProgress
+    from app.domain.models.quiz import QuizAttempt
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    email: Mapped[str] = mapped_column(String, unique=True, index=True)
+    name: Mapped[str] = mapped_column(String)
+    preferred_language: Mapped[str] = mapped_column(String(2), server_default="fr")
+    country: Mapped[str | None] = mapped_column(String)
+    professional_role: Mapped[str | None] = mapped_column(String)
+    current_level: Mapped[int] = mapped_column(server_default="1")
+    streak_days: Mapped[int] = mapped_column(server_default="0")
+    last_active: Mapped[datetime] = mapped_column(server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(server_default=func.now())
+
+    module_progress: Mapped[list[UserModuleProgress]] = relationship(back_populates="user")
+    quiz_attempts: Mapped[list[QuizAttempt]] = relationship(back_populates="user")
+    flashcard_reviews: Mapped[list[FlashcardReview]] = relationship(back_populates="user")
+    tutor_conversations: Mapped[list[TutorConversation]] = relationship(back_populates="user")

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -5,7 +5,7 @@ from alembic import context
 from sqlalchemy import pool
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
-from app.domain.models.base import Base
+from app.domain.models import Base  # noqa: F401 — imports all models for autogenerate
 from app.infrastructure.config.settings import settings
 
 config = context.config

--- a/backend/migrations/versions/001_initial_schema.py
+++ b/backend/migrations/versions/001_initial_schema.py
@@ -1,0 +1,152 @@
+"""Initial database schema — all 7 tables from SRS Section 9.
+
+Revision ID: 001_initial_schema
+Revises:
+Create Date: 2026-03-30
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "001_initial_schema"
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # --- users ---
+    op.create_table(
+        "users",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("preferred_language", sa.String(2), server_default="fr"),
+        sa.Column("country", sa.String(), nullable=True),
+        sa.Column("professional_role", sa.String(), nullable=True),
+        sa.Column("current_level", sa.Integer(), server_default="1"),
+        sa.Column("streak_days", sa.Integer(), server_default="0"),
+        sa.Column("last_active", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+    )
+    op.create_index("ix_users_email", "users", ["email"], unique=True)
+    op.create_index("idx_users_last_active", "users", ["last_active"])
+
+    # --- modules ---
+    op.create_table(
+        "modules",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("module_number", sa.Integer(), nullable=False),
+        sa.Column("level", sa.Integer(), nullable=False),
+        sa.Column("title_fr", sa.Text(), nullable=False),
+        sa.Column("title_en", sa.Text(), nullable=False),
+        sa.Column("description_fr", sa.Text(), nullable=True),
+        sa.Column("description_en", sa.Text(), nullable=True),
+        sa.Column("estimated_hours", sa.Integer(), server_default="20"),
+        sa.Column("bloom_level", sa.String(), nullable=True),
+        sa.Column(
+            "prereq_modules",
+            postgresql.ARRAY(postgresql.UUID(as_uuid=True)),
+            server_default="{}",
+        ),
+        sa.Column("books_sources", sa.JSON(), nullable=True),
+    )
+    op.create_index("ix_modules_module_number", "modules", ["module_number"], unique=True)
+    op.create_index("idx_modules_level", "modules", ["level"])
+
+    # --- user_module_progress ---
+    op.create_table(
+        "user_module_progress",
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("module_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("status", sa.String(), server_default="locked"),
+        sa.Column("completion_pct", sa.Float(), server_default="0.0"),
+        sa.Column("quiz_score_avg", sa.Float(), nullable=True),
+        sa.Column("time_spent_minutes", sa.Integer(), server_default="0"),
+        sa.Column("last_accessed", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("user_id", "module_id"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["module_id"], ["modules.id"]),
+    )
+    op.create_index("idx_progress_user_id", "user_module_progress", ["user_id"])
+    op.create_index("idx_progress_module_id", "user_module_progress", ["module_id"])
+    op.create_index("idx_progress_status", "user_module_progress", ["status"])
+
+    # --- generated_content ---
+    op.create_table(
+        "generated_content",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("module_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("content_type", sa.String(), nullable=False),
+        sa.Column("language", sa.String(2), nullable=False),
+        sa.Column("level", sa.Integer(), nullable=False),
+        sa.Column("content", sa.JSON(), nullable=False),
+        sa.Column("sources_cited", sa.JSON(), nullable=True),
+        sa.Column("country_context", sa.String(), nullable=True),
+        sa.Column("generated_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+        sa.Column("validated", sa.Boolean(), server_default="false"),
+        sa.ForeignKeyConstraint(["module_id"], ["modules.id"]),
+    )
+    op.create_index("idx_content_module_id", "generated_content", ["module_id"])
+    op.create_index("idx_content_type", "generated_content", ["content_type"])
+    op.create_index("idx_content_language", "generated_content", ["language"])
+
+    # --- quiz_attempts ---
+    op.create_table(
+        "quiz_attempts",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("quiz_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("answers", sa.JSON(), nullable=False),
+        sa.Column("score", sa.Float(), nullable=True),
+        sa.Column("time_taken_sec", sa.Integer(), nullable=True),
+        sa.Column("attempted_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["quiz_id"], ["generated_content.id"]),
+    )
+    op.create_index("idx_quiz_user_id", "quiz_attempts", ["user_id"])
+    op.create_index("idx_quiz_quiz_id", "quiz_attempts", ["quiz_id"])
+
+    # --- flashcard_reviews ---
+    op.create_table(
+        "flashcard_reviews",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("card_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("rating", sa.String(), nullable=False),
+        sa.Column("next_review", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("stability", sa.Float(), server_default="1.0"),
+        sa.Column("difficulty", sa.Float(), server_default="5.0"),
+        sa.Column("reviewed_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["card_id"], ["generated_content.id"]),
+    )
+    op.create_index("idx_flashcard_user_id", "flashcard_reviews", ["user_id"])
+    op.create_index("idx_flashcard_card_id", "flashcard_reviews", ["card_id"])
+    op.create_index("idx_flashcard_next_review", "flashcard_reviews", ["next_review"])
+
+    # --- tutor_conversations ---
+    op.create_table(
+        "tutor_conversations",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("module_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("messages", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["module_id"], ["modules.id"]),
+    )
+    op.create_index("idx_conversation_user_id", "tutor_conversations", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("tutor_conversations")
+    op.drop_table("flashcard_reviews")
+    op.drop_table("quiz_attempts")
+    op.drop_table("generated_content")
+    op.drop_table("user_module_progress")
+    op.drop_table("modules")
+    op.drop_table("users")

--- a/backend/migrations/versions/002_rls_policies.py
+++ b/backend/migrations/versions/002_rls_policies.py
@@ -1,0 +1,49 @@
+"""Row Level Security policies for user data isolation.
+
+Revision ID: 002_rls_policies
+Revises: 001_initial_schema
+Create Date: 2026-03-30
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "002_rls_policies"
+down_revision: str | None = "001_initial_schema"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Tables with user-scoped data that need RLS
+_USER_TABLES = [
+    "users",
+    "user_module_progress",
+    "quiz_attempts",
+    "flashcard_reviews",
+    "tutor_conversations",
+]
+
+
+def upgrade() -> None:
+    # Users table — can only see own profile
+    op.execute("ALTER TABLE users ENABLE ROW LEVEL SECURITY")
+    op.execute("""
+        CREATE POLICY users_isolation ON users
+        USING (id = current_setting('app.current_user_id')::uuid)
+    """)
+
+    # User-scoped tables — filter by user_id
+    for table in _USER_TABLES[1:]:
+        op.execute(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY")
+        op.execute(f"""
+            CREATE POLICY {table}_isolation ON {table}
+            USING (user_id = current_setting('app.current_user_id')::uuid)
+        """)
+
+    # Note: modules and generated_content are shared — no RLS needed
+
+
+def downgrade() -> None:
+    for table in reversed(_USER_TABLES):
+        op.execute(f"DROP POLICY IF EXISTS {table}_isolation ON {table}")
+        op.execute(f"ALTER TABLE {table} DISABLE ROW LEVEL SECURITY")

--- a/backend/migrations/versions/003_seed_modules.py
+++ b/backend/migrations/versions/003_seed_modules.py
@@ -1,0 +1,243 @@
+"""Seed 15 learning modules M01-M15 from syllabus.
+
+Revision ID: 003_seed_modules
+Revises: 002_rls_policies
+Create Date: 2026-03-30
+"""
+
+from collections.abc import Sequence
+from uuid import uuid4
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.sql import column, table
+
+revision: str = "003_seed_modules"
+down_revision: str | None = "002_rls_policies"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    modules_table = table(
+        "modules",
+        column("id", sa.String),
+        column("module_number", sa.Integer),
+        column("level", sa.Integer),
+        column("title_fr", sa.String),
+        column("title_en", sa.String),
+        column("description_fr", sa.String),
+        column("description_en", sa.String),
+        column("estimated_hours", sa.Integer),
+        column("bloom_level", sa.String),
+        column("prereq_modules", sa.String),
+        column("books_sources", sa.String),
+    )
+
+    modules = [
+        # === Level 1 — Beginner (60h) ===
+        {
+            "id": str(uuid4()),
+            "module_number": 1,
+            "level": 1,
+            "title_fr": "Fondements de la Sante Publique",
+            "title_en": "Foundations of Public Health",
+            "description_fr": "Concepts, histoire et vision globale de la sante publique en contexte AOF",
+            "description_en": "Concepts, history and global vision of public health in West African context",
+            "estimated_hours": 20,
+            "bloom_level": "Remember",
+            "prereq_modules": "{}",
+            "books_sources": '{"donaldson": ["ch1", "ch13"], "scutchfield": ["ch1", "ch2", "ch3", "ch4"]}',
+        },
+        {
+            "id": str(uuid4()),
+            "module_number": 2,
+            "level": 1,
+            "title_fr": "Introduction aux Donnees de Sante & Statistiques",
+            "title_en": "Introduction to Health Data & Statistics",
+            "description_fr": "Comprendre, collecter et lire les donnees de sante — bases du raisonnement statistique",
+            "description_en": "Understanding, collecting and reading health data — basics of statistical reasoning",
+            "estimated_hours": 22,
+            "bloom_level": "Understand",
+            "prereq_modules": "{}",
+            "books_sources": '{"triola": ["ch1", "ch2", "ch3"], "donaldson": ["ch2"], "scutchfield": ["ch13"]}',
+        },
+        {
+            "id": str(uuid4()),
+            "module_number": 3,
+            "level": 1,
+            "title_fr": "Systemes de Sante en Afrique de l'Ouest",
+            "title_en": "Health Systems in West Africa",
+            "description_fr": "Architecture, financement et performance des systemes de sante des pays CEDEAO",
+            "description_en": "Architecture, financing and performance of health systems in ECOWAS countries",
+            "estimated_hours": 18,
+            "bloom_level": "Understand",
+            "prereq_modules": "{}",
+            "books_sources": '{"donaldson": ["ch6"], "scutchfield": ["ch6", "ch7", "ch8", "ch28"]}',
+        },
+        # === Level 2 — Intermediate (90h) ===
+        {
+            "id": str(uuid4()),
+            "module_number": 4,
+            "level": 2,
+            "title_fr": "Epidemiologie Appliquee",
+            "title_en": "Applied Epidemiology",
+            "description_fr": "Mesurer la maladie dans les populations — methodes et indicateurs pour la sante publique en AOF",
+            "description_en": "Measuring disease in populations — methods and indicators for public health in West Africa",
+            "estimated_hours": 25,
+            "bloom_level": "Apply",
+            "prereq_modules": "{}",
+            "books_sources": '{"donaldson": ["ch2"], "scutchfield": ["ch11", "ch13"]}',
+        },
+        {
+            "id": str(uuid4()),
+            "module_number": 5,
+            "level": 2,
+            "title_fr": "Biostatistiques pour la Sante Publique",
+            "title_en": "Biostatistics for Public Health",
+            "description_fr": "Probabilites, distributions, estimation et tests d'hypothese appliques a la sante",
+            "description_en": "Probabilities, distributions, estimation and hypothesis testing applied to health",
+            "estimated_hours": 28,
+            "bloom_level": "Apply",
+            "prereq_modules": "{}",
+            "books_sources": '{"triola": ["ch4", "ch5", "ch6", "ch7", "ch8", "ch9"]}',
+        },
+        {
+            "id": str(uuid4()),
+            "module_number": 6,
+            "level": 2,
+            "title_fr": "Maladies et Determinants en AOF",
+            "title_en": "Diseases & Health Determinants in West Africa",
+            "description_fr": "Profil epidemiologique, maladies prioritaires et determinants sociaux en Afrique de l'Ouest",
+            "description_en": "Epidemiological profile, priority diseases and social determinants in West Africa",
+            "estimated_hours": 22,
+            "bloom_level": "Analyze",
+            "prereq_modules": "{}",
+            "books_sources": '{"donaldson": ["ch3", "ch4", "ch5"], "scutchfield": ["ch17", "ch18", "ch22", "ch25"]}',
+        },
+        {
+            "id": str(uuid4()),
+            "module_number": 7,
+            "level": 2,
+            "title_fr": "Outils et Pratiques de Sante Publique",
+            "title_en": "Public Health Tools & Practice",
+            "description_fr": "Leadership, evaluation communautaire, performance, gestion des donnees de sante",
+            "description_en": "Leadership, community assessment, performance, health data management",
+            "estimated_hours": 20,
+            "bloom_level": "Apply",
+            "prereq_modules": "{}",
+            "books_sources": '{"scutchfield": ["ch9", "ch10", "ch11", "ch12", "ch14", "ch15", "ch16"]}',
+        },
+        # === Level 3 — Advanced (100h) ===
+        {
+            "id": str(uuid4()),
+            "module_number": 8,
+            "level": 3,
+            "title_fr": "Surveillance Epidemiologique Numerique",
+            "title_en": "Digital Epidemiological Surveillance",
+            "description_fr": "Systemes de surveillance, alerte precoce et donnees en temps reel pour la riposte en AOF",
+            "description_en": "Surveillance systems, early warning and real-time data for response in West Africa",
+            "estimated_hours": 22,
+            "bloom_level": "Analyze",
+            "prereq_modules": "{}",
+            "books_sources": '{"donaldson": ["ch2", "ch3"], "scutchfield": ["ch13"]}',
+        },
+        {
+            "id": str(uuid4()),
+            "module_number": 9,
+            "level": 3,
+            "title_fr": "Statistiques Avancees et Analyse de Donnees",
+            "title_en": "Advanced Statistics & Data Analysis",
+            "description_fr": "Regression, ANOVA, tests non-parametriques, analyse de survie pour la recherche en sante",
+            "description_en": "Regression, ANOVA, non-parametric tests, survival analysis for health research",
+            "estimated_hours": 28,
+            "bloom_level": "Analyze",
+            "prereq_modules": "{}",
+            "books_sources": '{"triola": ["ch10", "ch11", "ch12", "ch13", "ch14"]}',
+        },
+        {
+            "id": str(uuid4()),
+            "module_number": 10,
+            "level": 3,
+            "title_fr": "Sante Numerique et Systemes d'Information Sanitaire",
+            "title_en": "Digital Health & Health Information Systems",
+            "description_fr": "Technologies numeriques pour la sante en AOF : DHIS2, mHealth, IA, interoperabilite",
+            "description_en": "Digital technologies for health in West Africa: DHIS2, mHealth, AI, interoperability",
+            "estimated_hours": 20,
+            "bloom_level": "Apply",
+            "prereq_modules": "{}",
+            "books_sources": '{"scutchfield": ["ch13"]}',
+        },
+        {
+            "id": str(uuid4()),
+            "module_number": 11,
+            "level": 3,
+            "title_fr": "Sante Environnementale et One Health",
+            "title_en": "Environmental Health & One Health",
+            "description_fr": "Changement climatique, eau, assainissement, interface animal-humain-environnement en AOF",
+            "description_en": "Climate change, water, sanitation, animal-human-environment interface in West Africa",
+            "estimated_hours": 16,
+            "bloom_level": "Analyze",
+            "prereq_modules": "{}",
+            "books_sources": '{"donaldson": ["ch12"], "scutchfield": ["ch23"]}',
+        },
+        {
+            "id": str(uuid4()),
+            "module_number": 12,
+            "level": 3,
+            "title_fr": "Sante Maternelle, Infantile et Communautaire",
+            "title_en": "Maternal, Child & Community Health",
+            "description_fr": "Reduire la mortalite maternelle et infantile — SMNI et sante communautaire en AOF",
+            "description_en": "Reducing maternal and child mortality — MCH and community health in West Africa",
+            "estimated_hours": 20,
+            "bloom_level": "Apply",
+            "prereq_modules": "{}",
+            "books_sources": '{"donaldson": ["ch8"], "scutchfield": ["ch25"]}',
+        },
+        # === Level 4 — Expert (70h) ===
+        {
+            "id": str(uuid4()),
+            "module_number": 13,
+            "level": 4,
+            "title_fr": "Leadership, Politique et Gouvernance",
+            "title_en": "Leadership, Policy & Governance",
+            "description_fr": "Elaborer et influencer des politiques de sante publique en Afrique de l'Ouest",
+            "description_en": "Developing and influencing public health policies in West Africa",
+            "estimated_hours": 22,
+            "bloom_level": "Evaluate",
+            "prereq_modules": "{}",
+            "books_sources": '{"scutchfield": ["ch9", "ch16", "ch19", "ch29"], "donaldson": ["ch6", "ch7"]}',
+        },
+        {
+            "id": str(uuid4()),
+            "module_number": 14,
+            "level": 4,
+            "title_fr": "Recherche et Evaluation Avancees",
+            "title_en": "Advanced Research & Evaluation",
+            "description_fr": "Concevoir, conduire et evaluer la recherche en sante publique et les programmes de sante",
+            "description_en": "Designing, conducting and evaluating public health research and health programs",
+            "estimated_hours": 24,
+            "bloom_level": "Evaluate",
+            "prereq_modules": "{}",
+            "books_sources": '{"triola": ["ch7", "ch8", "ch9", "ch10", "ch14"], "scutchfield": ["ch17", "ch12"]}',
+        },
+        {
+            "id": str(uuid4()),
+            "module_number": 15,
+            "level": 4,
+            "title_fr": "Projet Integratif Capstone",
+            "title_en": "Integrative Capstone Project",
+            "description_fr": "Synthese de toutes les competences — projet de sante publique numerique pour un district AOF reel",
+            "description_en": "Synthesis of all skills — digital public health project for a real West African district",
+            "estimated_hours": 24,
+            "bloom_level": "Create",
+            "prereq_modules": "{}",
+            "books_sources": '{"donaldson": ["all"], "scutchfield": ["all"], "triola": ["all"]}',
+        },
+    ]
+
+    op.bulk_insert(modules_table, modules)
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM modules WHERE module_number BETWEEN 1 AND 15")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -40,6 +40,9 @@ line-length = 100
 [tool.ruff.lint]
 select = ["E", "W", "F", "I", "UP", "B", "SIM"]
 
+[tool.ruff.lint.per-file-ignores]
+"migrations/**" = ["E501"]
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]


### PR DESCRIPTION
Closes #20

## Summary

- **7 SQLAlchemy 2.0 models** with `Mapped` type annotations, `TYPE_CHECKING` imports, split into individual files per our architecture
- **Migration 001**: all 7 tables (users, modules, user_module_progress, generated_content, quiz_attempts, flashcard_reviews, tutor_conversations) with comprehensive indexes
- **Migration 002**: Row Level Security policies — users can only access their own data (progress, quizzes, flashcards, conversations). Modules and generated_content are shared.
- **Migration 003**: seed data for all 15 modules M01-M15 across 4 levels (Beginner → Expert) with book source references from syllabus
- **CLAUDE.md**: added "Do NOT re-scaffold" guard to prevent GitHub Claude from recreating the project structure

## Test plan

- [ ] `cd backend && uv run pytest` — 2 tests pass
- [ ] `cd backend && uv run ruff check .` — lint clean
- [ ] Start PostgreSQL (`make dev-infra`) then `make db-migrate` — all 3 migrations apply cleanly
- [ ] Verify 15 modules seeded: `SELECT module_number, title_en, level FROM modules ORDER BY module_number`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)