### PR TITLE
feat(backend): generated_images table + Alembic migration (#222)

### DIFF
--- a/backend/app/domain/models/__init__.py
+++ b/backend/app/domain/models/__init__.py
@@ -4,6 +4,7 @@ from app.domain.models.content import GeneratedContent
 from app.domain.models.conversation import TutorConversation
 from app.domain.models.document_chunk import DocumentChunk
 from app.domain.models.flashcard import FlashcardReview
+from app.domain.models.generated_image import GeneratedImage, ImageStatus
 from app.domain.models.module import Module
 from app.domain.models.progress import UserModuleProgress
 from app.domain.models.quiz import QuizAttempt
@@ -13,6 +14,8 @@ __all__ = [
     "Base",
     "DocumentChunk",
     "GeneratedContent",
+    "GeneratedImage",
+    "ImageStatus",
     "TutorConversation",
     "FlashcardReview",
     "MagicLink",

--- a/backend/app/domain/models/generated_image.py
+++ b/backend/app/domain/models/generated_image.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, Enum, ForeignKey, Index, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.domain.models.base import Base
+
+if TYPE_CHECKING:
+    from app.domain.models.content import GeneratedContent
+    from app.domain.models.module import Module
+
+
+class ImageStatus(enum.StrEnum):
+    pending = "pending"
+    generating = "generating"
+    ready = "ready"
+    failed = "failed"
+
+
+class GeneratedImage(Base):
+    __tablename__ = "generated_images"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    lesson_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("generated_content.id"), nullable=True
+    )
+    module_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("modules.id"), nullable=True
+    )
+    unit_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    concept: Mapped[str | None] = mapped_column(Text, nullable=True)
+    prompt: Mapped[str | None] = mapped_column(Text, nullable=True)
+    image_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    format: Mapped[str] = mapped_column(String(20), server_default="webp")
+    width: Mapped[int] = mapped_column(Integer, server_default="512")
+    alt_text_fr: Mapped[str | None] = mapped_column(Text, nullable=True)
+    alt_text_en: Mapped[str | None] = mapped_column(Text, nullable=True)
+    semantic_tags: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    reuse_count: Mapped[int] = mapped_column(Integer, server_default="0")
+    status: Mapped[ImageStatus] = mapped_column(
+        Enum(ImageStatus, name="imagestatus"), server_default="pending"
+    )
+    generated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    file_size_bytes: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    lesson: Mapped[GeneratedContent | None] = relationship(
+        "GeneratedContent", foreign_keys=[lesson_id]
+    )
+    module: Mapped[Module | None] = relationship("Module", foreign_keys=[module_id])
+
+    __table_args__ = (
+        Index("ix_generated_images_status", "status"),
+        Index("ix_generated_images_semantic_tags", "semantic_tags", postgresql_using="gin"),
+    )

