### PR TITLE
fix: nav locale prefix — unblock all navigation

### DIFF
--- a/frontend/app/[locale]/(app)/dashboard/dashboard-client.tsx
+++ b/frontend/app/[locale]/(app)/dashboard/dashboard-client.tsx
@@ -1,14 +1,15 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { useLocale } from 'next-intl';
 import { ModuleMap } from '@/components/learning/module-map';
 
 export function DashboardClient() {
   const router = useRouter();
+  const locale = useLocale();
 
   const handleModuleClick = (moduleId: string) => {
-    // Navigate to module overview page
-    router.push(`/modules/${moduleId}`);
+    router.push(`/${locale}/modules/${moduleId}`);
   };
 
   return <ModuleMap onModuleClick={handleModuleClick} />;

--- a/frontend/app/[locale]/(app)/modules/page.tsx
+++ b/frontend/app/[locale]/(app)/modules/page.tsx
@@ -1,15 +1,16 @@
 'use client';
 
-import { useTranslations } from 'next-intl';
+import { useTranslations, useLocale } from 'next-intl';
 import { useRouter } from 'next/navigation';
 import { ModuleMap } from '@/components/learning/module-map';
 
 export default function ModulesPage() {
   const t = useTranslations('ModuleMap');
   const router = useRouter();
+  const locale = useLocale();
 
   const handleModuleClick = (moduleId: string) => {
-    router.push(`/modules/${moduleId}`);
+    router.push(`/${locale}/modules/${moduleId}`);
   };
 
   return (

--- a/frontend/app/[locale]/page.tsx
+++ b/frontend/app/[locale]/page.tsx
@@ -1,5 +1,9 @@
 import { redirect } from "next/navigation";
 
-export default function LocaleRoot() {
-  redirect("dashboard");
+export default function LocaleRoot({
+  params,
+}: {
+  params: { locale: string };
+}) {
+  redirect(`/${params.locale}/dashboard`);
 }

--- a/frontend/components/dashboard/upcoming-reviews.tsx
+++ b/frontend/components/dashboard/upcoming-reviews.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useTranslations } from 'next-intl';
+import { useTranslations, useLocale } from 'next-intl';
 import { useQuery } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -12,7 +12,8 @@ import { cn } from '@/lib/utils';
 export function UpcomingReviews() {
   const t = useTranslations('Dashboard');
   const router = useRouter();
-  
+  const locale = useLocale();
+
   const { data: upcomingReviews, isLoading, error } = useQuery({
     queryKey: ['upcoming-reviews'],
     queryFn: getUpcomingReviews,
@@ -21,7 +22,7 @@ export function UpcomingReviews() {
   });
 
   const handleStartReview = () => {
-    router.push('/flashcards');
+    router.push(`/${locale}/flashcards`);
   };
 
   const formatDate = (dateString: string) => {

--- a/frontend/components/layout/bottom-nav.tsx
+++ b/frontend/components/layout/bottom-nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import {
   Home,
   BookOpen,
@@ -15,37 +15,38 @@ import { cn } from "@/lib/utils";
 export function BottomNav() {
   const t = useTranslations("Navigation");
   const pathname = usePathname();
+  const locale = useLocale();
 
   const navItems = [
-    { 
-      href: "/dashboard", 
-      label: t("dashboard"), 
+    {
+      href: `/${locale}/dashboard`,
+      label: t("dashboard"),
       icon: Home,
-      description: t("dashboardDescription") 
+      description: t("dashboardDescription")
     },
-    { 
-      href: "/modules", 
-      label: t("modules"), 
+    {
+      href: `/${locale}/modules`,
+      label: t("modules"),
       icon: BookOpen,
-      description: t("modulesDescription") 
+      description: t("modulesDescription")
     },
-    { 
-      href: "/flashcards", 
-      label: t("flashcards"), 
+    {
+      href: `/${locale}/flashcards`,
+      label: t("flashcards"),
       icon: CreditCard,
-      description: t("flashcardsDescription") 
+      description: t("flashcardsDescription")
     },
-    { 
-      href: "/tutor", 
-      label: t("tutor"), 
+    {
+      href: `/${locale}/tutor`,
+      label: t("tutor"),
       icon: Bot,
-      description: t("tutorDescription") 
+      description: t("tutorDescription")
     },
-    { 
-      href: "/settings", 
-      label: t("settings"), 
+    {
+      href: `/${locale}/settings`,
+      label: t("settings"),
       icon: Settings,
-      description: t("settingsDescription") 
+      description: t("settingsDescription")
     },
   ];
 

--- a/frontend/components/layout/breadcrumb-nav.tsx
+++ b/frontend/components/layout/breadcrumb-nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import { ChevronRight, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -15,18 +15,19 @@ interface BreadcrumbItem {
 export function BreadcrumbNav() {
   const pathname = usePathname();
   const t = useTranslations("Navigation");
+  const locale = useLocale();
 
   // Generate breadcrumb items based on current path
   const generateBreadcrumbs = (): BreadcrumbItem[] => {
     const segments = pathname.split('/').filter(Boolean);
-    
+
     // Remove locale from segments (first segment in our app structure)
     const pathSegments = segments.slice(1);
-    
+
     const breadcrumbs: BreadcrumbItem[] = [
       {
         label: t("dashboard"),
-        href: "/dashboard",
+        href: `/${locale}/dashboard`,
         current: pathSegments.length === 0 || pathSegments[0] === 'dashboard'
       }
     ];
@@ -35,12 +36,12 @@ export function BreadcrumbNav() {
     for (let i = 0; i < pathSegments.length; i++) {
       const segment = pathSegments[i];
       const isLast = i === pathSegments.length - 1;
-      
+
       // Skip if it's already the dashboard
       if (segment === 'dashboard') continue;
-      
+
       let label = segment;
-      const href = `/${pathSegments.slice(0, i + 1).join('/')}`;
+      const href = `/${locale}/${pathSegments.slice(0, i + 1).join('/')}`;
 
       // Map segments to readable labels
       switch (segment) {

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useState } from "react";
 import { usePathname } from "next/navigation";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import {
   Home,
   BookOpen,
@@ -23,44 +23,45 @@ export function Sidebar() {
   const t = useTranslations("Navigation");
   const tCommon = useTranslations("Common");
   const pathname = usePathname();
+  const locale = useLocale();
   const [isCollapsed, setIsCollapsed] = useState(false);
 
   const navItems = [
-    { 
-      href: "/dashboard", 
-      label: t("dashboard"), 
+    {
+      href: `/${locale}/dashboard`,
+      label: t("dashboard"),
       icon: Home,
-      description: t("dashboardDescription") 
+      description: t("dashboardDescription")
     },
-    { 
-      href: "/modules", 
-      label: t("modules"), 
+    {
+      href: `/${locale}/modules`,
+      label: t("modules"),
       icon: BookOpen,
-      description: t("modulesDescription") 
+      description: t("modulesDescription")
     },
-    { 
-      href: "/flashcards", 
-      label: t("flashcards"), 
+    {
+      href: `/${locale}/flashcards`,
+      label: t("flashcards"),
       icon: CreditCard,
-      description: t("flashcardsDescription") 
+      description: t("flashcardsDescription")
     },
-    { 
-      href: "/tutor", 
-      label: t("tutor"), 
+    {
+      href: `/${locale}/tutor`,
+      label: t("tutor"),
       icon: Bot,
-      description: t("tutorDescription") 
+      description: t("tutorDescription")
     },
-    { 
-      href: "/profile", 
-      label: t("profile"), 
+    {
+      href: `/${locale}/profile`,
+      label: t("profile"),
       icon: User,
-      description: t("profileDescription") 
+      description: t("profileDescription")
     },
-    { 
-      href: "/settings", 
-      label: t("settings"), 
+    {
+      href: `/${locale}/settings`,
+      label: t("settings"),
       icon: Settings,
-      description: t("settingsDescription") 
+      description: t("settingsDescription")
     },
   ];
 


### PR DESCRIPTION
## Summary
- Fixes all navigation 404s by adding locale prefix to every link
- Root URL, sidebar, bottom-nav, breadcrumb, module clicks all work now

Merges Benidrissa/etutor-digital-ph#143

🤖 Generated with [Claude Code](https://claude.com/claude-code)