### PR TITLE
fix(chat): refresh access token before SSE tutor requests

### DIFF
--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -27,6 +27,8 @@ import { TypingIndicator } from './typing-indicator';
 import { UsageCounter } from './usage-counter';
 import { ChatSkeleton } from './chat-skeleton';
 import { cn } from '@/lib/utils';
+import { authClient, AuthError } from '@/lib/auth';
+import { useRouter } from 'next/navigation';
 
 interface ChatPanelProps {
   isOpen: boolean;
@@ -37,6 +39,7 @@ interface ChatPanelProps {
 
 export function ChatPanel({ isOpen, onClose, moduleId, className }: ChatPanelProps) {
   const t = useTranslations('ChatTutor');
+  const router = useRouter();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isTyping, setIsTyping] = useState(false);
@@ -86,12 +89,21 @@ export function ChatPanel({ isOpen, onClose, moduleId, className }: ChatPanelPro
 
     try {
       const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
-      const token = localStorage.getItem("access_token");
+      let token: string;
+      try {
+        token = await authClient.getValidToken();
+      } catch (err) {
+        if (err instanceof AuthError && err.status === 401) {
+          router.push('/login');
+          return;
+        }
+        throw err;
+      }
       const response = await fetch(`${API_BASE}/api/v1/tutor/chat`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
           message: messageContent,
@@ -100,6 +112,10 @@ export function ChatPanel({ isOpen, onClose, moduleId, className }: ChatPanelPro
       });
 
       if (!response.ok) {
+        if (response.status === 401) {
+          router.push('/login');
+          return;
+        }
         throw new Error(`API error: ${response.status}`);
       }
 

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -314,6 +314,42 @@ class AuthClient {
   }
 
   /**
+   * Get a valid (non-expired) access token, refreshing if needed.
+   * Throws AuthError if no refresh token is available or refresh fails.
+   */
+  async getValidToken(): Promise<string> {
+    if (this.accessToken && !this.isTokenExpired(this.accessToken)) {
+      return this.accessToken;
+    }
+
+    if (!this.refreshToken) {
+      this.clearTokens();
+      throw new AuthError('Session expired. Please log in again.', 401);
+    }
+
+    await this.refreshAccessToken();
+
+    if (!this.accessToken) {
+      this.clearTokens();
+      throw new AuthError('Session expired. Please log in again.', 401);
+    }
+
+    return this.accessToken;
+  }
+
+  private isTokenExpired(token: string): boolean {
+    try {
+      const payload = token.split('.')[1];
+      if (!payload) return true;
+      const decoded = JSON.parse(atob(payload));
+      if (!decoded.exp) return false;
+      return decoded.exp * 1000 < Date.now() + 30_000;
+    } catch {
+      return true;
+    }
+  }
+
+  /**
    * Make an authenticated API call to any endpoint
    */
   async authenticatedFetch<T>(


### PR DESCRIPTION
## Summary

- Add `getValidToken()` to `AuthClient` in `frontend/lib/auth.ts`: decodes JWT expiry proactively, refreshes 30s before expiry, throws `AuthError(401)` when refresh fails
- Add private `isTokenExpired()` helper using `atob` JWT payload decode  
- Fix `frontend/components/chat/chat-panel.tsx` lines 89-90: replace `localStorage.getItem("access_token")` with `authClient.getValidToken()` for token-refreshing SSE requests
- Redirect to `/login` when token refresh fails or server returns 401

## Changes

- `frontend/lib/auth.ts` — added `getValidToken(): Promise<string>` and `private isTokenExpired()` methods
- `frontend/components/chat/chat-panel.tsx` — import `authClient` + `AuthError`, use `getValidToken()` before SSE fetch, redirect to login on 401

## Test plan

- [x] `npm run lint` passes (0 errors)
- [x] `npm run build` passes
- [ ] Manually verify: log in, wait 15+ min, send tutor message → works without 401
- [ ] Manually verify: with expired refresh token → redirected to /login

Closes #256

Generated with [Claude Code](https://claude.ai/code)