### PR TITLE
fix(placement): internationalize hardcoded error messages in placement test

### DIFF
--- a/frontend/components/placement/placement-test-interface.tsx
+++ b/frontend/components/placement/placement-test-interface.tsx
@@ -148,7 +148,7 @@ export function PlacementTestInterface({ onComplete, locale }: PlacementTestInte
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Loading Assessment...</CardTitle>
+          <CardTitle>{t('loading', { ns: 'Common' })}</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="flex items-center justify-center py-8">
@@ -163,10 +163,10 @@ export function PlacementTestInterface({ onComplete, locale }: PlacementTestInte
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Error</CardTitle>
+          <CardTitle>{t('error', { ns: 'Common' })}</CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-destructive">Failed to load assessment questions.</p>
+          <p className="text-destructive">{t('error.failedToLoad')}</p>
         </CardContent>
       </Card>
     );


### PR DESCRIPTION
Closes #190

## Summary
This PR fixes the issue where French users saw English error messages on  when clicking "Commencer l'Évaluation".

## Changes
- Replace hardcoded "Failed to load assessment questions." with   
- Replace hardcoded "Loading Assessment..." with 
- Replace hardcoded "Error" with 

## Root Cause
The placement test backend endpoints were working correctly. The issue was in the frontend React component where error messages were hardcoded in English instead of using the proper next-intl translations.

## Test Plan
- [x] Frontend linting passes
- [x] Proper French translations already exist in 
- [x] Backend endpoints functioning correctly

The placement test now properly displays:
- French: "Échec du chargement de l'évaluation. Veuillez réessayer."
- English: "Failed to load assessment. Please try again."

🤖 Generated with [Claude Code](https://claude.ai/code)