### PR TITLE
fix: profile + tutor + locale + flashcards — 4 frontend bugs

### DIFF
--- a/frontend/app/[locale]/(app)/flashcards/flashcards-container.tsx
+++ b/frontend/app/[locale]/(app)/flashcards/flashcards-container.tsx
@@ -297,5 +297,17 @@ export function FlashcardsContainer() {
     );
   }
 
-  return null;
+  // No cards due — show empty state
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <div className="text-center py-12">
+        <div className="text-6xl mb-4">🎉</div>
+        <h1 className="text-3xl font-bold mb-2">{t('noCardsToday')}</h1>
+        <p className="text-muted-foreground mb-6">{t('wellDone')}</p>
+        <Button onClick={() => refetch()}>
+          {t('tryAgain')}
+        </Button>
+      </div>
+    </div>
+  );
 }

--- a/frontend/app/[locale]/(app)/profile/profile-client.tsx
+++ b/frontend/app/[locale]/(app)/profile/profile-client.tsx
@@ -25,7 +25,7 @@ const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 const fetchUserProfile = async () => {
   const response = await fetch(`${API_BASE}/api/v1/users/me`, {
     headers: {
-      Authorization: `Bearer ${localStorage.getItem("token")}`,
+      Authorization: `Bearer ${localStorage.getItem("access_token")}`,
     },
   });
   if (!response.ok) throw new Error("Failed to fetch profile");
@@ -37,7 +37,7 @@ const updateProfile = async (data: Record<string, unknown>) => {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${localStorage.getItem("token")}`,
+      Authorization: `Bearer ${localStorage.getItem("access_token")}`,
     },
     body: JSON.stringify(data),
   });
@@ -49,10 +49,10 @@ const uploadAvatar = async (file: File) => {
   const formData = new FormData();
   formData.append("file", file);
   
-  const response = await fetch("/api/v1/users/me/avatar", {
+  const response = await fetch(`${API_BASE}/api/v1/users/me/avatar`, {
     method: "POST",
     headers: {
-      Authorization: `Bearer ${localStorage.getItem("token")}`,
+      Authorization: `Bearer ${localStorage.getItem("access_token")}`,
     },
     body: formData,
   });

--- a/frontend/app/[locale]/page.tsx
+++ b/frontend/app/[locale]/page.tsx
@@ -1,10 +1,5 @@
 import { redirect } from "next/navigation";
 
-export default async function LocaleRoot({
-  params,
-}: {
-  params: Promise<{ locale: string }>;
-}) {
-  const { locale } = await params;
-  redirect(`/${locale}/dashboard`);
+export default function LocaleRoot() {
+  redirect("/dashboard");
 }

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -85,33 +85,47 @@ export function ChatPanel({ isOpen, onClose, moduleId, className }: ChatPanelPro
     setIsTyping(true);
 
     try {
-      // Simulate API call delay
-      await new Promise(resolve => setTimeout(resolve, 1500));
-      
-      // Mock AI response with sources
+      const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+      const token = localStorage.getItem("access_token");
+      const response = await fetch(`${API_BASE}/api/v1/tutor/chat`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({
+          message: messageContent,
+          conversation_id: null,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`API error: ${response.status}`);
+      }
+
+      const data = await response.json();
       const aiResponse: ChatMessage = {
         id: (Date.now() + 1).toString(),
-        content: `Thank you for your question about "${messageContent}". This is a mock response from the AI tutor. In a real implementation, this would connect to the Claude API to generate contextual responses based on the course materials and user's current module progress.`,
+        content: data.response || data.message || data.content || "...",
         isUser: false,
         timestamp: new Date(),
-        sources: [
-          {
-            title: t('publicHealthFundamentals'),
-            chapter: 3,
-            page: 45
-          },
-          {
-            title: t('epidemiologyBasics'),
-            chapter: 1,
-            page: 12
-          }
-        ]
+        sources: data.sources_cited?.map((s: string, i: number) => ({
+          title: s,
+          chapter: i + 1,
+          page: 0,
+        })) || [],
       };
 
       setMessages(prev => [...prev, aiResponse]);
     } catch (error) {
       console.error('Failed to send message:', error);
-      // TODO: Show error message
+      const errorMsg: ChatMessage = {
+        id: (Date.now() + 1).toString(),
+        content: t('error') || "An error occurred. Please try again.",
+        isUser: false,
+        timestamp: new Date(),
+      };
+      setMessages(prev => [...prev, errorMsg]);
     } finally {
       setIsLoading(false);
       setIsTyping(false);


### PR DESCRIPTION
## Fixes
1. **Profile "Profil non trouvé"** — wrong localStorage key (`token` → `access_token`)
2. **Tutor mock responses** — replaced hardcoded mock with real API call to POST /api/v1/tutor/chat
3. **Double locale /fr/fr/dashboard** — root redirect no longer adds locale manually
4. **Flashcards blank page** — show empty state when no cards due