### PR TITLE
feat(flashcards): auto-generate flashcards via RAG with real module data

### DIFF
--- a/backend/app/api/v1/flashcards.py
+++ b/backend/app/api/v1/flashcards.py
@@ -1,16 +1,21 @@
 """Flashcard review API endpoints."""
 
+import re
 import uuid
 from collections import defaultdict
 from datetime import datetime, timedelta
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.ai.claude_service import ClaudeService
+from app.ai.rag.embeddings import EmbeddingService
+from app.ai.rag.retriever import SemanticRetriever
 from app.api.deps import get_db
 from app.api.deps_local_auth import get_current_user
+from app.api.v1.schemas.content import FlashcardSetResponse
 from app.api.v1.schemas.flashcards import (
     FlashcardDueResponse,
     FlashcardReviewRequest,
@@ -21,10 +26,119 @@ from app.api.v1.schemas.flashcards import (
 )
 from app.domain.models.content import GeneratedContent
 from app.domain.models.flashcard import FlashcardReview
+from app.domain.models.module import Module
 from app.domain.models.user import User
+from app.domain.services.flashcard_service import FlashcardGenerationService
+from app.infrastructure.config.settings import get_settings
 
 logger = structlog.get_logger()
 router = APIRouter(prefix="/flashcards", tags=["flashcards"])
+
+
+def get_flashcard_generation_service() -> FlashcardGenerationService:
+    """Dependency to build FlashcardGenerationService with real dependencies."""
+    app_settings = get_settings()
+    claude_service = ClaudeService()
+    embedding_service = EmbeddingService(
+        api_key=app_settings.openai_api_key,
+        model=app_settings.embedding_model,
+    )
+    semantic_retriever = SemanticRetriever(embedding_service=embedding_service)
+    return FlashcardGenerationService(
+        claude_service=claude_service,
+        semantic_retriever=semantic_retriever,
+    )
+
+
+async def _resolve_module_id(module_id_str: str, session: AsyncSession) -> uuid.UUID:
+    """Resolve module code (M01) or UUID string to UUID."""
+    try:
+        return uuid.UUID(module_id_str)
+    except ValueError:
+        pass
+
+    module_code_pattern = re.match(r"^M(\d{2})$", module_id_str.upper())
+    if module_code_pattern:
+        module_number = int(module_code_pattern.group(1))
+        result = await session.execute(select(Module).where(Module.module_number == module_number))
+        module = result.scalar_one_or_none()
+        if module:
+            return module.id
+        raise ValueError(f"Module with code {module_id_str} not found")
+
+    raise ValueError(
+        f"Invalid module identifier: {module_id_str}. Expected UUID or module code (M01, M02, etc.)"
+    )
+
+
+@router.get(
+    "/modules/{module_id}",
+    response_model=FlashcardSetResponse,
+    status_code=status.HTTP_200_OK,
+    responses={
+        401: {"description": "Unauthorized"},
+        404: {"description": "Module not found"},
+        500: {"description": "Generation failed"},
+    },
+)
+async def get_module_flashcards(
+    module_id: str,
+    language: str = Query(default="fr", pattern="^(fr|en)$"),
+    country: str = Query(default="SN"),
+    level: int = Query(default=1, ge=1, le=4),
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+    flashcard_service: FlashcardGenerationService = Depends(get_flashcard_generation_service),
+) -> FlashcardSetResponse:
+    """
+    Get or auto-generate flashcards for a module.
+
+    On first access, generates 15-30 bilingual flashcards via RAG pipeline using
+    the module's learning objectives and reference book chapters. Subsequent
+    requests return the cached set.
+
+    Each flashcard contains:
+    - **term**: Key concept in the primary language
+    - **definition_fr / definition_en**: Bilingual definitions (50-100 words each)
+    - **example_aof**: Concrete West African example
+    - **formula**: LaTeX formula (optional, for statistics/epidemiology)
+    - **sources_cited**: Reference book citations
+
+    Accepts module code (e.g. `M01`) or full UUID.
+    """
+    try:
+        resolved_id = await _resolve_module_id(module_id, session)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "module_not_found", "message": str(e)},
+        )
+
+    try:
+        result = await flashcard_service.get_or_generate_flashcard_set(
+            module_id=resolved_id,
+            language=language,
+            country=country,
+            level=level,
+            session=session,
+        )
+        return result
+    except ValueError as e:
+        if "not found" in str(e).lower():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"error": "module_not_found", "message": str(e)},
+            )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"error": "generation_failed", "message": str(e)},
+        )
+    except Exception as e:
+        logger.error("Flashcard generation failed", error=str(e), exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"error": "generation_failed", "message": "Unable to generate flashcards"},
+        )
 
 
 @router.get(

--- a/backend/app/domain/services/flashcard_service.py
+++ b/backend/app/domain/services/flashcard_service.py
@@ -13,6 +13,7 @@ from app.ai.prompts.flashcard import format_rag_context_for_flashcards, get_flas
 from app.ai.rag.retriever import SemanticRetriever
 from app.api.v1.schemas.content import FlashcardContent, FlashcardSetResponse
 from app.domain.models.content import GeneratedContent
+from app.domain.models.module import Module
 
 if TYPE_CHECKING:
     pass
@@ -121,6 +122,29 @@ class FlashcardGenerationService:
         result = await session.execute(query)
         return result.scalar_one_or_none()
 
+    async def _get_module(
+        self,
+        module_id: uuid.UUID,
+        session: AsyncSession,
+    ) -> Module:
+        """Fetch module from database.
+
+        Args:
+            module_id: Module UUID
+            session: Database session
+
+        Returns:
+            Module instance
+
+        Raises:
+            ValueError: If module not found
+        """
+        result = await session.execute(select(Module).where(Module.id == module_id))
+        module = result.scalar_one_or_none()
+        if module is None:
+            raise ValueError(f"Module {module_id} not found")
+        return module
+
     async def _generate_flashcard_set(
         self,
         module_id: uuid.UUID,
@@ -144,14 +168,25 @@ class FlashcardGenerationService:
         Raises:
             ValueError: If module not found or generation fails
         """
-        # Get module information (simplified - in real implementation would fetch from modules table)
-        module_title = f"Module {module_id}"  # Placeholder - should fetch real module title
+        module = await self._get_module(module_id, session)
 
-        # Build search query for RAG retrieval
+        module_title = module.title_fr if language == "fr" else module.title_en
+
+        books_sources: dict = module.books_sources or {}
+        source_names = list(books_sources.keys()) if books_sources else []
+
         if language == "fr":
-            query = f"concepts clés module santé publique niveau {level}"
+            sources_hint = f" ({', '.join(source_names)})" if source_names else ""
+            query = (
+                f"concepts clés vocabulaire définitions {module_title} "
+                f"santé publique niveau {level}{sources_hint}"
+            )
         else:
-            query = f"key concepts public health module level {level}"
+            sources_hint = f" ({', '.join(source_names)})" if source_names else ""
+            query = (
+                f"key concepts vocabulary definitions {module_title} "
+                f"public health level {level}{sources_hint}"
+            )
 
         logger.info("Retrieving relevant content chunks", query=query)
 

--- a/backend/tests/test_flashcard_generation.py
+++ b/backend/tests/test_flashcard_generation.py
@@ -12,6 +12,7 @@ from app.ai.claude_service import ClaudeService
 from app.ai.rag.retriever import SemanticRetriever
 from app.api.v1.schemas.content import FlashcardContent, FlashcardGenerationRequest
 from app.domain.models.content import GeneratedContent
+from app.domain.models.module import Module
 from app.domain.services.flashcard_service import FlashcardGenerationService
 
 
@@ -82,6 +83,34 @@ def sample_search_results():
     return [mock_result1, mock_result2]
 
 
+@pytest.fixture
+def sample_module():
+    """Sample Module ORM object for testing."""
+    module = Module(
+        id=uuid.uuid4(),
+        module_number=1,
+        level=1,
+        title_fr="Introduction à la Santé Publique",
+        title_en="Introduction to Public Health",
+        description_fr="Module introductif",
+        description_en="Introductory module",
+        estimated_hours=20,
+        bloom_level="knowledge",
+        books_sources={"donaldson": [1, 2, 3], "scutchfield": [1]},
+    )
+    return module
+
+
+def _make_session_with_execute_sequence(return_values: list) -> AsyncMock:
+    """Create a mock session whose execute calls return values in sequence."""
+    session = AsyncMock(spec=AsyncSession)
+    mock_results = [MagicMock() for _ in return_values]
+    for mock_result, value in zip(mock_results, return_values, strict=True):
+        mock_result.scalar_one_or_none.return_value = value
+    session.execute = AsyncMock(side_effect=mock_results)
+    return session
+
+
 class TestFlashcardGenerationService:
     """Test cases for FlashcardGenerationService."""
 
@@ -93,36 +122,27 @@ class TestFlashcardGenerationService:
         mock_semantic_retriever,
         sample_flashcard_data,
         sample_search_results,
+        sample_module,
     ):
         """Test generating new flashcard set when none exists in cache."""
-        # Arrange
-        module_id = uuid.uuid4()
+        module_id = sample_module.id
         language = "fr"
         country = "SN"
         level = 2
 
-        # Mock session without existing content
-        session = AsyncMock(spec=AsyncSession)
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
-        session.execute = AsyncMock(return_value=mock_result)
+        session = _make_session_with_execute_sequence([None, sample_module])
 
-        # Mock session.refresh to set generated_at timestamp
         def mock_refresh(obj):
             if hasattr(obj, "generated_at") and obj.generated_at is None:
                 obj.generated_at = datetime.now(UTC)
 
         session.refresh = AsyncMock(side_effect=mock_refresh)
 
-        # Mock RAG retrieval
         mock_semantic_retriever.search.return_value = sample_search_results
-
-        # Mock Claude API response
         mock_claude_service.generate_structured_content.return_value = json.dumps(
             sample_flashcard_data
         )
 
-        # Act
         result = await flashcard_service.get_or_generate_flashcard_set(
             module_id=module_id,
             language=language,
@@ -131,7 +151,6 @@ class TestFlashcardGenerationService:
             session=session,
         )
 
-        # Assert
         assert result is not None
         assert result.module_id == module_id
         assert result.language == language
@@ -141,13 +160,11 @@ class TestFlashcardGenerationService:
         assert not result.cached
         assert len(result.flashcards) == 2
 
-        # Verify flashcard content
         assert result.flashcards[0].term == "Surveillance épidémiologique"
         assert "Sénégal" in result.flashcards[0].example_aof
         assert result.flashcards[1].formula is not None
         assert "Incidence Rate" in result.flashcards[1].formula
 
-        # Verify service calls
         mock_semantic_retriever.search.assert_called_once()
         mock_claude_service.generate_structured_content.assert_called_once()
         session.add.assert_called_once()
@@ -162,13 +179,11 @@ class TestFlashcardGenerationService:
         sample_flashcard_data,
     ):
         """Test retrieving existing flashcard set from cache."""
-        # Arrange
         module_id = uuid.uuid4()
         language = "fr"
         country = "SN"
         level = 2
 
-        # Mock existing content in database
         existing_content = GeneratedContent(
             id=uuid.uuid4(),
             module_id=module_id,
@@ -187,7 +202,6 @@ class TestFlashcardGenerationService:
         mock_result.scalar_one_or_none.return_value = existing_content
         session.execute = AsyncMock(return_value=mock_result)
 
-        # Act
         result = await flashcard_service.get_or_generate_flashcard_set(
             module_id=module_id,
             language=language,
@@ -196,37 +210,97 @@ class TestFlashcardGenerationService:
             session=session,
         )
 
-        # Assert
         assert result is not None
         assert result.cached
         assert len(result.flashcards) == 2
 
-        # Verify no generation calls were made
         mock_semantic_retriever.search.assert_not_called()
         mock_claude_service.generate_structured_content.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_generate_flashcard_set_module_not_found(
+        self,
+        flashcard_service,
+        mock_semantic_retriever,
+    ):
+        """Test error handling when module does not exist in database."""
+        module_id = uuid.uuid4()
+        language = "fr"
+        country = "SN"
+        level = 2
+
+        session = _make_session_with_execute_sequence([None, None])
+
+        with pytest.raises(ValueError, match="not found"):
+            await flashcard_service.get_or_generate_flashcard_set(
+                module_id=module_id,
+                language=language,
+                country=country,
+                level=level,
+                session=session,
+            )
+
+        mock_semantic_retriever.search.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_generate_flashcard_set_uses_module_title_in_rag_query(
+        self,
+        flashcard_service,
+        mock_claude_service,
+        mock_semantic_retriever,
+        sample_flashcard_data,
+        sample_search_results,
+        sample_module,
+    ):
+        """Test that RAG search query contains the actual module title."""
+        module_id = sample_module.id
+        language = "fr"
+        country = "SN"
+        level = 1
+
+        session = _make_session_with_execute_sequence([None, sample_module])
+
+        def mock_refresh(obj):
+            if hasattr(obj, "generated_at") and obj.generated_at is None:
+                obj.generated_at = datetime.now(UTC)
+
+        session.refresh = AsyncMock(side_effect=mock_refresh)
+        mock_semantic_retriever.search.return_value = sample_search_results
+        mock_claude_service.generate_structured_content.return_value = json.dumps(
+            sample_flashcard_data
+        )
+
+        await flashcard_service.get_or_generate_flashcard_set(
+            module_id=module_id,
+            language=language,
+            country=country,
+            level=level,
+            session=session,
+        )
+
+        search_call_kwargs = mock_semantic_retriever.search.call_args
+        query_used = (
+            search_call_kwargs[1]["query"] if search_call_kwargs[1] else search_call_kwargs[0][0]
+        )
+        assert sample_module.title_fr in query_used
 
     @pytest.mark.asyncio
     async def test_generate_flashcard_set_no_search_results(
         self,
         flashcard_service,
         mock_semantic_retriever,
+        sample_module,
     ):
         """Test error handling when no relevant content is found."""
-        # Arrange
-        module_id = uuid.uuid4()
+        module_id = sample_module.id
         language = "fr"
         country = "SN"
         level = 2
 
-        session = AsyncMock(spec=AsyncSession)
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
-        session.execute = AsyncMock(return_value=mock_result)
+        session = _make_session_with_execute_sequence([None, sample_module])
 
-        # Mock empty search results
         mock_semantic_retriever.search.return_value = []
 
-        # Act & Assert
         with pytest.raises(ValueError, match="No relevant content found"):
             await flashcard_service.get_or_generate_flashcard_set(
                 module_id=module_id,
@@ -243,20 +317,16 @@ class TestFlashcardGenerationService:
         mock_claude_service,
         mock_semantic_retriever,
         sample_search_results,
+        sample_module,
     ):
         """Test error handling when Claude API fails."""
-        # Arrange
-        module_id = uuid.uuid4()
+        module_id = sample_module.id
         language = "fr"
         country = "SN"
         level = 2
 
-        session = AsyncMock(spec=AsyncSession)
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
-        session.execute = AsyncMock(return_value=mock_result)
+        session = _make_session_with_execute_sequence([None, sample_module])
 
-        # Mock session.refresh to set generated_at timestamp
         def mock_refresh(obj):
             if hasattr(obj, "generated_at") and obj.generated_at is None:
                 obj.generated_at = datetime.now(UTC)
@@ -266,7 +336,6 @@ class TestFlashcardGenerationService:
         mock_semantic_retriever.search.return_value = sample_search_results
         mock_claude_service.generate_structured_content.side_effect = Exception("API Error")
 
-        # Act & Assert
         with pytest.raises(ValueError, match="Content generation failed"):
             await flashcard_service.get_or_generate_flashcard_set(
                 module_id=module_id,
@@ -283,20 +352,16 @@ class TestFlashcardGenerationService:
         mock_claude_service,
         mock_semantic_retriever,
         sample_search_results,
+        sample_module,
     ):
         """Test error handling when Claude returns invalid JSON."""
-        # Arrange
-        module_id = uuid.uuid4()
+        module_id = sample_module.id
         language = "fr"
         country = "SN"
         level = 2
 
-        session = AsyncMock(spec=AsyncSession)
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
-        session.execute = AsyncMock(return_value=mock_result)
+        session = _make_session_with_execute_sequence([None, sample_module])
 
-        # Mock session.refresh to set generated_at timestamp
         def mock_refresh(obj):
             if hasattr(obj, "generated_at") and obj.generated_at is None:
                 obj.generated_at = datetime.now(UTC)
@@ -306,7 +371,6 @@ class TestFlashcardGenerationService:
         mock_semantic_retriever.search.return_value = sample_search_results
         mock_claude_service.generate_structured_content.return_value = "Invalid JSON"
 
-        # Act & Assert
         with pytest.raises(ValueError, match="Invalid JSON response"):
             await flashcard_service.get_or_generate_flashcard_set(
                 module_id=module_id,
@@ -322,10 +386,8 @@ class TestFlashcardGenerationService:
         sample_flashcard_data,
     ):
         """Test extracting unique sources from flashcard data."""
-        # Act
         sources = flashcard_service._extract_sources_from_flashcards(sample_flashcard_data)
 
-        # Assert
         assert len(sources) == 3
         assert "Donaldson Ch.4, p.67" in sources
         assert "Scutchfield Ch.8, p.145" in sources
@@ -337,7 +399,6 @@ class TestFlashcardGenerationService:
         sample_flashcard_data,
     ):
         """Test building response from GeneratedContent."""
-        # Arrange
         content = GeneratedContent(
             id=uuid.uuid4(),
             module_id=uuid.uuid4(),
@@ -351,10 +412,8 @@ class TestFlashcardGenerationService:
             generated_at=datetime.now(UTC),
         )
 
-        # Act
         result = flashcard_service._build_response_from_content(content, cached=True)
 
-        # Assert
         assert result.id == content.id
         assert result.module_id == content.module_id
         assert result.cached
@@ -367,7 +426,6 @@ class TestFlashcardGenerationRequest:
 
     def test_flashcard_generation_request_validation(self):
         """Test FlashcardGenerationRequest validation."""
-        # Valid request
         request = FlashcardGenerationRequest(
             module_id=uuid.uuid4(),
             language="fr",
@@ -377,27 +435,24 @@ class TestFlashcardGenerationRequest:
         assert request.language == "fr"
         assert request.level == 2
 
-        # Invalid language
         with pytest.raises(ValueError):
             FlashcardGenerationRequest(
                 module_id=uuid.uuid4(),
-                language="es",  # Not in allowed values
+                language="es",
                 country="SN",
                 level=2,
             )
 
-        # Invalid level
         with pytest.raises(ValueError):
             FlashcardGenerationRequest(
                 module_id=uuid.uuid4(),
                 language="fr",
                 country="SN",
-                level=5,  # Outside 1-4 range
+                level=5,
             )
 
     def test_flashcard_content_validation(self):
         """Test FlashcardContent validation."""
-        # Valid flashcard
         flashcard = FlashcardContent(
             term="Test Term",
             definition_fr="Définition française",
@@ -409,7 +464,6 @@ class TestFlashcardGenerationRequest:
         assert flashcard.term == "Test Term"
         assert flashcard.formula == "$x = y$"
 
-        # Optional formula
         flashcard_no_formula = FlashcardContent(
             term="Test Term",
             definition_fr="Définition française",


### PR DESCRIPTION
## Summary

Fixes #290 — flashcards were not being generated because:
1. `flashcard_service.py` used a placeholder `f"Module {module_id}"` instead of the real module title, making RAG queries too generic
2. There was no `GET /flashcards/modules/{module_id}` endpoint for auto-generating per-module flashcard sets

## Changes

**`backend/app/domain/services/flashcard_service.py`**
- Added `_get_module()` helper to fetch real `Module` from DB
- RAG query now uses actual `title_fr`/`title_en` + `books_sources` keys (e.g. `"concepts clés vocabulaire définitions Introduction à la Santé Publique santé publique niveau 1 (donaldson, scutchfield)"`)
- Raises `ValueError` (→ 404) when module not found in DB

**`backend/app/api/v1/flashcards.py`**
- Added `GET /flashcards/modules/{module_id}` endpoint
- Accepts module code (`M01`) or full UUID
- Query params: `language` (fr/en), `country`, `level` (1-4)
- Auto-generates 15-30 bilingual flashcards on first access via RAG + Claude, returns cached `FlashcardSetResponse` on subsequent calls
- Proper 404 handling for unknown modules

**`backend/tests/test_flashcard_generation.py`**
- Updated all generation-path tests to mock two `session.execute` calls (cache lookup + module lookup)
- Added `test_generate_flashcard_set_module_not_found` — 404 path
- Added `test_generate_flashcard_set_uses_module_title_in_rag_query` — verifies real title in RAG query
- All 98 tests pass, ruff clean

## Test plan

- [x] Backend tests pass (98/98)
- [x] Backend lint passes (ruff: all checks passed)
- [ ] Manually verified on mobile viewport

Closes #290

Generated with [Claude Code](https://claude.ai/code)