### PR TITLE
fix: resolve SQL parameter binding in semantic retriever

### DIFF
--- a/backend/app/ai/rag/retriever.py
+++ b/backend/app/ai/rag/retriever.py
@@ -141,9 +141,15 @@ class SemanticRetriever:
         params["min_similarity"] = min_similarity
         params["limit"] = top_k
 
-        # Execute query
+        # Execute query with proper parameter binding
         try:
-            result = await session.execute(text(query_str), params)
+            # Convert embedding list to string format for PostgreSQL vector type
+            embedding_str = "[" + ",".join(map(str, query_embedding)) + "]"
+            params["query_embedding"] = embedding_str
+
+            # Use bindparams to properly bind all named parameters
+            query_obj = text(query_str).bindparams(**params)
+            result = await session.execute(query_obj)
             rows = result.fetchall()
         except Exception as e:
             logger.error("Semantic search query failed", error=str(e))


### PR DESCRIPTION
Fixes #165

## Problem
`POST /api/v1/content/generate-lesson` returned 500 — `:query_embedding` not bound in asyncpg.

## Solution
- Convert embedding list to PostgreSQL vector string format
- Use SQLAlchemy `.bindparams()` to properly bind all named parameters

All 26 tests pass, ruff clean.