### PR TITLE
feat(frontend): lesson image placeholder with fade-in and lazy loading

### DIFF
--- a/frontend/components/learning/lesson-image.tsx
+++ b/frontend/components/learning/lesson-image.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { useTranslations } from 'next-intl';
+import { X, Maximize2 } from 'lucide-react';
+import { getLessonImageStatus, LessonImageStatus } from '@/lib/api';
+
+const POLL_INTERVAL_MS = 3000;
+const MAX_POLL_DURATION_MS = 120000;
+
+interface LessonImageProps {
+  lessonId: string;
+}
+
+export function LessonImage({ lessonId }: LessonImageProps) {
+  const t = useTranslations('LessonViewer');
+  const [status, setStatus] = useState<LessonImageStatus>('pending');
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [altText, setAltText] = useState<string>('');
+  const [imageLoaded, setImageLoaded] = useState(false);
+  const [fullscreen, setFullscreen] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startTimeRef = useRef<number>(0);
+  const activeRef = useRef<boolean>(true);
+
+  useEffect(() => {
+    activeRef.current = true;
+    startTimeRef.current = Date.now();
+
+    const schedulePoll = () => {
+      timerRef.current = setTimeout(async () => {
+        if (!activeRef.current) return;
+
+        if (Date.now() - startTimeRef.current > MAX_POLL_DURATION_MS) {
+          setStatus('failed');
+          return;
+        }
+
+        try {
+          const data = await getLessonImageStatus(lessonId);
+          if (!activeRef.current) return;
+
+          setStatus(data.status);
+
+          if (data.status === 'ready' && data.image_url) {
+            setImageUrl(data.image_url);
+            setAltText(data.alt_text ?? '');
+          } else if (data.status !== 'failed') {
+            schedulePoll();
+          }
+        } catch {
+          if (activeRef.current) {
+            schedulePoll();
+          }
+        }
+      }, POLL_INTERVAL_MS);
+    };
+
+    schedulePoll();
+
+    return () => {
+      activeRef.current = false;
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [lessonId]);
+
+  if (status === 'failed') {
+    return null;
+  }
+
+  if (status !== 'ready' || !imageUrl) {
+    return (
+      <div
+        className="w-full rounded-lg overflow-hidden bg-gray-100 animate-pulse"
+        role="status"
+        aria-label={t('imagePending')}
+      >
+        <div className="w-full aspect-video flex items-center justify-center">
+          <p className="text-sm text-gray-500 px-4 text-center">{t('imagePending')}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="w-full rounded-lg overflow-hidden relative">
+        <div
+          className={`transition-opacity duration-300 ${imageLoaded ? 'opacity-100' : 'opacity-0'}`}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={imageUrl}
+            alt={altText}
+            loading="lazy"
+            width={512}
+            className="w-full max-w-[512px] mx-auto block rounded-lg"
+            onLoad={() => setImageLoaded(true)}
+          />
+        </div>
+
+        {!imageLoaded && (
+          <div
+            className="absolute inset-0 bg-gray-100 animate-pulse rounded-lg flex items-center justify-center"
+            aria-hidden="true"
+          >
+            <p className="text-sm text-gray-500 px-4 text-center">{t('imagePending')}</p>
+          </div>
+        )}
+
+        {imageLoaded && (
+          <button
+            type="button"
+            onClick={() => setFullscreen(true)}
+            className="absolute top-2 right-2 bg-black/40 text-white rounded-md p-1.5 min-h-11 min-w-11 flex items-center justify-center hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+            aria-label={t('imageViewFullscreen')}
+          >
+            <Maximize2 className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+
+      {fullscreen && (
+        <div
+          className="fixed inset-0 z-50 bg-black/90 flex items-center justify-center p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label={altText}
+          onClick={() => setFullscreen(false)}
+        >
+          <button
+            type="button"
+            onClick={() => setFullscreen(false)}
+            className="absolute top-4 right-4 bg-white/20 text-white rounded-md p-2 min-h-11 min-w-11 flex items-center justify-center hover:bg-white/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+            aria-label={t('imageCloseFullscreen')}
+          >
+            <X className="w-5 h-5" />
+          </button>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={imageUrl}
+            alt={altText}
+            className="max-w-full max-h-full object-contain rounded-lg"
+            onClick={(e) => e.stopPropagation()}
+          />
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/components/learning/lesson-viewer.tsx
+++ b/frontend/components/learning/lesson-viewer.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import ReactMarkdown from 'react-markdown';
 import { LessonSkeleton } from './lesson-skeleton';
+import { LessonImage } from './lesson-image';
 import { SourceCitations } from './source-citations';
 import { apiFetch } from '@/lib/api';
 
@@ -191,6 +192,11 @@ export function LessonViewer({
             <div className={mdClass}>
               <ReactMarkdown>{content.introduction}</ReactMarkdown>
             </div>
+          </div>
+
+          {/* Lesson Illustration */}
+          <div className="mb-8">
+            <LessonImage lessonId={lessonData.id} />
           </div>
 
           {/* Key Concepts */}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -220,3 +220,20 @@ export async function submitSummativeAssessmentAttempt(
     body: JSON.stringify(request),
   });
 }
+
+// Lesson Image API Types
+export type LessonImageStatus = 'pending' | 'generating' | 'ready' | 'failed';
+
+export interface LessonImageResponse {
+  lesson_id: string;
+  status: LessonImageStatus;
+  image_url?: string;
+  alt_text?: string;
+  width?: number;
+  height?: number;
+}
+
+// Lesson Image API Functions
+export async function getLessonImageStatus(lessonId: string): Promise<LessonImageResponse> {
+  return apiFetch<LessonImageResponse>(`/api/v1/images/lesson/${lessonId}`);
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -566,7 +566,10 @@
     "synthesis": "Synthesis",
     "keyPoints": "Key Points",
     "markComplete": "Mark as Complete",
-    "completed": "Completed"
+    "completed": "Completed",
+    "imagePending": "Generating illustration...",
+    "imageViewFullscreen": "View fullscreen",
+    "imageCloseFullscreen": "Close fullscreen"
   },
   "LessonPage": {
     "modules": "Modules",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -566,7 +566,10 @@
     "synthesis": "Synthèse",
     "keyPoints": "Points Clés",
     "markComplete": "Marquer comme Terminé",
-    "completed": "Terminé"
+    "completed": "Terminé",
+    "imagePending": "Illustration en cours de génération...",
+    "imageViewFullscreen": "Voir en plein écran",
+    "imageCloseFullscreen": "Fermer le plein écran"
   },
   "LessonPage": {
     "modules": "Modules",


### PR DESCRIPTION
## Summary

- New `LessonImage` component polls `GET /api/v1/images/lesson/{lesson_id}` every 3s
- Animated skeleton placeholder (`animate-pulse`) shown while image is generating
- 300ms CSS fade-in transition (`opacity-0 → opacity-100`) when image becomes ready
- On failure, placeholder is removed gracefully (returns `null`, no broken image icon)
- `<img loading="lazy" width="512">` with WebP-compatible rendering
- Fullscreen tap-to-view modal for mobile with 44×44px touch targets (WCAG 2.1 AA)
- i18n keys added for `imagePending`, `imageViewFullscreen`, `imageCloseFullscreen` in both FR and EN
- `LessonImageStatus` type and `getLessonImageStatus()` added to `lib/api.ts`

## Changes

- `frontend/components/learning/lesson-image.tsx` — new component (polling + skeleton + fade-in + fullscreen)
- `frontend/components/learning/lesson-viewer.tsx` — integrate `<LessonImage lessonId={lessonData.id} />`
- `frontend/lib/api.ts` — add `LessonImageResponse`, `LessonImageStatus`, `getLessonImageStatus()`
- `frontend/messages/fr.json` — add `imagePending`, `imageViewFullscreen`, `imageCloseFullscreen`
- `frontend/messages/en.json` — same keys in English

## Test plan

- [ ] Frontend lint passes (`npm run lint` — 0 errors)
- [ ] Placeholder renders while image status is `pending` / `generating`
- [ ] Image fades in (300ms) when status becomes `ready`
- [ ] Alt text is present and comes from backend response
- [ ] Placeholder removed gracefully when status is `failed` (no broken icon)
- [ ] Works on mobile 360×640 — image scales to container width
- [ ] Both `imagePending` i18n keys present in FR and EN
- [ ] Fullscreen works on mobile tap

Closes #225

Generated with [Claude Code](https://claude.ai/code)