### PR TITLE
feat(quiz): lesson validation quiz generation endpoint (#219)

### DIFF
--- a/backend/app/api/v1/quiz.py
+++ b/backend/app/api/v1/quiz.py
@@ -15,6 +15,8 @@ from app.ai.rag.retriever import SemanticRetriever
 from app.api.deps import get_db
 from app.api.v1.schemas.quiz import (
     ErrorResponse,
+    LessonValidationQuizRequest,
+    LessonValidationQuizResponse,
     QuizAttemptRequest,
     QuizAttemptResponse,
     QuizAttemptResult,
@@ -817,5 +819,87 @@ async def submit_summative_assessment_attempt(
             detail={
                 "error": "submission_failed",
                 "message": "Failed to submit summative assessment attempt",
+            },
+        )
+
+
+@router.post(
+    "/lesson-validation/generate",
+    response_model=LessonValidationQuizResponse,
+    status_code=status.HTTP_200_OK,
+    responses={
+        400: {"model": ErrorResponse, "description": "Invalid request"},
+        404: {"model": ErrorResponse, "description": "Lesson content not found"},
+        500: {"model": ErrorResponse, "description": "Generation failed"},
+    },
+    summary="Generate lesson validation quiz",
+    description=(
+        "Generates a scenario-based validation quiz from an existing lesson's content "
+        "using RAG retrieval + Claude API. "
+        "The quiz is **always regenerated** on each call (never cached) to prevent answer memorization. "
+        "Returns a realistic West African public health scenario with 5-10 QCM/true-false questions, "
+        "each with an explanation and source citation."
+    ),
+)
+async def generate_lesson_validation_quiz(
+    request: LessonValidationQuizRequest,
+    quiz_service: QuizService = Depends(get_quiz_service),
+    session: AsyncSession = Depends(get_db),
+) -> LessonValidationQuizResponse:
+    """
+    Generate a scenario-based lesson validation quiz (SRS US-024, US-040, FR-03.3).
+
+    Each call produces a fresh quiz — questions are regenerated to prevent memorization.
+    The scenario is contextualized for the user's ECOWAS country.
+    """
+    try:
+        logger.info(
+            "Lesson validation quiz generation requested",
+            lesson_id=str(request.lesson_id),
+            module_id=str(request.module_id),
+            unit_id=request.unit_id,
+            language=request.language,
+            country=request.country,
+            level=request.level,
+        )
+
+        response = await quiz_service.generate_lesson_validation_quiz(
+            lesson_id=request.lesson_id,
+            module_id=request.module_id,
+            unit_id=request.unit_id,
+            language=request.language,
+            country=request.country,
+            level=request.level,
+            session=session,
+        )
+
+        logger.info(
+            "Lesson validation quiz generated",
+            quiz_id=str(response.id),
+            num_questions=len(response.content.questions),
+            country=response.country_context,
+        )
+
+        return response
+
+    except ValueError as e:
+        logger.warning("Lesson validation quiz request invalid", error=str(e))
+        if "not found" in str(e).lower():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"error": "lesson_not_found", "message": str(e)},
+            )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": "invalid_request", "message": str(e)},
+        )
+
+    except Exception as e:
+        logger.error("Lesson validation quiz generation failed", error=str(e), exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={
+                "error": "generation_failed",
+                "message": "Lesson validation quiz generation failed due to internal error",
             },
         )

--- a/backend/app/api/v1/schemas/quiz.py
+++ b/backend/app/api/v1/schemas/quiz.py
@@ -211,3 +211,59 @@ class ErrorResponse(BaseModel):
 
     error: str = Field(description="Error code")
     message: str = Field(description="Human-readable error message")
