### PR TITLE
feat(offline): background sync — auto-sync progression when back online

### DIFF
--- a/frontend/app/[locale]/(app)/layout.tsx
+++ b/frontend/app/[locale]/(app)/layout.tsx
@@ -3,6 +3,7 @@ import { Header } from "@/components/layout/header";
 import { Sidebar } from "@/components/layout/sidebar";
 import { BreadcrumbNav } from "@/components/layout/breadcrumb-nav";
 import { ChatLayout } from "@/components/chat/chat-layout";
+import { SyncStatusIndicator } from "@/components/shared/sync-status-indicator";
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -12,6 +13,9 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
         <div className="flex flex-1 flex-col">
           <Header />
           <BreadcrumbNav />
+          <div className="flex items-center justify-end px-4 py-1">
+            <SyncStatusIndicator />
+          </div>
           <main className="flex-1 pb-16 pt-0 md:pb-0">{children}</main>
         </div>
         <BottomNav />

--- a/frontend/components/shared/sync-status-indicator.tsx
+++ b/frontend/components/shared/sync-status-indicator.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { getSyncManager, type SyncStatus } from "@/lib/offline/sync-manager";
+
+export function SyncStatusIndicator() {
+  const t = useTranslations("Sync");
+  const [status, setStatus] = useState<SyncStatus>({
+    state: "idle",
+    pendingCount: 0,
+    lastSyncedCounts: null,
+  });
+  const [showSuccess, setShowSuccess] = useState(false);
+
+  useEffect(() => {
+    const manager = getSyncManager();
+    const unsubscribe = manager.subscribe((s) => {
+      setStatus((prev) => {
+        if (
+          prev.lastSyncedCounts === null &&
+          s.lastSyncedCounts !== null
+        ) {
+          setShowSuccess(true);
+          setTimeout(() => setShowSuccess(false), 5000);
+        }
+        return s;
+      });
+    });
+    return unsubscribe;
+  }, []);
+
+  if (showSuccess && status.lastSyncedCounts) {
+    const counts = status.lastSyncedCounts;
+    const parts: string[] = [];
+    if (counts.quiz_attempt > 0) {
+      parts.push(
+        t("successQuiz", { count: counts.quiz_attempt })
+      );
+    }
+    if (counts.flashcard_review > 0) {
+      parts.push(
+        t("successFlashcards", { count: counts.flashcard_review })
+      );
+    }
+    if (counts.lesson_reading > 0) {
+      parts.push(
+        t("successLessons", { count: counts.lesson_reading })
+      );
+    }
+    const message = parts.join(", ");
+
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex items-center gap-1.5 rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300"
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden="true" />
+        {message}
+      </div>
+    );
+  }
+
+  if (status.state === "syncing") {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex items-center gap-1.5 rounded-full bg-blue-100 px-3 py-1 text-xs font-medium text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
+      >
+        <span
+          className="h-3 w-3 animate-spin rounded-full border-2 border-blue-500 border-t-transparent"
+          aria-hidden="true"
+        />
+        {t("syncing")}
+      </div>
+    );
+  }
+
+  if (status.pendingCount > 0) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex items-center gap-1.5 rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-300"
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-amber-500" aria-hidden="true" />
+        {t("pending", { count: status.pendingCount })}
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/frontend/lib/offline/db.ts
+++ b/frontend/lib/offline/db.ts
@@ -1,0 +1,189 @@
+const DB_NAME = "santeaof-offline";
+const DB_VERSION = 1;
+
+export type ActionType = "quiz_attempt" | "flashcard_review" | "lesson_reading";
+export type ActionStatus = "pending" | "synced" | "failed";
+
+export interface OfflineAction {
+  id?: number;
+  type: ActionType;
+  payload: Record<string, unknown>;
+  timestamp: number;
+  status: ActionStatus;
+  retryCount: number;
+  serverTimestamp?: number;
+}
+
+let dbInstance: IDBDatabase | null = null;
+
+export async function openDB(): Promise<IDBDatabase> {
+  if (dbInstance) return dbInstance;
+
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result;
+
+      if (!db.objectStoreNames.contains("offline_actions")) {
+        const store = db.createObjectStore("offline_actions", {
+          keyPath: "id",
+          autoIncrement: true,
+        });
+        store.createIndex("status", "status", { unique: false });
+        store.createIndex("timestamp", "timestamp", { unique: false });
+        store.createIndex("type", "type", { unique: false });
+      }
+    };
+
+    request.onsuccess = (event) => {
+      dbInstance = (event.target as IDBOpenDBRequest).result;
+      resolve(dbInstance);
+    };
+
+    request.onerror = () => {
+      reject(request.error);
+    };
+  });
+}
+
+export async function addOfflineAction(
+  action: Omit<OfflineAction, "id">
+): Promise<number> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction("offline_actions", "readwrite");
+    const store = tx.objectStore("offline_actions");
+    const req = store.add(action);
+    req.onsuccess = () => resolve(req.result as number);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function getPendingActions(): Promise<OfflineAction[]> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction("offline_actions", "readonly");
+    const store = tx.objectStore("offline_actions");
+    const index = store.index("status");
+    const req = index.getAll("pending");
+    req.onsuccess = () => {
+      const actions = (req.result as OfflineAction[]).sort(
+        (a, b) => a.timestamp - b.timestamp
+      );
+      resolve(actions);
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function getPendingCount(): Promise<number> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction("offline_actions", "readonly");
+    const store = tx.objectStore("offline_actions");
+    const index = store.index("status");
+    const req = index.count("pending");
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function markActionSynced(id: number): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction("offline_actions", "readwrite");
+    const store = tx.objectStore("offline_actions");
+    const getReq = store.get(id);
+    getReq.onsuccess = () => {
+      const action = getReq.result as OfflineAction;
+      if (!action) {
+        resolve();
+        return;
+      }
+      action.status = "synced";
+      const putReq = store.put(action);
+      putReq.onsuccess = () => resolve();
+      putReq.onerror = () => reject(putReq.error);
+    };
+    getReq.onerror = () => reject(getReq.error);
+  });
+}
+
+export async function markActionFailed(
+  id: number,
+  incrementRetry = true
+): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction("offline_actions", "readwrite");
+    const store = tx.objectStore("offline_actions");
+    const getReq = store.get(id);
+    getReq.onsuccess = () => {
+      const action = getReq.result as OfflineAction;
+      if (!action) {
+        resolve();
+        return;
+      }
+      if (incrementRetry) {
+        action.retryCount += 1;
+      }
+      const putReq = store.put(action);
+      putReq.onsuccess = () => resolve();
+      putReq.onerror = () => reject(putReq.error);
+    };
+    getReq.onerror = () => reject(getReq.error);
+  });
+}
+
+export async function getSyncedActionCounts(): Promise<
+  Record<ActionType, number>
+> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction("offline_actions", "readonly");
+    const store = tx.objectStore("offline_actions");
+    const index = store.index("status");
+    const req = index.getAll("synced");
+    req.onsuccess = () => {
+      const actions = req.result as OfflineAction[];
+      const counts: Record<ActionType, number> = {
+        quiz_attempt: 0,
+        flashcard_review: 0,
+        lesson_reading: 0,
+      };
+      for (const action of actions) {
+        counts[action.type] = (counts[action.type] || 0) + 1;
+      }
+      resolve(counts);
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function clearSyncedActions(): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction("offline_actions", "readwrite");
+    const store = tx.objectStore("offline_actions");
+    const index = store.index("status");
+    const req = index.getAllKeys("synced");
+    req.onsuccess = () => {
+      const keys = req.result as number[];
+      let deleted = 0;
+      if (keys.length === 0) {
+        resolve();
+        return;
+      }
+      for (const key of keys) {
+        const delReq = store.delete(key);
+        delReq.onsuccess = () => {
+          deleted++;
+          if (deleted === keys.length) resolve();
+        };
+        delReq.onerror = () => reject(delReq.error);
+      }
+    };
+    req.onerror = () => reject(req.error);
+  });
+}

