### PR TITLE
fix: Sentry sourcemaps config + close #38 monitoring setup

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -13,6 +13,8 @@ export default withSentryConfig(withNextIntl(nextConfig), {
   project: process.env.SENTRY_PROJECT,
   authToken: process.env.SENTRY_AUTH_TOKEN,
   silent: !process.env.CI,
-  hideSourceMaps: true,
+  sourcemaps: {
+    deleteSourcemapsAfterUpload: true,
+  },
   tunnelRoute: "/monitoring",
 });


### PR DESCRIPTION
## Summary
- Fixes `hideSourceMaps` deprecation in `@sentry/nextjs` — replaced with `sourcemaps.deleteSourcemapsAfterUpload`
- Completes issue #38 (the bulk of Sentry + PostHog was committed directly to main via auto-hooks)

## What was implemented for #38 (across recent main commits)

**Backend (Sentry):**
- `sentry-sdk[fastapi]` dependency
- Settings: `sentry_dsn`, `sentry_traces_sample_rate`, `sentry_profiles_sample_rate`
- GDPR PII scrubber in `before_send` (strips IP, email, auth headers)

**Frontend (Sentry):**
- `@sentry/nextjs` with client/server/edge configs
- `instrumentation.ts`, `global-error.tsx`
- `next.config.ts` wrapped with `withSentryConfig` — source map upload + `/monitoring` tunnel

**Frontend (PostHog):**
- `posthog-js` with privacy-first config (no cookies, no IP, no autocapture, EU data residency)
- `posthog-provider.tsx` with UUID pseudonymization
- `analytics.ts` typed event helper

**Deployment:**
- `.env.example`, `docker-compose.prod.yml`, `deploy.yml`, `Dockerfile` updated

## Test plan
- [x] Backend: 17/17 tests pass, ruff clean
- [x] Frontend: `npm run build` succeeds with Node 20
- [x] Both SDKs no-op when DSN/key env vars are empty (safe for dev)
- [ ] Configure Sentry alert rules (5xx >1%, P95 >5s) in dashboard after deploy

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)