### PR TITLE
feat(tutor): persist conversations to server + offline localStorage cache

### DIFF
--- a/backend/tests/test_tutor_service.py
+++ b/backend/tests/test_tutor_service.py
@@ -269,6 +269,93 @@ async def test_send_message_daily_limit_error_has_code(tutor_service, sample_use
     assert error_chunks[0]["data"]["limit_reached"] is True
 
 
+async def test_list_conversations_returns_summaries(tutor_service, sample_user, sample_conversation):
+    """Verify list_conversations returns conversation summaries with required fields."""
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    with patch.object(
+        mock_session,
+        "execute",
+        new_callable=AsyncMock,
+    ) as mock_execute:
+        scalars_result = MagicMock()
+        scalars_result.scalars.return_value.all.return_value = [sample_conversation]
+        count_result = MagicMock()
+        count_result.scalar.return_value = 1
+        mock_execute.side_effect = [scalars_result, count_result]
+
+        result = await tutor_service.list_conversations(
+            user_id=sample_user.id,
+            session=mock_session,
+        )
+
+    assert "conversations" in result
+    assert "total" in result
+    assert result["total"] == 1
+    assert len(result["conversations"]) == 1
+    summary = result["conversations"][0]
+    assert "id" in summary
+    assert "message_count" in summary
+    assert "last_message_at" in summary
+    assert "preview" in summary
+
+
+async def test_get_conversation_returns_none_for_wrong_user(tutor_service, sample_user):
+    """Verify get_conversation returns None when conversation belongs to a different user."""
+    mock_session = AsyncMock(spec=AsyncSession)
+    other_conv_id = uuid.uuid4()
+
+    with patch.object(
+        mock_session,
+        "execute",
+        new_callable=AsyncMock,
+    ) as mock_execute:
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none.return_value = None
+        mock_execute.return_value = result_mock
+
+        result = await tutor_service.get_conversation(
+            user_id=sample_user.id,
+            conversation_id=other_conv_id,
+            session=mock_session,
+        )
+
+    assert result is None
+
+
+async def test_get_conversation_returns_messages(tutor_service, sample_user, sample_conversation):
+    """Verify get_conversation returns full conversation with messages."""
+    sample_conversation.messages = [
+        {"role": "user", "content": "Bonjour", "timestamp": datetime.now(UTC).isoformat()},
+        {
+            "role": "assistant",
+            "content": "Bonjour! Comment puis-je vous aider?",
+            "sources": [],
+            "timestamp": datetime.now(UTC).isoformat(),
+        },
+    ]
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    with patch.object(
+        mock_session,
+        "execute",
+        new_callable=AsyncMock,
+    ) as mock_execute:
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none.return_value = sample_conversation
+        mock_execute.return_value = result_mock
+
+        result = await tutor_service.get_conversation(
+            user_id=sample_user.id,
+            conversation_id=sample_conversation.id,
+            session=mock_session,
+        )
+
+    assert result is not None
+    assert result["id"] == sample_conversation.id
+    assert len(result["messages"]) == 2
+
+
 async def test_send_message_never_yields_text_type(tutor_service, sample_user, sample_conversation):
     """Regression test: ensure type='text' is never yielded (was the bug in #213)."""
     mock_session = AsyncMock(spec=AsyncSession)

--- a/frontend/app/[locale]/(app)/tutor/tutor-client.tsx
+++ b/frontend/app/[locale]/(app)/tutor/tutor-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
 import { Plus, MessageSquare } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -8,46 +8,47 @@ import { Card } from '@/components/ui/card';
 import { ChatPanel } from '@/components/chat';
 import { ChatProvider } from '@/components/chat';
 import { cn } from '@/lib/utils';
-
-interface Conversation {
-  id: string;
-  title: string;
-  lastMessage: string;
-  timestamp: Date;
-  messageCount: number;
-}
-
-const INITIAL_CONVERSATIONS: Conversation[] = [
-  {
-    id: '1',
-    title: 'Public Health Basics',
-    lastMessage: 'What are the main determinants of health?',
-    timestamp: new Date(2026, 2, 31, 14, 45),
-    messageCount: 5,
-  },
-  {
-    id: '2',
-    title: 'Epidemiology Questions',
-    lastMessage: 'Explain the difference between incidence and prevalence',
-    timestamp: new Date(2026, 2, 31, 13, 15),
-    messageCount: 12,
-  },
-  {
-    id: '3',
-    title: 'DHIS2 Data Analysis',
-    lastMessage: 'How do I create indicators in DHIS2?',
-    timestamp: new Date(2026, 2, 30, 15, 15),
-    messageCount: 8,
-  },
-];
+import {
+  fetchConversations,
+  getCachedConversations,
+  setCachedConversations,
+  type ConversationSummary,
+} from '@/lib/tutor-api';
 
 export function TutorPageClient() {
   const t = useTranslations('ChatTutor');
 
-  const [conversations, setConversations] = useState<Conversation[]>(INITIAL_CONVERSATIONS);
-  const [selectedConversation, setSelectedConversation] = useState<string | null>('1');
+  const [conversations, setConversations] = useState<ConversationSummary[]>([]);
+  const [selectedConversation, setSelectedConversation] = useState<string | null>(null);
+  const [isLoadingConversations, setIsLoadingConversations] = useState(true);
 
-  const formatRelativeTime = (date: Date) => {
+  useEffect(() => {
+    const load = async () => {
+      const cached = getCachedConversations();
+      if (cached.length > 0) {
+        setConversations(cached);
+        setSelectedConversation((prev) => (prev === null ? cached[0].id : prev));
+      }
+
+      try {
+        const result = await fetchConversations(20, 0);
+        setConversations(result.conversations);
+        setCachedConversations(result.conversations);
+        if (result.conversations.length > 0) {
+          setSelectedConversation((prev) => (prev === null ? result.conversations[0].id : prev));
+        }
+      } catch {
+        // Use cached data on network error
+      } finally {
+        setIsLoadingConversations(false);
+      }
+    };
+
+    load();
+  }, []);
+
+  const formatRelativeTime = (dateStr: string) => {
+    const date = new Date(dateStr);
     const now = new Date();
     const diffInMinutes = Math.floor((now.getTime() - date.getTime()) / (1000 * 60));
 
@@ -61,26 +62,49 @@ export function TutorPageClient() {
   };
 
   const handleNewConversation = () => {
-    const newId = Date.now().toString();
-    const newConversation: Conversation = {
+    setSelectedConversation(null);
+  };
+
+  const handleConversationCreated = (newId: string) => {
+    const newSummary: ConversationSummary = {
       id: newId,
-      title: t('newConversationTitle'),
-      lastMessage: '',
-      timestamp: new Date(),
-      messageCount: 0,
+      module_id: null,
+      message_count: 0,
+      last_message_at: new Date().toISOString(),
+      preview: '',
     };
-    setConversations(prev => [newConversation, ...prev]);
+    setConversations((prev) => {
+      const updated = [newSummary, ...prev];
+      setCachedConversations(updated);
+      return updated;
+    });
     setSelectedConversation(newId);
   };
 
-  const selectedConvData = conversations.find(c => c.id === selectedConversation);
+  const handleMessagesUpdated = (convId: string, preview: string, count: number) => {
+    setConversations((prev) => {
+      const updated = prev.map((c) =>
+        c.id === convId
+          ? {
+              ...c,
+              preview: preview + (preview.length >= 50 ? '...' : ''),
+              message_count: count,
+              last_message_at: new Date().toISOString(),
+            }
+          : c
+      );
+      updated.sort(
+        (a, b) => new Date(b.last_message_at).getTime() - new Date(a.last_message_at).getTime()
+      );
+      setCachedConversations(updated);
+      return updated;
+    });
+  };
 
   return (
     <ChatProvider>
       <div className="flex flex-1 min-h-0">
-        {/* Conversations Sidebar - Hidden on mobile, shown on desktop */}
         <div className="w-80 border-r bg-card hidden md:flex flex-col">
-          {/* Sidebar Header */}
           <div className="p-4 border-b">
             <Button
               className="w-full justify-start gap-2"
@@ -92,9 +116,10 @@ export function TutorPageClient() {
             </Button>
           </div>
 
-          {/* Conversations List */}
           <div className="flex-1 overflow-y-auto">
-            {conversations.length === 0 ? (
+            {isLoadingConversations && conversations.length === 0 ? (
+              <div className="p-4 text-sm text-muted-foreground text-center">{t('loading')}</div>
+            ) : conversations.length === 0 ? (
               <div className="flex flex-col items-center justify-center p-6 text-center">
                 <MessageSquare className="h-12 w-12 text-muted-foreground mb-4" />
                 <h3 className="font-medium mb-2">{t('noConversations')}</h3>
@@ -128,20 +153,22 @@ export function TutorPageClient() {
                   >
                     <div className="flex justify-between items-start mb-2">
                       <h3 className="font-medium text-sm truncate pr-2">
-                        {conversation.title}
+                        {conversation.preview
+                          ? conversation.preview.slice(0, 30)
+                          : t('newConversationTitle')}
                       </h3>
                       <span className="text-xs text-muted-foreground shrink-0">
-                        {formatRelativeTime(conversation.timestamp)}
+                        {formatRelativeTime(conversation.last_message_at)}
                       </span>
                     </div>
-                    {conversation.lastMessage && (
+                    {conversation.preview && (
                       <p className="text-xs text-muted-foreground truncate mb-1">
-                        {conversation.lastMessage}
+                        {conversation.preview}
                       </p>
                     )}
                     <div className="flex justify-between items-center">
                       <span className="text-xs text-muted-foreground">
-                        {t('messageCount', { count: conversation.messageCount })}
+                        {t('messageCount', { count: conversation.message_count })}
                       </span>
                     </div>
                   </Card>
@@ -151,14 +178,15 @@ export function TutorPageClient() {
           </div>
         </div>
 
-        {/* Main Chat Area */}
         <div className="flex-1 flex flex-col min-h-0">
-          {selectedConversation ? (
+          {selectedConversation !== undefined ? (
             <ChatPanel
               isOpen={true}
               onClose={() => {}}
               conversationId={selectedConversation}
               className="relative border-none w-full h-full"
+              onConversationCreated={handleConversationCreated}
+              onMessagesUpdated={handleMessagesUpdated}
             />
           ) : (
             <div className="flex-1 flex flex-col items-center justify-center text-center p-6">
@@ -175,13 +203,6 @@ export function TutorPageClient() {
           )}
         </div>
       </div>
-
-      {/* Mobile: show conversation info if needed */}
-      {selectedConvData && (
-        <div className="sr-only" aria-live="polite">
-          {selectedConvData.title}
-        </div>
-      )}
     </ChatProvider>
   );
 }

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import { X, MoreVertical, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -29,6 +29,12 @@ import { ChatSkeleton } from './chat-skeleton';
 import { cn } from '@/lib/utils';
 import { authClient, AuthError } from '@/lib/auth';
 import { useRouter } from 'next/navigation';
+import {
+  fetchConversation,
+  getCachedConversation,
+  setCachedConversation,
+  type ConversationDetail,
+} from '@/lib/tutor-api';
 
 interface ChatPanelProps {
   isOpen: boolean;
@@ -36,9 +42,21 @@ interface ChatPanelProps {
   moduleId?: string;
   conversationId?: string | null;
   className?: string;
+  onConversationCreated?: (id: string) => void;
+  onMessagesUpdated?: (conversationId: string, preview: string, count: number) => void;
 }
 
-export function ChatPanel({ isOpen, onClose, moduleId, conversationId, className }: ChatPanelProps) {
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+export function ChatPanel({
+  isOpen,
+  onClose,
+  moduleId,
+  conversationId,
+  className,
+  onConversationCreated,
+  onMessagesUpdated,
+}: ChatPanelProps) {
   const t = useTranslations('ChatTutor');
   const router = useRouter();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -46,25 +64,87 @@ export function ChatPanel({ isOpen, onClose, moduleId, conversationId, className
   const [isTyping, setIsTyping] = useState(false);
   const [showClearDialog, setShowClearDialog] = useState(false);
   const [currentUsage, setCurrentUsage] = useState(0);
+  const [activeConversationId, setActiveConversationId] = useState<string | null>(
+    conversationId ?? null
+  );
   const scrollAreaRef = useRef<HTMLDivElement>(null);
 
   const maxDailyUsage = 50;
   const isLimitReached = currentUsage >= maxDailyUsage;
 
-  // Reset messages when conversation changes (including new conversation)
   useEffect(() => {
-    setMessages([
-      {
+    setActiveConversationId(conversationId ?? null);
+  }, [conversationId]);
+
+  const hydrateMessages = useCallback(
+    (detail: ConversationDetail) => {
+      const welcome: ChatMessage = {
         id: 'welcome',
         content: t('welcomeMessage'),
         isUser: false,
-        timestamp: new Date(),
-      }
-    ]);
-    setCurrentUsage(0);
-  }, [conversationId, t]);
+        timestamp: new Date(detail.created_at),
+      };
 
-  // Scroll to bottom when new messages are added
+      const hydrated: ChatMessage[] = detail.messages.map((msg) => ({
+        id: `${msg.role}-${msg.timestamp}`,
+        content: msg.content,
+        isUser: msg.role === 'user',
+        timestamp: new Date(msg.timestamp),
+        sources: msg.sources?.map((s, i) => ({
+          title: s.source ?? String(i + 1),
+          chapter: s.chapter ?? i + 1,
+          page: s.page ?? 0,
+        })),
+      }));
+
+      const userMessages = detail.messages.filter((m) => m.role === 'user').length;
+      setCurrentUsage(userMessages);
+      setMessages([welcome, ...hydrated]);
+    },
+    [t]
+  );
+
+  useEffect(() => {
+    if (!activeConversationId) {
+      setMessages([
+        {
+          id: 'welcome',
+          content: t('welcomeMessage'),
+          isUser: false,
+          timestamp: new Date(),
+        },
+      ]);
+      setCurrentUsage(0);
+      return;
+    }
+
+    const loadConversation = async () => {
+      const cached = getCachedConversation(activeConversationId);
+      if (cached) {
+        hydrateMessages(cached);
+      }
+
+      try {
+        const detail = await fetchConversation(activeConversationId);
+        setCachedConversation(detail);
+        hydrateMessages(detail);
+      } catch {
+        if (!cached) {
+          setMessages([
+            {
+              id: 'welcome',
+              content: t('welcomeMessage'),
+              isUser: false,
+              timestamp: new Date(),
+            },
+          ]);
+        }
+      }
+    };
+
+    loadConversation();
+  }, [activeConversationId, t, hydrateMessages]);
+
   useEffect(() => {
     if (scrollAreaRef.current) {
       const scrollArea = scrollAreaRef.current;
@@ -82,13 +162,12 @@ export function ChatPanel({ isOpen, onClose, moduleId, conversationId, className
       timestamp: new Date(),
     };
 
-    setMessages(prev => [...prev, userMessage]);
-    setCurrentUsage(prev => prev + 1);
+    setMessages((prev) => [...prev, userMessage]);
+    setCurrentUsage((prev) => prev + 1);
     setIsLoading(true);
     setIsTyping(true);
 
     try {
-      const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
       let token: string;
       try {
         token = await authClient.getValidToken();
@@ -99,15 +178,17 @@ export function ChatPanel({ isOpen, onClose, moduleId, conversationId, className
         }
         throw err;
       }
+
       const response = await fetch(`${API_BASE}/api/v1/tutor/chat`, {
-        method: "POST",
+        method: 'POST',
         headers: {
-          "Content-Type": "application/json",
+          'Content-Type': 'application/json',
           Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
           message: messageContent,
-          conversation_id: null,
+          conversation_id: activeConversationId ?? null,
+          module_id: moduleId ?? null,
         }),
       });
 
@@ -119,19 +200,20 @@ export function ChatPanel({ isOpen, onClose, moduleId, conversationId, className
         throw new Error(`API error: ${response.status}`);
       }
 
-      // Read SSE stream
       const reader = response.body?.getReader();
       const decoder = new TextDecoder();
-      let fullContent = "";
+      let fullContent = '';
       const aiMessageId = (Date.now() + 1).toString();
 
-      // Add placeholder message
-      setMessages(prev => [...prev, {
-        id: aiMessageId,
-        content: "",
-        isUser: false,
-        timestamp: new Date(),
-      }]);
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: aiMessageId,
+          content: '',
+          isUser: false,
+          timestamp: new Date(),
+        },
+      ]);
 
       if (reader) {
         while (true) {
@@ -139,50 +221,91 @@ export function ChatPanel({ isOpen, onClose, moduleId, conversationId, className
           if (done) break;
 
           const text = decoder.decode(value, { stream: true });
-          const lines = text.split("\n");
+          const lines = text.split('\n');
 
           for (const line of lines) {
-            if (!line.startsWith("data: ")) continue;
+            if (!line.startsWith('data: ')) continue;
             try {
               const chunk = JSON.parse(line.slice(6));
-              if (chunk.type === "content" && chunk.data?.text) {
-                fullContent += chunk.data.text;
-                setMessages(prev => prev.map(m =>
-                  m.id === aiMessageId ? { ...m, content: fullContent } : m
-                ));
-              } else if (chunk.type === "sources_cited" && chunk.data?.sources) {
-                setMessages(prev => prev.map(m =>
-                  m.id === aiMessageId ? {
-                    ...m,
-                    sources: chunk.data.sources.map((s: { source: string; chapter?: number; page?: number }, i: number) => ({
-                      title: s.source ?? String(i + 1), chapter: s.chapter ?? i + 1, page: s.page ?? 0,
-                    })),
-                  } : m
-                ));
-              } else if (chunk.type === "error") {
-                const errorCode = chunk.data?.code;
-                fullContent = errorCode === "limit_reached" ? t('errorLimitReached') : t('error');
-                setMessages(prev => prev.map(m =>
-                  m.id === aiMessageId ? { ...m, content: fullContent } : m
-                ));
+
+              if (chunk.type === 'conversation_id' && chunk.data?.conversation_id) {
+                const newId = chunk.data.conversation_id as string;
+                if (!activeConversationId) {
+                  setActiveConversationId(newId);
+                  onConversationCreated?.(newId);
+                }
+              } else if (chunk.type === 'content' && chunk.data?.text) {
+                fullContent += chunk.data.text as string;
+                setMessages((prev) =>
+                  prev.map((m) => (m.id === aiMessageId ? { ...m, content: fullContent } : m))
+                );
+              } else if (chunk.type === 'sources_cited' && chunk.data?.sources) {
+                setMessages((prev) =>
+                  prev.map((m) =>
+                    m.id === aiMessageId
+                      ? {
+                          ...m,
+                          sources: (
+                            chunk.data.sources as Array<{
+                              source: string;
+                              chapter?: number;
+                              page?: number;
+                            }>
+                          ).map((s, i) => ({
+                            title: s.source ?? String(i + 1),
+                            chapter: s.chapter ?? i + 1,
+                            page: s.page ?? 0,
+                          })),
+                        }
+                      : m
+                  )
+                );
+              } else if (chunk.type === 'finished' && chunk.data?.conversation_id) {
+                const finishedConvId = chunk.data.conversation_id as string;
+                const updatedMessages = await syncConversationCache(finishedConvId);
+                onMessagesUpdated?.(
+                  finishedConvId,
+                  messageContent.slice(0, 50),
+                  updatedMessages
+                );
+              } else if (chunk.type === 'error') {
+                const errorCode = chunk.data?.code as string | undefined;
+                fullContent =
+                  errorCode === 'limit_reached' ? t('errorLimitReached') : t('error');
+                setMessages((prev) =>
+                  prev.map((m) => (m.id === aiMessageId ? { ...m, content: fullContent } : m))
+                );
               }
             } catch {
-              // Skip unparseable lines
+              // skip unparseable lines
             }
           }
         }
       }
     } catch (error) {
       console.error('Failed to send message:', error);
-      setMessages(prev => [...prev, {
-        id: (Date.now() + 1).toString(),
-        content: t('error'),
-        isUser: false,
-        timestamp: new Date(),
-      }]);
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: (Date.now() + 1).toString(),
+          content: t('error'),
+          isUser: false,
+          timestamp: new Date(),
+        },
+      ]);
     } finally {
       setIsLoading(false);
       setIsTyping(false);
+    }
+  };
+
+  const syncConversationCache = async (convId: string): Promise<number> => {
+    try {
+      const detail = await fetchConversation(convId);
+      setCachedConversation(detail);
+      return detail.messages.length;
+    } catch {
+      return 0;
     }
   };
 
@@ -199,7 +322,7 @@ export function ChatPanel({ isOpen, onClose, moduleId, conversationId, className
         content: t('welcomeMessage'),
         isUser: false,
         timestamp: new Date(),
-      }
+      },
     ]);
     setShowClearDialog(false);
   };
@@ -208,19 +331,15 @@ export function ChatPanel({ isOpen, onClose, moduleId, conversationId, className
 
   return (
     <>
-      <div 
+      <div
         className={cn(
-          // Mobile: Full screen overlay
           'fixed inset-0 z-50 bg-background',
-          // Desktop: Side panel
           'md:relative md:inset-auto md:w-96 md:border-l',
-          // Animation
           'transition-transform duration-300 ease-in-out',
           isOpen ? 'translate-x-0' : 'translate-x-full md:translate-x-0',
           className
         )}
       >
-        {/* Header */}
         <div className="flex items-center justify-between p-4 border-b bg-background">
           <h2 className="text-lg font-semibold">{t('title')}</h2>
           <div className="flex items-center gap-2">
@@ -248,19 +367,14 @@ export function ChatPanel({ isOpen, onClose, moduleId, conversationId, className
           </div>
         </div>
 
-        {/* Usage Counter */}
-        <UsageCounter 
-          currentUsage={currentUsage} 
+        <UsageCounter
+          currentUsage={currentUsage}
           maxUsage={maxDailyUsage}
           className="p-4 pb-2"
         />
 
-        {/* Messages */}
         <div className="flex-1 flex flex-col min-h-0">
-          <div
-            ref={scrollAreaRef}
-            className="flex-1 overflow-y-auto px-4 py-2"
-          >
+          <div ref={scrollAreaRef} className="flex-1 overflow-y-auto px-4 py-2">
             {isLoading && messages.length <= 1 ? (
               <ChatSkeleton />
             ) : (
@@ -272,28 +386,18 @@ export function ChatPanel({ isOpen, onClose, moduleId, conversationId, className
               </>
             )}
 
-            {/* Empty state */}
             {messages.length === 0 && !isLoading && (
               <div className="flex flex-col items-center justify-center h-full text-center p-6">
-                <div className="text-muted-foreground mb-2">
-                  {t('emptyState')}
-                </div>
-                <div className="text-sm text-muted-foreground">
-                  {t('emptyStateDescription')}
-                </div>
+                <div className="text-muted-foreground mb-2">{t('emptyState')}</div>
+                <div className="text-sm text-muted-foreground">{t('emptyStateDescription')}</div>
               </div>
             )}
           </div>
 
-          {/* Suggestions */}
           {!isLimitReached && (
-            <ChatSuggestions
-              onSuggestionClick={handleSuggestionClick}
-              disabled={isLoading}
-            />
+            <ChatSuggestions onSuggestionClick={handleSuggestionClick} disabled={isLoading} />
           )}
 
-          {/* Input */}
           <ChatInput
             onSendMessage={handleSendMessage}
             disabled={isLimitReached || isLoading}
@@ -301,14 +405,11 @@ export function ChatPanel({ isOpen, onClose, moduleId, conversationId, className
         </div>
       </div>
 
-      {/* Clear History Dialog */}
       <AlertDialog open={showClearDialog} onOpenChange={setShowClearDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>{t('confirmClearHistory')}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {t('confirmClearHistoryDescription')}
-            </AlertDialogDescription>
+            <AlertDialogDescription>{t('confirmClearHistoryDescription')}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>{t('cancel')}</AlertDialogCancel>

--- a/frontend/lib/tutor-api.ts
+++ b/frontend/lib/tutor-api.ts
@@ -1,0 +1,109 @@
+import { authClient, AuthError } from '@/lib/auth';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+export interface ConversationSummary {
+  id: string;
+  module_id: string | null;
+  message_count: number;
+  last_message_at: string;
+  preview: string;
+}
+
+export interface TutorMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  sources: Array<{ source: string; chapter?: number; page?: number }>;
+  timestamp: string;
+  activity_suggestions?: Array<{ type: string; label: string }>;
+}
+
+export interface ConversationDetail {
+  id: string;
+  module_id: string | null;
+  messages: TutorMessage[];
+  created_at: string;
+}
+
+export interface ConversationListResponse {
+  conversations: ConversationSummary[];
+  total: number;
+}
+
+const CACHE_KEY = 'tutor_conversations_cache';
+const CONVERSATION_CACHE_PREFIX = 'tutor_conv_';
+
+export function getCachedConversations(): ConversationSummary[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as ConversationSummary[];
+  } catch {
+    return [];
+  }
+}
+
+export function setCachedConversations(conversations: ConversationSummary[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify(conversations));
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export function getCachedConversation(id: string): ConversationDetail | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(`${CONVERSATION_CACHE_PREFIX}${id}`);
+    if (!raw) return null;
+    return JSON.parse(raw) as ConversationDetail;
+  } catch {
+    return null;
+  }
+}
+
+export function setCachedConversation(conversation: ConversationDetail): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(
+      `${CONVERSATION_CACHE_PREFIX}${conversation.id}`,
+      JSON.stringify(conversation)
+    );
+  } catch {
+    // ignore storage errors
+  }
+}
+
+async function getAuthHeaders(): Promise<Record<string, string>> {
+  const token = await authClient.getValidToken();
+  return {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${token}`,
+  };
+}
+
+export async function fetchConversations(
+  limit = 20,
+  offset = 0
+): Promise<ConversationListResponse> {
+  const headers = await getAuthHeaders();
+  const response = await fetch(
+    `${API_BASE}/api/v1/tutor/conversations?limit=${limit}&offset=${offset}`,
+    { headers }
+  );
+  if (!response.ok) {
+    throw new AuthError(`Failed to fetch conversations: ${response.status}`, response.status);
+  }
+  return response.json() as Promise<ConversationListResponse>;
+}
+
+export async function fetchConversation(id: string): Promise<ConversationDetail> {
+  const headers = await getAuthHeaders();
+  const response = await fetch(`${API_BASE}/api/v1/tutor/conversations/${id}`, { headers });
+  if (!response.ok) {
+    throw new AuthError(`Failed to fetch conversation: ${response.status}`, response.status);
+  }
+  return response.json() as Promise<ConversationDetail>;
+}


### PR DESCRIPTION
## Summary

- Fixes conversations being lost on browser reload
- Frontend now loads conversation history from the backend API on page mount
- Conversations are cached in localStorage for offline access (cache-then-network pattern)
- Real `conversation_id` is passed to the `/chat` endpoint so messages accumulate in the correct DB record
- Tutor page sidebar shows real conversations from the server instead of hardcoded fake data

## Changes

- **`frontend/lib/tutor-api.ts`** (new): Typed API helpers (`fetchConversations`, `fetchConversation`) with localStorage cache utilities (`getCachedConversations`, `setCachedConversations`, `getCachedConversation`, `setCachedConversation`)
- **`frontend/components/chat/chat-panel.tsx`**: Load conversation on mount (server fetch + cache fallback), pass real `conversation_id`, sync cache on `finished` SSE event, notify parent via `onConversationCreated` / `onMessagesUpdated` callbacks
- **`frontend/app/[locale]/(app)/tutor/tutor-client.tsx`**: Load real conversations from API on mount, update sidebar in real-time when messages are sent, cache updates written to localStorage
- **`backend/tests/test_tutor_service.py`**: 3 new tests for `list_conversations` and `get_conversation`

## Test plan

- [x] Backend tests pass (8/8)
- [x] Frontend lint passes (0 errors)
- [x] `npm run build` passes
- [ ] Manually verify: have a conversation → reload → messages persist
- [ ] Manually verify: go offline → cached conversations still visible in sidebar
- [ ] Manually verify: switching conversations loads correct message history

Closes #299

Generated with [Claude Code](https://claude.ai/code)