### PR TITLE
fix: create /tutor page to resolve 404 navigation issue

### DIFF
--- a/frontend/app/[locale]/(app)/tutor/page.tsx
+++ b/frontend/app/[locale]/(app)/tutor/page.tsx
@@ -1,0 +1,25 @@
+import { getTranslations } from 'next-intl/server';
+import { TutorPageClient } from './tutor-client';
+
+export async function generateMetadata() {
+  const t = await getTranslations('ChatTutor');
+  
+  return {
+    title: t('title'),
+    description: t('tutorPageDescription'),
+  };
+}
+
+export default async function TutorPage() {
+  const t = await getTranslations('ChatTutor');
+  
+  return (
+    <div className="flex h-[calc(100vh-theme(space.16))] md:h-[calc(100vh-theme(space.14))] flex-col">
+      <div className="border-b bg-background p-4">
+        <h1 className="text-2xl font-bold">{t('title')}</h1>
+        <p className="text-muted-foreground">{t('tutorPageDescription')}</p>
+      </div>
+      <TutorPageClient />
+    </div>
+  );
+}

--- a/frontend/app/[locale]/(app)/tutor/tutor-client.tsx
+++ b/frontend/app/[locale]/(app)/tutor/tutor-client.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Plus, MessageSquare } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { ChatPanel } from '@/components/chat';
+import { ChatProvider } from '@/components/chat';
+import { cn } from '@/lib/utils';
+
+interface Conversation {
+  id: string;
+  title: string;
+  lastMessage: string;
+  timestamp: Date;
+  messageCount: number;
+}
+
+export function TutorPageClient() {
+  const t = useTranslations('ChatTutor');
+  
+  // Static mock conversations data
+  const conversations: Conversation[] = [
+    {
+      id: '1',
+      title: 'Public Health Basics',
+      lastMessage: 'What are the main determinants of health?',
+      timestamp: new Date(2026, 2, 31, 14, 45), // 30 minutes ago (static)
+      messageCount: 5,
+    },
+    {
+      id: '2', 
+      title: 'Epidemiology Questions',
+      lastMessage: 'Explain the difference between incidence and prevalence',
+      timestamp: new Date(2026, 2, 31, 13, 15), // 2 hours ago (static)
+      messageCount: 12,
+    },
+    {
+      id: '3',
+      title: 'DHIS2 Data Analysis',
+      lastMessage: 'How do I create indicators in DHIS2?',
+      timestamp: new Date(2026, 2, 30, 15, 15), // 1 day ago (static)
+      messageCount: 8,
+    },
+  ];
+  
+  const [selectedConversation, setSelectedConversation] = useState<string | null>('1');
+
+  const formatRelativeTime = (date: Date) => {
+    const now = new Date();
+    const diffInMinutes = Math.floor((now.getTime() - date.getTime()) / (1000 * 60));
+    
+    if (diffInMinutes < 60) {
+      return `${diffInMinutes}m ago`;
+    } else if (diffInMinutes < 1440) {
+      return `${Math.floor(diffInMinutes / 60)}h ago`;
+    } else {
+      return `${Math.floor(diffInMinutes / 1440)}d ago`;
+    }
+  };
+
+  return (
+    <ChatProvider>
+      <div className="flex flex-1 min-h-0">
+        {/* Conversations Sidebar - Hidden on mobile, shown on desktop */}
+        <div className="w-80 border-r bg-card hidden md:flex flex-col">
+          {/* Sidebar Header */}
+          <div className="p-4 border-b">
+            <Button 
+              className="w-full justify-start gap-2" 
+              variant="outline"
+            >
+              <Plus className="h-4 w-4" />
+              {t('newConversation')}
+            </Button>
+          </div>
+
+          {/* Conversations List */}
+          <div className="flex-1 overflow-y-auto">
+            {conversations.length === 0 ? (
+              <div className="flex flex-col items-center justify-center p-6 text-center">
+                <MessageSquare className="h-12 w-12 text-muted-foreground mb-4" />
+                <h3 className="font-medium mb-2">{t('noConversations')}</h3>
+                <p className="text-sm text-muted-foreground mb-4">
+                  {t('noConversationsDescription')}
+                </p>
+                <Button size="sm">
+                  <Plus className="h-4 w-4 mr-2" />
+                  {t('startFirstConversation')}
+                </Button>
+              </div>
+            ) : (
+              <div className="p-2 space-y-2">
+                {conversations.map((conversation) => (
+                  <Card
+                    key={conversation.id}
+                    className={cn(
+                      'p-3 cursor-pointer transition-colors hover:bg-accent/50',
+                      selectedConversation === conversation.id && 'bg-accent'
+                    )}
+                    onClick={() => setSelectedConversation(conversation.id)}
+                  >
+                    <div className="flex justify-between items-start mb-2">
+                      <h3 className="font-medium text-sm truncate pr-2">
+                        {conversation.title}
+                      </h3>
+                      <span className="text-xs text-muted-foreground shrink-0">
+                        {formatRelativeTime(conversation.timestamp)}
+                      </span>
+                    </div>
+                    <p className="text-xs text-muted-foreground truncate mb-1">
+                      {conversation.lastMessage}
+                    </p>
+                    <div className="flex justify-between items-center">
+                      <span className="text-xs text-muted-foreground">
+                        {t('messageCount', { count: conversation.messageCount })}
+                      </span>
+                    </div>
+                  </Card>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Main Chat Area */}
+        <div className="flex-1 flex flex-col min-h-0">
+          {selectedConversation ? (
+            <ChatPanel 
+              isOpen={true}
+              onClose={() => {}} // No close action needed for full page
+              className="relative border-none w-full h-full"
+            />
+          ) : (
+            <div className="flex-1 flex flex-col items-center justify-center text-center p-6">
+              <MessageSquare className="h-16 w-16 text-muted-foreground mb-4" />
+              <h2 className="text-xl font-semibold mb-2">{t('selectConversation')}</h2>
+              <p className="text-muted-foreground mb-6 max-w-sm">
+                {t('selectConversationDescription')}
+              </p>
+              <Button>
+                <Plus className="h-4 w-4 mr-2" />
+                {t('newConversation')}
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+    </ChatProvider>
+  );
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -243,6 +243,7 @@
   },
   "ChatTutor": {
     "title": "AI Tutor",
+    "tutorPageDescription": "Get personalized help with your public health studies from your AI tutor",
     "placeholder": "Ask me anything about public health...",
     "send": "Send",
     "typing": "The tutor is typing...",
@@ -278,7 +279,15 @@
     "emptyStateDescription": "Ask questions, request quizzes, or get explanations about public health topics",
     "moreThan99": "99+",
     "publicHealthFundamentals": "Public Health Fundamentals",
-    "epidemiologyBasics": "Epidemiology Basics"
+    "epidemiologyBasics": "Epidemiology Basics",
+    "newConversation": "New Conversation",
+    "noConversations": "No conversations yet",
+    "noConversationsDescription": "Start your first conversation with the AI tutor",
+    "startFirstConversation": "Start First Conversation",
+    "selectConversation": "Select a conversation",
+    "selectConversationDescription": "Choose a conversation from the sidebar or start a new one",
+    "messageCount": "{count} {count, plural, one {message} other {messages}}",
+    "cancel": "Cancel"
   },
   "Flashcards": {
     "title": "Flashcards",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -243,6 +243,7 @@
   },
   "ChatTutor": {
     "title": "Tuteur IA",
+    "tutorPageDescription": "Obtenez une aide personnalisée pour vos études en santé publique grâce à votre tuteur IA",
     "placeholder": "Demandez-moi n'importe quoi sur la santé publique...",
     "send": "Envoyer",
     "typing": "Le tuteur écrit...",
@@ -278,7 +279,15 @@
     "emptyStateDescription": "Posez des questions, demandez des quiz, ou obtenez des explications sur les sujets de santé publique",
     "moreThan99": "99+",
     "publicHealthFundamentals": "Fondamentaux de la Santé Publique",
-    "epidemiologyBasics": "Bases de l'Épidémiologie"
+    "epidemiologyBasics": "Bases de l'Épidémiologie",
+    "newConversation": "Nouvelle Conversation",
+    "noConversations": "Aucune conversation encore",
+    "noConversationsDescription": "Commencez votre première conversation avec le tuteur IA",
+    "startFirstConversation": "Commencer la Première Conversation",
+    "selectConversation": "Sélectionner une conversation",
+    "selectConversationDescription": "Choisissez une conversation dans la barre latérale ou commencez-en une nouvelle",
+    "messageCount": "{count} {count, plural, one {message} other {messages}}",
+    "cancel": "Annuler"
   },
   "Flashcards": {
     "title": "Flashcards",


### PR DESCRIPTION
## Summary

Resolves the 404 error when users click "Tuteur IA" / "AI Tutor" in navigation by creating the missing  page route.

## Changes

- **Add ** - Server component with proper metadata generation
- **Add ** - Full-page chat interface with conversations sidebar
- **Update translation files (FR/EN)** - Add all required ChatTutor keys for the new page
- **Quality fixes** - Resolve React hooks purity issues and linting errors

## Implementation Details

- Leverages existing  component for consistent chat experience
- Shows conversation history sidebar on desktop (hidden on mobile for mobile-first design)
- Integrates seamlessly with existing ChatProvider and chat components
- Follows all guidelines from skill files (mobile-first, bilingual, component patterns)
- Mock conversation data with realistic timestamps for demo purposes

## Test Plan

- [x] Build passes successfully -  route now generated
- [x] No linting errors
- [x] No TypeScript errors
- [x] Follows established patterns from other pages

Fixes #113

🤖 Generated with [Claude Code](https://claude.ai/code)