### PR TITLE
revert: restore per-issue concurrency

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,7 +9,7 @@ on:
     types: [labeled]
 
 concurrency:
-  group: claude-code
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Global lock was cancelling runs. Per-issue concurrency restored.