--- a/frontend/lib/offline/sync-manager.ts
+++ b/frontend/lib/offline/sync-manager.ts
@@ -1,0 +1,194 @@
+import {
+  getPendingActions,
+  getPendingCount,
+  markActionSynced,
+  markActionFailed,
+  getSyncedActionCounts,
+  clearSyncedActions,
+  type ActionType,
+  type OfflineAction,
+} from "./db";
+
+export type SyncState = "idle" | "syncing" | "error";
+
+export interface SyncStatus {
+  state: SyncState;
+  pendingCount: number;
+  lastSyncedCounts: Record<ActionType, number> | null;
+}
+
+type SyncStatusListener = (status: SyncStatus) => void;
+
+const API_ENDPOINTS: Record<ActionType, string> = {
+  quiz_attempt: "/api/v1/quiz/lesson-validation/submit",
+  flashcard_review: "/api/v1/flashcards/review",
+  lesson_reading: "/api/v1/progress/lesson-reading",
+};
+
+const MAX_RETRY_COUNT = 5;
+const BASE_BACKOFF_MS = 1000;
+
+function getBackoffDelay(retryCount: number): number {
+  return Math.min(BASE_BACKOFF_MS * Math.pow(2, retryCount), 30000);
+}
+
+async function syncAction(action: OfflineAction): Promise<boolean> {
+  const endpoint = API_ENDPOINTS[action.type];
+  if (!endpoint) return false;
+
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...action.payload,
+        client_timestamp: action.timestamp,
+      }),
+    });
+
+    if (response.ok) {
+      return true;
+    }
+
+    if (response.status >= 400 && response.status < 500) {
+      return false;
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+class SyncManager {
+  private listeners: Set<SyncStatusListener> = new Set();
+  private state: SyncState = "idle";
+  private pendingCount = 0;
+  private lastSyncedCounts: Record<ActionType, number> | null = null;
+  private isSyncing = false;
+  private retryTimeouts: Map<number, ReturnType<typeof setTimeout>> = new Map();
+
+  constructor() {
+    if (typeof window !== "undefined") {
+      window.addEventListener("online", this.handleOnline);
+      this.refreshPendingCount();
+    }
+  }
+
+  destroy() {
+    if (typeof window !== "undefined") {
+      window.removeEventListener("online", this.handleOnline);
+    }
+    for (const timeout of this.retryTimeouts.values()) {
+      clearTimeout(timeout);
+    }
+    this.retryTimeouts.clear();
+  }
+
+  private handleOnline = () => {
+    this.sync();
+  };
+
+  subscribe(listener: SyncStatusListener): () => void {
+    this.listeners.add(listener);
+    listener(this.getStatus());
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private notify() {
+    const status = this.getStatus();
+    for (const listener of this.listeners) {
+      listener(status);
+    }
+  }
+
+  getStatus(): SyncStatus {
+    return {
+      state: this.state,
+      pendingCount: this.pendingCount,
+      lastSyncedCounts: this.lastSyncedCounts,
+    };
+  }
+
+  async refreshPendingCount() {
+    try {
+      this.pendingCount = await getPendingCount();
+      this.notify();
+    } catch {
+      // ignore DB errors silently
+    }
+  }
+
+  async sync(): Promise<void> {
+    if (this.isSyncing) return;
+    if (typeof window !== "undefined" && !navigator.onLine) return;
+
+    this.isSyncing = true;
+    this.state = "syncing";
+    this.notify();
+
+    try {
+      const pending = await getPendingActions();
+
+      if (pending.length === 0) {
+        this.state = "idle";
+        this.isSyncing = false;
+        this.notify();
+        return;
+      }
+
+      let anyFailed = false;
+
+      for (const action of pending) {
+        if (action.id === undefined) continue;
+        if (action.retryCount >= MAX_RETRY_COUNT) continue;
+
+        const success = await syncAction(action);
+
+        if (success) {
+          await markActionSynced(action.id);
+        } else {
+          await markActionFailed(action.id);
+          anyFailed = true;
+
+          const delay = getBackoffDelay(action.retryCount + 1);
+          const timeoutId = setTimeout(() => {
+            this.retryTimeouts.delete(action.id!);
+            if (typeof window !== "undefined" && navigator.onLine) {
+              this.sync();
+            }
+          }, delay);
+          this.retryTimeouts.set(action.id, timeoutId);
+        }
+      }
+
+      const syncedCounts = await getSyncedActionCounts();
+      const hasSynced = Object.values(syncedCounts).some((c) => c > 0);
+      if (hasSynced) {
+        this.lastSyncedCounts = syncedCounts;
+        await clearSyncedActions();
+      }
+
+      this.pendingCount = await getPendingCount();
+      this.state = anyFailed ? "error" : "idle";
+    } catch {
+      this.state = "error";
+    } finally {
+      this.isSyncing = false;
+      this.notify();
+    }
+  }
+}
+
+let syncManagerInstance: SyncManager | null = null;
+
+export function getSyncManager(): SyncManager {
+  if (!syncManagerInstance) {
+    syncManagerInstance = new SyncManager();
+  }
+  return syncManagerInstance;
+}
+
+export { SyncManager };

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -613,6 +613,13 @@
     "availableInLibrary": "Available in reference library",
     "footnote": "{count, plural, one {# source cited} other {# sources cited}}"
   },
+  "Sync": {
+    "pending": "{count, plural, one {# action pending} other {# actions pending}}",
+    "syncing": "Syncing...",
+    "successQuiz": "{count, plural, one {# quiz synced} other {# quizzes synced}}",
+    "successFlashcards": "{count, plural, one {# flashcard updated} other {# flashcards updated}}",
+    "successLessons": "{count, plural, one {# lesson synced} other {# lessons synced}}"
+  },
   "Profile": {
     "title": "Profile",
     "description": "Manage your account and learning preferences",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -613,6 +613,13 @@
     "availableInLibrary": "Disponible dans la bibliothèque de référence",
     "footnote": "{count, plural, one {# source référencée} other {# sources référencées}}"
   },
+  "Sync": {
+    "pending": "{count, plural, one {# action en attente} other {# actions en attente}}",
+    "syncing": "Synchronisation en cours...",
+    "successQuiz": "{count, plural, one {# quiz synchronisé} other {# quiz synchronisés}}",
+    "successFlashcards": "{count, plural, one {# flashcard mise à jour} other {# flashcards mises à jour}}",
+    "successLessons": "{count, plural, one {# leçon synchronisée} other {# leçons synchronisées}}"
+  },
   "Profile": {
     "title": "Profil",
     "description": "Gérez votre compte et vos préférences d'apprentissage",


### PR DESCRIPTION
## Summary

Implements the background synchronization system that automatically syncs offline progression (quiz attempts, flashcard reviews, lesson readings) to the backend when connectivity is restored.

## Changes

- **`frontend/lib/offline/db.ts`** — IndexedDB wrapper with `offline_actions` store CRUD: `addOfflineAction`, `getPendingActions`, `getPendingCount`, `markActionSynced`, `markActionFailed`, `getSyncedActionCounts`, `clearSyncedActions`
- **`frontend/lib/offline/sync-manager.ts`** — `SyncManager` singleton: listens to `online` event, processes queue in FIFO order, maps action types to API endpoints, marks success/failure, retries with exponential backoff (max 5 attempts, 30s cap), last-write-wins conflict resolution via `client_timestamp`, subscriber pattern for UI updates
- **`frontend/components/shared/sync-status-indicator.tsx`** — Pill indicator showing: pending count (amber), syncing animation (blue spinner), success notification (green) with per-type counts (quiz / flashcards / lessons), auto-hides after 5s
- **`frontend/app/[locale]/(app)/layout.tsx`** — Mounts `SyncStatusIndicator` in the app layout
- **`frontend/messages/fr.json`** + **`frontend/messages/en.json`** — `Sync` i18n namespace with all bilingual strings

## Test plan

- [ ] Frontend lint passes (0 errors)
- [ ] Frontend build passes
- [ ] Sync triggers on `online` event
- [ ] Actions processed in chronological order (FIFO)
- [ ] Failed sync retained for retry with exponential backoff
- [ ] Success notification shows correct per-type counts
- [ ] i18n: all strings present in both FR and EN
- [ ] Manually verified on mobile viewport (320px)

Closes #298

---
Generated with [Claude Code](https://claude.ai/code)