### PR TITLE
fix(nav): use next-intl Link for proper locale routing

### DIFF
--- a/frontend/components/layout/bottom-nav.tsx
+++ b/frontend/components/layout/bottom-nav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+import { Link } from "@/i18n/routing";
 import { usePathname } from "next/navigation";
 import { useTranslations, useLocale } from "next-intl";
 import {
@@ -19,31 +19,31 @@ export function BottomNav() {
 
   const navItems = [
     {
-      href: `/${locale}/dashboard`,
+      href: "/dashboard",
       label: t("dashboard"),
       icon: Home,
       description: t("dashboardDescription")
     },
     {
-      href: `/${locale}/modules`,
+      href: "/modules",
       label: t("modules"),
       icon: BookOpen,
       description: t("modulesDescription")
     },
     {
-      href: `/${locale}/flashcards`,
+      href: "/flashcards",
       label: t("flashcards"),
       icon: CreditCard,
       description: t("flashcardsDescription")
     },
     {
-      href: `/${locale}/tutor`,
+      href: "/tutor",
       label: t("tutor"),
       icon: Bot,
       description: t("tutorDescription")
     },
     {
-      href: `/${locale}/settings`,
+      href: "/settings",
       label: t("settings"),
       icon: Settings,
       description: t("settingsDescription")

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+import { Link } from "@/i18n/routing";
 import { useState } from "react";
 import { usePathname } from "next/navigation";
 import { useTranslations, useLocale } from "next-intl";
@@ -28,37 +28,37 @@ export function Sidebar() {
 
   const navItems = [
     {
-      href: `/${locale}/dashboard`,
+      href: "/dashboard",
       label: t("dashboard"),
       icon: Home,
       description: t("dashboardDescription")
     },
     {
-      href: `/${locale}/modules`,
+      href: "/modules",
       label: t("modules"),
       icon: BookOpen,
       description: t("modulesDescription")
     },
     {
-      href: `/${locale}/flashcards`,
+      href: "/flashcards",
       label: t("flashcards"),
       icon: CreditCard,
       description: t("flashcardsDescription")
     },
     {
-      href: `/${locale}/tutor`,
+      href: "/tutor",
       label: t("tutor"),
       icon: Bot,
       description: t("tutorDescription")
     },
     {
-      href: `/${locale}/profile`,
+      href: "/profile",
       label: t("profile"),
       icon: User,
       description: t("profileDescription")
     },
     {
-      href: `/${locale}/settings`,
+      href: "/settings",
       label: t("settings"),
       icon: Settings,
       description: t("settingsDescription")

--- a/frontend/i18n/routing.ts
+++ b/frontend/i18n/routing.ts
@@ -1,7 +1,10 @@
 import { defineRouting } from "next-intl/routing";
+import { createNavigation } from "next-intl/navigation";
 
 export const routing = defineRouting({
   locales: ["fr", "en"],
   defaultLocale: "fr",
   localeDetection: true,
 });
+
+export const { Link, redirect, usePathname, useRouter } = createNavigation(routing);


### PR DESCRIPTION
Fixes P0 issue where all navigation links were missing locale prefixes, causing 404 errors on every click.

## Changes
- **sidebar.tsx**: Replace `next/link` with `@/i18n/routing` Link component  
- **bottom-nav.tsx**: Same fix as sidebar
- **routing.ts**: Add proper `createNavigation` export for Link component
- Remove manual locale prefix construction (`/${locale}/dashboard` → `/dashboard`)

## Testing
✅ Build passes successfully  
✅ All routes now generate with proper locale prefixes (`/fr/dashboard`, `/en/dashboard`)  

Closes #146

Generated with [Claude Code](https://claude.ai/code)