### PR TITLE
fix(quiz): resolve frontend quiz page errors before backend reaches handler

### DIFF
--- a/backend/app/api/v1/quiz.py
+++ b/backend/app/api/v1/quiz.py
@@ -1,5 +1,6 @@
 """Quiz API endpoints for generating and taking quizzes."""
 
+import re
 import uuid
 from datetime import UTC
 from uuid import UUID
@@ -33,6 +34,34 @@ from app.infrastructure.config.settings import get_settings
 
 logger = structlog.get_logger()
 router = APIRouter(prefix="/quiz", tags=["quiz"])
+
+
+async def _resolve_module_uuid(module_id_str: str, session: AsyncSession) -> UUID:
+    """
+    Resolve a module identifier to a UUID.
+
+    Accepts:
+    - A bare UUID string (e.g. "123e4567-e89b-12d3-a456-426614174000")
+    - A module-number shorthand (e.g. "M01", "m1", "1")
+
+    Raises ValueError if not found.
+    """
+    try:
+        return UUID(module_id_str)
+    except ValueError:
+        pass
+
+    # Extract the numeric part from strings like "M01", "M1", "01", "1"
+    match = re.fullmatch(r"[Mm]?0*(\d+)", module_id_str.strip())
+    if not match:
+        raise ValueError(f"Module '{module_id_str}' not found")
+    module_number = int(match.group(1))
+
+    result = await session.execute(select(Module).where(Module.module_number == module_number))
+    module = result.scalar_one_or_none()
+    if not module:
+        raise ValueError(f"Module '{module_id_str}' not found")
+    return module.id
 
 
 def get_claude_service() -> ClaudeService:
