### PR TITLE
fix(rag): use unit-specific metadata in lesson RAG query (#243)

### DIFF
--- a/backend/app/domain/models/__init__.py
+++ b/backend/app/domain/models/__init__.py
@@ -5,6 +5,7 @@ from app.domain.models.conversation import TutorConversation
 from app.domain.models.document_chunk import DocumentChunk
 from app.domain.models.flashcard import FlashcardReview
 from app.domain.models.module import Module
+from app.domain.models.module_unit import ModuleUnit
 from app.domain.models.progress import UserModuleProgress
 from app.domain.models.quiz import QuizAttempt
 from app.domain.models.user import User
@@ -17,6 +18,7 @@ __all__ = [
     "FlashcardReview",
     "MagicLink",
     "Module",
+    "ModuleUnit",
     "RefreshToken",
     "TOTPSecret",
     "UserModuleProgress",

--- a/backend/app/domain/models/module.py
+++ b/backend/app/domain/models/module.py
@@ -12,6 +12,7 @@ from app.domain.models.base import Base
 if TYPE_CHECKING:
     from app.domain.models.content import GeneratedContent
     from app.domain.models.conversation import TutorConversation
+    from app.domain.models.module_unit import ModuleUnit
     from app.domain.models.progress import UserModuleProgress
     from app.domain.models.quiz import SummativeAssessmentAttempt
 
@@ -39,3 +40,4 @@ class Module(Base):
     summative_attempts: Mapped[list[SummativeAssessmentAttempt]] = relationship(
         back_populates="module"
     )
+    units: Mapped[list[ModuleUnit]] = relationship(back_populates="module")

--- a/backend/app/domain/models/module_unit.py
+++ b/backend/app/domain/models/module_unit.py
@@ -1,0 +1,38 @@
+"""Domain model for module units in the curriculum."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from app.domain.models.base import Base
+
+if TYPE_CHECKING:
+    from app.domain.models.module import Module
+
+
+class ModuleUnit(Base):
+    """Represents a unit within a curriculum module."""
+
+    __tablename__ = "module_units"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    module_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("modules.id"), nullable=False, index=True
+    )
+    unit_number: Mapped[str] = mapped_column(String(10), nullable=False)
+    title_fr: Mapped[str] = mapped_column(Text, nullable=False)
+    title_en: Mapped[str] = mapped_column(Text, nullable=False)
+    description_fr: Mapped[str | None] = mapped_column(Text, nullable=True)
+    description_en: Mapped[str | None] = mapped_column(Text, nullable=True)
+    estimated_minutes: Mapped[int] = mapped_column(Integer, server_default="45")
+    order_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(default=func.now())
+
+    module: Mapped[Module] = relationship(back_populates="units")

--- a/backend/app/domain/services/lesson_service.py
+++ b/backend/app/domain/services/lesson_service.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncGenerator
 from datetime import datetime
 
 import structlog
-from sqlalchemy import select
+from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.ai.claude_service import ClaudeService
@@ -14,6 +14,7 @@ from app.ai.rag.retriever import SemanticRetriever
 from app.api.v1.schemas.content import LessonContent, LessonResponse, StreamingEvent
 from app.domain.models.content import GeneratedContent
 from app.domain.models.module import Module
+from app.domain.models.module_unit import ModuleUnit
 
 logger = structlog.get_logger()
 
@@ -143,7 +144,7 @@ class LessonGenerationService:
             # Perform RAG retrieval
             yield StreamingEvent(event="chunk", data="Recherche des documents pertinents...")
 
-            query = await self._build_lesson_query(module, unit_id, language)
+            query = await self._build_lesson_query(module, unit_id, language, session)
             rag_chunks = await self.semantic_retriever.search_for_module(
                 query=query,
                 user_level=level,
@@ -255,7 +256,7 @@ class LessonGenerationService:
     ) -> LessonResponse:
         """Generate new lesson content using RAG + Claude."""
         # Build search query
-        query = await self._build_lesson_query(module, unit_id, language)
+        query = await self._build_lesson_query(module, unit_id, language, session)
 
         # Perform RAG retrieval
         rag_chunks = await self.semantic_retriever.search_for_module(
@@ -306,20 +307,52 @@ class LessonGenerationService:
             cached=False,
         )
 
-    async def _build_lesson_query(self, module: Module, unit_id: str, language: str) -> str:
-        """Build search query for RAG retrieval."""
-        # Use module title and description as base query
-        title = module.title_fr if language == "fr" else module.title_en
-        description = module.description_fr if language == "fr" else module.description_en
+    async def _build_lesson_query(
+        self, module: Module, unit_id: str, language: str, session: AsyncSession
+    ) -> str:
+        """Build search query for RAG retrieval using unit-specific metadata."""
+        unit_number = self._unit_id_to_unit_number(unit_id, module.module_number)
+        unit: ModuleUnit | None = None
 
-        # Combine title, unit_id and description for comprehensive search
-        query_parts = [title]
-        if unit_id:
-            query_parts.append(f"unit {unit_id}")
-        if description:
-            query_parts.append(description[:200])  # Limit description length
+        if unit_number:
+            unit_result = await session.execute(
+                select(ModuleUnit).where(
+                    and_(
+                        ModuleUnit.module_id == module.id,
+                        ModuleUnit.unit_number == unit_number,
+                    )
+                )
+            )
+            unit = unit_result.scalar_one_or_none()
+
+        if unit:
+            unit_title = unit.title_fr if language == "fr" else unit.title_en
+            unit_description = unit.description_fr if language == "fr" else unit.description_en
+            query_parts = [unit_title]
+            if unit_description:
+                query_parts.append(unit_description[:200])
+        else:
+            title = module.title_fr if language == "fr" else module.title_en
+            description = module.description_fr if language == "fr" else module.description_en
+            query_parts = [title]
+            if unit_id:
+                query_parts.append(f"unit {unit_id}")
+            if description:
+                query_parts.append(description[:200])
 
         return " ".join(query_parts)
+
+    @staticmethod
+    def _unit_id_to_unit_number(unit_id: str, module_number: int) -> str | None:
+        """Convert unit_id like 'M01-U02' to unit_number like '1.2'."""
+        try:
+            parts = unit_id.upper().split("-U")
+            if len(parts) != 2:
+                return None
+            unit_ordinal = int(parts[1])
+            return f"{module_number}.{unit_ordinal}"
+        except (ValueError, IndexError):
+            return None
 
     async def _parse_lesson_content(self, content_text: str, rag_chunks: list) -> LessonContent:
         """Parse generated content into structured lesson format."""

--- a/backend/migrations/versions/012_invalidate_m01_m03_cached_lessons.py
+++ b/backend/migrations/versions/012_invalidate_m01_m03_cached_lessons.py
@@ -1,0 +1,32 @@
+"""Invalidate cached lesson content for M01-M03 units
+
+Deletes previously generated lesson content for modules M01, M02, and M03
+so that lessons are regenerated with unit-specific RAG queries.
+
+Revision ID: 012_invalidate_m01_m03_cached_lessons
+Revises: 0d1135672916
+Create Date: 2026-04-01
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "012_invalidate_m01_m03_cached_lessons"
+down_revision: str | None = "0d1135672916"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        DELETE FROM generated_content
+        WHERE content_type = 'lesson'
+          AND module_id IN (
+              SELECT id FROM modules WHERE module_number IN (1, 2, 3)
+          )
+    """)
+
+
+def downgrade() -> None:
+    pass

--- a/backend/tests/test_lesson_query_builder.py
+++ b/backend/tests/test_lesson_query_builder.py
@@ -1,0 +1,167 @@
+"""Tests for lesson query builder — verifies unit-specific RAG queries."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.ai.claude_service import ClaudeService
+from app.ai.rag.retriever import SemanticRetriever
+from app.domain.models.module import Module
+from app.domain.models.module_unit import ModuleUnit
+from app.domain.services.lesson_service import LessonGenerationService
+
+
+@pytest.fixture
+def lesson_service():
+    return LessonGenerationService(
+        claude_service=AsyncMock(spec=ClaudeService),
+        semantic_retriever=AsyncMock(spec=SemanticRetriever),
+    )
+
+
+@pytest.fixture
+def sample_module() -> Module:
+    module = Module(
+        id=uuid.uuid4(),
+        module_number=1,
+        level=1,
+        title_fr="Fondements de la Santé Publique",
+        title_en="Foundations of Public Health",
+        description_fr="Introduction aux concepts de santé publique",
+        description_en="Introduction to public health concepts",
+        bloom_level="remember",
+        books_sources={"donaldson": ["chapter_1", "chapter_2"]},
+    )
+    return module
+
+
+@pytest.fixture
+def sample_unit_u01() -> ModuleUnit:
+    return ModuleUnit(
+        id=uuid.uuid4(),
+        module_id=uuid.uuid4(),
+        unit_number="1.1",
+        title_fr="Histoire et définition de la santé publique",
+        title_en="History and definition of public health",
+        description_fr="Evolution de la santé publique, définitions clés, cadre conceptuel moderne",
+        description_en="Evolution of public health, key definitions, modern conceptual framework",
+        order_index=1,
+    )
+
+
+@pytest.fixture
+def sample_unit_u02() -> ModuleUnit:
+    return ModuleUnit(
+        id=uuid.uuid4(),
+        module_id=uuid.uuid4(),
+        unit_number="1.2",
+        title_fr="Principes de prévention et promotion",
+        title_en="Prevention and promotion principles",
+        description_fr="Prévention primaire, secondaire, tertiaire et promotion de la santé",
+        description_en="Primary, secondary, tertiary prevention and health promotion",
+        order_index=2,
+    )
+
+
+class TestUnitIdToUnitNumber:
+    def test_m01_u01_maps_to_1_1(self, lesson_service):
+        assert lesson_service._unit_id_to_unit_number("M01-U01", 1) == "1.1"
+
+    def test_m01_u02_maps_to_1_2(self, lesson_service):
+        assert lesson_service._unit_id_to_unit_number("M01-U02", 1) == "1.2"
+
+    def test_m01_u03_maps_to_1_3(self, lesson_service):
+        assert lesson_service._unit_id_to_unit_number("M01-U03", 1) == "1.3"
+
+    def test_m02_u01_maps_to_2_1(self, lesson_service):
+        assert lesson_service._unit_id_to_unit_number("M02-U01", 2) == "2.1"
+
+    def test_lowercase_unit_id(self, lesson_service):
+        assert lesson_service._unit_id_to_unit_number("m01-u02", 1) == "1.2"
+
+    def test_invalid_unit_id_returns_none(self, lesson_service):
+        assert lesson_service._unit_id_to_unit_number("INVALID", 1) is None
+
+    def test_empty_unit_id_returns_none(self, lesson_service):
+        assert lesson_service._unit_id_to_unit_number("", 1) is None
+
+
+class TestBuildLessonQuery:
+    @pytest.mark.asyncio
+    async def test_uses_unit_title_when_unit_found(
+        self, lesson_service, sample_module, sample_unit_u01
+    ):
+        session = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = sample_unit_u01
+        session.execute = AsyncMock(return_value=mock_result)
+
+        query = await lesson_service._build_lesson_query(sample_module, "M01-U01", "fr", session)
+
+        assert "Histoire et définition de la santé publique" in query
+        assert "Evolution de la santé publique" in query
+        assert "unit M01-U01" not in query
+
+    @pytest.mark.asyncio
+    async def test_uses_english_title_for_en_language(
+        self, lesson_service, sample_module, sample_unit_u01
+    ):
+        session = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = sample_unit_u01
+        session.execute = AsyncMock(return_value=mock_result)
+
+        query = await lesson_service._build_lesson_query(sample_module, "M01-U01", "en", session)
+
+        assert "History and definition of public health" in query
+        assert "Evolution of public health" in query
+
+    @pytest.mark.asyncio
+    async def test_different_units_produce_different_queries(
+        self, lesson_service, sample_module, sample_unit_u01, sample_unit_u02
+    ):
+        session = AsyncMock(spec=AsyncSession)
+
+        mock_result_u01 = MagicMock()
+        mock_result_u01.scalar_one_or_none.return_value = sample_unit_u01
+
+        mock_result_u02 = MagicMock()
+        mock_result_u02.scalar_one_or_none.return_value = sample_unit_u02
+
+        session.execute = AsyncMock(side_effect=[mock_result_u01, mock_result_u02])
+
+        query_u01 = await lesson_service._build_lesson_query(
+            sample_module, "M01-U01", "fr", session
+        )
+        query_u02 = await lesson_service._build_lesson_query(
+            sample_module, "M01-U02", "fr", session
+        )
+
+        assert query_u01 != query_u02
+        assert "Histoire et définition" in query_u01
+        assert "Principes de prévention" in query_u02
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_module_data_when_unit_not_found(
+        self, lesson_service, sample_module
+    ):
+        session = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+
+        query = await lesson_service._build_lesson_query(sample_module, "M01-U99", "fr", session)
+
+        assert "Fondements de la Santé Publique" in query
+        assert "unit M01-U99" in query
+
+    @pytest.mark.asyncio
+    async def test_falls_back_for_invalid_unit_id(self, lesson_service, sample_module):
+        session = AsyncMock(spec=AsyncSession)
+
+        query = await lesson_service._build_lesson_query(sample_module, "INVALID", "fr", session)
+
+        assert "Fondements de la Santé Publique" in query
+        session.execute.assert_not_called()


### PR DESCRIPTION
## Summary

- All M01-M03 units were generating identical lesson content because `_build_lesson_query()` only used the raw `unit_id` string ("unit M01-U01"), not the unit's actual topic metadata
- Added `ModuleUnit` ORM model mapping to the existing `module_units` table
- Fixed `_build_lesson_query()` to look up the unit's `title_fr`/`title_en` and `description_fr`/`description_en` from `module_units`, producing topic-specific RAG queries
- Added a `_unit_id_to_unit_number()` helper that converts "M01-U01" → "1.1" to join against `unit_number` in the table
- Added Alembic migration to delete stale M01-M03 cached lessons so they regenerate with correct queries

## Changes

- `backend/app/domain/models/module_unit.py` — new ORM model for `module_units` table
- `backend/app/domain/models/module.py` — added `units` relationship
- `backend/app/domain/models/__init__.py` — registered `ModuleUnit`
- `backend/app/domain/services/lesson_service.py` — fixed `_build_lesson_query()` and `_unit_id_to_unit_number()` helper
- `backend/migrations/versions/012_invalidate_m01_m03_cached_lessons.py` — deletes stale cached lessons
- `backend/tests/test_lesson_query_builder.py` — 12 new tests (all passing)

## Test plan

- [x] Backend lint passes (`ruff check --fix .` — 1 auto-fix applied)
- [x] 12 new unit tests pass (`pytest tests/test_lesson_query_builder.py`)
- [ ] Manually verify M01-U01, M01-U02, M01-U03 generate distinct content on staging

Closes #243

Generated with [Claude Code](https://claude.ai/code)