+
+
+class LessonValidationQuestion(BaseModel):
+    """Single question in a lesson validation quiz (QCM or true/false)."""
+
+    id: str = Field(description="Question identifier")
+    question_type: str = Field(description="Question type: 'mcq' or 'true_false'")
+    question: str = Field(description="Question text")
+    options: list[str] = Field(description="2 options for true/false, 4 for MCQ")
+    correct_answer: int = Field(description="Index of correct option (0-based)", ge=0, le=3)
+    explanation: str = Field(description="Explanation for correct answer with source citation")
+    sources_cited: list[str] = Field(
+        description="Source citations from reference materials", default_factory=list
+    )
+    difficulty: str = Field(description="Question difficulty", default="medium")
+
+
+class LessonValidationContent(BaseModel):
+    """Content structure for lesson validation quiz."""
+
+    scenario_title: str = Field(description="Title of the AOF public health scenario")
+    scenario_context: str = Field(
+        description="Realistic West African public health scenario description"
+    )
+    questions: list[LessonValidationQuestion] = Field(
+        description="5-10 scenario-based questions", min_length=5, max_length=10
+    )
+    time_limit_minutes: int = Field(description="Suggested time limit in minutes", default=15)
+    passing_score: float = Field(
+        description="Minimum passing score (0-100)", ge=0, le=100, default=70.0
+    )
+
+
+class LessonValidationQuizRequest(BaseModel):
+    """Request to generate a lesson validation quiz."""
+
+    lesson_id: UUID = Field(description="ID of the generated lesson content")
+    module_id: UUID = Field(description="Module ID containing the lesson")
+    unit_id: str = Field(description="Unit identifier within the module")
+    language: str = Field(description="Content language (fr/en)", pattern="^(fr|en)$")
+    country: str = Field(description="User's ECOWAS country code for contextualization")
+    level: int = Field(description="User's learning level (1-4)", ge=1, le=4)
+
+
+class LessonValidationQuizResponse(BaseModel):
+    """Response containing the generated lesson validation quiz."""
+
+    id: UUID = Field(description="Generated quiz ID (new UUID per request, never cached)")
+    lesson_id: UUID = Field(description="Source lesson content ID")
+    module_id: UUID = Field(description="Module ID")
+    unit_id: str = Field(description="Unit identifier")
+    language: str = Field(description="Content language")
+    level: int = Field(description="Learning level (1-4)")
+    country_context: str = Field(description="Country used for scenario contextualization")
+    content: LessonValidationContent = Field(description="Scenario and questions")
+    generated_at: str = Field(description="ISO timestamp when quiz was generated")

--- a/backend/app/domain/services/quiz_service.py
+++ b/backend/app/domain/services/quiz_service.py
@@ -2,6 +2,7 @@
 
 import json
 import uuid
+from datetime import UTC, datetime
 from uuid import UUID
 
 import structlog
@@ -10,7 +11,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.ai.claude_service import ClaudeService
 from app.ai.rag.retriever import SemanticRetriever
-from app.api.v1.schemas.quiz import QuizContent, QuizResponse
+from app.api.v1.schemas.quiz import (
+    LessonValidationContent,
+    LessonValidationQuizResponse,
+    QuizContent,
+    QuizResponse,
+)
 from app.domain.models.content import GeneratedContent
 
 logger = structlog.get_logger()
@@ -391,3 +397,258 @@ Generate the quiz now, ensuring all questions are relevant to public health prac
         for question in quiz_content.questions:
             sources.update(question.sources_cited)
         return list(sources)
