### PR TITLE
fix(api): add Authorization header to apiFetch with token refresh

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -4,9 +4,24 @@ export async function apiFetch<T>(
   path: string,
   options?: RequestInit
 ): Promise<T> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...(options?.headers as Record<string, string>),
+  };
+
+  if (typeof window !== "undefined") {
+    try {
+      const { authClient } = await import("./auth");
+      const token = await authClient.getValidToken();
+      headers["Authorization"] = `Bearer ${token}`;
+    } catch {
+      // No valid token — proceed without auth header (unauthenticated call)
+    }
+  }
+
   const res = await fetch(`${API_BASE}${path}`, {
     ...options,
-    headers: { "Content-Type": "application/json", ...options?.headers },
+    headers,
   });
   if (!res.ok) throw new Error(`API error: ${res.status}`);
   return res.json();


### PR DESCRIPTION
## Summary

`apiFetch` in `frontend/lib/api.ts` was not including an `Authorization` header, causing all authenticated API calls (quiz generation, quiz submission, summative assessment, etc.) to fail with 401.

## Changes

- `frontend/lib/api.ts`: Updated `apiFetch` to dynamically import `authClient` and call `getValidToken()` (which handles token refresh automatically). If no token is available (unauthenticated), the call proceeds without the header.

## How it works

- On client-side (`typeof window !== "undefined"`), `authClient.getValidToken()` is called
- If the token is valid, `Authorization: Bearer <token>` is added to the request
- If the token is expired but a refresh token exists, it is automatically refreshed
- If no token exists (unauthenticated call), the error is caught and the request proceeds without auth

## Test plan

- [x] `npm run lint` passes (0 errors)
- [x] `npm run build` passes
- [ ] Quiz page loads and generates questions
- [ ] Unauthenticated calls still work

Closes #263

Generated with [Claude Code](https://claude.ai/code)