### PR TITLE
fix(docker): add missing backend service to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,31 @@ services:
       timeout: 5s
       retries: 5
 
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: santepublique-backend
+    environment:
+      DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/santepublique_aof
+      DATABASE_URL_SYNC: postgresql://postgres:postgres@postgres:5432/santepublique_aof
+      REDIS_URL: redis://redis:6379/0
+      APP_ENV: development
+      CORS_ORIGINS: http://localhost:3000
+    ports:
+      - "8000:8000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
+
 volumes:
   pgdata:
   redisdata:


### PR DESCRIPTION
## Summary
- `docker-compose.yml` was missing the `backend` service entirely, causing `docker compose up` to fail with exit code 1 when trying to start the backend container
- Added a complete `backend` service definition matching the pattern from `docker-compose.prod.yml`

## Changes
- `docker-compose.yml`: Added `backend` service with build context, environment variables (DATABASE_URL, DATABASE_URL_SYNC, REDIS_URL, APP_ENV, CORS_ORIGINS), port mapping (8000), `depends_on` postgres and redis health checks, and healthcheck using the `/health` endpoint

## Test plan
- [ ] `docker compose up backend` starts without crash
- [ ] `docker compose logs backend` shows uvicorn startup, no import errors
- [ ] `curl http://localhost:8000/health` returns `{"status":"healthy","service":"santepublique-aof-api"}`
- [ ] Backend lint passes: `cd backend && uv run ruff check .`

Closes #171

Generated with [Claude Code](https://claude.ai/code)