+
+    async def generate_lesson_validation_quiz(
+        self,
+        lesson_id: UUID,
+        module_id: UUID,
+        unit_id: str,
+        language: str,
+        country: str,
+        level: int,
+        session: AsyncSession,
+    ) -> LessonValidationQuizResponse:
+        """
+        Generate a scenario-based validation quiz from a lesson's content.
+
+        Always regenerates on each call (never cached) to prevent memorization.
+
+        Args:
+            lesson_id: ID of the generated lesson content to validate
+            module_id: Module ID for additional RAG context
+            unit_id: Unit identifier within the module
+            language: Content language (fr/en)
+            country: User's ECOWAS country code for scenario contextualization
+            level: Learning level (1-4)
+            session: Database session
+
+        Returns:
+            LessonValidationQuizResponse with scenario and 5-10 questions
+
+        Raises:
+            ValueError: If lesson not found or generation fails
+        """
+        logger.info(
+            "Generating lesson validation quiz",
+            lesson_id=str(lesson_id),
+            module_id=str(module_id),
+            unit_id=unit_id,
+            language=language,
+            country=country,
+            level=level,
+        )
+
+        result = await session.execute(
+            select(GeneratedContent).where(
+                GeneratedContent.id == lesson_id,
+                GeneratedContent.content_type == "lesson",
+            )
+        )
+        lesson_content = result.scalar_one_or_none()
+
+        if not lesson_content:
+            raise ValueError(f"Lesson {lesson_id} not found in generated_content")
+
+        lesson_text = self._extract_lesson_text(lesson_content.content)
+
+        search_query = f"public health scenario {unit_id} {country} validation assessment"
+        rag_chunks = await self.semantic_retriever.search(
+            query=search_query,
+            top_k=6,
+            filters={"level": {"$lte": level}},
+            session=session,
+        )
+
+        rag_context = "\n\n".join(
+            f"Source: {r.chunk.source}, ch. {r.chunk.chapter}, p. {r.chunk.page}\n{r.chunk.content}"
+            for r in rag_chunks
+        )
+
+        prompt = self._build_lesson_validation_prompt(
+            lesson_text=lesson_text,
+            rag_context=rag_context,
+            unit_id=unit_id,
+            language=language,
+            country=country,
+            level=level,
+        )
+
+        raw_response = await self.claude_service.generate_structured_content(
+            system_prompt=self._lesson_validation_system_prompt(language),
+            user_message=prompt,
+            content_type="lesson_validation_quiz",
+        )
+
+        content = self._parse_lesson_validation_response(raw_response, language)
+
+        return LessonValidationQuizResponse(
+            id=uuid.uuid4(),
+            lesson_id=lesson_id,
+            module_id=module_id,
+            unit_id=unit_id,
+            language=language,
+            level=level,
+            country_context=country,
+            content=content,
+            generated_at=datetime.now(UTC).isoformat(),
+        )
+
+    def _extract_lesson_text(self, lesson_content_dict: dict) -> str:
+        """Extract readable text from lesson content JSONB."""
+        parts: list[str] = []
+        for key in ("introduction", "concepts", "aof_example", "synthesis", "key_points"):
+            value = lesson_content_dict.get(key)
+            if isinstance(value, str) and value:
+                parts.append(value)
+            elif isinstance(value, list):
+                parts.extend(str(v) for v in value if v)
+        if not parts:
+            parts.append(str(lesson_content_dict))
+        return "\n\n".join(parts)
+
+    def _lesson_validation_system_prompt(self, language: str) -> str:
+        if language == "fr":
+            return (
+                "Tu es un expert en santé publique en Afrique de l'Ouest (AOF). "
+                "Tu crées des quiz de validation pédagogiques basés sur des scénarios réalistes "
+                "pour des professionnels de santé. "
+                "Réponds UNIQUEMENT avec un objet JSON valide, sans texte avant ni après."
+            )
+        return (
+            "You are a public health expert in West Africa (AOF). "
+            "You create pedagogical validation quizzes based on realistic scenarios "
+            "for health professionals. "
+            "Respond ONLY with a valid JSON object, no text before or after."
+        )
+
+    def _build_lesson_validation_prompt(
+        self,
+        lesson_text: str,
+        rag_context: str,
+        unit_id: str,
+        language: str,
+        country: str,
+        level: int,
+        num_questions: int = 7,
+    ) -> str:
+        lang_instr = "in French" if language == "fr" else "in English"
+        level_desc = {
+            1: "beginner",
+            2: "intermediate",
+            3: "advanced",
+            4: "expert",
+        }.get(level, "intermediate")
+        country_name = {
+            "SN": "Senegal",
+            "GH": "Ghana",
+            "NG": "Nigeria",
+            "CI": "Côte d'Ivoire",
+            "ML": "Mali",
+            "BF": "Burkina Faso",
+            "GN": "Guinea",
+            "BJ": "Benin",
+            "TG": "Togo",
+            "NE": "Niger",
+        }.get(country.upper(), country)
+
+        return f"""Generate a lesson validation quiz {lang_instr} for a public health professional in {country_name}.
+
+LESSON CONTENT (source of key points):
+{lesson_text[:3000]}
+
+ADDITIONAL RAG CONTEXT (reference materials for source citations):
+{rag_context[:2000]}
+
+REQUIREMENTS:
+- Unit: {unit_id}
+- Level: {level_desc}
+- Country context: {country_name}
+- Number of questions: {num_questions} (between 5 and 10)
+- Mix: at least 70% MCQ (4 options), rest true/false (2 options)
+- Scenario: a realistic AOF public health situation (epidemic management, DHIS2 data, health policy)
+- Every question must relate to the scenario and the lesson content
+- Every explanation must cite a specific source from the RAG context
+
+RESPONSE FORMAT (JSON only):
+{{
+  "scenario_title": "Short scenario title",
+  "scenario_context": "2-3 paragraph realistic AOF public health scenario in {country_name}",
+  "questions": [
+    {{
+      "id": "q1",
+      "question_type": "mcq",
+      "question": "Question text referencing the scenario?",
+      "options": ["Option A", "Option B", "Option C", "Option D"],
+      "correct_answer": 0,
+      "explanation": "Explanation citing source (e.g. Donaldson Ch.3, p.45)",
+      "sources_cited": ["Donaldson Ch.3, p.45"],
+      "difficulty": "medium"
+    }},
+    {{
+      "id": "q2",
+      "question_type": "true_false",
+      "question": "True/false statement about scenario?",
+      "options": ["True", "False"],
+      "correct_answer": 1,
+      "explanation": "Explanation with source citation",
+      "sources_cited": ["Triola Ch.2, p.18"],
+      "difficulty": "easy"
+    }}
+  ],
+  "time_limit_minutes": 15,
+  "passing_score": 70.0
+}}"""
+
+    def _parse_lesson_validation_response(
+        self, raw_response: dict | str, language: str
+    ) -> LessonValidationContent:
+        """Parse and validate Claude's lesson validation quiz response."""
+        try:
+            if isinstance(raw_response, str):
+                text = raw_response.strip()
+                if "```json" in text:
+                    start = text.find("```json") + 7
+                    end = text.find("```", start)
+                    text = text[start:end].strip()
+                elif "```" in text:
+                    start = text.find("```") + 3
+                    end = text.rfind("```")
+                    text = text[start:end].strip()
+                data = json.loads(text)
+            else:
+                data = raw_response
+
+            questions_raw = data.get("questions", [])
+            if not isinstance(questions_raw, list) or len(questions_raw) < 5:
+                raise ValueError(
+                    f"Expected 5-10 questions, got {len(questions_raw) if isinstance(questions_raw, list) else 0}"
+                )
+            if len(questions_raw) > 10:
+                questions_raw = questions_raw[:10]
+
+            for i, q in enumerate(questions_raw):
+                for field in (
+                    "id",
+                    "question_type",
+                    "question",
+                    "options",
+                    "correct_answer",
+                    "explanation",
+                ):
+                    if field not in q:
+                        raise ValueError(f"Question {i + 1}: missing field '{field}'")
+                if q["question_type"] == "true_false" and len(q["options"]) != 2:
+                    q["options"] = ["True", "False"]
+                elif q["question_type"] == "mcq" and len(q["options"]) != 4:
+                    raise ValueError(f"Question {i + 1}: MCQ must have 4 options")
+                q.setdefault("sources_cited", [])
+                q.setdefault("difficulty", "medium")
+
+            data.setdefault("time_limit_minutes", 15)
+            data.setdefault("passing_score", 70.0)
+
+            return LessonValidationContent(**data)
+
+        except (json.JSONDecodeError, KeyError, TypeError) as exc:
+            logger.error("Failed to parse lesson validation quiz response", error=str(exc))
+            raise ValueError(f"Invalid lesson validation quiz format: {exc}") from exc

