### PR TITLE
fix(modules): fix broken quiz, case-study, and lessons route URLs

### DIFF
--- a/frontend/app/[locale]/(app)/modules/[moduleId]/lessons/page.tsx
+++ b/frontend/app/[locale]/(app)/modules/[moduleId]/lessons/page.tsx
@@ -1,0 +1,12 @@
+import { redirect } from 'next/navigation';
+import { getLocale } from 'next-intl/server';
+
+interface LessonsIndexPageProps {
+  params: Promise<{ moduleId: string }>;
+}
+
+export default async function LessonsIndexPage({ params }: LessonsIndexPageProps) {
+  const { moduleId } = await params;
+  const locale = await getLocale();
+  redirect(`/${locale}/modules/${moduleId}`);
+}

--- a/frontend/app/[locale]/(app)/modules/[moduleId]/page.tsx
+++ b/frontend/app/[locale]/(app)/modules/[moduleId]/page.tsx
@@ -178,7 +178,7 @@ export default async function ModuleOverviewPage({ params }: ModuleOverviewPageP
                   {moduleData.units.map((unit) => (
                     <Link
                       key={unit.id}
-                      href={unit.type === 'lesson' ? `/modules/${moduleId}/lessons/${unit.id}` : `/modules/${moduleId}/${unit.type}/${unit.id}`}
+                      href={unit.type === 'quiz' ? `/modules/${moduleId}/quiz?unit=${unit.id}` : `/modules/${moduleId}/lessons/${unit.id}`}
                       className="block"
                     >
                       <div className="flex items-center gap-4 p-4 border border-stone-200 rounded-lg hover:border-stone-300 hover:bg-stone-50 transition-colors cursor-pointer">
@@ -214,7 +214,7 @@ export default async function ModuleOverviewPage({ params }: ModuleOverviewPageP
         <div className="space-y-4">
           {/* Continue Learning */}
           {nextUnit ? (
-            <Link href={`/modules/${moduleId}/lessons/${nextUnit.id}`} className="block">
+            <Link href={nextUnit.type === 'quiz' ? `/modules/${moduleId}/quiz?unit=${nextUnit.id}` : `/modules/${moduleId}/lessons/${nextUnit.id}`} className="block">
               <Button className="w-full min-h-11" size="lg">
                 <Play className="w-4 h-4 mr-2" />
                 {nextUnit.status === 'in-progress' ? t('continueReading') : t('startReading')}


### PR DESCRIPTION
## Summary

Three URLs from the module overview page returned 404. All routes are now fixed.

## Changes

- **`frontend/app/[locale]/(app)/modules/[moduleId]/page.tsx`** — fixed href generation in two places:
  - Unit list: quiz units → `/modules/{id}/quiz?unit={unitId}`, lesson/case-study → `/modules/{id}/lessons/{unitId}`
  - Sidebar "Continue Learning" button: same corrected logic
- **`frontend/app/[locale]/(app)/modules/[moduleId]/lessons/page.tsx`** (new) — server component that redirects `/modules/{id}/lessons` → `/modules/{id}`

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run build` — passes, all routes visible in build output
- [x] Quiz unit links resolve to `/modules/{id}/quiz?unit={unitId}` (quiz page reads `unit` from `searchParams`)
- [x] Case-study unit links resolve to `/modules/{id}/lessons/{unitId}` (lesson viewer handles both lesson and case-study types)
- [x] `/modules/{id}/lessons` redirects to `/modules/{id}`
- [ ] Manually verified on mobile viewport

Closes #214

Generated with [Claude Code](https://claude.ai/code)