### PR TITLE
feat(images): DALL-E 3 async image generation Celery task + semantic reuse

### DIFF
--- a/backend/app/domain/models/__init__.py
+++ b/backend/app/domain/models/__init__.py
@@ -4,6 +4,7 @@ from app.domain.models.content import GeneratedContent
 from app.domain.models.conversation import TutorConversation
 from app.domain.models.document_chunk import DocumentChunk
 from app.domain.models.flashcard import FlashcardReview
+from app.domain.models.image import GeneratedImage
 from app.domain.models.module import Module
 from app.domain.models.progress import UserModuleProgress
 from app.domain.models.quiz import QuizAttempt
@@ -13,6 +14,7 @@ __all__ = [
     "Base",
     "DocumentChunk",
     "GeneratedContent",
+    "GeneratedImage",
     "TutorConversation",
     "FlashcardReview",
     "MagicLink",

--- a/backend/app/domain/models/image.py
+++ b/backend/app/domain/models/image.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Integer, String, Text, func
+from sqlalchemy.dialects.postgresql import ARRAY, JSON
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.domain.models.base import Base
+
+
+class GeneratedImage(Base):
+    __tablename__ = "generated_images"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    lesson_id: Mapped[uuid.UUID | None] = mapped_column(index=True, nullable=True)
+    module_id: Mapped[uuid.UUID] = mapped_column(index=True)
+    unit_id: Mapped[str] = mapped_column(String)
+    status: Mapped[str] = mapped_column(String(20), index=True, server_default="pending")
+    dalle_prompt: Mapped[str | None] = mapped_column(Text, nullable=True)
+    semantic_tags: Mapped[list | None] = mapped_column(ARRAY(String), nullable=True)
+    key_concept: Mapped[str | None] = mapped_column(Text, nullable=True)
+    image_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    image_data: Mapped[bytes | None] = mapped_column(nullable=True)
+    alt_text_fr: Mapped[str | None] = mapped_column(Text, nullable=True)
+    alt_text_en: Mapped[str | None] = mapped_column(Text, nullable=True)
+    reuse_count: Mapped[int] = mapped_column(Integer, server_default="0")
+    width: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    height: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    extra_metadata: Mapped[dict | None] = mapped_column("metadata", JSON, nullable=True)
+    generated_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    created_at: Mapped[datetime] = mapped_column(server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(server_default=func.now(), onupdate=func.now())

--- a/backend/app/domain/services/image_service.py
+++ b/backend/app/domain/services/image_service.py
@@ -1,0 +1,308 @@
+"""Service for async DALL-E 3 image generation with semantic reuse (US-025, FR-03.2)."""
+
+import io
+import uuid
+from datetime import UTC, datetime
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.models.image import GeneratedImage
+from app.infrastructure.config.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+SEMANTIC_REUSE_THRESHOLD = 0.85
+
+
+class ImageGenerationService:
+    """Service for generating lesson illustrations using DALL-E 3 with semantic reuse."""
+
+    async def extract_concept_and_tags(
+        self,
+        lesson_content: str,
+        lesson_id: uuid.UUID,
+        module_id: uuid.UUID,
+        unit_id: str,
+    ) -> tuple[str, str, list[str]]:
+        """
+        Use Claude API to extract key concept, generate DALL-E prompt, and semantic tags.
+
+        Returns:
+            Tuple of (key_concept, dalle_prompt, semantic_tags)
+        """
+        import anthropic
+
+        client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+
+        system_prompt = (
+            "You are an expert at extracting visual concepts from public health educational content "
+            "for West African learners. Your task is to:\n"
+            "1. Identify the single most important visual concept in the lesson\n"
+            "2. Write a DALL-E 3 prompt for an educational illustration (no text in image, "
+            "culturally appropriate for West Africa, medical/health context)\n"
+            "3. Generate 5-10 semantic tags describing the concept\n\n"
+            "Respond ONLY with valid JSON in this exact format:\n"
+            '{"key_concept": "...", "dalle_prompt": "...", "semantic_tags": ["tag1", "tag2", ...]}'
+        )
+
+        excerpt = lesson_content[:3000] if len(lesson_content) > 3000 else lesson_content
+        user_message = (
+            f"Extract the key visual concept from this public health lesson:\n\n{excerpt}"
+        )
+
+        response = client.messages.create(
+            model="claude-sonnet-4-6",
+            max_tokens=512,
+            system=system_prompt,
+            messages=[{"role": "user", "content": user_message}],
+        )
+
+        import json
+
+        content_text = ""
+        for block in response.content:
+            if hasattr(block, "text"):
+                content_text += block.text
+
+        data = json.loads(content_text)
+        return data["key_concept"], data["dalle_prompt"], data["semantic_tags"]
+
+    async def find_reusable_image(
+        self,
+        semantic_tags: list[str],
+        session: AsyncSession,
+    ) -> GeneratedImage | None:
+        """
+        Search generated_images for an existing image with >= 85% semantic tag overlap.
+
+        Returns:
+            Matching GeneratedImage record or None
+        """
+        if not semantic_tags:
+            return None
+
+        query = select(GeneratedImage).where(
+            GeneratedImage.status == "ready",
+            GeneratedImage.semantic_tags.isnot(None),
+        )
+        result = await session.execute(query)
+        candidates = result.scalars().all()
+
+        tags_set = set(t.lower() for t in semantic_tags)
+
+        best_match: GeneratedImage | None = None
+        best_overlap = 0.0
+
+        for candidate in candidates:
+            if not candidate.semantic_tags:
+                continue
+            candidate_set = set(t.lower() for t in candidate.semantic_tags)
+            union = tags_set | candidate_set
+            if not union:
+                continue
+            intersection = tags_set & candidate_set
+            overlap = len(intersection) / len(union)
+            if overlap >= SEMANTIC_REUSE_THRESHOLD and overlap > best_overlap:
+                best_overlap = overlap
+                best_match = candidate
+
+        if best_match:
+            logger.info(
+                "Found reusable image",
+                image_id=str(best_match.id),
+                overlap=best_overlap,
+            )
+
+        return best_match
+
+    async def generate_alt_text(
+        self,
+        key_concept: str,
+        dalle_prompt: str,
+    ) -> tuple[str, str]:
+        """
+        Generate accessibility alt-text in French and English using Claude API.
+
+        Returns:
+            Tuple of (alt_text_fr, alt_text_en)
+        """
+        import json
+
+        import anthropic
+
+        client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+
+        system_prompt = (
+            "Generate concise accessibility alt-text for an educational illustration. "
+            "Respond ONLY with valid JSON:\n"
+            '{"alt_text_fr": "...", "alt_text_en": "..."}\n'
+            "Keep each alt-text under 125 characters."
+        )
+        user_message = f"Key concept: {key_concept}\nImage description: {dalle_prompt}"
+
+        response = client.messages.create(
+            model="claude-sonnet-4-6",
+            max_tokens=256,
+            system=system_prompt,
+            messages=[{"role": "user", "content": user_message}],
+        )
+
+        content_text = ""
+        for block in response.content:
+            if hasattr(block, "text"):
+                content_text += block.text
+
+        data = json.loads(content_text)
+        return data["alt_text_fr"], data["alt_text_en"]
+
+    async def call_dalle_and_save(
+        self,
+        image_record: GeneratedImage,
+        session: AsyncSession,
+    ) -> GeneratedImage:
+        """
+        Call DALL-E 3 API, convert image to WebP (max 512px), and persist.
+        Updates status: generating → ready | failed.
+        """
+        import openai
+        from PIL import Image
+
+        image_record.status = "generating"
+        await session.commit()
+
+        try:
+            openai_client = openai.OpenAI(api_key=settings.openai_api_key)
+
+            response = openai_client.images.generate(
+                model="dall-e-3",
+                prompt=image_record.dalle_prompt,
+                size="1024x1024",
+                quality="standard",
+                response_format="url",
+                n=1,
+            )
+
+            image_url = response.data[0].url
+
+            import httpx
+
+            async with httpx.AsyncClient(timeout=30.0) as http_client:
+                img_response = await http_client.get(image_url)
+                img_response.raise_for_status()
+                raw_bytes = img_response.content
+
+            img = Image.open(io.BytesIO(raw_bytes))
+            if img.width > 512 or img.height > 512:
+                img.thumbnail((512, 512), Image.LANCZOS)
+
+            webp_buffer = io.BytesIO()
+            img.save(webp_buffer, format="WEBP", quality=85)
+            webp_bytes = webp_buffer.getvalue()
+
+            image_record.image_data = webp_bytes
+            image_record.width = img.width
+            image_record.height = img.height
+            image_record.status = "ready"
+            image_record.generated_at = datetime.now(UTC)
+
+            await session.commit()
+            logger.info(
+                "Image generated and saved",
+                image_id=str(image_record.id),
+                width=img.width,
+                height=img.height,
+            )
+
+        except Exception as exc:
+            logger.error(
+                "DALL-E image generation failed",
+                image_id=str(image_record.id),
+                error=str(exc),
+            )
+            image_record.status = "failed"
+            image_record.error_message = str(exc)
+            await session.commit()
+
+        return image_record
+
+    async def process_lesson_image(
+        self,
+        lesson_id: uuid.UUID,
+        module_id: uuid.UUID,
+        unit_id: str,
+        lesson_content: str,
+        session: AsyncSession,
+    ) -> GeneratedImage:
+        """
+        Full pipeline: extract concept → check reuse → generate or reuse image.
+
+        Status flow: pending → generating → ready | failed
+        """
+        image_record = GeneratedImage(
+            id=uuid.uuid4(),
+            lesson_id=lesson_id,
+            module_id=module_id,
+            unit_id=unit_id,
+            status="pending",
+        )
+        session.add(image_record)
+        await session.commit()
+
+        try:
+            key_concept, dalle_prompt, semantic_tags = await self.extract_concept_and_tags(
+                lesson_content=lesson_content,
+                lesson_id=lesson_id,
+                module_id=module_id,
+                unit_id=unit_id,
+            )
+
+            image_record.key_concept = key_concept
+            image_record.dalle_prompt = dalle_prompt
+            image_record.semantic_tags = semantic_tags
+            await session.commit()
+
+            reusable = await self.find_reusable_image(semantic_tags, session)
+
+            if reusable:
+                alt_fr, alt_en = await self.generate_alt_text(key_concept, dalle_prompt)
+                reusable.reuse_count = (reusable.reuse_count or 0) + 1
+                await session.commit()
+
+                image_record.status = "ready"
+                image_record.image_data = reusable.image_data
+                image_record.image_url = reusable.image_url
+                image_record.alt_text_fr = alt_fr
+                image_record.alt_text_en = alt_en
+                image_record.width = reusable.width
+                image_record.height = reusable.height
+                image_record.generated_at = datetime.now(UTC)
+                image_record.extra_metadata = {"reused_from": str(reusable.id)}
+                await session.commit()
+
+                logger.info(
+                    "Reused existing image",
+                    new_image_id=str(image_record.id),
+                    source_image_id=str(reusable.id),
+                )
+                return image_record
+
+            alt_fr, alt_en = await self.generate_alt_text(key_concept, dalle_prompt)
+            image_record.alt_text_fr = alt_fr
+            image_record.alt_text_en = alt_en
+            await session.commit()
+
+            image_record = await self.call_dalle_and_save(image_record, session)
+
+        except Exception as exc:
+            logger.error(
+                "Image pipeline failed",
+                image_id=str(image_record.id),
+                error=str(exc),
+            )
+            image_record.status = "failed"
+            image_record.error_message = str(exc)
+            await session.commit()
+
+        return image_record

--- a/backend/app/domain/services/lesson_service.py
+++ b/backend/app/domain/services/lesson_service.py
@@ -92,7 +92,44 @@ class LessonGenerationService:
         # Cache the generated content
         await self._cache_lesson_content(lesson_response, session)
 
+        # Dispatch background image generation (non-blocking, lesson served independently)
+        self._dispatch_image_generation(lesson_response)
+
         return lesson_response
+
+    def _dispatch_image_generation(self, lesson_response: "LessonResponse") -> None:
+        """Dispatch the generate_lesson_image Celery task (fire-and-forget)."""
+        try:
+            from app.tasks.content_generation import generate_lesson_image
+
+            lesson_text = ""
+            if lesson_response.content:
+                parts = []
+                if lesson_response.content.introduction:
+                    parts.append(lesson_response.content.introduction)
+                if lesson_response.content.concepts:
+                    parts.extend(lesson_response.content.concepts)
+                if lesson_response.content.synthesis:
+                    parts.append(lesson_response.content.synthesis)
+                lesson_text = " ".join(parts)
+
+            generate_lesson_image.delay(
+                lesson_id=str(lesson_response.id),
+                module_id=str(lesson_response.module_id),
+                unit_id=lesson_response.unit_id,
+                lesson_content=lesson_text,
+            )
+            logger.info(
+                "Dispatched image generation task",
+                lesson_id=str(lesson_response.id),
+                module_id=str(lesson_response.module_id),
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to dispatch image generation task",
+                lesson_id=str(lesson_response.id),
+                error=str(exc),
+            )
 
     async def stream_lesson_generation(
         self,

--- a/backend/app/tasks/content_generation.py
+++ b/backend/app/tasks/content_generation.py
@@ -1,5 +1,8 @@
 """Celery tasks for AI content generation."""
 
+import asyncio
+import uuid
+
 import structlog
 from celery import Task
 
@@ -187,6 +190,102 @@ def generate_flashcards(self, module_id: str, language: str = "fr", count: int =
         logger.error(
             "Flashcard generation failed",
             module_id=module_id,
+            exception=str(exc),
+            task_id=self.request.id,
+        )
+        raise
+
+
+@celery_app.task(
+    bind=True,
+    base=CallbackTask,
+    autoretry_for=(Exception,),
+    retry_kwargs={"max_retries": 2, "countdown": 30},
+    rate_limit="3/m",
+    time_limit=60,
+    soft_time_limit=55,
+)
+def generate_lesson_image(
+    self,
+    lesson_id: str,
+    module_id: str,
+    unit_id: str,
+    lesson_content: str,
+) -> dict:
+    """Async Celery task to generate a DALL-E 3 illustration for a lesson (US-025, FR-03.2).
+
+    Pipeline:
+    1. Claude API extracts key concept + generates DALL-E prompt + semantic tags
+    2. Check generated_images for semantic tag overlap >= 85%
+    3. If match found: reuse image (increment reuse_count), skip DALL-E
+    4. If no match: call DALL-E 3, save as WebP (max 512px), store metadata
+    5. Generate FR/EN alt-text for accessibility
+
+    Status transitions: pending -> generating -> ready | failed
+    Lesson content is served independently (non-blocking).
+
+    Args:
+        lesson_id: UUID of the lesson (GeneratedContent.id)
+        module_id: UUID of the module
+        unit_id: Unit identifier within the module
+        lesson_content: Full lesson text for concept extraction
+
+    Returns:
+        dict with image_id, status, reused flag
+    """
+    logger.info(
+        "Starting lesson image generation",
+        lesson_id=lesson_id,
+        module_id=module_id,
+        unit_id=unit_id,
+        task_id=self.request.id,
+    )
+
+    async def _run() -> dict:
+        from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+        from app.domain.services.image_service import ImageGenerationService
+        from app.infrastructure.config.settings import settings
+
+        engine = create_async_engine(settings.database_url, echo=False)
+        session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+        try:
+            async with session_factory() as session:
+                service = ImageGenerationService()
+                image = await service.process_lesson_image(
+                    lesson_id=uuid.UUID(lesson_id),
+                    module_id=uuid.UUID(module_id),
+                    unit_id=unit_id,
+                    lesson_content=lesson_content,
+                    session=session,
+                )
+                reused = bool(image.extra_metadata and image.extra_metadata.get("reused_from"))
+                return {
+                    "image_id": str(image.id),
+                    "status": image.status,
+                    "reused": reused,
+                    "lesson_id": lesson_id,
+                    "module_id": module_id,
+                    "unit_id": unit_id,
+                }
+        finally:
+            await engine.dispose()
+
+    try:
+        result = asyncio.run(_run())
+        logger.info(
+            "Lesson image generation completed",
+            lesson_id=lesson_id,
+            result=result,
+            task_id=self.request.id,
+        )
+        return result
+
+    except Exception as exc:
+        logger.error(
+            "Lesson image generation failed",
+            lesson_id=lesson_id,
             exception=str(exc),
             task_id=self.request.id,
         )

--- a/backend/migrations/versions/012_add_generated_images_table.py
+++ b/backend/migrations/versions/012_add_generated_images_table.py
@@ -1,0 +1,65 @@
+"""Add generated_images table for DALL-E 3 async image generation (US-025, FR-03.2)
+
+Revision ID: 012_add_generated_images_table
+Revises: 011_add_email_otps_table
+Create Date: 2026-04-01 14:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "012_add_generated_images_table"
+down_revision: str | None = "011_add_email_otps_table"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "generated_images",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("lesson_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("module_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("unit_id", sa.String(), nullable=False),
+        sa.Column("status", sa.String(20), nullable=False, server_default="pending"),
+        sa.Column("dalle_prompt", sa.Text(), nullable=True),
+        sa.Column("semantic_tags", postgresql.ARRAY(sa.String()), nullable=True),
+        sa.Column("key_concept", sa.Text(), nullable=True),
+        sa.Column("image_url", sa.Text(), nullable=True),
+        sa.Column("image_data", sa.LargeBinary(), nullable=True),
+        sa.Column("alt_text_fr", sa.Text(), nullable=True),
+        sa.Column("alt_text_en", sa.Text(), nullable=True),
+        sa.Column("reuse_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("width", sa.Integer(), nullable=True),
+        sa.Column("height", sa.Integer(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("metadata", sa.JSON(), nullable=True),
+        sa.Column("generated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_generated_images_lesson_id", "generated_images", ["lesson_id"])
+    op.create_index("ix_generated_images_module_id", "generated_images", ["module_id"])
+    op.create_index("ix_generated_images_status", "generated_images", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_generated_images_status", table_name="generated_images")
+    op.drop_index("ix_generated_images_module_id", table_name="generated_images")
+    op.drop_index("ix_generated_images_lesson_id", table_name="generated_images")
+    op.drop_table("generated_images")

--- a/backend/tests/test_image_generation.py
+++ b/backend/tests/test_image_generation.py
@@ -1,0 +1,445 @@
+"""Tests for DALL-E 3 async image generation pipeline (US-025, FR-03.2)."""
+
+import json
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.models.image import GeneratedImage
+from app.domain.services.image_service import ImageGenerationService
+
+
+@pytest.fixture
+def image_service():
+    return ImageGenerationService()
+
+
+@pytest.fixture
+def sample_lesson_content():
+    return (
+        "La surveillance épidémiologique est essentielle pour le contrôle des maladies. "
+        "En Afrique de l'Ouest, le paludisme reste la principale cause de morbidité. "
+        "Les systèmes de santé doivent collecter des données de manière systématique."
+    )
+
+
+@pytest.fixture
+def sample_image_ready():
+    return GeneratedImage(
+        id=uuid.uuid4(),
+        lesson_id=uuid.uuid4(),
+        module_id=uuid.uuid4(),
+        unit_id="unit-01",
+        status="ready",
+        dalle_prompt="A West African health worker recording malaria data in a rural clinic",
+        semantic_tags=[
+            "malaria",
+            "surveillance",
+            "health_worker",
+            "west_africa",
+            "data_collection",
+        ],
+        key_concept="Épidémiological surveillance",
+        alt_text_fr="Agent de santé enregistrant des données de paludisme dans une clinique",
+        alt_text_en="Health worker recording malaria data in a rural clinic",
+        reuse_count=0,
+        width=512,
+        height=512,
+        image_data=b"fake_webp_bytes",
+        generated_at=datetime.now(UTC),
+    )
+
+
+class TestSemanticReuse:
+    """Tests for semantic tag overlap reuse logic."""
+
+    @pytest.mark.asyncio
+    async def test_reuse_image_when_overlap_above_threshold(
+        self, image_service, sample_image_ready
+    ):
+        """Images with >= 85% tag overlap should be reused."""
+        session = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [sample_image_ready]
+        session.execute = AsyncMock(return_value=mock_result)
+
+        overlapping_tags = [
+            "malaria",
+            "surveillance",
+            "health_worker",
+            "west_africa",
+            "data_collection",
+        ]
+
+        result = await image_service.find_reusable_image(overlapping_tags, session)
+
+        assert result is not None
+        assert result.id == sample_image_ready.id
+
+    @pytest.mark.asyncio
+    async def test_no_reuse_when_overlap_below_threshold(self, image_service, sample_image_ready):
+        """Images with < 85% tag overlap should NOT be reused."""
+        session = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [sample_image_ready]
+        session.execute = AsyncMock(return_value=mock_result)
+
+        low_overlap_tags = ["nutrition", "maternal_health", "vaccination", "hiv", "tuberculosis"]
+
+        result = await image_service.find_reusable_image(low_overlap_tags, session)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_reuse_increments_reuse_count(self, image_service, sample_image_ready):
+        """Reusing an image must increment its reuse_count."""
+        module_id = uuid.uuid4()
+        lesson_id = uuid.uuid4()
+
+        session = AsyncMock(spec=AsyncSession)
+        call_count = 0
+
+        def execute_side_effect(query):
+            nonlocal call_count
+            call_count += 1
+            mock_result = MagicMock()
+            if call_count == 1:
+                mock_result.scalars.return_value.all.return_value = [sample_image_ready]
+            else:
+                mock_result.scalars.return_value.all.return_value = []
+            return mock_result
+
+        session.execute = AsyncMock(side_effect=execute_side_effect)
+        session.add = MagicMock()
+        session.commit = AsyncMock()
+
+        with (
+            patch.object(
+                image_service,
+                "extract_concept_and_tags",
+                new=AsyncMock(
+                    return_value=(
+                        "Surveillance",
+                        "A health worker in West Africa",
+                        [
+                            "malaria",
+                            "surveillance",
+                            "health_worker",
+                            "west_africa",
+                            "data_collection",
+                        ],
+                    )
+                ),
+            ),
+            patch.object(
+                image_service,
+                "generate_alt_text",
+                new=AsyncMock(return_value=("Texte alt FR", "Alt text EN")),
+            ),
+        ):
+            await image_service.process_lesson_image(
+                lesson_id=lesson_id,
+                module_id=module_id,
+                unit_id="unit-01",
+                lesson_content="Surveillance du paludisme en Afrique de l'Ouest",
+                session=session,
+            )
+
+        assert sample_image_ready.reuse_count == 1
+
+    @pytest.mark.asyncio
+    async def test_no_reuse_when_no_images_exist(self, image_service):
+        """Should return None when generated_images is empty."""
+        session = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=mock_result)
+
+        result = await image_service.find_reusable_image(["malaria", "surveillance"], session)
+
+        assert result is None
+
+
+class TestNewImageGeneration:
+    """Tests for new DALL-E 3 image generation."""
+
+    @pytest.mark.asyncio
+    async def test_new_image_generated_when_no_reusable(self, image_service, sample_lesson_content):
+        """When no reusable image exists, DALL-E should be called and image saved."""
+        module_id = uuid.uuid4()
+        lesson_id = uuid.uuid4()
+
+        session = AsyncMock(spec=AsyncSession)
+        call_count = 0
+
+        def execute_side_effect(query):
+            nonlocal call_count
+            call_count += 1
+            mock_result = MagicMock()
+            mock_result.scalars.return_value.all.return_value = []
+            return mock_result
+
+        session.execute = AsyncMock(side_effect=execute_side_effect)
+        session.add = MagicMock()
+        session.commit = AsyncMock()
+
+        with (
+            patch.object(
+                image_service,
+                "extract_concept_and_tags",
+                new=AsyncMock(
+                    return_value=(
+                        "Malaria surveillance",
+                        "A West African health worker at a clinic",
+                        ["malaria", "surveillance", "clinic"],
+                    )
+                ),
+            ),
+            patch.object(
+                image_service,
+                "generate_alt_text",
+                new=AsyncMock(return_value=("Texte alt FR", "Alt text EN")),
+            ),
+            patch.object(
+                image_service,
+                "call_dalle_and_save",
+                new=AsyncMock(side_effect=lambda img, sess: setattr(img, "status", "ready") or img),
+            ),
+        ):
+            result = await image_service.process_lesson_image(
+                lesson_id=lesson_id,
+                module_id=module_id,
+                unit_id="unit-01",
+                lesson_content=sample_lesson_content,
+                session=session,
+            )
+
+        assert result.status == "ready"
+        assert result.dalle_prompt == "A West African health worker at a clinic"
+        assert result.semantic_tags == ["malaria", "surveillance", "clinic"]
+        assert result.alt_text_fr == "Texte alt FR"
+        assert result.alt_text_en == "Alt text EN"
+
+    @pytest.mark.asyncio
+    async def test_dalle_called_with_generated_prompt(self, image_service):
+        """DALL-E API must be called with the Claude-generated prompt."""
+        module_id = uuid.uuid4()
+        lesson_id = uuid.uuid4()
+
+        session = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=mock_result)
+        session.add = MagicMock()
+        session.commit = AsyncMock()
+
+        dalle_mock = AsyncMock(side_effect=lambda img, sess: setattr(img, "status", "ready") or img)
+
+        with (
+            patch.object(
+                image_service,
+                "extract_concept_and_tags",
+                new=AsyncMock(
+                    return_value=("Test concept", "Test DALL-E prompt", ["tag1", "tag2"])
+                ),
+            ),
+            patch.object(
+                image_service,
+                "generate_alt_text",
+                new=AsyncMock(return_value=("Alt FR", "Alt EN")),
+            ),
+            patch.object(image_service, "call_dalle_and_save", new=dalle_mock),
+        ):
+            await image_service.process_lesson_image(
+                lesson_id=lesson_id,
+                module_id=module_id,
+                unit_id="unit-02",
+                lesson_content="Public health lesson content",
+                session=session,
+            )
+
+        dalle_mock.assert_called_once()
+        called_image = dalle_mock.call_args[0][0]
+        assert called_image.dalle_prompt == "Test DALL-E prompt"
+
+
+class TestFailureHandling:
+    """Tests for graceful failure handling."""
+
+    @pytest.mark.asyncio
+    async def test_status_set_to_failed_on_dalle_error(self, image_service):
+        """If DALL-E fails, image status must be 'failed' and lesson remains usable."""
+        module_id = uuid.uuid4()
+        lesson_id = uuid.uuid4()
+
+        session = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=mock_result)
+        session.add = MagicMock()
+        session.commit = AsyncMock()
+
+        async def failing_dalle(img, sess):
+            img.status = "failed"
+            img.error_message = "DALL-E API error: rate limit exceeded"
+            return img
+
+        with (
+            patch.object(
+                image_service,
+                "extract_concept_and_tags",
+                new=AsyncMock(return_value=("Concept", "Prompt", ["tag1"])),
+            ),
+            patch.object(
+                image_service,
+                "generate_alt_text",
+                new=AsyncMock(return_value=("Alt FR", "Alt EN")),
+            ),
+            patch.object(image_service, "call_dalle_and_save", new=failing_dalle),
+        ):
+            result = await image_service.process_lesson_image(
+                lesson_id=lesson_id,
+                module_id=module_id,
+                unit_id="unit-01",
+                lesson_content="Lesson content",
+                session=session,
+            )
+
+        assert result.status == "failed"
+        assert result.error_message is not None
+
+    @pytest.mark.asyncio
+    async def test_status_set_to_failed_on_concept_extraction_error(self, image_service):
+        """If Claude concept extraction fails, image status must be 'failed'."""
+        module_id = uuid.uuid4()
+        lesson_id = uuid.uuid4()
+
+        session = AsyncMock(spec=AsyncSession)
+        session.add = MagicMock()
+        session.commit = AsyncMock()
+
+        with patch.object(
+            image_service,
+            "extract_concept_and_tags",
+            new=AsyncMock(side_effect=Exception("Claude API unavailable")),
+        ):
+            result = await image_service.process_lesson_image(
+                lesson_id=lesson_id,
+                module_id=module_id,
+                unit_id="unit-01",
+                lesson_content="Lesson content",
+                session=session,
+            )
+
+        assert result.status == "failed"
+        assert "Claude API unavailable" in result.error_message
+
+
+class TestAltText:
+    """Tests for bilingual alt-text generation."""
+
+    @pytest.mark.asyncio
+    async def test_alt_text_generated_in_fr_and_en(self, image_service):
+        """Alt-text must be generated in both French and English."""
+        mock_response = MagicMock()
+        mock_block = MagicMock()
+        mock_block.text = json.dumps(
+            {
+                "alt_text_fr": "Agent de santé collectant des données de paludisme",
+                "alt_text_en": "Health worker collecting malaria data",
+            }
+        )
+        mock_response.content = [mock_block]
+
+        with patch("anthropic.Anthropic") as mock_anthropic_cls:
+            mock_client = MagicMock()
+            mock_client.messages.create.return_value = mock_response
+            mock_anthropic_cls.return_value = mock_client
+
+            alt_fr, alt_en = await image_service.generate_alt_text(
+                key_concept="Surveillance du paludisme",
+                dalle_prompt="A health worker in West Africa collecting malaria data",
+            )
+
+        assert alt_fr == "Agent de santé collectant des données de paludisme"
+        assert alt_en == "Health worker collecting malaria data"
+        assert len(alt_fr) > 0
+        assert len(alt_en) > 0
+
+
+class TestStatusTransitions:
+    """Tests for image status state machine."""
+
+    @pytest.mark.asyncio
+    async def test_image_starts_as_pending(self, image_service):
+        """New image record must start with status='pending'."""
+        module_id = uuid.uuid4()
+        lesson_id = uuid.uuid4()
+
+        captured_images = []
+
+        session = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=mock_result)
+        session.commit = AsyncMock()
+
+        initial_statuses: list[str] = []
+
+        def capture_add(obj):
+            if isinstance(obj, GeneratedImage):
+                initial_statuses.append(obj.status)
+                captured_images.append(obj)
+
+        session.add = MagicMock(side_effect=capture_add)
+
+        with (
+            patch.object(
+                image_service,
+                "extract_concept_and_tags",
+                new=AsyncMock(return_value=("Concept", "Prompt", ["tag1"])),
+            ),
+            patch.object(
+                image_service,
+                "generate_alt_text",
+                new=AsyncMock(return_value=("Alt FR", "Alt EN")),
+            ),
+            patch.object(
+                image_service,
+                "call_dalle_and_save",
+                new=AsyncMock(side_effect=lambda img, sess: setattr(img, "status", "ready") or img),
+            ),
+        ):
+            await image_service.process_lesson_image(
+                lesson_id=lesson_id,
+                module_id=module_id,
+                unit_id="unit-01",
+                lesson_content="Lesson",
+                session=session,
+            )
+
+        assert len(initial_statuses) == 1
+        assert initial_statuses[0] == "pending"
+
+
+class TestOpenAIKeyNotExposed:
+    """Verify OpenAI API key is server-side only."""
+
+    def test_openai_key_not_in_image_service_module(self):
+        """The image_service module must not contain hardcoded API keys."""
+        import inspect
+
+        from app.domain.services import image_service as img_svc_module
+
+        source = inspect.getsource(img_svc_module)
+        assert "sk-" not in source, "No hardcoded OpenAI API key in image_service"
+
+    def test_openai_key_loaded_from_settings(self):
+        """OPENAI_API_KEY must be loaded from settings (env var), not hardcoded."""
+        from app.infrastructure.config.settings import Settings
+
+        settings_fields = Settings.model_fields
+        assert "openai_api_key" in settings_fields


### PR DESCRIPTION
## Summary

Implements the asynchronous DALL-E 3 image generation pipeline with semantic reuse (US-025, FR-03.2).

- **`GeneratedImage` model** — new SQLAlchemy model with status transitions: `pending → generating → ready | failed`, semantic tags (ARRAY), alt-text in FR/EN, WebP image data
- **Alembic migration 012** — creates `generated_images` table with appropriate indexes
- **`ImageGenerationService`** — full pipeline: Claude extracts key concept + DALL-E prompt + semantic tags → semantic reuse check (≥85% Jaccard overlap) → DALL-E 3 call → WebP conversion (max 512px) → bilingual alt-text generation
- **`generate_lesson_image` Celery task** — async, non-blocking, dispatched after lesson content is served
- **`lesson_service.py`** — dispatches image task fire-and-forget after lesson is cached
- **`OPENAI_API_KEY`** — loaded from `settings.openai_api_key` (already existed), never exposed to frontend

## Changes

- `backend/app/domain/models/image.py` — new `GeneratedImage` SQLAlchemy model
- `backend/app/domain/models/__init__.py` — register new model
- `backend/app/domain/services/image_service.py` — new `ImageGenerationService`
- `backend/app/tasks/content_generation.py` — add `generate_lesson_image` Celery task
- `backend/app/domain/services/lesson_service.py` — dispatch image task after lesson generation
- `backend/migrations/versions/012_add_generated_images_table.py` — Alembic migration
- `backend/tests/test_image_generation.py` — 12 pytest tests (all passing)

## Test plan

- [x] 12 backend unit tests pass (`pytest tests/test_image_generation.py`)
- [x] Full test suite: 38 tests pass (`pytest tests/`)
- [x] `ruff check` and `ruff format` pass with no errors
- [x] Semantic reuse: tests verify ≥85% Jaccard overlap reuses image, <85% generates new
- [x] Failure handling: DALL-E error and Claude error both set `status='failed'`
- [x] Alt-text in both FR and EN verified
- [x] `OPENAI_API_KEY` not hardcoded (test verifies server-side settings only)
- [x] Task is non-blocking — lesson is served before image dispatch

Closes #223

Generated with [Claude Code](https://claude.ai/code)