### PR TITLE
fix(placement): use authClient.authenticatedFetch instead of wrong token key

### DIFF
--- a/frontend/components/placement/placement-test-interface.tsx
+++ b/frontend/components/placement/placement-test-interface.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
-import { API_BASE } from '@/lib/api';
+import { authClient } from '@/lib/auth';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -51,17 +51,7 @@ export function PlacementTestInterface({ onComplete, locale }: PlacementTestInte
   useEffect(() => {
     const loadQuestions = async () => {
       try {
-        const response = await fetch(`${API_BASE}/api/v1/placement-test/questions`, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-          },
-        });
-
-        if (!response.ok) {
-          throw new Error('Failed to load questions');
-        }
-
-        const data = await response.json();
+        const data = await authClient.authenticatedFetch<PlacementTestData>('/api/v1/placement-test/questions');
         setTestData(data);
         setTimeLeft(data.time_limit_minutes * 60);
       } catch (error) {
@@ -120,24 +110,17 @@ export function PlacementTestInterface({ onComplete, locale }: PlacementTestInte
 
     try {
       const timeTaken = Math.floor((Date.now() - startTime) / 1000);
-      
-      const response = await fetch(`${API_BASE}/api/v1/placement-test/submit`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${localStorage.getItem('token')}`,
-        },
-        body: JSON.stringify({
-          answers,
-          time_taken_sec: timeTaken,
-        }),
-      });
 
-      if (!response.ok) {
-        throw new Error('Failed to submit placement test');
-      }
-
-      const result = await response.json();
+      const result = await authClient.authenticatedFetch(
+        '/api/v1/placement-test/submit',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            answers,
+            time_taken_sec: timeTaken,
+          }),
+        }
+      );
       onComplete(result);
     } catch (error) {
       console.error('Failed to submit placement test:', error);


### PR DESCRIPTION
## Summary

- Replace `localStorage.getItem('token')` with `authClient.authenticatedFetch()` in `placement-test-interface.tsx`
- Auth system stores JWT as `access_token` but placement test was reading `token` key → `null` → `"Bearer null"` → 401
- Both the questions fetch (line 55) and the submit fetch (line 127) are fixed
- Now uses the same auth pattern as `getDashboardStats` in `lib/api.ts` (with automatic token refresh on 401)

## Changes

- `frontend/components/placement/placement-test-interface.tsx` — replaced raw `fetch` calls with `authClient.authenticatedFetch`

## Test plan

- [x] Frontend lint passes (`npm run lint` — 0 errors)
- [x] Frontend build passes (`npm run build`)
- [ ] Manually verify placement test loads after login

Closes #252

Generated with [Claude Code](https://claude.ai/code)