### PR TITLE
fix: root URL /undefined/dashboard — await params (Next.js 15)

### DIFF
--- a/.claude/skills/nextjs-app-router/SKILL.md
+++ b/.claude/skills/nextjs-app-router/SKILL.md
@@ -212,3 +212,53 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 - All dates: locale-aware formatting (`Intl.DateTimeFormat`)
 - Performance: <150KB JS gzipped, TTI <3s on 3G
 - Dark mode: support for battery saving on OLED screens
+
+## CRITICAL — Next.js 15 async params
+
+In Next.js 15, `params` and `searchParams` are **Promises**. You MUST `await` them.
+
+**WRONG (Next.js 14 pattern — will produce `undefined`):**
+```tsx
+export default function Page({ params }: { params: { locale: string } }) {
+  // params.locale is UNDEFINED at runtime
+}
+```
+
+**CORRECT (Next.js 15 pattern):**
+```tsx
+export default async function Page({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  // locale is now correctly "fr" or "en"
+}
+```
+
+Same for `searchParams`:
+```tsx
+export default async function Page({ searchParams }: { searchParams: Promise<{ unit?: string }> }) {
+  const { unit } = await searchParams;
+}
+```
+
+This applies to ALL `page.tsx`, `layout.tsx`, and `generateMetadata` functions.
+
+## CRITICAL — i18n routing (no double locale)
+
+NEVER manually prepend locale to paths. Use the i18n-aware router from `@/i18n/routing`:
+
+**WRONG (causes /fr/fr/dashboard):**
+```tsx
+router.push(`/${locale}/dashboard`);
+```
+
+**CORRECT:**
+```tsx
+import { useRouter } from '@/i18n/routing';
+const router = useRouter();
+router.push('/dashboard'); // automatically prepends /fr or /en
+```
+
+For server-side redirects:
+```tsx
+import { redirect } from '@/i18n/routing';
+redirect({ href: '/dashboard', locale });
+```

--- a/frontend/app/[locale]/page.tsx
+++ b/frontend/app/[locale]/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from '@/i18n/routing';
 
-export default function RootPage({ params }: { params: { locale: string } }) {
-  redirect({ href: '/dashboard', locale: params.locale });
+export default async function RootPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  redirect({ href: '/dashboard', locale });
 }


### PR DESCRIPTION
## Summary
Fixes root URL redirecting to `/undefined/dashboard` instead of `/fr/dashboard`. The root page used Next.js 14 sync params pattern but Next.js 15 requires `await`.

Also adds two CRITICAL sections to the `nextjs-app-router` skill to prevent these recurring bugs:
- Must `await` params/searchParams (Next.js 15)
- Must use i18n router, never manually prepend locale

## Changes
- `frontend/app/[locale]/page.tsx` — async function + await params
- `.claude/skills/nextjs-app-router/SKILL.md` — two critical rules added

## Test plan
- [ ] `/` redirects to `/fr/dashboard`
- [ ] `/fr` redirects to `/fr/dashboard`
- [ ] No `/undefined/` in any URL

Closes #235