### PR TITLE
fix: root redirect + profile API URL (#149, #121)

### DIFF
--- a/frontend/app/[locale]/(app)/profile/profile-client.tsx
+++ b/frontend/app/[locale]/(app)/profile/profile-client.tsx
@@ -20,10 +20,10 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Upload, User as UserIcon, AlertTriangle, CheckCircle } from "lucide-react";
 
-// Mock API functions - replace with actual API calls
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
 const fetchUserProfile = async () => {
-  // In real implementation, call GET /api/v1/users/me
-  const response = await fetch("/api/v1/users/me", {
+  const response = await fetch(`${API_BASE}/api/v1/users/me`, {
     headers: {
       Authorization: `Bearer ${localStorage.getItem("token")}`,
     },
@@ -33,8 +33,7 @@ const fetchUserProfile = async () => {
 };
 
 const updateProfile = async (data: Record<string, unknown>) => {
-  // In real implementation, call PATCH /api/v1/users/me
-  const response = await fetch("/api/v1/users/me", {
+  const response = await fetch(`${API_BASE}/api/v1/users/me`, {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/app/[locale]/page.tsx
+++ b/frontend/app/[locale]/page.tsx
@@ -1,9 +1,10 @@
 import { redirect } from "next/navigation";
 
-export default function LocaleRoot({
+export default async function LocaleRoot({
   params,
 }: {
-  params: { locale: string };
+  params: Promise<{ locale: string }>;
 }) {
-  redirect(`/${params.locale}/dashboard`);
+  const { locale } = await params;
+  redirect(`/${locale}/dashboard`);
 }


### PR DESCRIPTION
## Summary
- **#149**: Root URL → `/undefined/dashboard` — `params` is a Promise in Next.js 15, needs `await`
- **#121**: Profile "Profil non trouvé" — was calling `/api/v1/users/me` on frontend server instead of backend API

## Test plan
- [ ] Visit root URL → redirects to `/fr/dashboard`
- [ ] Sidebar → Profil → shows user profile data

🤖 Generated with [Claude Code](https://claude.com/claude-code)