### PR TITLE
feat(auth): implement auth guard for protected routes

### DIFF
--- a/frontend/app/[locale]/(app)/layout.tsx
+++ b/frontend/app/[locale]/(app)/layout.tsx
@@ -3,19 +3,22 @@ import { Header } from "@/components/layout/header";
 import { Sidebar } from "@/components/layout/sidebar";
 import { BreadcrumbNav } from "@/components/layout/breadcrumb-nav";
 import { ChatLayout } from "@/components/chat/chat-layout";
+import { AuthGuard } from "@/components/auth/auth-guard";
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
-    <ChatLayout>
-      <div className="flex min-h-dvh flex-col md:flex-row">
-        <Sidebar />
-        <div className="flex flex-1 flex-col">
-          <Header />
-          <BreadcrumbNav />
-          <main className="flex-1 pb-16 pt-0 md:pb-0">{children}</main>
+    <AuthGuard>
+      <ChatLayout>
+        <div className="flex min-h-dvh flex-col md:flex-row">
+          <Sidebar />
+          <div className="flex flex-1 flex-col">
+            <Header />
+            <BreadcrumbNav />
+            <main className="flex-1 pb-16 pt-0 md:pb-0">{children}</main>
+          </div>
+          <BottomNav />
         </div>
-        <BottomNav />
-      </div>
-    </ChatLayout>
+      </ChatLayout>
+    </AuthGuard>
   );
 }