--- a/backend/migrations/versions/012_merge_module_units_and_email_otps.py
+++ b/backend/migrations/versions/012_merge_module_units_and_email_otps.py
@@ -1,0 +1,22 @@
+"""Merge module_units and email_otps branches
+
+Revision ID: 012_merge_module_units_and_email_otps
+Revises: 0d1135672916, 011_add_email_otps_table
+Create Date: 2026-04-01 14:44:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+revision: str = "012_merge_module_units_and_email_otps"
+down_revision: tuple[str, str] = ("0d1135672916", "011_add_email_otps_table")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/migrations/versions/013_add_generated_images_table.py
+++ b/backend/migrations/versions/013_add_generated_images_table.py
@@ -1,0 +1,75 @@
+"""Add generated_images table
+
+Revision ID: 013_add_generated_images_table
+Revises: 012_merge_module_units_and_email_otps
+Create Date: 2026-04-01 14:45:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "013_add_generated_images_table"
+down_revision: str | None = "012_merge_module_units_and_email_otps"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    imagestatus_enum = postgresql.ENUM(
+        "pending", "generating", "ready", "failed", name="imagestatus", create_type=False
+    )
+    imagestatus_enum.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "generated_images",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("lesson_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("module_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("unit_id", sa.Text(), nullable=True),
+        sa.Column("concept", sa.Text(), nullable=True),
+        sa.Column("prompt", sa.Text(), nullable=True),
+        sa.Column("image_url", sa.Text(), nullable=True),
+        sa.Column("format", sa.String(20), server_default="webp", nullable=False),
+        sa.Column("width", sa.Integer(), server_default="512", nullable=False),
+        sa.Column("alt_text_fr", sa.Text(), nullable=True),
+        sa.Column("alt_text_en", sa.Text(), nullable=True),
+        sa.Column("semantic_tags", postgresql.JSONB(), nullable=True),
+        sa.Column("reuse_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum("pending", "generating", "ready", "failed", name="imagestatus"),
+            server_default="pending",
+            nullable=False,
+        ),
+        sa.Column("generated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("file_size_bytes", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(["lesson_id"], ["generated_content.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["module_id"], ["modules.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_index(
+        "ix_generated_images_status",
+        "generated_images",
+        ["status"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_generated_images_semantic_tags",
+        "generated_images",
+        ["semantic_tags"],
+        unique=False,
+        postgresql_using="gin",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_generated_images_semantic_tags", table_name="generated_images")
+    op.drop_index("ix_generated_images_status", table_name="generated_images")
+    op.drop_table("generated_images")
+
+    sa.Enum(name="imagestatus").drop(op.get_bind(), checkfirst=True)

--- a/backend/tests/test_generated_image_model.py
+++ b/backend/tests/test_generated_image_model.py
@@ -1,0 +1,77 @@
+"""Unit tests for the GeneratedImage model (issue #222)."""
+
+import uuid
+
+import pytest
+
+from app.domain.models.generated_image import GeneratedImage, ImageStatus
+
+
+class TestGeneratedImageModel:
+    def test_instantiation_with_minimal_fields(self):
+        img = GeneratedImage(id=uuid.uuid4())
+        assert img.id is not None
+
+    def test_instantiation_with_all_fields(self):
+        img = GeneratedImage(
+            id=uuid.uuid4(),
+            lesson_id=uuid.uuid4(),
+            module_id=uuid.uuid4(),
+            unit_id="1.2",
+            concept="paludisme",
+            prompt="Illustrate malaria transmission in West Africa",
+            image_url="images/abc123.webp",
+            format="webp",
+            width=512,
+            alt_text_fr="Cycle de transmission du paludisme",
+            alt_text_en="Malaria transmission cycle",
+            semantic_tags=["épidémiologie", "paludisme", "AOF"],
+            reuse_count=0,
+            status=ImageStatus.pending,
+            file_size_bytes=40960,
+        )
+        assert img.concept == "paludisme"
+        assert img.format == "webp"
+        assert img.width == 512
+
+    def test_status_enum_values(self):
+        assert ImageStatus.pending == "pending"
+        assert ImageStatus.generating == "generating"
+        assert ImageStatus.ready == "ready"
+        assert ImageStatus.failed == "failed"
+
+    def test_status_field_accepts_enum(self):
+        img = GeneratedImage(id=uuid.uuid4(), status=ImageStatus.ready)
+        assert img.status == ImageStatus.ready
+
+    def test_status_field_accepts_string(self):
+        img = GeneratedImage(id=uuid.uuid4(), status=ImageStatus("generating"))
+        assert img.status == ImageStatus.generating
+
+    def test_semantic_tags_accepts_list_of_strings(self):
+        tags = ["épidémiologie", "paludisme", "AOF", "Sénégal"]
+        img = GeneratedImage(id=uuid.uuid4(), semantic_tags=tags)
+        assert img.semantic_tags == tags
+        assert isinstance(img.semantic_tags, list)
+        assert all(isinstance(t, str) for t in img.semantic_tags)
+
+    def test_semantic_tags_accepts_none(self):
+        img = GeneratedImage(id=uuid.uuid4(), semantic_tags=None)
+        assert img.semantic_tags is None
+
+    def test_semantic_tags_accepts_empty_list(self):
+        img = GeneratedImage(id=uuid.uuid4(), semantic_tags=[])
+        assert img.semantic_tags == []
+
+    def test_nullable_fk_fields(self):
+        img = GeneratedImage(id=uuid.uuid4())
+        assert img.lesson_id is None
+        assert img.module_id is None
+
+    def test_uuid_pk_uniqueness(self):
+        ids = {GeneratedImage(id=uuid.uuid4()).id for _ in range(100)}
+        assert len(ids) == 100
+
+    def test_invalid_status_raises(self):
+        with pytest.raises(ValueError):
+            ImageStatus("unknown_status")


### PR DESCRIPTION
## Summary

- Adds `GeneratedImage` SQLAlchemy 2.0 async model (`backend/app/domain/models/generated_image.py`) with all fields from SRS Section 9 / US-025 / FR-03.2
- `ImageStatus` uses `enum.StrEnum` with values: `pending`, `generating`, `ready`, `failed`
- JSONB `semantic_tags` column with GIN index for fast similarity search
- Index on `status` for querying pending/ready images
- FK to `generated_content` (lesson_id) and `modules` (module_id) with `ON DELETE SET NULL`

## Changes

- `backend/app/domain/models/generated_image.py` — new model file
- `backend/app/domain/models/__init__.py` — exports `GeneratedImage`, `ImageStatus`
- `backend/migrations/versions/012_merge_module_units_and_email_otps.py` — merge migration resolving two diverged heads before applying new table
- `backend/migrations/versions/013_add_generated_images_table.py` — creates `generated_images` table; fully reversible (`upgrade`/`downgrade`)
- `backend/tests/test_generated_image_model.py` — 11 unit tests

## Test plan

- [x] `ruff check` — all checks pass
- [x] `pytest` — 13 tests pass (11 new model tests + 2 health tests)
- [x] Model instantiation with minimal and full field sets
- [x] `semantic_tags` JSONB accepts list of strings, empty list, and None
- [x] `ImageStatus` enum values match migration ENUM definition
- [ ] Migration upgrade/downgrade (requires live PostgreSQL — tested locally via Alembic chain)

Closes #222

Generated with [Claude Code](https://claude.ai/code)