### PR TITLE
fix: double locale prefix in all redirects (#212)

### DIFF
--- a/frontend/app/[locale]/(app)/dashboard/dashboard-client.tsx
+++ b/frontend/app/[locale]/(app)/dashboard/dashboard-client.tsx
@@ -1,15 +1,13 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-import { useLocale } from 'next-intl';
+import { useRouter } from '@/i18n/routing';
 import { ModuleMap } from '@/components/learning/module-map';
 
 export function DashboardClient() {
   const router = useRouter();
-  const locale = useLocale();
 
   const handleModuleClick = (moduleId: string) => {
-    router.push(`/${locale}/modules/${moduleId}`);
+    router.push(`/modules/${moduleId}`);
   };
 
   return <ModuleMap onModuleClick={handleModuleClick} />;

--- a/frontend/app/[locale]/(app)/flashcards/flashcards-container.tsx
+++ b/frontend/app/[locale]/(app)/flashcards/flashcards-container.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useTranslations, useLocale } from 'next-intl';
 import { useQuery, useMutation } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
+import { useRouter } from '@/i18n/routing';
 import { FlashcardDeck } from '@/components/learning/flashcard-deck';
 import { FlashcardSessionSummary } from '@/components/learning/flashcard-session-summary';
 import { Button } from '@/components/ui/button';
@@ -62,10 +62,10 @@ export function FlashcardsContainer() {
   // Redirect to login if not authenticated
   useEffect(() => {
     if (!isAuthenticated) {
-      router.push(`/${locale}/login`);
+      router.push('/login');
       return;
     }
-  }, [isAuthenticated, router, locale]);
+  }, [isAuthenticated, router]);
 
   // Fetch due flashcards
   const { data: dueCards, isLoading, error, refetch } = useQuery({

--- a/frontend/app/[locale]/(app)/modules/page.tsx
+++ b/frontend/app/[locale]/(app)/modules/page.tsx
@@ -1,16 +1,15 @@
 'use client';
 
-import { useTranslations, useLocale } from 'next-intl';
-import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { useRouter } from '@/i18n/routing';
 import { ModuleMap } from '@/components/learning/module-map';
 
 export default function ModulesPage() {
   const t = useTranslations('ModuleMap');
   const router = useRouter();
-  const locale = useLocale();
 
   const handleModuleClick = (moduleId: string) => {
-    router.push(`/${locale}/modules/${moduleId}`);
+    router.push(`/modules/${moduleId}`);
   };
 
   return (

--- a/frontend/app/[locale]/(auth)/magic-link/page.tsx
+++ b/frontend/app/[locale]/(auth)/magic-link/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
+import { useRouter } from '@/i18n/routing';
 import { useTranslations } from 'next-intl';
 
 import { Button } from '@/components/ui/button';
@@ -14,13 +15,7 @@ import {
 } from '@/components/ui/card';
 import { authClient, AuthError, RegisterResponse } from '@/lib/auth';
 
-interface MagicLinkPageProps {
-  params: {
-    locale: string;
-  };
-}
-
-export default function MagicLinkPage({ params }: MagicLinkPageProps) {
+export default function MagicLinkPage() {
   const t = useTranslations('Auth');
   const tCommon = useTranslations('Common');
   const router = useRouter();
@@ -93,7 +88,7 @@ export default function MagicLinkPage({ params }: MagicLinkPageProps) {
             
             <div className="space-y-2">
               <Button
-                onClick={() => router.push(`/${params.locale}/login`)}
+                onClick={() => router.push('/login')}
                 className="w-full"
               >
                 {t('backToLogin')}
@@ -101,7 +96,7 @@ export default function MagicLinkPage({ params }: MagicLinkPageProps) {
               
               <Button
                 variant="outline"
-                onClick={() => router.push(`/${params.locale}/register`)}
+                onClick={() => router.push('/register')}
                 className="w-full"
               >
                 {t('createNewAccount')}
@@ -164,7 +159,7 @@ export default function MagicLinkPage({ params }: MagicLinkPageProps) {
 
             <div className="text-center">
               <Button
-                onClick={() => router.push(`/${params.locale}/login`)}
+                onClick={() => router.push('/login')}
                 className="w-full"
               >
                 {t('continueToLogin')}

--- a/frontend/components/auth/email-otp-register-form.tsx
+++ b/frontend/components/auth/email-otp-register-form.tsx
@@ -122,7 +122,7 @@ export function EmailOTPRegisterForm() {
       );
       
       // Registration complete - redirect to onboarding
-      router.push(`/${locale}/onboarding`);
+      router.push('/onboarding');
     } catch (error) {
       console.error('OTP verification error:', error);
       
@@ -334,7 +334,7 @@ export function EmailOTPRegisterForm() {
             <div className="text-center text-sm">
               <span className="text-muted-foreground">{t('alreadyHaveAccount')} </span>
               <Link 
-                href={`/${locale}/login`}
+                href="/login"
                 className="font-medium text-primary hover:underline"
               >
                 {t('signIn')}
@@ -345,7 +345,7 @@ export function EmailOTPRegisterForm() {
             <div className="text-center text-sm border-t pt-4">
               <span className="text-muted-foreground">{t('preferAuthenticatorApp')} </span>
               <Link 
-                href={`/${locale}/register`}
+                href="/register"
                 className="font-medium text-primary hover:underline"
               >
                 {t('useAuthenticatorApp')}

--- a/frontend/components/auth/totp-login-form.tsx
+++ b/frontend/components/auth/totp-login-form.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useLocale, useTranslations } from 'next-intl';
+import { useTranslations } from 'next-intl';
 import { z } from 'zod';
 import { Link, useRouter } from '@/i18n/routing';
 
@@ -37,7 +37,6 @@ export function TOTPLoginForm() {
   const t = useTranslations('Auth');
   const tCommon = useTranslations('Common');
   const router = useRouter();
-  const locale = useLocale();
   
   const [isLoading, setIsLoading] = useState(false);
   const [showMagicLink, setShowMagicLink] = useState(false);
@@ -79,7 +78,7 @@ export function TOTPLoginForm() {
       });
       
       // Login successful - redirect to dashboard
-      router.push(`/${locale}/dashboard`);
+      router.push('/dashboard');
     } catch (error) {
       console.error('Login error:', error);
       

--- a/frontend/components/auth/totp-register-form.tsx
+++ b/frontend/components/auth/totp-register-form.tsx
@@ -110,7 +110,7 @@ export function TOTPRegisterForm() {
       );
       
       // Registration complete - redirect to onboarding
-      router.push(`/${locale}/onboarding`);
+      router.push('/onboarding');
     } catch (error) {
       console.error('TOTP verification error:', error);
       

--- a/frontend/components/dashboard/upcoming-reviews.tsx
+++ b/frontend/components/dashboard/upcoming-reviews.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-import { useTranslations, useLocale } from 'next-intl';
+import { useRouter } from '@/i18n/routing';
+import { useTranslations } from 'next-intl';
 import { useQuery } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -12,7 +12,6 @@ import { cn } from '@/lib/utils';
 export function UpcomingReviews() {
   const t = useTranslations('Dashboard');
   const router = useRouter();
-  const locale = useLocale();
 
   const { data: upcomingReviews, isLoading, error } = useQuery({
     queryKey: ['upcoming-reviews'],
@@ -22,7 +21,7 @@ export function UpcomingReviews() {
   });
 
   const handleStartReview = () => {
-    router.push(`/${locale}/flashcards`);
+    router.push('/flashcards');
   };
 
   const formatDate = (dateString: string) => {

--- a/frontend/components/onboarding/onboarding-flow.tsx
+++ b/frontend/components/onboarding/onboarding-flow.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { useRouter, usePathname } from 'next/navigation';
+import { useRouter } from '@/i18n/routing';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
@@ -24,8 +24,6 @@ const TOTAL_STEPS = 4;
 export function OnboardingFlow() {
   const t = useTranslations('Onboarding');
   const router = useRouter();
-  const pathname = usePathname();
-  const locale = pathname.split('/')[1]; // Extract locale from path
   const [currentStep, setCurrentStep] = useState(1);
   const [data, setData] = useState<OnboardingData>({
     language: 'fr',
@@ -77,7 +75,7 @@ export function OnboardingFlow() {
       });
       
       // Redirect to diagnostic assessment
-      router.push(`/${locale}/placement-test`);
+      router.push('/placement-test');
     } catch (err) {
       console.error('Onboarding completion failed:', err);
     }

--- a/frontend/components/placement/placement-test-results.tsx
+++ b/frontend/components/placement/placement-test-results.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
-import { useRouter } from 'next/navigation';
+import { useRouter } from '@/i18n/routing';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -42,7 +42,7 @@ export function PlacementTestResults({ result, locale, isSkipped = false }: Plac
   const router = useRouter();
 
   const handleContinue = () => {
-    router.push(`/${locale}/dashboard`);
+    router.push('/dashboard');
   };
 
   const getLevelColor = (level: number) => {


### PR DESCRIPTION
## Summary
Merges the fix for double locale prefix (`/fr/fr/dashboard`) from dev to main to trigger deploy.

## Changes
- 10 frontend files fixed: replaced manual `/${locale}/path` with bare `/path` when using i18n-aware router

Closes #212