--- a/frontend/components/auth/auth-guard.tsx
+++ b/frontend/components/auth/auth-guard.tsx
@@ -1,0 +1,65 @@
+/**
+ * AuthGuard component to protect routes and redirect unauthenticated users
+ * Shows loading state while checking authentication
+ */
+
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter, usePathname } from 'next/navigation';
+import { useAuth } from '@/lib/hooks/use-auth';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
+
+interface AuthGuardProps {
+  children: React.ReactNode;
+}
+
+export function AuthGuard({ children }: AuthGuardProps) {
+  const { isAuthenticated, isLoading } = useAuth();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    // Don't redirect if still loading
+    if (isLoading) return;
+
+    // If not authenticated, redirect to login with return URL
+    if (!isAuthenticated) {
+      const locale = pathname.split('/')[1] || 'en';
+      const returnUrl = encodeURIComponent(pathname);
+      router.push(`/${locale}/login?returnUrl=${returnUrl}`);
+      return;
+    }
+  }, [isAuthenticated, isLoading, pathname, router]);
+
+  // Show loading spinner while checking auth
+  if (isLoading) {
+    return (
+      <div className="flex h-dvh items-center justify-center">
+        <div className="flex flex-col items-center gap-4">
+          <LoadingSpinner size="lg" />
+          <p className="text-sm text-muted-foreground">
+            Checking authentication...
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Show nothing while redirecting unauthenticated users
+  if (!isAuthenticated) {
+    return (
+      <div className="flex h-dvh items-center justify-center">
+        <div className="flex flex-col items-center gap-4">
+          <LoadingSpinner size="lg" />
+          <p className="text-sm text-muted-foreground">
+            Redirecting to login...
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Render children if authenticated
+  return <>{children}</>;
+}

--- a/frontend/components/auth/totp-login-form.tsx
+++ b/frontend/components/auth/totp-login-form.tsx
@@ -6,7 +6,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useTranslations } from 'next-intl';
 import { z } from 'zod';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -17,6 +17,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { authClient, AuthError } from '@/lib/auth';
+import { useAuth } from '@/lib/hooks/use-auth';
 
 const createLoginSchema = (t: (key: string) => string) => z.object({
   email: z.string().min(1, t('emailRequired')).email(t('emailInvalid')),
@@ -42,10 +43,15 @@ export function TOTPLoginForm({ locale }: TOTPLoginFormProps) {
   const t = useTranslations('Auth');
   const tCommon = useTranslations('Common');
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const { login } = useAuth();
   
   const [isLoading, setIsLoading] = useState(false);
   const [showMagicLink, setShowMagicLink] = useState(false);
   const [magicLinkSent, setMagicLinkSent] = useState(false);
+
+  // Get return URL from search params
+  const returnUrl = searchParams.get('returnUrl') || `/${locale}/dashboard`;
 
   // Login form
   const loginSchema = createLoginSchema(t);
@@ -77,13 +83,10 @@ export function TOTPLoginForm({ locale }: TOTPLoginFormProps) {
     setIsLoading(true);
     
     try {
-      const response = await authClient.login({
-        email: data.email,
-        totp_code: data.totp_code,
-      });
+      await login(data.email, data.totp_code);
       
-      // Login successful - redirect to dashboard
-      router.push(`/${locale}/dashboard`);
+      // Login successful - redirect to return URL or dashboard
+      router.push(returnUrl);
     } catch (error) {
       console.error('Login error:', error);
       

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -14,16 +14,28 @@ import {
   ChevronLeft,
   ChevronRight,
   Menu,
+  LogOut,
 } from "lucide-react";
 import { LocaleSwitcher } from "@/components/shared/locale-switcher";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { useAuth } from "@/lib/hooks/use-auth";
 
 export function Sidebar() {
   const t = useTranslations("Navigation");
   const tCommon = useTranslations("Common");
+  const tAuth = useTranslations("Auth");
   const pathname = usePathname();
   const [isCollapsed, setIsCollapsed] = useState(false);
+  const { user, logout } = useAuth();
+
+  const handleLogout = async () => {
+    try {
+      await logout();
+    } catch (error) {
+      console.error('Logout failed:', error);
+    }
+  };
 
   const navItems = [
     { 
@@ -129,7 +141,23 @@ export function Sidebar() {
         })}
       </nav>
       
-      <div className="border-t p-2">
+      <div className="border-t p-2 space-y-2">
+        {/* User info section */}
+        {!isCollapsed && user && (
+          <div className="p-2 rounded-md bg-muted/50">
+            <div className="flex items-center gap-2 mb-2">
+              <div className="w-8 h-8 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-semibold">
+                {user.name.charAt(0).toUpperCase()}
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium truncate">{user.name}</p>
+                <p className="text-xs text-muted-foreground truncate">{user.email}</p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Language switcher */}
         {!isCollapsed ? (
           <div className="p-2">
             <LocaleSwitcher />
@@ -146,6 +174,25 @@ export function Sidebar() {
             </Button>
           </div>
         )}
+
+        {/* Logout button */}
+        <div className={cn("p-2", isCollapsed && "flex justify-center")}>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleLogout}
+            className={cn(
+              "min-h-11 text-destructive hover:text-destructive hover:bg-destructive/10",
+              isCollapsed 
+                ? "min-w-11 p-2" 
+                : "w-full justify-start gap-3 px-3"
+            )}
+            aria-label={tAuth("logout")}
+          >
+            <LogOut className="h-4 w-4 shrink-0" />
+            {!isCollapsed && <span>{tAuth("logout")}</span>}
+          </Button>
+        </div>
       </div>
     </aside>
   );

--- a/frontend/lib/hooks/use-auth.ts
+++ b/frontend/lib/hooks/use-auth.ts
@@ -1,0 +1,78 @@
+/**
+ * Authentication hook that provides auth operations and state
+ * Integrates with Zustand auth store and auth client
+ */
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuthStore } from '../store';
+import { authClient } from '../auth';
+
+export function useAuth() {
+  const {
+    user,
+    isAuthenticated,
+    isLoading,
+    login,
+    logout,
+    initialize,
+    setUser,
+    setLoading,
+  } = useAuthStore();
+
+  const router = useRouter();
+
+  // Initialize auth state on first mount
+  useEffect(() => {
+    initialize();
+  }, [initialize]);
+
+  const requireAuth = () => {
+    if (!isAuthenticated && !isLoading) {
+      const currentPath = window.location.pathname;
+      const locale = currentPath.split('/')[1] || 'en';
+      
+      // Construct return URL
+      const returnUrl = encodeURIComponent(currentPath);
+      router.push(`/${locale}/login?returnUrl=${returnUrl}`);
+      return false;
+    }
+    return true;
+  };
+
+  const handleLogin = async (email: string, totpCode: string) => {
+    try {
+      await login(email, totpCode);
+      return true;
+    } catch (error) {
+      throw error;
+    }
+  };
+
+  const handleLogout = async () => {
+    try {
+      await logout();
+      const currentPath = window.location.pathname;
+      const locale = currentPath.split('/')[1] || 'en';
+      router.push(`/${locale}/login`);
+    } catch (error) {
+      // Still redirect on logout error
+      const currentPath = window.location.pathname;
+      const locale = currentPath.split('/')[1] || 'en';
+      router.push(`/${locale}/login`);
+      throw error;
+    }
+  };
+
+  return {
+    user,
+    isAuthenticated,
+    isLoading,
+    login: handleLogin,
+    logout: handleLogout,
+    requireAuth,
+    setUser,
+    setLoading,
+    authClient, // Expose auth client for advanced usage
+  };
+}

--- a/frontend/lib/store.ts
+++ b/frontend/lib/store.ts
@@ -1,0 +1,100 @@
+/**
+ * Zustand store for authentication state management
+ * Integrates with the existing AuthClient for TOTP MFA authentication
+ */
+
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { authClient, type User } from './auth';
+
+interface AuthState {
+  user: User | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  
+  // Actions
+  login: (email: string, totpCode: string) => Promise<void>;
+  logout: () => Promise<void>;
+  initialize: () => void;
+  setUser: (user: User | null) => void;
+  setLoading: (loading: boolean) => void;
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      user: null,
+      isAuthenticated: false,
+      isLoading: true,
+
+      login: async (email: string, totpCode: string) => {
+        set({ isLoading: true });
+        try {
+          const response = await authClient.login({ email, totp_code: totpCode });
+          set({
+            user: response.user,
+            isAuthenticated: true,
+            isLoading: false,
+          });
+        } catch (error) {
+          set({ isLoading: false });
+          throw error;
+        }
+      },
+
+      logout: async () => {
+        set({ isLoading: true });
+        try {
+          await authClient.logout();
+          set({
+            user: null,
+            isAuthenticated: false,
+            isLoading: false,
+          });
+        } catch (error) {
+          // Still clear state on logout error
+          set({
+            user: null,
+            isAuthenticated: false,
+            isLoading: false,
+          });
+          throw error;
+        }
+      },
+
+      initialize: () => {
+        set({ isLoading: true });
+        
+        // Check if user is authenticated via existing auth client
+        const isAuth = authClient.isAuthenticated();
+        const currentUser = authClient.getCurrentUser();
+        
+        set({
+          user: currentUser,
+          isAuthenticated: isAuth,
+          isLoading: false,
+        });
+      },
+
+      setUser: (user: User | null) => {
+        set({
+          user,
+          isAuthenticated: !!user,
+        });
+      },
+
+      setLoading: (loading: boolean) => {
+        set({ isLoading: loading });
+      },
+    }),
+    {
+      name: 'auth-storage',
+      storage: createJSONStorage(() => localStorage),
+      // Only persist user data, not loading state
+      partialize: (state) => ({
+        user: state.user,
+        isAuthenticated: state.isAuthenticated,
+      }),
+    }
+  )
+);

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -109,7 +109,8 @@
     "accountRecovered": "Account Recovered",
     "setupNewAuthenticator": "Please set up your authenticator app with the new QR code below",
     "newBackupCodes": "New backup codes (save these securely):",
-    "continueToLogin": "Continue to Login"
+    "continueToLogin": "Continue to Login",
+    "logout": "Logout"
   },
   "LanguageSwitcher": {
     "switchTo": "Switch to French",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -109,7 +109,8 @@
     "accountRecovered": "Compte récupéré",
     "setupNewAuthenticator": "Veuillez configurer votre application d'authentification avec le nouveau code QR ci-dessous",
     "newBackupCodes": "Nouveaux codes de secours (sauvegardez-les en sécurité) :",
-    "continueToLogin": "Continuer vers la connexion"
+    "continueToLogin": "Continuer vers la connexion",
+    "logout": "Se déconnecter"
   },
   "LanguageSwitcher": {
     "switchTo": "Passer en anglais",


### PR DESCRIPTION
Implement auth guard functionality to protect app routes and redirect unauthenticated users.

## Features
- Zustand auth store for state management
- useAuth hook for auth operations
- AuthGuard component with redirect logic
- Protected (app)/* routes with authentication check
- Updated sidebar with user info and logout button
- Return URL support for post-login redirect
- Bilingual FR/EN support

## Acceptance Criteria ✅
- [x] Unauthenticated users visiting `/fr/dashboard` are redirected to `/fr/login`
- [x] After login with TOTP, user is redirected to dashboard (or original page)
- [x] JWT stored in localStorage (as specified in requirements)
- [x] `(app)/layout.tsx` checks auth state before rendering children
- [x] Auth state available via Zustand store and useAuth hook
- [x] Logout button clears token and redirects to login
- [x] Bilingual (FR/EN) support for all new UI elements

Closes #105