@@ -93,9 +122,11 @@ async def generate_quiz(
     **Rate Limiting**: Quiz generation is subject to API limits.
     """
     try:
+        module_uuid = await _resolve_module_uuid(request.module_id, session)
+
         logger.info(
             "Quiz generation requested",
-            module_id=str(request.module_id),
+            module_id=str(module_uuid),
             unit_id=request.unit_id,
             language=request.language,
             country=request.country,
@@ -104,7 +135,7 @@ async def generate_quiz(
         )
 
         quiz_response = await quiz_service.get_or_generate_quiz(
-            module_id=request.module_id,
+            module_id=module_uuid,
             unit_id=request.unit_id,
             language=request.language,
             country=request.country,
@@ -408,9 +439,11 @@ async def generate_summative_assessment(
     - Can gate progression to next module
     """
     try:
+        module_uuid = await _resolve_module_uuid(request.module_id, session)
+
         logger.info(
             "Summative assessment generation requested",
-            module_id=str(request.module_id),
+            module_id=str(module_uuid),
             language=request.language,
             country=request.country,
             level=request.level,
@@ -418,7 +451,7 @@ async def generate_summative_assessment(
 
         # Generate summative assessment with specific parameters
         quiz_response = await quiz_service.get_or_generate_quiz(
-            module_id=request.module_id,
+            module_id=module_uuid,
             unit_id="summative",  # Special unit ID for summative assessments
             language=request.language,
             country=request.country,

--- a/backend/app/api/v1/schemas/quiz.py
+++ b/backend/app/api/v1/schemas/quiz.py
@@ -88,7 +88,9 @@ class QuizResponse(BaseModel):
 class QuizGenerationRequest(BaseModel):
     """Request to generate or retrieve a quiz."""
 
-    module_id: UUID = Field(description="Module ID to generate quiz for")
+    module_id: str = Field(
+        description="Module ID or module number string (e.g. 'M01') to generate quiz for"
+    )
     unit_id: str = Field(description="Unit identifier within module")
     language: str = Field(description="Content language", pattern="^(fr|en)$")
     country: str = Field(description="User's country for contextualization")
@@ -101,7 +103,9 @@ class QuizGenerationRequest(BaseModel):
 class SummativeAssessmentRequest(BaseModel):
     """Request to generate or retrieve a summative assessment."""
 
-    module_id: UUID = Field(description="Module ID to generate assessment for")
+    module_id: str = Field(
+        description="Module ID or module number string (e.g. 'M01') to generate assessment for"
+    )
     language: str = Field(description="Content language", pattern="^(fr|en)$")
     country: str = Field(description="User's country for contextualization")
     level: int = Field(description="User's learning level (1-4)", ge=1, le=4)

--- a/frontend/app/[locale]/(app)/modules/[moduleId]/quiz/page.tsx
+++ b/frontend/app/[locale]/(app)/modules/[moduleId]/quiz/page.tsx
@@ -1,9 +1,9 @@
-import { notFound, redirect } from 'next/navigation';
-import { getLocale } from 'next-intl/server';
+import { notFound } from 'next/navigation';
+import { getTranslations, getLocale } from 'next-intl/server';
 import { Link } from '@/i18n/routing';
 import { ChevronLeft } from 'lucide-react';
-import { QuizContainer } from '@/components/quiz/quiz-container';
 import { getModuleById } from '@/lib/modules';
+import { QuizPageClient } from './quiz-page-client';
 
 interface QuizPageProps {
   params: Promise<{ moduleId: string }>;
@@ -14,53 +14,40 @@ export default async function QuizPage({ params, searchParams }: QuizPageProps) 
   const { moduleId } = await params;
   const { unit } = await searchParams;
   const locale = await getLocale();
-  
+  const t = await getTranslations('QuizPage');
+
   const moduleData = getModuleById(moduleId);
-  
+
   if (!moduleData) {
     notFound();
   }
-  
-  // Default to a unit if not specified (for now use a default)
+
   const unitId = unit || 'unit-1';
   const language = locale as 'en' | 'fr';
-  
-  // Mock user data - in real app, get from auth context
+
   const userData = {
-    country: 'senegal', // Default country
-    level: 2, // Default level
+    country: 'senegal',
+    level: 2,
   };
-  
-  const handleQuizComplete = () => {
-    // Redirect back to module overview
-    redirect(`/${locale}/modules/${moduleId}`);
-  };
-  
+
   return (
     <div className="container mx-auto max-w-6xl px-4 py-6">
-      {/* Breadcrumb */}
       <div className="mb-6">
-        <Link 
-          href={`/modules/${moduleId}`} 
+        <Link
+          href={`/modules/${moduleId}`}
           className="inline-flex items-center text-stone-600 hover:text-stone-900 transition-colors"
         >
           <ChevronLeft className="w-4 h-4 mr-1" />
-          Back to {moduleData.title[language]}
+          {t('backToModule', { module: moduleData.title[language] })}
         </Link>
       </div>
-      
-      {/* Quiz Container */}
-      <QuizContainer
+
+      <QuizPageClient
         moduleId={moduleId}
         unitId={unitId}
         language={language}
         country={userData.country}
         level={userData.level}
-        onComplete={handleQuizComplete}
-        onError={(error) => {
-          console.error('Quiz error:', error);
-          // In real app, might show toast notification
-        }}
       />
     </div>
   );

--- a/frontend/app/[locale]/(app)/modules/[moduleId]/quiz/quiz-page-client.tsx
+++ b/frontend/app/[locale]/(app)/modules/[moduleId]/quiz/quiz-page-client.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useRouter } from '@/i18n/routing';
+import { QuizContainer } from '@/components/quiz/quiz-container';
+
+interface QuizPageClientProps {
+  moduleId: string;
+  unitId: string;
+  language: string;
+  country: string;
+  level: number;
+}
+
+export function QuizPageClient({
+  moduleId,
+  unitId,
+  language,
+  country,
+  level,
+}: QuizPageClientProps) {
+  const router = useRouter();
+
+  const handleQuizComplete = () => {
+    router.push(`/modules/${moduleId}`);
+  };
+
+  return (
+    <QuizContainer
+      moduleId={moduleId}
+      unitId={unitId}
+      language={language}
+      country={country}
+      level={level}
+      onComplete={handleQuizComplete}
+    />
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -23,7 +23,17 @@ export async function apiFetch<T>(
     ...options,
     headers,
   });
-  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  if (!res.ok) {
+    let message = `API error: ${res.status}`;
+    try {
+      const body = await res.json();
+      if (body?.detail?.message) message = body.detail.message;
+      else if (typeof body?.detail === 'string') message = body.detail;
+    } catch {
+      // ignore parse errors — keep the status-code message
+    }
+    throw new Error(message);
+  }
   return res.json();
 }
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -590,6 +590,9 @@
     "markComplete": "Mark as Complete",
     "completed": "Completed"
   },
+  "QuizPage": {
+    "backToModule": "Back to {module}"
+  },
   "LessonPage": {
     "modules": "Modules",
     "backToModule": "Back to Module",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -590,6 +590,9 @@
     "markComplete": "Marquer comme Terminé",
     "completed": "Terminé"
   },
+  "QuizPage": {
+    "backToModule": "Retour à {module}"
+  },
   "LessonPage": {
     "modules": "Modules",
     "backToModule": "Retour au Module",


### PR DESCRIPTION
## Summary

- **Backend type mismatch (root cause)**: `QuizGenerationRequest.module_id` was `UUID` in Pydantic — frontend sends `"M01"` causing HTTP 422 *before* the handler ran. Changed to `str` and added `_resolve_module_uuid()` helper that accepts `"M01"`, `"m1"`, `"1"`, or bare UUID strings, looking up the actual UUID from the `modules` table.
- **Server→Client function prop (Next.js error)**: `quiz/page.tsx` (Server Component) passed `handleQuizComplete` as a function prop to `<QuizContainer>` (Client Component). Next.js App Router forbids non-serializable server→client props. Extracted `QuizPageClient` (`'use client'`) that owns `router.push()` navigation.
- **Silent error details**: `apiFetch` threw `"API error: 422"` discarding FastAPI's error body. Now reads `body.detail.message` on error responses.
- **Hardcoded i18n text**: Replaced hardcoded `"Back to {module}"` in `page.tsx` with `t('QuizPage.backToModule')` (FR/EN translations added).

## Changes

- `backend/app/api/v1/quiz.py` — added `_resolve_module_uuid()` helper; updated `generate_quiz` and `generate_summative_assessment` to call it
- `backend/app/api/v1/schemas/quiz.py` — `QuizGenerationRequest.module_id` and `SummativeAssessmentRequest.module_id`: `UUID` → `str`
- `frontend/app/[locale]/(app)/modules/[moduleId]/quiz/page.tsx` — now uses `getTranslations`, renders `<QuizPageClient>` instead of passing function props
- `frontend/app/[locale]/(app)/modules/[moduleId]/quiz/quiz-page-client.tsx` — new `'use client'` component owning `onComplete` navigation
- `frontend/lib/api.ts` — `apiFetch` now surfaces `body.detail.message` on error responses
- `frontend/messages/en.json` + `fr.json` — added `QuizPage.backToModule` translation key

## Test plan

- [ ] Backend: `POST /api/v1/quiz/generate` with `{"module_id": "M01", ...}` returns 200 (previously 422)
- [ ] Frontend: quiz page at `/fr/modules/M01/quiz?unit=M01-U04` renders without error
- [ ] Frontend: `npm run lint` passes (no new errors)
- [ ] Frontend: TypeScript passes (no new errors beyond pre-existing e2e test issues)
- [ ] On quiz complete, navigates back to `/modules/M01` without double-locale

Closes #274

Generated with [Claude Code](https://claude.ai/code)