### PR TITLE
fix(tutor): wire conversation selection to reload chat panel

### DIFF
--- a/frontend/app/[locale]/(app)/tutor/tutor-client.tsx
+++ b/frontend/app/[locale]/(app)/tutor/tutor-client.tsx
@@ -17,40 +17,40 @@ interface Conversation {
   messageCount: number;
 }
 
+const INITIAL_CONVERSATIONS: Conversation[] = [
+  {
+    id: '1',
+    title: 'Public Health Basics',
+    lastMessage: 'What are the main determinants of health?',
+    timestamp: new Date(2026, 2, 31, 14, 45),
+    messageCount: 5,
+  },
+  {
+    id: '2',
+    title: 'Epidemiology Questions',
+    lastMessage: 'Explain the difference between incidence and prevalence',
+    timestamp: new Date(2026, 2, 31, 13, 15),
+    messageCount: 12,
+  },
+  {
+    id: '3',
+    title: 'DHIS2 Data Analysis',
+    lastMessage: 'How do I create indicators in DHIS2?',
+    timestamp: new Date(2026, 2, 30, 15, 15),
+    messageCount: 8,
+  },
+];
+
 export function TutorPageClient() {
   const t = useTranslations('ChatTutor');
-  
-  // Static mock conversations data
-  const conversations: Conversation[] = [
-    {
-      id: '1',
-      title: 'Public Health Basics',
-      lastMessage: 'What are the main determinants of health?',
-      timestamp: new Date(2026, 2, 31, 14, 45), // 30 minutes ago (static)
-      messageCount: 5,
-    },
-    {
-      id: '2', 
-      title: 'Epidemiology Questions',
-      lastMessage: 'Explain the difference between incidence and prevalence',
-      timestamp: new Date(2026, 2, 31, 13, 15), // 2 hours ago (static)
-      messageCount: 12,
-    },
-    {
-      id: '3',
-      title: 'DHIS2 Data Analysis',
-      lastMessage: 'How do I create indicators in DHIS2?',
-      timestamp: new Date(2026, 2, 30, 15, 15), // 1 day ago (static)
-      messageCount: 8,
-    },
-  ];
-  
+
+  const [conversations, setConversations] = useState<Conversation[]>(INITIAL_CONVERSATIONS);
   const [selectedConversation, setSelectedConversation] = useState<string | null>('1');
 
   const formatRelativeTime = (date: Date) => {
     const now = new Date();
     const diffInMinutes = Math.floor((now.getTime() - date.getTime()) / (1000 * 60));
-    
+
     if (diffInMinutes < 60) {
       return `${diffInMinutes}m ago`;
     } else if (diffInMinutes < 1440) {
@@ -60,6 +60,21 @@ export function TutorPageClient() {
     }
   };
 
+  const handleNewConversation = () => {
+    const newId = Date.now().toString();
+    const newConversation: Conversation = {
+      id: newId,
+      title: t('newConversationTitle'),
+      lastMessage: '',
+      timestamp: new Date(),
+      messageCount: 0,
+    };
+    setConversations(prev => [newConversation, ...prev]);
+    setSelectedConversation(newId);
+  };
+
+  const selectedConvData = conversations.find(c => c.id === selectedConversation);
+
   return (
     <ChatProvider>
       <div className="flex flex-1 min-h-0">
@@ -67,9 +82,10 @@ export function TutorPageClient() {
         <div className="w-80 border-r bg-card hidden md:flex flex-col">
           {/* Sidebar Header */}
           <div className="p-4 border-b">
-            <Button 
-              className="w-full justify-start gap-2" 
+            <Button
+              className="w-full justify-start gap-2"
               variant="outline"
+              onClick={handleNewConversation}
             >
               <Plus className="h-4 w-4" />
               {t('newConversation')}
@@ -85,7 +101,7 @@ export function TutorPageClient() {
                 <p className="text-sm text-muted-foreground mb-4">
                   {t('noConversationsDescription')}
                 </p>
-                <Button size="sm">
+                <Button size="sm" onClick={handleNewConversation}>
                   <Plus className="h-4 w-4 mr-2" />
                   {t('startFirstConversation')}
                 </Button>
@@ -97,9 +113,18 @@ export function TutorPageClient() {
                     key={conversation.id}
                     className={cn(
                       'p-3 cursor-pointer transition-colors hover:bg-accent/50',
-                      selectedConversation === conversation.id && 'bg-accent'
+                      selectedConversation === conversation.id && 'bg-accent border-primary'
                     )}
                     onClick={() => setSelectedConversation(conversation.id)}
+                    role="button"
+                    aria-pressed={selectedConversation === conversation.id}
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        setSelectedConversation(conversation.id);
+                      }
+                    }}
                   >
                     <div className="flex justify-between items-start mb-2">
                       <h3 className="font-medium text-sm truncate pr-2">
@@ -109,9 +134,11 @@ export function TutorPageClient() {
                         {formatRelativeTime(conversation.timestamp)}
                       </span>
                     </div>
-                    <p className="text-xs text-muted-foreground truncate mb-1">
-                      {conversation.lastMessage}
-                    </p>
+                    {conversation.lastMessage && (
+                      <p className="text-xs text-muted-foreground truncate mb-1">
+                        {conversation.lastMessage}
+                      </p>
+                    )}
                     <div className="flex justify-between items-center">
                       <span className="text-xs text-muted-foreground">
                         {t('messageCount', { count: conversation.messageCount })}
@@ -127,9 +154,10 @@ export function TutorPageClient() {
         {/* Main Chat Area */}
         <div className="flex-1 flex flex-col min-h-0">
           {selectedConversation ? (
-            <ChatPanel 
+            <ChatPanel
               isOpen={true}
-              onClose={() => {}} // No close action needed for full page
+              onClose={() => {}}
+              conversationId={selectedConversation}
               className="relative border-none w-full h-full"
             />
           ) : (
@@ -139,7 +167,7 @@ export function TutorPageClient() {
               <p className="text-muted-foreground mb-6 max-w-sm">
                 {t('selectConversationDescription')}
               </p>
-              <Button>
+              <Button onClick={handleNewConversation}>
                 <Plus className="h-4 w-4 mr-2" />
                 {t('newConversation')}
               </Button>
@@ -147,6 +175,13 @@ export function TutorPageClient() {
           )}
         </div>
       </div>
+
+      {/* Mobile: show conversation info if needed */}
+      {selectedConvData && (
+        <div className="sr-only" aria-live="polite">
+          {selectedConvData.title}
+        </div>
+      )}
     </ChatProvider>
   );
 }

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -34,10 +34,11 @@ interface ChatPanelProps {
   isOpen: boolean;
   onClose: () => void;
   moduleId?: string;
+  conversationId?: string | null;
   className?: string;
 }
 
-export function ChatPanel({ isOpen, onClose, moduleId, className }: ChatPanelProps) {
+export function ChatPanel({ isOpen, onClose, moduleId, conversationId, className }: ChatPanelProps) {
   const t = useTranslations('ChatTutor');
   const router = useRouter();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -50,19 +51,18 @@ export function ChatPanel({ isOpen, onClose, moduleId, className }: ChatPanelPro
   const maxDailyUsage = 50;
   const isLimitReached = currentUsage >= maxDailyUsage;
 
-  // Initialize with welcome message
+  // Reset messages when conversation changes (including new conversation)
   useEffect(() => {
-    if (messages.length === 0) {
-      setMessages([
-        {
-          id: 'welcome',
-          content: t('welcomeMessage'),
-          isUser: false,
-          timestamp: new Date(),
-        }
-      ]);
-    }
-  }, [t, messages.length]);
+    setMessages([
+      {
+        id: 'welcome',
+        content: t('welcomeMessage'),
+        isUser: false,
+        timestamp: new Date(),
+      }
+    ]);
+    setCurrentUsage(0);
+  }, [conversationId, t]);
 
   // Scroll to bottom when new messages are added
   useEffect(() => {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -318,7 +318,8 @@
     "selectConversation": "Select a conversation",
     "selectConversationDescription": "Choose a conversation from the sidebar or start a new one",
     "messageCount": "{count} {count, plural, one {message} other {messages}}",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "newConversationTitle": "New Conversation"
   },
   "Flashcards": {
     "title": "Flashcards",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -318,7 +318,8 @@
     "selectConversation": "Sélectionner une conversation",
     "selectConversationDescription": "Choisissez une conversation dans la barre latérale ou commencez-en une nouvelle",
     "messageCount": "{count} {count, plural, one {message} other {messages}}",
-    "cancel": "Annuler"
+    "cancel": "Annuler",
+    "newConversationTitle": "Nouvelle Conversation"
   },
   "Flashcards": {
     "title": "Flashcards",


### PR DESCRIPTION
## Summary

- Clicking a conversation in the sidebar now loads a fresh chat (reset messages + usage counter)
- "New Conversation" button creates a new entry and auto-selects it
- Active conversation is visually highlighted with `border-primary`
- Keyboard-accessible conversation cards (Enter/Space support)

## Root cause

`TutorPageClient` tracked `selectedConversation` state but never passed it to `ChatPanel`. The panel had no `conversationId` prop, so clicking sidebar items only updated the highlight — the chat itself never changed.

## Changes

- `frontend/components/chat/chat-panel.tsx` — add `conversationId` prop; `useEffect` resets messages and usage when it changes
- `frontend/app/[locale]/(app)/tutor/tutor-client.tsx` — pass `conversationId` to `ChatPanel`; wire "New Conversation" button; improve active highlight + a11y
- `frontend/messages/en.json` + `fr.json` — add `newConversationTitle` i18n key

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes (0 errors)
- [ ] Click "Epidemiology Questions" → chat resets with welcome message
- [ ] Click "New Conversation" → new entry appears selected in sidebar, fresh chat
- [ ] Active conversation has visible border highlight
- [ ] Works on mobile viewport (sidebar hidden, chat full-width)

Closes #286

Generated with [Claude Code](https://claude.ai/code)