### PR TITLE
fix(frontend): use i18n-aware redirect on locale root page

### DIFF
--- a/frontend/app/[locale]/page.tsx
+++ b/frontend/app/[locale]/page.tsx
@@ -1,5 +1,5 @@
-import { redirect } from "next/navigation";
+import { redirect } from '@/i18n/routing';
 
-export default function LocaleRoot() {
-  redirect("/dashboard");
+export default function RootPage({ params }: { params: { locale: string } }) {
+  redirect({ href: '/dashboard', locale: params.locale });
 }


### PR DESCRIPTION
## Summary

- Replace `redirect('/dashboard')` from `next/navigation` with `redirect({ href: '/dashboard', locale: params.locale })` from `@/i18n/routing`
- This ensures `/` and `/fr` correctly redirect to `/fr/dashboard` (locale-prefixed), and `/en` to `/en/dashboard`

## Changes

- `frontend/app/[locale]/page.tsx` — fixed import and redirect call

## Test plan

- [x] Frontend lint passes (0 errors)
- [ ] Manually verify `/` → `/fr/dashboard` in production
- [ ] Manually verify `/en` → `/en/dashboard`

Closes #235

Generated with [Claude Code](https://claude.ai/code)