### PR TITLE
fix(modules): fix quiz/case-study/lessons route 404s

### DIFF
--- a/frontend/app/[locale]/(app)/modules/[moduleId]/lessons/page.tsx
+++ b/frontend/app/[locale]/(app)/modules/[moduleId]/lessons/page.tsx
@@ -1,0 +1,12 @@
+import { redirect } from 'next/navigation';
+import { getLocale } from 'next-intl/server';
+
+interface LessonsIndexPageProps {
+  params: Promise<{ moduleId: string }>;
+}
+
+export default async function LessonsIndexPage({ params }: LessonsIndexPageProps) {
+  const { moduleId } = await params;
+  const locale = await getLocale();
+  redirect(`/${locale}/modules/${moduleId}`);
+}

--- a/frontend/app/[locale]/(app)/modules/[moduleId]/page.tsx
+++ b/frontend/app/[locale]/(app)/modules/[moduleId]/page.tsx
@@ -178,7 +178,7 @@ export default async function ModuleOverviewPage({ params }: ModuleOverviewPageP
                   {moduleData.units.map((unit) => (
                     <Link
                       key={unit.id}
-                      href={unit.type === 'lesson' ? `/modules/${moduleId}/lessons/${unit.id}` : `/modules/${moduleId}/${unit.type}/${unit.id}`}
+                      href={unit.type === 'quiz' ? `/modules/${moduleId}/quiz?unit=${unit.id}` : `/modules/${moduleId}/lessons/${unit.id}`}
                       className="block"
                     >
                       <div className="flex items-center gap-4 p-4 border border-stone-200 rounded-lg hover:border-stone-300 hover:bg-stone-50 transition-colors cursor-pointer">
@@ -214,7 +214,7 @@ export default async function ModuleOverviewPage({ params }: ModuleOverviewPageP
         <div className="space-y-4">
           {/* Continue Learning */}
           {nextUnit ? (
-            <Link href={`/modules/${moduleId}/lessons/${nextUnit.id}`} className="block">
+            <Link href={nextUnit.type === 'quiz' ? `/modules/${moduleId}/quiz?unit=${nextUnit.id}` : `/modules/${moduleId}/lessons/${nextUnit.id}`} className="block">
               <Button className="w-full min-h-11" size="lg">
                 <Play className="w-4 h-4 mr-2" />
                 {nextUnit.status === 'in-progress' ? t('continueReading') : t('startReading')}


### PR DESCRIPTION
## Summary

- Quiz unit links now use query param: `/modules/{id}/quiz?unit={unitId}` (quiz page already reads `unit` from `searchParams`)
- Case-study unit links reuse the lesson viewer: `/modules/{id}/lessons/{unitId}` (no new route needed)
- Add redirect page at `/modules/{id}/lessons` (without unitId) → `/modules/{id}`
- Fix sidebar "Continue Learning" button to use the same corrected href logic

## Changes

- `frontend/app/[locale]/(app)/modules/[moduleId]/page.tsx` — fixed href generation at lines 181 & 217
- `frontend/app/[locale]/(app)/modules/[moduleId]/lessons/page.tsx` — new redirect page (server component)

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run build` — passes, new route appears in build output
- [ ] Manually verify quiz unit click → `/modules/M01/quiz?unit=M01-U04`
- [ ] Manually verify case-study click → `/modules/M01/lessons/M01-U05`
- [ ] Manually verify `/modules/M01/lessons` redirects to `/modules/M01`

Closes #214

Generated with [Claude Code](https://claude.ai/code)