### PR TITLE
feat(e2e): add navigation tests to prevent redirect regressions (#244)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,48 @@ jobs:
         run: npm run build
         env:
           NEXT_PUBLIC_API_URL: http://localhost:8000
+
+  e2e:
+    name: E2E Tests (Playwright)
+    runs-on: ubuntu-latest
+    needs: frontend
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Build
+        run: npm run build
+        env:
+          NEXT_PUBLIC_API_URL: http://localhost:8000
+
+      - name: Start app and run E2E tests
+        run: |
+          npm run start &
+          for i in $(seq 1 30); do curl -sf http://localhost:3000 && break || sleep 2; done
+          NO_WEB_SERVER=1 npx playwright test e2e/navigation.spec.ts --project=mobile-chrome
+        env:
+          BASE_URL: http://localhost:3000
+          NEXT_PUBLIC_API_URL: http://localhost:8000
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect } from '@playwright/test';
+
+test.use({ viewport: { width: 360, height: 640 } });
+
+test.describe('Navigation redirects', () => {
+  test('/ redirects to /fr/dashboard (not /undefined/dashboard, not /fr/fr/dashboard)', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('access_token', 'fake-token');
+      localStorage.setItem('refresh_token', 'fake-refresh');
+    });
+
+    await page.route('**/api/v1/dashboard/stats', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          streak_days: 0,
+          is_active_today: false,
+          average_quiz_score: 0,
+          total_time_studied_this_week: 0,
+          next_review_count: 0,
+          modules_in_progress: 0,
+          completion_percentage: 0,
+        }),
+      })
+    );
+
+    await page.goto('/');
+    await page.waitForURL(/\/fr\/dashboard/, { timeout: 10000 });
+
+    const url = page.url();
+    expect(url).toMatch(/\/fr\/dashboard/);
+    expect(url).not.toMatch(/\/undefined\//);
+    expect(url).not.toMatch(/\/fr\/fr\//);
+  });
+
+  test('/fr redirects to /fr/dashboard', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('access_token', 'fake-token');
+      localStorage.setItem('refresh_token', 'fake-refresh');
+    });
+
+    await page.route('**/api/v1/dashboard/stats', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          streak_days: 0,
+          is_active_today: false,
+          average_quiz_score: 0,
+          total_time_studied_this_week: 0,
+          next_review_count: 0,
+          modules_in_progress: 0,
+          completion_percentage: 0,
+        }),
+      })
+    );
+
+    await page.goto('/fr');
+    await page.waitForURL(/\/fr\/dashboard/, { timeout: 10000 });
+
+    const url = page.url();
+    expect(url).toMatch(/\/fr\/dashboard/);
+    expect(url).not.toMatch(/\/undefined\//);
+    expect(url).not.toMatch(/\/fr\/fr\//);
+  });
+
+  test('login with valid credentials redirects to /fr/dashboard', async ({ page }) => {
+    await page.route('**/api/v1/auth/login', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          access_token: 'fake-token',
+          refresh_token: 'fake-refresh',
+          user: { id: '1', name: 'Dr. Test', email: 'test@example.com' },
+        }),
+      })
+    );
+
+    await page.route('**/api/v1/dashboard/stats', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          streak_days: 0,
+          is_active_today: false,
+          average_quiz_score: 0,
+          total_time_studied_this_week: 0,
+          next_review_count: 0,
+          modules_in_progress: 0,
+          completion_percentage: 0,
+        }),
+      })
+    );
+
+    await page.goto('/fr/login');
+    await page.locator('#email').fill('test@example.com');
+    await page.locator('#totp_code').fill('123456');
+    await page.getByRole('button', { name: /Se connecter|Sign in/i }).click();
+
+    await page.waitForURL(/\/fr\/dashboard/, { timeout: 10000 });
+
+    const url = page.url();
+    expect(url).toMatch(/\/fr\/dashboard/);
+    expect(url).not.toMatch(/\/undefined\//);
+    expect(url).not.toMatch(/\/fr\/fr\//);
+  });
+
+  test('module unit links resolve without 404', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('access_token', 'fake-token');
+      localStorage.setItem('refresh_token', 'fake-refresh');
+    });
+
+    await page.goto('/fr/modules/M01');
+
+    const unitLinks = page.locator('a[href*="/modules/M01/"]');
+    const count = await unitLinks.count();
+
+    if (count > 0) {
+      const href = await unitLinks.first().getAttribute('href');
+      expect(href).toBeTruthy();
+      expect(href).not.toMatch(/\/undefined\//);
+      expect(href).not.toMatch(/\/fr\/fr\//);
+
+      const [response] = await Promise.all([
+        page.waitForResponse((r) => r.url().includes(href!) && r.status() !== 500, {
+          timeout: 5000,
+        }).catch(() => null),
+        page.goto(href!),
+      ]);
+
+      const url = page.url();
+      expect(url).not.toMatch(/\/undefined\//);
+      expect(url).not.toMatch(/\/fr\/fr\//);
+      await expect(page.locator('body')).not.toContainText('404', { timeout: 5000 });
+
+      void response;
+    }
+  });
+
+  test('module unit links do not contain /undefined/ in href', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('access_token', 'fake-token');
+      localStorage.setItem('refresh_token', 'fake-refresh');
+    });
+
+    await page.goto('/fr/modules/M01');
+
+    const allLinks = await page.locator('a[href]').all();
+    for (const link of allLinks) {
+      const href = await link.getAttribute('href');
+      if (href && href.includes('/modules/')) {
+        expect(href).not.toMatch(/\/undefined\//);
+        expect(href).not.toMatch(/\/fr\/fr\//);
+      }
+    }
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "test:e2e:dashboard": "npx playwright test e2e/dashboard.spec.ts",
     "test:e2e:modules": "npx playwright test e2e/modules.spec.ts",
     "test:e2e:quiz": "npx playwright test e2e/quiz.spec.ts",
-    "test:e2e:i18n": "npx playwright test e2e/i18n.spec.ts"
+    "test:e2e:i18n": "npx playwright test e2e/i18n.spec.ts",
+    "test:e2e:navigation": "npx playwright test e2e/navigation.spec.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",


### PR DESCRIPTION
## Summary

Adds Playwright E2E tests that catch the two most recurring bug classes on this platform:
- **Double locale prefix** (`/fr/fr/dashboard`) — 9+ issues historically
- **Undefined params** (`/undefined/dashboard`)

Also adds a new `e2e` CI job that runs the navigation tests on every PR.

## Changes

- `frontend/e2e/navigation.spec.ts` — new test file with 5 navigation tests
  - `/` → `/fr/dashboard` (not `/undefined/`, not `/fr/fr/`)
  - `/fr` → `/fr/dashboard` (same guards)
  - Login redirect → `/fr/dashboard`
  - Module unit links resolve (no `/undefined/` in hrefs)
  - All unit link hrefs free of double-prefix or undefined params
- `.github/workflows/ci.yml` — new `e2e` job (runs after `frontend`, builds the app, installs Playwright Chromium, starts `next start`, runs navigation spec at 360×640 mobile viewport)
- `frontend/package.json` — added `test:e2e:navigation` convenience script

## Test plan

- [ ] `npm run test:e2e:navigation` passes locally
- [ ] CI `e2e` job green on this PR

Closes #244

Generated with [Claude Code](https://claude.ai/code)