### PR TITLE
fix(tutor): update Claude model name to fix AI tutor mock responses

### DIFF
--- a/backend/app/ai/claude_service.py
+++ b/backend/app/ai/claude_service.py
@@ -40,7 +40,7 @@ class ClaudeService:
         """
         try:
             async with self.client.messages.stream(
-                model="claude-sonnet-4-6",
+                model="claude-sonnet-4-20250514",
                 max_tokens=4096,
                 system=system_prompt,
                 messages=[{"role": "user", "content": user_message}],
@@ -71,7 +71,7 @@ class ClaudeService:
         """
         try:
             response = await self.client.messages.create(
-                model="claude-sonnet-4-6",
+                model="claude-sonnet-4-20250514",
                 max_tokens=4096,
                 system=system_prompt,
                 messages=[{"role": "user", "content": user_message}],
@@ -102,7 +102,7 @@ class ClaudeService:
         """
         try:
             response = await self.client.messages.create(
-                model="claude-sonnet-4-6",
+                model="claude-sonnet-4-20250514",
                 max_tokens=4096,
                 system=system_prompt,
                 messages=[{"role": "user", "content": user_message}],

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -146,7 +146,7 @@ class TutorService:
             activity_suggestions = []
 
             async with self.anthropic.messages.stream(
-                model="claude-sonnet-4-6",
+                model="claude-sonnet-4-20250514",
                 system=system_prompt,
                 messages=[
                     {"role": msg["role"], "content": msg["content"]} for msg in conversation_history


### PR DESCRIPTION
Closes #183

## Summary
Fixed the AI tutor endpoint returning mock responses instead of real Claude API responses by updating the invalid model name.

## Issue
The AI tutor service was using , which is not a valid Anthropic model name. This caused API calls to fail and likely triggered fallback behavior that appeared as mock responses during UAT testing.

## Changes
- ✅ Updated model name from  to  
- ✅ Fixed in both  and  (4 total occurrences)
- ✅ Model name now matches the GitHub Actions workflow configuration
- ✅ All tests pass and code is properly formatted

## Testing
- All existing tests pass (26/26)
- Code formatting and linting clean
- Model name verified against Anthropic SDK valid models list

The AI tutor should now properly connect to the Claude API and provide real responses with RAG context as intended.