### PR TITLE
feat(auth): add logout button to profile page and sidebar

### DIFF
--- a/frontend/app/[locale]/(app)/profile/profile-client.tsx
+++ b/frontend/app/[locale]/(app)/profile/profile-client.tsx
@@ -2,7 +2,10 @@
 
 import { useState } from "react";
 import { useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+import { useLocale } from "next-intl";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { authClient } from "@/lib/auth";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -18,7 +21,7 @@ import { Separator } from "@/components/ui/separator";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
-import { Upload, User as UserIcon, AlertTriangle, CheckCircle } from "lucide-react";
+import { Upload, User as UserIcon, AlertTriangle, CheckCircle, LogOut } from "lucide-react";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -103,10 +106,24 @@ const PROFESSIONAL_ROLES = [
 
 export function ProfileClient() {
   const t = useTranslations("Profile");
+  const router = useRouter();
+  const locale = useLocale();
   const [isEditing, setIsEditing] = useState(false);
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
   const [showRecontextAlert, setShowRecontextAlert] = useState(false);
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
   const queryClient = useQueryClient();
+
+  const handleLogout = async () => {
+    setIsLoggingOut(true);
+    try {
+      await authClient.logout();
+      queryClient.clear();
+      router.push(`/${locale}/login`);
+    } catch {
+      setIsLoggingOut(false);
+    }
+  };
 
   const { data: profile, isLoading } = useQuery({
     queryKey: ["profile"],
@@ -438,6 +455,26 @@ export function ProfileClient() {
               <p className="text-xs text-muted-foreground">{t("levelReadonly")}</p>
             </div>
           </div>
+        </CardContent>
+      </Card>
+
+      {/* Logout */}
+      <Card className="border-destructive/50">
+        <CardContent className="pt-6">
+          <Button
+            variant="destructive"
+            className="w-full min-h-11 gap-2"
+            onClick={handleLogout}
+            disabled={isLoggingOut}
+            aria-label={t("logoutDescription")}
+          >
+            {isLoggingOut ? (
+              <LoadingSpinner className="h-4 w-4" />
+            ) : (
+              <LogOut className="h-4 w-4" aria-hidden="true" />
+            )}
+            {isLoggingOut ? t("loggingOut") : t("logout")}
+          </Button>
         </CardContent>
       </Card>
     </div>

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useTranslations, useLocale } from "next-intl";
 import {
   Home,
@@ -14,17 +14,32 @@ import {
   ChevronLeft,
   ChevronRight,
   Menu,
+  LogOut,
 } from "lucide-react";
 import { LocaleSwitcher } from "@/components/shared/locale-switcher";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { authClient } from "@/lib/auth";
 
 export function Sidebar() {
   const t = useTranslations("Navigation");
+  const tProfile = useTranslations("Profile");
   const tCommon = useTranslations("Common");
   const pathname = usePathname();
   const locale = useLocale();
+  const router = useRouter();
   const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  const handleLogout = async () => {
+    setIsLoggingOut(true);
+    try {
+      await authClient.logout();
+      router.push(`/${locale}/login`);
+    } catch {
+      setIsLoggingOut(false);
+    }
+  };
 
   const navItems = [
     {
@@ -130,13 +145,28 @@ export function Sidebar() {
         })}
       </nav>
       
-      <div className="border-t p-2">
+      <div className="border-t p-2 space-y-1">
         {!isCollapsed ? (
-          <div className="p-2">
-            <LocaleSwitcher />
-          </div>
+          <>
+            <div className="p-2">
+              <LocaleSwitcher />
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full justify-start gap-3 px-3 min-h-11 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
+              onClick={handleLogout}
+              disabled={isLoggingOut}
+              aria-label={tProfile("logoutDescription")}
+            >
+              <LogOut className="h-4 w-4 shrink-0" aria-hidden="true" />
+              <span className="truncate">
+                {isLoggingOut ? tProfile("loggingOut") : tProfile("logout")}
+              </span>
+            </Button>
+          </>
         ) : (
-          <div className="flex justify-center">
+          <div className="flex flex-col items-center gap-1">
             <Button
               variant="ghost"
               size="sm"
@@ -144,6 +174,16 @@ export function Sidebar() {
               aria-label={t("languageSettings")}
             >
               <Menu className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="min-h-11 min-w-11 p-2 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
+              onClick={handleLogout}
+              disabled={isLoggingOut}
+              aria-label={tProfile("logoutDescription")}
+            >
+              <LogOut className="h-4 w-4" aria-hidden="true" />
             </Button>
           </div>
         )}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -33,7 +33,9 @@
     "navigateTo": "Navigate to",
     "lessons": "Lessons",
     "quiz": "Quiz",
-    "caseStudy": "Case Study"
+    "caseStudy": "Case Study",
+    "logout": "Log out",
+    "logoutDescription": "Sign out of your account"
   },
   "Auth": {
     "login": "Sign in",
@@ -615,6 +617,13 @@
     "edit": "Edit",
     "cancel": "Cancel",
     "save": "Save Changes",
+    "logout": "Log out",
+    "logoutDescription": "Sign out of your account",
+    "logoutConfirmTitle": "Confirm log out",
+    "logoutConfirmMessage": "Are you sure you want to log out?",
+    "logoutConfirm": "Log out",
+    "logoutCancel": "Cancel",
+    "loggingOut": "Logging out...",
     "languages": {
       "french": "Fran\u00e7ais",
       "english": "English"

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -33,7 +33,9 @@
     "navigateTo": "Naviguer vers",
     "lessons": "Leçons",
     "quiz": "Quiz",
-    "caseStudy": "Étude de cas"
+    "caseStudy": "Étude de cas",
+    "logout": "Déconnexion",
+    "logoutDescription": "Se déconnecter de votre compte"
   },
   "Auth": {
     "login": "Se connecter",
@@ -615,6 +617,13 @@
     "edit": "Modifier",
     "cancel": "Annuler",
     "save": "Sauvegarder",
+    "logout": "Déconnexion",
+    "logoutDescription": "Se déconnecter de votre compte",
+    "logoutConfirmTitle": "Confirmer la déconnexion",
+    "logoutConfirmMessage": "Êtes-vous sûr de vouloir vous déconnecter ?",
+    "logoutConfirm": "Se déconnecter",
+    "logoutCancel": "Annuler",
+    "loggingOut": "Déconnexion en cours...",
     "languages": {
       "french": "Français",
       "english": "English"


### PR DESCRIPTION
## Summary

Fixes the missing logout button reported in #228. Users can now sign out from two locations:

- **Profile page** — a full-width destructive "Déconnexion / Log out" button in a red-bordered card at the bottom of the profile screen (mobile + desktop)
- **Desktop sidebar** — a ghost "Log out" button with destructive hover style in the sidebar footer (both expanded and collapsed states)

## Changes

- `frontend/app/[locale]/(app)/profile/profile-client.tsx` — adds `handleLogout` handler and logout card
- `frontend/components/layout/sidebar.tsx` — adds logout button in sidebar footer
- `frontend/messages/fr.json` — adds `logout`, `logoutDescription`, `logoutConfirmTitle`, `logoutConfirmMessage`, `logoutConfirm`, `logoutCancel`, `loggingOut` strings
- `frontend/messages/en.json` — same keys in English

## Test plan
- [ ] Backend tests pass
- [ ] Frontend lint passes (`npm run lint`)
- [ ] Manually verify: click Logout on profile page → clears tokens → redirects to /login
- [ ] Manually verify: click Logout in desktop sidebar → same behavior
- [ ] Verify bilingual: FR shows "Déconnexion", EN shows "Log out"
- [ ] Verify mobile viewport (320px) — logout button is full-width, min 44px height

Closes #228

Generated with [Claude Code](https://claude.ai/code)