--- a/backend/tests/test_lesson_validation_quiz.py
+++ b/backend/tests/test_lesson_validation_quiz.py
@@ -1,0 +1,519 @@
+"""Tests for lesson validation quiz generation (issue #219)."""
+
+import json
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.ai.claude_service import ClaudeService
+from app.ai.rag.retriever import SemanticRetriever
+from app.api.v1.schemas.quiz import (
+    LessonValidationContent,
+    LessonValidationQuizRequest,
+    LessonValidationQuizResponse,
+)
+from app.domain.models.content import GeneratedContent
+from app.domain.services.quiz_service import QuizService
+
+
+@pytest.fixture
+def mock_claude_service():
+    return AsyncMock(spec=ClaudeService)
+
+
+@pytest.fixture
+def mock_semantic_retriever():
+    return AsyncMock(spec=SemanticRetriever)
+
+
+@pytest.fixture
+def quiz_service(mock_claude_service, mock_semantic_retriever):
+    return QuizService(mock_claude_service, mock_semantic_retriever)
+
+
+@pytest.fixture
+def sample_lesson_content():
+    return GeneratedContent(
+        id=uuid.uuid4(),
+        module_id=uuid.uuid4(),
+        content_type="lesson",
+        language="fr",
+        level=2,
+        content={
+            "introduction": "Introduction à l'épidémiologie en Afrique de l'Ouest.",
+            "concepts": "Les indicateurs de santé publique incluent l'incidence et la prévalence.",
+            "aof_example": "Au Sénégal, la surveillance du paludisme utilise le DHIS2.",
+            "synthesis": "La surveillance épidémiologique est essentielle pour la santé publique.",
+            "key_points": ["Incidence", "Prévalence", "Surveillance"],
+        },
+        sources_cited=["Donaldson Ch.2, p.34"],
+        country_context="SN",
+        validated=False,
+        generated_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def sample_rag_results():
+    chunk = MagicMock()
+    chunk.source = "donaldson"
+    chunk.chapter = "3"
+    chunk.page = 45
+    chunk.content = "Epidemiological surveillance is the systematic collection of data..."
+
+    result = MagicMock()
+    result.chunk = chunk
+    return [result]
+
+
+@pytest.fixture
+def sample_validation_quiz_data():
+    return {
+        "scenario_title": "Épidémie de méningite à Dakar",
+        "scenario_context": (
+            "Une épidémie de méningite bactérienne est signalée dans le district de Dakar. "
+            "Le médecin chef du district reçoit des rapports de 15 cas en une semaine. "
+            "Il doit décider des mesures de réponse appropriées."
+        ),
+        "questions": [
+            {
+                "id": "q1",
+                "question_type": "mcq",
+                "question": "Quelle est la première action à entreprendre face à cette épidémie?",
+                "options": [
+                    "Fermer les écoles immédiatement",
+                    "Confirmer le diagnostic en laboratoire",
+                    "Lancer une campagne de vaccination de masse",
+                    "Informer les médias",
+                ],
+                "correct_answer": 1,
+                "explanation": "La confirmation diagnostique est prioritaire (Donaldson Ch.3, p.45).",
+                "sources_cited": ["Donaldson Ch.3, p.45"],
+                "difficulty": "medium",
+            },
+            {
+                "id": "q2",
+                "question_type": "mcq",
+                "question": "Quel indicateur permet de mesurer la vitesse de propagation?",
+                "options": ["Prévalence", "Taux d'attaque", "Létalité", "Incidence cumulée"],
+                "correct_answer": 1,
+                "explanation": "Le taux d'attaque mesure la proportion de cas (Donaldson Ch.4, p.67).",
+                "sources_cited": ["Donaldson Ch.4, p.67"],
+                "difficulty": "medium",
+            },
+            {
+                "id": "q3",
+                "question_type": "true_false",
+                "question": "La méningite bactérienne est une maladie à déclaration obligatoire au Sénégal.",
+                "options": ["True", "False"],
+                "correct_answer": 0,
+                "explanation": "Oui, elle est à déclaration obligatoire (Scutchfield Ch.5, p.89).",
+                "sources_cited": ["Scutchfield Ch.5, p.89"],
+                "difficulty": "easy",
+            },
+            {
+                "id": "q4",
+                "question_type": "mcq",
+                "question": "Quel seuil d'incidence déclenche une alerte épidémique pour la méningite?",
+                "options": ["1 cas/100k", "5 cas/100k", "10 cas/100k", "15 cas/100k"],
+                "correct_answer": 2,
+                "explanation": "Le seuil OMS est 10 cas/100k habitants (WHO AFRO 2019).",
+                "sources_cited": ["WHO AFRO 2019"],
+                "difficulty": "hard",
+            },
+            {
+                "id": "q5",
+                "question_type": "mcq",
+                "question": "Dans le DHIS2, quelle entrée documente les nouveaux cas?",
+                "options": [
+                    "Cas suspects confirmés en labo",
+                    "Cas probables selon critères cliniques",
+                    "Cas confirmés ET probables",
+                    "Uniquement les décès",
+                ],
+                "correct_answer": 2,
+                "explanation": "Le DHIS2 enregistre les cas confirmés et probables (Donaldson Ch.7, p.112).",
+                "sources_cited": ["Donaldson Ch.7, p.112"],
+                "difficulty": "medium",
+            },
+        ],
+        "time_limit_minutes": 15,
+        "passing_score": 70.0,
+    }
+
+
+class TestQuizServiceGenerateLessonValidationQuiz:
+    """Tests for QuizService.generate_lesson_validation_quiz."""
+
+    @pytest.mark.asyncio
+    async def test_generates_quiz_with_5_to_10_questions(
+        self,
+        quiz_service,
+        mock_claude_service,
+        mock_semantic_retriever,
+        sample_lesson_content,
+        sample_rag_results,
+        sample_validation_quiz_data,
+    ):
+        session = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = sample_lesson_content
+        session.execute = AsyncMock(return_value=mock_result)
+
+        mock_semantic_retriever.search.return_value = sample_rag_results
+        mock_claude_service.generate_structured_content.return_value = sample_validation_quiz_data
+
+        result = await quiz_service.generate_lesson_validation_quiz(
+            lesson_id=sample_lesson_content.id,
+            module_id=sample_lesson_content.module_id,
+            unit_id="unit-1",
+            language="fr",
+            country="SN",
+            level=2,
+            session=session,
+        )
+
+        assert isinstance(result, LessonValidationQuizResponse)
+        assert 5 <= len(result.content.questions) <= 10
+        mock_claude_service.generate_structured_content.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_response_never_cached(
+        self,
+        quiz_service,
+        mock_claude_service,
+        mock_semantic_retriever,
+        sample_lesson_content,
+        sample_rag_results,
+        sample_validation_quiz_data,
+    ):
+        """Quiz is always freshly generated — no cached flag in response."""
+        session = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = sample_lesson_content
+        session.execute = AsyncMock(return_value=mock_result)
+
+        mock_semantic_retriever.search.return_value = sample_rag_results
+        mock_claude_service.generate_structured_content.return_value = sample_validation_quiz_data
+
+        result1 = await quiz_service.generate_lesson_validation_quiz(
+            lesson_id=sample_lesson_content.id,
+            module_id=sample_lesson_content.module_id,
+            unit_id="unit-1",
+            language="fr",
+            country="SN",
+            level=2,
+            session=session,
+        )
+        result2 = await quiz_service.generate_lesson_validation_quiz(
+            lesson_id=sample_lesson_content.id,
+            module_id=sample_lesson_content.module_id,
+            unit_id="unit-1",
+            language="fr",
+            country="SN",
+            level=2,
+            session=session,
+        )
+
+        assert result1.id != result2.id
+        assert mock_claude_service.generate_structured_content.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_country_context_included_in_response(
+        self,
+        quiz_service,
+        mock_claude_service,
+        mock_semantic_retriever,
+        sample_lesson_content,
+        sample_rag_results,
+        sample_validation_quiz_data,
+    ):
+        session = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = sample_lesson_content
+        session.execute = AsyncMock(return_value=mock_result)
+
+        mock_semantic_retriever.search.return_value = sample_rag_results
+        mock_claude_service.generate_structured_content.return_value = sample_validation_quiz_data
+
+        result = await quiz_service.generate_lesson_validation_quiz(
+            lesson_id=sample_lesson_content.id,
+            module_id=sample_lesson_content.module_id,
+            unit_id="unit-1",
+            language="fr",
+            country="SN",
+            level=2,
+            session=session,
+        )
+
+        assert result.country_context == "SN"
+
+    @pytest.mark.asyncio
+    async def test_each_question_has_explanation_and_source(
+        self,
+        quiz_service,
+        mock_claude_service,
+        mock_semantic_retriever,
+        sample_lesson_content,
+        sample_rag_results,
+        sample_validation_quiz_data,
+    ):
+        session = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = sample_lesson_content
+        session.execute = AsyncMock(return_value=mock_result)
+
+        mock_semantic_retriever.search.return_value = sample_rag_results
+        mock_claude_service.generate_structured_content.return_value = sample_validation_quiz_data
+
+        result = await quiz_service.generate_lesson_validation_quiz(
+            lesson_id=sample_lesson_content.id,
+            module_id=sample_lesson_content.module_id,
+            unit_id="unit-1",
+            language="fr",
+            country="SN",
+            level=2,
+            session=session,
+        )
+
+        for question in result.content.questions:
+            assert question.explanation, f"Question {question.id} has no explanation"
+            assert isinstance(question.sources_cited, list)
+
+    @pytest.mark.asyncio
+    async def test_raises_value_error_when_lesson_not_found(
+        self,
+        quiz_service,
+        mock_semantic_retriever,
+    ):
+        session = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with pytest.raises(ValueError, match="not found"):
+            await quiz_service.generate_lesson_validation_quiz(
+                lesson_id=uuid.uuid4(),
+                module_id=uuid.uuid4(),
+                unit_id="unit-1",
+                language="fr",
+                country="SN",
+                level=2,
+                session=session,
+            )
+
+    @pytest.mark.asyncio
+    async def test_raises_on_too_few_questions(
+        self,
+        quiz_service,
+        mock_claude_service,
+        mock_semantic_retriever,
+        sample_lesson_content,
+        sample_rag_results,
+    ):
+        session = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = sample_lesson_content
+        session.execute = AsyncMock(return_value=mock_result)
+
+        mock_semantic_retriever.search.return_value = sample_rag_results
+        mock_claude_service.generate_structured_content.return_value = {
+            "scenario_title": "Test",
+            "scenario_context": "Context",
+            "questions": [
+                {
+                    "id": "q1",
+                    "question_type": "mcq",
+                    "question": "Q?",
+                    "options": ["A", "B", "C", "D"],
+                    "correct_answer": 0,
+                    "explanation": "Exp",
+                    "sources_cited": [],
+                    "difficulty": "easy",
+                }
+            ],
+            "time_limit_minutes": 10,
+            "passing_score": 70.0,
+        }
+
+        with pytest.raises(ValueError, match="5-10 questions"):
+            await quiz_service.generate_lesson_validation_quiz(
+                lesson_id=sample_lesson_content.id,
+                module_id=sample_lesson_content.module_id,
+                unit_id="unit-1",
+                language="fr",
+                country="SN",
+                level=2,
+                session=session,
+            )
+
+    @pytest.mark.asyncio
+    async def test_rag_retrieval_called(
+        self,
+        quiz_service,
+        mock_claude_service,
+        mock_semantic_retriever,
+        sample_lesson_content,
+        sample_rag_results,
+        sample_validation_quiz_data,
+    ):
+        session = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = sample_lesson_content
+        session.execute = AsyncMock(return_value=mock_result)
+
+        mock_semantic_retriever.search.return_value = sample_rag_results
+        mock_claude_service.generate_structured_content.return_value = sample_validation_quiz_data
+
+        await quiz_service.generate_lesson_validation_quiz(
+            lesson_id=sample_lesson_content.id,
+            module_id=sample_lesson_content.module_id,
+            unit_id="unit-1",
+            language="en",
+            country="GH",
+            level=3,
+            session=session,
+        )
+
+        mock_semantic_retriever.search.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_response_includes_scenario_context(
+        self,
+        quiz_service,
+        mock_claude_service,
+        mock_semantic_retriever,
+        sample_lesson_content,
+        sample_rag_results,
+        sample_validation_quiz_data,
+    ):
+        session = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = sample_lesson_content
+        session.execute = AsyncMock(return_value=mock_result)
+
+        mock_semantic_retriever.search.return_value = sample_rag_results
+        mock_claude_service.generate_structured_content.return_value = sample_validation_quiz_data
+
+        result = await quiz_service.generate_lesson_validation_quiz(
+            lesson_id=sample_lesson_content.id,
+            module_id=sample_lesson_content.module_id,
+            unit_id="unit-1",
+            language="fr",
+            country="SN",
+            level=2,
+            session=session,
+        )
+
+        assert result.content.scenario_title
+        assert result.content.scenario_context
+        assert len(result.content.scenario_context) > 50
+
+
+class TestLessonValidationQuizSchemas:
+    """Unit tests for the new Pydantic schemas."""
+
+    def test_request_validates_language(self):
+        with pytest.raises(ValueError):
+            LessonValidationQuizRequest(
+                lesson_id=uuid.uuid4(),
+                module_id=uuid.uuid4(),
+                unit_id="unit-1",
+                language="es",
+                country="SN",
+                level=2,
+            )
+
+    def test_request_validates_level_range(self):
+        with pytest.raises(ValueError):
+            LessonValidationQuizRequest(
+                lesson_id=uuid.uuid4(),
+                module_id=uuid.uuid4(),
+                unit_id="unit-1",
+                language="fr",
+                country="SN",
+                level=5,
+            )
+
+    def test_content_validates_question_count_minimum(self):
+        with pytest.raises(ValueError):
+            LessonValidationContent(
+                scenario_title="Test",
+                scenario_context="Context",
+                questions=[],
+                time_limit_minutes=10,
+                passing_score=70.0,
+            )
+
+    def test_valid_request_passes_validation(self):
+        req = LessonValidationQuizRequest(
+            lesson_id=uuid.uuid4(),
+            module_id=uuid.uuid4(),
+            unit_id="unit-1",
+            language="fr",
+            country="SN",
+            level=2,
+        )
+        assert req.language == "fr"
+        assert req.level == 2
+
+
+class TestParseResponseHelper:
+    """Tests for the private parsing helper."""
+
+    def test_parses_json_string_response(self):
+        service = QuizService.__new__(QuizService)
+        data = {
+            "scenario_title": "Test Scenario",
+            "scenario_context": "A realistic health scenario in West Africa with details.",
+            "questions": [
+                {
+                    "id": f"q{i}",
+                    "question_type": "mcq",
+                    "question": f"Question {i}?",
+                    "options": ["A", "B", "C", "D"],
+                    "correct_answer": 0,
+                    "explanation": f"Explanation {i} (Source Ch.{i}, p.{i * 10})",
+                    "sources_cited": [f"Source Ch.{i}, p.{i * 10}"],
+                    "difficulty": "medium",
+                }
+                for i in range(1, 6)
+            ],
+            "time_limit_minutes": 15,
+            "passing_score": 70.0,
+        }
+        result = service._parse_lesson_validation_response(json.dumps(data), "fr")
+        assert isinstance(result, LessonValidationContent)
+        assert len(result.questions) == 5
+
+    def test_parses_dict_response_directly(self):
+        service = QuizService.__new__(QuizService)
+        data = {
+            "scenario_title": "Test",
+            "scenario_context": "Realistic scenario context for public health in West Africa.",
+            "questions": [
+                {
+                    "id": f"q{i}",
+                    "question_type": "true_false" if i % 3 == 0 else "mcq",
+                    "question": f"Q{i}?",
+                    "options": ["True", "False"] if i % 3 == 0 else ["A", "B", "C", "D"],
+                    "correct_answer": 0,
+                    "explanation": f"Exp {i}",
+                    "sources_cited": ["Donaldson Ch.1"],
+                    "difficulty": "easy",
+                }
+                for i in range(1, 8)
+            ],
+            "time_limit_minutes": 15,
+            "passing_score": 70.0,
+        }
+        result = service._parse_lesson_validation_response(data, "en")
+        assert len(result.questions) == 7
+
+    def test_raises_on_invalid_json(self):
+        service = QuizService.__new__(QuizService)
+        with pytest.raises(ValueError):
+            service._parse_lesson_validation_response("not json at all", "fr")


### PR DESCRIPTION
## Summary

- Implements `POST /api/v1/quiz/lesson-validation/generate` (SRS US-024, US-040, FR-03.3)
- Generates a scenario-based validation quiz from a lesson's content using RAG pipeline + Claude API
- Quiz is **always regenerated** on each call (never cached) to prevent answer memorization
- Scenario is contextualized for the user's ECOWAS country

## Changes

- `backend/app/api/v1/schemas/quiz.py` — new schemas: `LessonValidationQuestion`, `LessonValidationContent`, `LessonValidationQuizRequest`, `LessonValidationQuizResponse`
- `backend/app/domain/services/quiz_service.py` — new method `generate_lesson_validation_quiz()` with helpers: RAG retrieval, prompt building, Claude API call, response parsing/validation
- `backend/app/api/v1/quiz.py` — new endpoint `POST /quiz/lesson-validation/generate`
- `backend/tests/test_lesson_validation_quiz.py` — 15 unit tests (all passing)

## Acceptance criteria covered

- ✅ Endpoint accepts `lesson_id`, `module_id`, `unit_id`
- ✅ Retrieves lesson content from `generated_content` table
- ✅ Uses RAG pipeline to fetch relevant chunks for scenario context
- ✅ Claude generates realistic AOF scenario with 5-10 questions (QCM + true/false)
- ✅ Each question includes: text, options, correct answer, explanation with source citation
- ✅ Scenario contextualized for user's country
- ✅ Quiz regenerated (not cached) on each call
- ✅ Response includes scenario context + questions array
- ✅ Error handling if lesson content not found (404)

## Test plan

- [x] 15 unit tests pass (`pytest tests/test_lesson_validation_quiz.py`)
- [x] All 41 existing backend tests still pass
- [x] Ruff lint + format clean
- [ ] Integration test with real DB + Claude API (requires running infra)
- [ ] Manual verification on mobile viewport

Closes #219

Generated with [Claude Code](https://claude.ai/code)