### PR TITLE
fix(ci): enforce single-issue concurrency for Claude

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,7 +9,7 @@ on:
     types: [labeled]
 
 concurrency:
-  group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  group: claude-code
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- Changes Claude workflow concurrency from per-issue to global (`claude-code` group)
- Ensures Claude only works on one issue at a time — no more parallel runs
- Prevents the cascading lint/format failures that broke CI/CD for 5+ hours

## Context
After enabling per-issue concurrency, multiple Claude runs landed conflicting changes on `main` simultaneously, causing 8 consecutive deploy failures. `main` and `dev` have been reverted to the last clean deploy (`0a85c8f`).

## Test plan
- [ ] Label an issue with `claude` — confirm only one workflow runs
- [ ] Label a second issue while first is running — confirm it queues (not parallel)
- [ ] Deploy succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)