### PR TITLE
feat(offline): serve lessons, quizzes, case studies from IndexedDB (#296)

### DIFF
--- a/frontend/components/learning/case-study-viewer.tsx
+++ b/frontend/components/learning/case-study-viewer.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
-import { CheckCircle, Clock, FileText } from 'lucide-react';
+import { CheckCircle, Clock, FileText, WifiOff } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -10,6 +10,12 @@ import ReactMarkdown from 'react-markdown';
 import { LessonSkeleton } from './lesson-skeleton';
 import { SourceCitations } from './source-citations';
 import { apiFetch } from '@/lib/api';
+import {
+  getContentFromDB,
+  saveContentToDB,
+  queueOfflineAction,
+  isOnline,
+} from '@/lib/offline/content-loader';
 
 interface CaseStudyContent {
   aof_context: string;
@@ -53,17 +59,39 @@ export function CaseStudyViewer({
   const [error, setError] = useState<string | null>(null);
   const [isCompleted, setIsCompleted] = useState(false);
   const [correctionVisible, setCorrectionVisible] = useState(false);
+  const [servedFromCache, setServedFromCache] = useState(false);
+  const [notAvailableOffline, setNotAvailableOffline] = useState(false);
 
   const t = useTranslations('CaseStudyViewer');
 
   useEffect(() => {
     let eventSource: EventSource | null = null;
 
-    const startStreaming = async () => {
+    const loadCaseStudy = async () => {
       try {
         setIsStreaming(true);
         setError(null);
+        setNotAvailableOffline(false);
 
+        // 1. Check IndexedDB first
+        const cached = await getContentFromDB<CaseStudyData>(
+          moduleId, unitId, language, level, countryContext, 'case'
+        );
+        if (cached) {
+          setCaseStudyData(cached);
+          setServedFromCache(true);
+          setIsStreaming(false);
+          return;
+        }
+
+        // 2. If offline and not in IndexedDB — show unavailable message
+        if (!isOnline()) {
+          setNotAvailableOffline(true);
+          setIsStreaming(false);
+          return;
+        }
+
+        // 3. Try API cache
         try {
           const cachedData = await apiFetch<CaseStudyData>(
             `/api/v1/content/lessons/${moduleId}/${unitId}?language=${language}&level=${level}&country=${countryContext}&content_type=case`
@@ -71,23 +99,28 @@ export function CaseStudyViewer({
 
           if (cachedData.cached) {
             setCaseStudyData(cachedData);
+            setServedFromCache(false);
             setIsStreaming(false);
+            await saveContentToDB(moduleId, unitId, language, level, countryContext, 'case', cachedData);
             return;
           }
         } catch {
+          // Cache check failed — continue to streaming
         }
 
+        // 4. Stream generation
         const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
         const streamUrl = `${API_BASE}/api/v1/content/lessons/${moduleId}/${unitId}/stream?language=${language}&level=${level}&country=${countryContext}&content_type=case`;
         eventSource = new EventSource(streamUrl);
 
-        eventSource.onmessage = (event) => {
+        eventSource.onmessage = async (event) => {
           try {
             const data = JSON.parse(event.data);
             if (data.event === 'complete') {
               setCaseStudyData(data.data);
               setIsStreaming(false);
               eventSource?.close();
+              await saveContentToDB(moduleId, unitId, language, level, countryContext, 'case', data.data);
             }
           } catch (e) {
             console.error('Error parsing SSE data:', e);
@@ -105,7 +138,7 @@ export function CaseStudyViewer({
       }
     };
 
-    startStreaming();
+    loadCaseStudy();
 
     return () => {
       eventSource?.close();
@@ -113,6 +146,21 @@ export function CaseStudyViewer({
   }, [moduleId, unitId, language, level, countryContext, t]);
 
   const handleMarkComplete = async () => {
+    if (!isOnline()) {
+      await queueOfflineAction({
+        type: 'lesson_progress',
+        payload: {
+          module_id: moduleId,
+          unit_id: unitId,
+          completed: true,
+        },
+        created_at: new Date().toISOString(),
+      });
+      setIsCompleted(true);
+      onComplete?.();
+      return;
+    }
+
     try {
       await apiFetch(`/api/v1/progress/complete-lesson`, {
         method: 'POST',
@@ -123,13 +171,37 @@ export function CaseStudyViewer({
       });
       setIsCompleted(true);
       onComplete?.();
-    } catch (err) {
-      console.error('Error marking case study complete:', err);
+    } catch {
+      await queueOfflineAction({
+        type: 'lesson_progress',
+        payload: {
+          module_id: moduleId,
+          unit_id: unitId,
+          completed: true,
+        },
+        created_at: new Date().toISOString(),
+      });
+      setIsCompleted(true);
+      onComplete?.();
     }
   };
 
   const mdClass =
     'prose prose-gray max-w-none prose-headings:text-gray-900 prose-p:text-gray-700 prose-li:text-gray-700 prose-strong:text-gray-900 prose-table:text-sm';
+
+  if (notAvailableOffline) {
+    return (
+      <div className="container mx-auto max-w-4xl px-4 py-6">
+        <Card className="border-amber-200">
+          <CardContent className="p-6 text-center">
+            <WifiOff className="w-10 h-10 text-amber-500 mx-auto mb-3" />
+            <div className="text-amber-700 font-medium mb-2">{t('offlineUnavailableTitle')}</div>
+            <p className="text-gray-600">{t('offlineUnavailable')}</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
 
   if (error) {
     return (
@@ -158,7 +230,7 @@ export function CaseStudyViewer({
     <div className="container mx-auto max-w-4xl px-4 py-6">
       {/* Header */}
       <div className="mb-8">
-        <div className="flex items-center gap-3 mb-3">
+        <div className="flex items-center gap-3 mb-3 flex-wrap">
           <Badge variant="outline" className="flex items-center gap-1">
             <FileText className="w-3 h-3" />
             {t('badge')}
@@ -169,6 +241,12 @@ export function CaseStudyViewer({
             {t('estimatedTime')}
           </div>
           {caseStudyData.cached && <Badge variant="secondary">{t('cached')}</Badge>}
+          {servedFromCache && (
+            <Badge variant="secondary" className="flex items-center gap-1 bg-amber-50 text-amber-700 border-amber-200">
+              <WifiOff className="w-3 h-3" />
+              {t('offlineBadge')}
+            </Badge>
+          )}
         </div>
         <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-3">
           {t('unitTitle', { unit: unitId })}
@@ -235,7 +313,7 @@ export function CaseStudyViewer({
                 onClick={() => setCorrectionVisible(true)}
                 className="min-h-11 border-green-300 text-green-700 hover:bg-green-50"
               >
-                {language === 'fr' ? 'Voir la correction' : 'Show correction'}
+                {t('showCorrection')}
               </Button>
             )}
           </div>

--- a/frontend/components/learning/flashcard-deck.tsx
+++ b/frontend/components/learning/flashcard-deck.tsx
@@ -4,7 +4,10 @@ import { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { WifiOff } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { queueOfflineAction, isOnline } from '@/lib/offline/content-loader';
 
 interface FlashcardData {
   id: string;
@@ -32,16 +35,18 @@ interface FlashcardDeckProps {
   }) => void;
   isLoading?: boolean;
   language: 'fr' | 'en';
+  servedFromCache?: boolean;
 }
 
 type Rating = 'again' | 'hard' | 'good' | 'easy';
 
-export function FlashcardDeck({ 
-  cards, 
-  onReview, 
-  onSessionComplete, 
-  isLoading = false, 
-  language = 'fr' 
+export function FlashcardDeck({
+  cards,
+  onReview,
+  onSessionComplete,
+  isLoading = false,
+  language = 'fr',
+  servedFromCache = false,
 }: FlashcardDeckProps) {
   const t = useTranslations('Flashcards');
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -52,7 +57,8 @@ export function FlashcardDeck({
   const [isDragging, setIsDragging] = useState(false);
   const [cardTransform, setCardTransform] = useState({ x: 0, rotation: 0 });
   const [pendingRating, setPendingRating] = useState<Rating | null>(null);
-  
+  const [offline] = useState(!isOnline());
+
   const cardRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -70,17 +76,28 @@ export function FlashcardDeck({
     setIsFlipped(!isFlipped);
   };
 
-  const handleRating = (rating: Rating) => {
+  const handleRating = async (rating: Rating) => {
     if (!currentCard) return;
 
-    // Record the review
+    if (!isOnline()) {
+      await queueOfflineAction({
+        type: 'flashcard_review',
+        payload: {
+          card_id: currentCard.id,
+          review_id: currentCard.review_id,
+          rating,
+          reviewed_at: new Date().toISOString(),
+        },
+        created_at: new Date().toISOString(),
+      });
+    }
+
     onReview(currentCard.id, currentCard.review_id, rating);
-    
+
     const newRatings = [...reviewedRatings, rating];
     setReviewedRatings(newRatings);
 
     if (isLastCard) {
-      // Complete the session
       const sessionDuration = Math.floor((Date.now() - sessionStartTime) / 1000);
       onSessionComplete({
         cardsReviewed: cards.length,
@@ -88,7 +105,6 @@ export function FlashcardDeck({
         ratings: newRatings,
       });
     } else {
-      // Advance to next card
       setCurrentIndex(prev => prev + 1);
     }
   };
@@ -102,21 +118,18 @@ export function FlashcardDeck({
 
   const handleTouchMove = (e: React.TouchEvent) => {
     if (!touchStart || !isDragging) return;
-    
+
     const touch = e.touches[0];
     const deltaX = touch.clientX - touchStart.x;
     const deltaY = Math.abs(touch.clientY - touchStart.y);
-    
-    // Only track horizontal swipes (ignore vertical scrolling)
+
     if (deltaY > 50) return;
-    
-    // Calculate rotation based on horizontal movement
+
     const maxDelta = 150;
     const rotation = Math.max(-15, Math.min(15, (deltaX / maxDelta) * 15));
-    
+
     setCardTransform({ x: deltaX, rotation });
 
-    // Visual feedback for rating zones
     if (Math.abs(deltaX) > 50) {
       if (deltaX < -100) setPendingRating('again');
       else if (deltaX < -50) setPendingRating('hard');
@@ -129,21 +142,19 @@ export function FlashcardDeck({
 
   const handleTouchEnd = (e: React.TouchEvent) => {
     if (!touchStart || !isDragging) return;
-    
+
     const touch = e.changedTouches[0];
     const deltaX = touch.clientX - touchStart.x;
-    
+
     setIsDragging(false);
     setTouchStart(null);
 
-    // Determine if swipe was strong enough to trigger rating
     if (Math.abs(deltaX) > 80 && isFlipped) {
       if (deltaX < -100) handleRating('again');
       else if (deltaX < -40) handleRating('hard');
       else if (deltaX > 100) handleRating('easy');
       else if (deltaX > 40) handleRating('good');
     } else {
-      // Snap back to center
       setCardTransform({ x: 0, rotation: 0 });
       setPendingRating(null);
     }
@@ -157,15 +168,15 @@ export function FlashcardDeck({
 
   const handleMouseMove = (e: React.MouseEvent) => {
     if (!touchStart || !isDragging) return;
-    
+
     const deltaX = e.clientX - touchStart.x;
     const deltaY = Math.abs(e.clientY - touchStart.y);
-    
+
     if (deltaY > 50) return;
-    
+
     const maxDelta = 150;
     const rotation = Math.max(-15, Math.min(15, (deltaX / maxDelta) * 15));
-    
+
     setCardTransform({ x: deltaX, rotation });
 
     if (Math.abs(deltaX) > 50) {
@@ -180,9 +191,9 @@ export function FlashcardDeck({
 
   const handleMouseUp = (e: React.MouseEvent) => {
     if (!touchStart || !isDragging) return;
-    
+
     const deltaX = e.clientX - touchStart.x;
-    
+
     setIsDragging(false);
     setTouchStart(null);
 
@@ -224,6 +235,16 @@ export function FlashcardDeck({
 
   return (
     <div className="max-w-md mx-auto px-4" ref={containerRef}>
+      {/* Offline banner */}
+      {(offline || servedFromCache) && (
+        <div className="mb-4">
+          <Badge variant="secondary" className="flex items-center gap-1 w-full justify-center py-2 bg-amber-50 text-amber-700 border border-amber-200">
+            <WifiOff className="w-3 h-3" />
+            {t('offline')}
+          </Badge>
+        </div>
+      )}
+
       {/* Progress indicator */}
       <div className="mb-6">
         <div className="flex justify-between items-center mb-2">
@@ -232,7 +253,7 @@ export function FlashcardDeck({
           </span>
         </div>
         <div className="w-full bg-gray-200 rounded-full h-2">
-          <div 
+          <div
             className="bg-blue-600 h-2 rounded-full transition-all duration-300"
             style={{ width: `${((currentIndex + 1) / cards.length) * 100}%` }}
           />
@@ -271,7 +292,7 @@ export function FlashcardDeck({
 
       {/* Flashcard */}
       <div className="relative mb-6">
-        <Card 
+        <Card
           ref={cardRef}
           className={cn(
             "w-full h-96 cursor-pointer transition-all duration-300",
@@ -360,7 +381,7 @@ export function FlashcardDeck({
                 <div className="text-xs opacity-75">{t('ratingDescription.again')}</div>
               </div>
             </Button>
-            
+
             <Button
               variant="outline"
               className="min-h-11 bg-orange-50 border-orange-200 hover:bg-orange-100 text-orange-700"
@@ -371,7 +392,7 @@ export function FlashcardDeck({
                 <div className="text-xs opacity-75">{t('ratingDescription.hard')}</div>
               </div>
             </Button>
-            
+
             <Button
               variant="outline"
               className="min-h-11 bg-green-50 border-green-200 hover:bg-green-100 text-green-700"
@@ -382,7 +403,7 @@ export function FlashcardDeck({
                 <div className="text-xs opacity-75">{t('ratingDescription.good')}</div>
               </div>
             </Button>
-            
+
             <Button
               variant="outline"
               className="min-h-11 bg-blue-50 border-blue-200 hover:bg-blue-100 text-blue-700"
@@ -400,7 +421,7 @@ export function FlashcardDeck({
       {/* Card flip prompt (shown only when card is not flipped) */}
       {!isFlipped && (
         <div className="text-center">
-          <Button 
+          <Button
             variant="default"
             size="lg"
             onClick={handleCardFlip}

--- a/frontend/components/learning/lesson-viewer.tsx
+++ b/frontend/components/learning/lesson-viewer.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useTranslations } from 'next-intl';
-import { CheckCircle, Clock } from 'lucide-react';
+import { CheckCircle, Clock, WifiOff } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -11,6 +11,12 @@ import remarkGfm from 'remark-gfm';
 import { LessonSkeleton } from './lesson-skeleton';
 import { SourceCitations } from './source-citations';
 import { apiFetch } from '@/lib/api';
+import {
+  getContentFromDB,
+  saveContentToDB,
+  queueOfflineAction,
+  isOnline,
+} from '@/lib/offline/content-loader';
 
 interface LessonContent {
   introduction: string;
@@ -53,69 +59,88 @@ export function LessonViewer({
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isCompleted, setIsCompleted] = useState(false);
-  
+  const [servedFromCache, setServedFromCache] = useState(false);
+  const [notAvailableOffline, setNotAvailableOffline] = useState(false);
+  const lessonStartTime = useRef<number>(0);
+
   const t = useTranslations('LessonViewer');
 
   useEffect(() => {
     let eventSource: EventSource | null = null;
-    
-    const startStreaming = async () => {
+    lessonStartTime.current = typeof Date !== 'undefined' ? Date.now() : 0;
+
+    const loadLesson = async () => {
       try {
         setIsStreaming(true);
         setError(null);
-        
-        // First check if cached content exists
+        setNotAvailableOffline(false);
+
+        // 1. Check IndexedDB first
+        const cached = await getContentFromDB<LessonData>(
+          moduleId, unitId, language, level, countryContext, 'lesson'
+        );
+        if (cached) {
+          setLessonData(cached);
+          setServedFromCache(true);
+          setIsStreaming(false);
+          return;
+        }
+
+        // 2. If offline and not in IndexedDB — show unavailable message
+        if (!isOnline()) {
+          setNotAvailableOffline(true);
+          setIsStreaming(false);
+          return;
+        }
+
+        // 3. Try API cache
         try {
           const cachedData = await apiFetch<LessonData>(
             `/api/v1/content/lessons/${moduleId}/${unitId}?language=${language}&level=${level}&country=${countryContext}`
           );
-          
+
           if (cachedData.cached) {
             setLessonData(cachedData);
+            setServedFromCache(false);
             setIsStreaming(false);
+            await saveContentToDB(moduleId, unitId, language, level, countryContext, 'lesson', cachedData);
             return;
           }
-        } catch (cacheErr) {
-          // If cache check fails, continue to streaming
-          console.log('Cache check failed, falling back to streaming:', cacheErr);
+        } catch {
+          // Cache check failed — continue to streaming
         }
 
-        // If no cached content, start streaming
-        const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+        // 4. Stream generation
+        const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
         const streamUrl = `${API_BASE}/api/v1/content/lessons/${moduleId}/${unitId}/stream?language=${language}&level=${level}&country=${countryContext}`;
         eventSource = new EventSource(streamUrl);
-        
-        eventSource.onmessage = (event) => {
+
+        eventSource.onmessage = async (event) => {
           try {
             const data = JSON.parse(event.data);
-            
-            if (data.event === 'chunk') {
-              // For now, we'll just handle chunks in the complete event
-            } else if (data.event === 'complete') {
+            if (data.event === 'complete') {
               setLessonData(data.data);
               setIsStreaming(false);
               eventSource?.close();
+              await saveContentToDB(moduleId, unitId, language, level, countryContext, 'lesson', data.data);
             }
           } catch (e) {
             console.error('Error parsing SSE data:', e);
           }
         };
-        
-        eventSource.onerror = (event) => {
-          console.error('SSE error:', event);
+
+        eventSource.onerror = () => {
           setError(t('streamError'));
           setIsStreaming(false);
           eventSource?.close();
         };
-        
-      } catch (err) {
-        console.error('Error starting lesson stream:', err);
+      } catch {
         setError(t('loadError'));
         setIsStreaming(false);
       }
     };
 
-    startStreaming();
+    loadLesson();
 
     return () => {
       eventSource?.close();
@@ -123,19 +148,49 @@ export function LessonViewer({
   }, [moduleId, unitId, language, level, countryContext, t]);
 
   const handleMarkComplete = async () => {
+    const timeSpentSeconds = Math.floor((Date.now() - lessonStartTime.current) / 1000);
+
+    if (!isOnline()) {
+      await queueOfflineAction({
+        type: 'lesson_progress',
+        payload: {
+          module_id: moduleId,
+          unit_id: unitId,
+          time_spent_seconds: timeSpentSeconds,
+          completed: true,
+        },
+        created_at: new Date().toISOString(),
+      });
+      setIsCompleted(true);
+      onComplete?.();
+      return;
+    }
+
     try {
       await apiFetch(`/api/v1/progress/complete-lesson`, {
         method: 'POST',
         body: JSON.stringify({
           module_id: moduleId,
-          unit_id: unitId
+          unit_id: unitId,
+          time_spent_seconds: timeSpentSeconds,
         })
       });
-      
       setIsCompleted(true);
       onComplete?.();
-    } catch (err) {
-      console.error('Error marking lesson complete:', err);
+    } catch {
+      // Queue for later sync on network failure
+      await queueOfflineAction({
+        type: 'lesson_progress',
+        payload: {
+          module_id: moduleId,
+          unit_id: unitId,
+          time_spent_seconds: timeSpentSeconds,
+          completed: true,
+        },
+        created_at: new Date().toISOString(),
+      });
+      setIsCompleted(true);
+      onComplete?.();
     }
   };
 
@@ -158,6 +213,19 @@ export function LessonViewer({
     ),
   };
 
+  if (notAvailableOffline) {
+    return (
+      <div className="container mx-auto max-w-4xl px-4 py-6">
+        <Card className="border-amber-200">
+          <CardContent className="p-6 text-center">
+            <WifiOff className="w-10 h-10 text-amber-500 mx-auto mb-3" />
+            <div className="text-amber-700 font-medium mb-2">{t('offlineUnavailableTitle')}</div>
+            <p className="text-gray-600">{t('offlineUnavailable')}</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
 
   if (error) {
     return (
@@ -186,7 +254,7 @@ export function LessonViewer({
     <div className="container mx-auto max-w-4xl px-4 py-6">
       {/* Header */}
       <div className="mb-8">
-        <div className="flex items-center gap-3 mb-3">
+        <div className="flex items-center gap-3 mb-3 flex-wrap">
           <Badge variant="outline">{t('level', { level })}</Badge>
           <div className="flex items-center text-gray-600">
             <Clock className="w-4 h-4 mr-1" />
@@ -194,6 +262,12 @@ export function LessonViewer({
           </div>
           {lessonData.cached && (
             <Badge variant="secondary">{t('cached')}</Badge>
+          )}
+          {servedFromCache && (
+            <Badge variant="secondary" className="flex items-center gap-1 bg-amber-50 text-amber-700 border-amber-200">
+              <WifiOff className="w-3 h-3" />
+              {t('offlineBadge')}
+            </Badge>
           )}
         </div>
         <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-3">

--- a/frontend/components/quiz/quiz-interface.tsx
+++ b/frontend/components/quiz/quiz-interface.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
-import { Clock, ChevronLeft, ChevronRight, CheckCircle, XCircle, AlertCircle } from 'lucide-react';
+import { Clock, ChevronLeft, ChevronRight, CheckCircle, XCircle, AlertCircle, WifiOff } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -10,11 +10,13 @@ import { Progress } from '@/components/ui/progress';
 import { Badge } from '@/components/ui/badge';
 import type { Quiz, QuizAnswerSubmission, QuizAttemptResponse } from '@/lib/api';
 import { submitQuizAttempt } from '@/lib/api';
+import { queueOfflineAction, isOnline } from '@/lib/offline/content-loader';
 
 interface QuizInterfaceProps {
   quiz: Quiz;
   onComplete: (result: QuizAttemptResponse) => void;
   onError: (error: string) => void;
+  servedFromCache?: boolean;
 }
 
 interface QuestionState {
@@ -23,9 +25,9 @@ interface QuestionState {
   showFeedback: boolean;
 }
 
-export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps) {
+export function QuizInterface({ quiz, onComplete, onError, servedFromCache = false }: QuizInterfaceProps) {
   const t = useTranslations('Quiz');
-  
+
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [questionStates, setQuestionStates] = useState<QuestionState[]>(
     quiz.content.questions.map(() => ({
@@ -37,88 +39,171 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
   const [startTime] = useState(Date.now());
   const [questionStartTime, setQuestionStartTime] = useState(Date.now());
   const [isSubmitting, setIsSubmitting] = useState(false);
-  
+  const [offline] = useState(!isOnline());
+
   const currentQuestion = quiz.content.questions[currentQuestionIndex];
   const currentState = questionStates[currentQuestionIndex];
   const totalQuestions = quiz.content.questions.length;
   const progressPercent = ((currentQuestionIndex + 1) / totalQuestions) * 100;
-  
+
   // Update time spent on current question every second
   useEffect(() => {
-    if (currentState.showFeedback) return; // Don't track time during feedback
-    
+    if (currentState.showFeedback) return;
+
     const interval = setInterval(() => {
-      setQuestionStates(prev => prev.map((state, index) => 
-        index === currentQuestionIndex 
+      setQuestionStates(prev => prev.map((state, index) =>
+        index === currentQuestionIndex
           ? { ...state, timeSpentSeconds: Math.floor((Date.now() - questionStartTime) / 1000) }
           : state
       ));
     }, 1000);
-    
+
     return () => clearInterval(interval);
   }, [currentQuestionIndex, questionStartTime, currentState.showFeedback]);
-  
+
   // Reset question start time when question changes
   useEffect(() => {
     setQuestionStartTime(Date.now());
   }, [currentQuestionIndex]);
-  
+
   const handleOptionSelect = useCallback((optionIndex: number) => {
     if (currentState.showFeedback) return;
-    
-    setQuestionStates(prev => prev.map((state, index) => 
-      index === currentQuestionIndex 
+
+    setQuestionStates(prev => prev.map((state, index) =>
+      index === currentQuestionIndex
         ? { ...state, selectedOption: optionIndex }
         : state
     ));
   }, [currentQuestionIndex, currentState.showFeedback]);
-  
+
   const handleSubmitAnswer = useCallback(() => {
     if (currentState.selectedOption === null) return;
-    
+
     const timeSpent = Math.floor((Date.now() - questionStartTime) / 1000);
-    setQuestionStates(prev => prev.map((state, index) => 
-      index === currentQuestionIndex 
+    setQuestionStates(prev => prev.map((state, index) =>
+      index === currentQuestionIndex
         ? { ...state, showFeedback: true, timeSpentSeconds: timeSpent }
         : state
     ));
   }, [currentQuestionIndex, currentState.selectedOption, questionStartTime]);
-  
+
   const handleFinishQuiz = useCallback(async () => {
     if (isSubmitting) return;
-    
-    // Check if all questions are answered
+
     const unansweredQuestions = questionStates.filter(state => state.selectedOption === null);
     if (unansweredQuestions.length > 0) {
       onError(t('selectAnswer'));
       return;
     }
-    
+
     setIsSubmitting(true);
-    
+
+    const totalTimeSeconds = Math.floor((Date.now() - startTime) / 1000);
+    const answers: QuizAnswerSubmission[] = quiz.content.questions.map((question, index) => ({
+      question_id: question.id,
+      selected_option: questionStates[index].selectedOption!,
+      time_taken_seconds: questionStates[index].timeSpentSeconds,
+    }));
+
+    // Offline: validate client-side and queue result
+    if (!isOnline()) {
+      const correctCount = quiz.content.questions.reduce((count, question, index) => {
+        return count + (questionStates[index].selectedOption === question.correct_answer ? 1 : 0);
+      }, 0);
+      const score = Math.round((correctCount / totalQuestions) * 100);
+
+      const offlineResult: QuizAttemptResponse = {
+        attempt_id: `offline-${Date.now()}`,
+        quiz_id: quiz.id,
+        score,
+        total_questions: totalQuestions,
+        correct_answers: correctCount,
+        total_time_seconds: totalTimeSeconds,
+        passed: score >= quiz.content.passing_score,
+        results: quiz.content.questions.map((question, index) => ({
+          question_id: question.id,
+          user_answer: questionStates[index].selectedOption!,
+          correct_answer: question.correct_answer,
+          is_correct: questionStates[index].selectedOption === question.correct_answer,
+          explanation: question.explanation,
+          time_taken_seconds: questionStates[index].timeSpentSeconds,
+        })),
+        attempted_at: new Date().toISOString(),
+      };
+
+      await queueOfflineAction({
+        type: 'quiz_result',
+        payload: {
+          quiz_id: quiz.id,
+          module_id: quiz.module_id,
+          unit_id: quiz.unit_id,
+          answers,
+          total_time_seconds: totalTimeSeconds,
+          score,
+          correct_answers: correctCount,
+          total_questions: totalQuestions,
+        },
+        created_at: new Date().toISOString(),
+      });
+
+      setIsSubmitting(false);
+      onComplete(offlineResult);
+      return;
+    }
+
     try {
-      const totalTimeSeconds = Math.floor((Date.now() - startTime) / 1000);
-      
-      const answers: QuizAnswerSubmission[] = quiz.content.questions.map((question, index) => ({
-        question_id: question.id,
-        selected_option: questionStates[index].selectedOption!,
-        time_taken_seconds: questionStates[index].timeSpentSeconds,
-      }));
-      
       const result = await submitQuizAttempt({
         quiz_id: quiz.id,
         answers,
         total_time_seconds: totalTimeSeconds,
       });
-      
       onComplete(result);
-    } catch (error) {
-      console.error('Quiz submission failed:', error);
-      onError(t('failedToSubmit'));
+    } catch {
+      // Network failed mid-session — compute result client-side and queue
+      const correctCount = quiz.content.questions.reduce((count, question, index) => {
+        return count + (questionStates[index].selectedOption === question.correct_answer ? 1 : 0);
+      }, 0);
+      const score = Math.round((correctCount / totalQuestions) * 100);
+
+      const offlineResult: QuizAttemptResponse = {
+        attempt_id: `offline-${Date.now()}`,
+        quiz_id: quiz.id,
+        score,
+        total_questions: totalQuestions,
+        correct_answers: correctCount,
+        total_time_seconds: totalTimeSeconds,
+        passed: score >= quiz.content.passing_score,
+        results: quiz.content.questions.map((question, index) => ({
+          question_id: question.id,
+          user_answer: questionStates[index].selectedOption!,
+          correct_answer: question.correct_answer,
+          is_correct: questionStates[index].selectedOption === question.correct_answer,
+          explanation: question.explanation,
+          time_taken_seconds: questionStates[index].timeSpentSeconds,
+        })),
+        attempted_at: new Date().toISOString(),
+      };
+
+      await queueOfflineAction({
+        type: 'quiz_result',
+        payload: {
+          quiz_id: quiz.id,
+          module_id: quiz.module_id,
+          unit_id: quiz.unit_id,
+          answers,
+          total_time_seconds: totalTimeSeconds,
+          score,
+          correct_answers: correctCount,
+          total_questions: totalQuestions,
+        },
+        created_at: new Date().toISOString(),
+      });
+
+      onComplete(offlineResult);
     } finally {
       setIsSubmitting(false);
     }
-  }, [quiz, questionStates, startTime, isSubmitting, onComplete, onError, t]);
+  }, [quiz, questionStates, startTime, totalQuestions, isSubmitting, onComplete, onError, t]);
 
   const handleNextQuestion = useCallback(() => {
     if (currentQuestionIndex < totalQuestions - 1) {
@@ -127,22 +212,34 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
       handleFinishQuiz();
     }
   }, [currentQuestionIndex, totalQuestions, handleFinishQuiz]);
-  
+
   const handlePreviousQuestion = useCallback(() => {
     if (currentQuestionIndex > 0) {
       setCurrentQuestionIndex(prev => prev - 1);
     }
   }, [currentQuestionIndex]);
-  
+
   const isCorrect = currentState.selectedOption === currentQuestion.correct_answer;
   const canNavigatePrevious = currentQuestionIndex > 0;
   const isLastQuestion = currentQuestionIndex === totalQuestions - 1;
-  
+
   return (
     <div className="max-w-4xl mx-auto p-4 space-y-6">
+      {/* Offline banner */}
+      {(offline || servedFromCache) && (
+        <Card className="bg-amber-50 border-amber-200">
+          <CardContent className="p-3">
+            <div className="flex items-center gap-2 text-amber-700">
+              <WifiOff className="w-4 h-4 flex-shrink-0" />
+              <span className="text-sm">{t('offlineBanner')}</span>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       {/* Progress Header */}
       <div className="space-y-4">
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between flex-wrap gap-2">
           <h1 className="text-2xl font-bold text-stone-900">
             {quiz.content.title}
           </h1>
@@ -150,7 +247,7 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
             {t('question', { current: currentQuestionIndex + 1, total: totalQuestions })}
           </Badge>
         </div>
-        
+
         <div className="space-y-2">
           <div className="flex justify-between text-sm text-stone-600">
             <span>{t('question', { current: currentQuestionIndex + 1, total: totalQuestions })}</span>
@@ -159,14 +256,14 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
           <Progress value={progressPercent} className="h-2" />
         </div>
       </div>
-      
+
       {/* Question Card */}
       <Card className="w-full">
         <CardHeader>
           <CardTitle className="text-lg leading-relaxed">
             {currentQuestion.question}
           </CardTitle>
-          
+
           {/* Question metadata */}
           <div className="flex items-center gap-3 text-sm text-stone-500">
             <div className="flex items-center gap-1">
@@ -178,7 +275,7 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
             </Badge>
           </div>
         </CardHeader>
-        
+
         <CardContent className="space-y-4">
           {/* Answer Options */}
           <div className="space-y-3">
@@ -186,10 +283,10 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
               const isSelected = currentState.selectedOption === index;
               const showResult = currentState.showFeedback;
               const isCorrectOption = index === currentQuestion.correct_answer;
-              
+
               let buttonVariant: "default" | "outline" | "secondary" = "outline";
               let className = "min-h-11 h-auto p-4 text-left justify-start";
-              
+
               if (showResult) {
                 if (isSelected && isCorrectOption) {
                   className += " bg-green-50 border-green-500 text-green-900";
@@ -201,7 +298,7 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
               } else if (isSelected) {
                 buttonVariant = "default";
               }
-              
+
               return (
                 <Button
                   key={index}
@@ -215,7 +312,7 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
                       {String.fromCharCode(65 + index)}
                     </div>
                     <span className="flex-1 text-wrap">{option}</span>
-                    
+
                     {showResult && isSelected && (
                       <div className="flex-shrink-0">
                         {isCorrectOption ? (
@@ -225,7 +322,7 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
                         )}
                       </div>
                     )}
-                    
+
                     {showResult && !isSelected && isCorrectOption && (
                       <div className="flex-shrink-0">
                         <CheckCircle className="w-5 h-5 text-green-600" />
@@ -236,7 +333,7 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
               );
             })}
           </div>
-          
+
           {/* Feedback Section */}
           {currentState.showFeedback && (
             <Card className={`${isCorrect ? 'bg-green-50 border-green-200' : 'bg-red-50 border-red-200'}`}>
@@ -249,19 +346,18 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
                       <XCircle className="w-5 h-5 text-red-600" />
                     )}
                   </div>
-                  
+
                   <div className="space-y-2">
                     <div className="flex items-center gap-2">
                       <span className={`font-medium ${isCorrect ? 'text-green-900' : 'text-red-900'}`}>
                         {isCorrect ? t('correct') : t('incorrect')}
                       </span>
                     </div>
-                    
+
                     <div className={`text-sm ${isCorrect ? 'text-green-800' : 'text-red-800'}`}>
                       <div className="font-medium mb-1">{t('explanation')}</div>
                       <p className="leading-relaxed">{currentQuestion.explanation}</p>
-                      
-                      {/* Sources */}
+
                       {currentQuestion.sources_cited.length > 0 && (
                         <div className="mt-3 pt-2 border-t border-current opacity-70">
                           <div className="text-xs">
@@ -281,7 +377,7 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
           )}
         </CardContent>
       </Card>
-      
+
       {/* Navigation Controls */}
       <div className="flex items-center justify-between gap-4">
         <Button
@@ -293,7 +389,7 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
           <ChevronLeft className="w-4 h-4 mr-2" />
           {t('previousQuestion')}
         </Button>
-        
+
         <div className="flex gap-2">
           {!currentState.showFeedback ? (
             <Button
@@ -326,7 +422,7 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
           )}
         </div>
       </div>
-      
+
       {/* Instructions */}
       {!currentState.showFeedback && currentState.selectedOption === null && (
         <Card className="bg-blue-50 border-blue-200">

--- a/frontend/lib/offline/content-loader.ts
+++ b/frontend/lib/offline/content-loader.ts
@@ -1,0 +1,286 @@
+const DB_NAME = 'santeaof-offline';
+const DB_VERSION = 1;
+
+const STORES = {
+  lessons: 'lessons',
+  quizzes: 'quizzes',
+  caseStudies: 'case_studies',
+  flashcards: 'flashcards',
+  offlineActions: 'offline_actions',
+  images: 'images',
+} as const;
+
+export type ContentType = 'lesson' | 'quiz' | 'case' | 'flashcard';
+
+export interface OfflineAction {
+  id?: number;
+  type: 'quiz_result' | 'flashcard_review' | 'lesson_progress';
+  payload: unknown;
+  created_at: string;
+  synced: boolean;
+}
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+function getDB(): Promise<IDBDatabase> {
+  if (dbPromise) return dbPromise;
+
+  dbPromise = new Promise((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') {
+      reject(new Error('IndexedDB not available'));
+      return;
+    }
+
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result;
+
+      if (!db.objectStoreNames.contains(STORES.lessons)) {
+        db.createObjectStore(STORES.lessons, { keyPath: 'cache_key' });
+      }
+      if (!db.objectStoreNames.contains(STORES.quizzes)) {
+        db.createObjectStore(STORES.quizzes, { keyPath: 'cache_key' });
+      }
+      if (!db.objectStoreNames.contains(STORES.caseStudies)) {
+        db.createObjectStore(STORES.caseStudies, { keyPath: 'cache_key' });
+      }
+      if (!db.objectStoreNames.contains(STORES.flashcards)) {
+        db.createObjectStore(STORES.flashcards, { keyPath: 'cache_key' });
+      }
+      if (!db.objectStoreNames.contains(STORES.offlineActions)) {
+        const actionStore = db.createObjectStore(STORES.offlineActions, {
+          keyPath: 'id',
+          autoIncrement: true,
+        });
+        actionStore.createIndex('synced', 'synced', { unique: false });
+      }
+      if (!db.objectStoreNames.contains(STORES.images)) {
+        db.createObjectStore(STORES.images, { keyPath: 'url' });
+      }
+    };
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+
+  return dbPromise;
+}
+
+function makeKey(
+  moduleId: string,
+  unitId: string,
+  language: string,
+  level: number,
+  countryContext: string,
+  contentType: ContentType
+): string {
+  return `${contentType}:${moduleId}:${unitId}:${language}:${level}:${countryContext}`;
+}
+
+function storeForType(contentType: ContentType): string {
+  switch (contentType) {
+    case 'lesson':
+      return STORES.lessons;
+    case 'quiz':
+      return STORES.quizzes;
+    case 'case':
+      return STORES.caseStudies;
+    case 'flashcard':
+      return STORES.flashcards;
+  }
+}
+
+export async function getContentFromDB<T>(
+  moduleId: string,
+  unitId: string,
+  language: string,
+  level: number,
+  countryContext: string,
+  contentType: ContentType
+): Promise<T | null> {
+  try {
+    const db = await getDB();
+    const key = makeKey(moduleId, unitId, language, level, countryContext, contentType);
+    const store = storeForType(contentType);
+
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(store, 'readonly');
+      const request = tx.objectStore(store).get(key);
+      request.onsuccess = () => {
+        const result = request.result;
+        if (result) {
+          resolve(result.data as T);
+        } else {
+          resolve(null);
+        }
+      };
+      request.onerror = () => reject(request.error);
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function saveContentToDB<T>(
+  moduleId: string,
+  unitId: string,
+  language: string,
+  level: number,
+  countryContext: string,
+  contentType: ContentType,
+  data: T
+): Promise<void> {
+  try {
+    const db = await getDB();
+    const key = makeKey(moduleId, unitId, language, level, countryContext, contentType);
+    const store = storeForType(contentType);
+
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(store, 'readwrite');
+      const request = tx.objectStore(store).put({ cache_key: key, data, saved_at: new Date().toISOString() });
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+    });
+  } catch {
+    // Silently fail — offline storage is best-effort
+  }
+}
+
+export async function getFlashcardsFromDB(moduleId: string): Promise<unknown[] | null> {
+  try {
+    const db = await getDB();
+    const key = `flashcard:${moduleId}`;
+
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.flashcards, 'readonly');
+      const request = tx.objectStore(STORES.flashcards).get(key);
+      request.onsuccess = () => {
+        const result = request.result;
+        resolve(result ? (result.data as unknown[]) : null);
+      };
+      request.onerror = () => reject(request.error);
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function saveFlashcardsToDB(moduleId: string, cards: unknown[]): Promise<void> {
+  try {
+    const db = await getDB();
+    const key = `flashcard:${moduleId}`;
+
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORES.flashcards, 'readwrite');
+      const request = tx.objectStore(STORES.flashcards).put({
+        cache_key: key,
+        data: cards,
+        saved_at: new Date().toISOString(),
+      });
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+    });
+  } catch {
+    // Silently fail
+  }
+}
+
+export async function queueOfflineAction(action: Omit<OfflineAction, 'id' | 'synced'>): Promise<void> {
+  try {
+    const db = await getDB();
+
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORES.offlineActions, 'readwrite');
+      const request = tx.objectStore(STORES.offlineActions).add({
+        ...action,
+        synced: false,
+      });
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+    });
+  } catch {
+    // Silently fail
+  }
+}
+
+export async function getPendingOfflineActions(): Promise<OfflineAction[]> {
+  try {
+    const db = await getDB();
+
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.offlineActions, 'readonly');
+      const store = tx.objectStore(STORES.offlineActions);
+      const index = store.index('synced');
+      const request = index.getAll(IDBKeyRange.only(false));
+      request.onsuccess = () => resolve(request.result as OfflineAction[]);
+      request.onerror = () => reject(request.error);
+    });
+  } catch {
+    return [];
+  }
+}
+
+export async function markActionSynced(id: number): Promise<void> {
+  try {
+    const db = await getDB();
+
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORES.offlineActions, 'readwrite');
+      const store = tx.objectStore(STORES.offlineActions);
+      const getRequest = store.get(id);
+      getRequest.onsuccess = () => {
+        const record = getRequest.result;
+        if (record) {
+          record.synced = true;
+          const putRequest = store.put(record);
+          putRequest.onsuccess = () => resolve();
+          putRequest.onerror = () => reject(putRequest.error);
+        } else {
+          resolve();
+        }
+      };
+      getRequest.onerror = () => reject(getRequest.error);
+    });
+  } catch {
+    // Silently fail
+  }
+}
+
+export async function getImageFromDB(url: string): Promise<Blob | null> {
+  try {
+    const db = await getDB();
+
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.images, 'readonly');
+      const request = tx.objectStore(STORES.images).get(url);
+      request.onsuccess = () => {
+        const result = request.result;
+        resolve(result ? (result.blob as Blob) : null);
+      };
+      request.onerror = () => reject(request.error);
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function saveImageToDB(url: string, blob: Blob): Promise<void> {
+  try {
+    const db = await getDB();
+
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORES.images, 'readwrite');
+      const request = tx.objectStore(STORES.images).put({ url, blob, saved_at: new Date().toISOString() });
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+    });
+  } catch {
+    // Silently fail
+  }
+}
+
+export function isOnline(): boolean {
+  if (typeof navigator === 'undefined') return true;
+  return navigator.onLine;
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -269,7 +269,8 @@
     "level": "Level",
     "cached": "Cached",
     "totalQuestions": "Total Questions",
-    "quizCompleteScreenReader": "Quiz completed with {score}% score. {correct} out of {total} questions correct. Time taken: {time}. {passed, select, true {Quiz passed.} other {Quiz not passed.}}"
+    "quizCompleteScreenReader": "Quiz completed with {score}% score. {correct} out of {total} questions correct. Time taken: {time}. {passed, select, true {Quiz passed.} other {Quiz not passed.}}",
+    "offlineBanner": "You are offline — answers validated locally, results queued for sync"
   },
   "ChatTutor": {
     "title": "AI Tutor",
@@ -563,6 +564,9 @@
     "level": "Level {level}",
     "readingTime": "5-10 min read",
     "cached": "Cached",
+    "offlineBadge": "Offline",
+    "offlineUnavailableTitle": "Content not available offline",
+    "offlineUnavailable": "This content has not been downloaded. Connect to the internet to access it.",
     "unitTitle": "Unit {unit}",
     "introduction": "Introduction",
     "keyConcepts": "Key Concepts",
@@ -580,6 +584,9 @@
     "level": "Level {level}",
     "estimatedTime": "40 min",
     "cached": "Cached",
+    "offlineBadge": "Offline",
+    "offlineUnavailableTitle": "Content not available offline",
+    "offlineUnavailable": "This case study has not been downloaded. Connect to the internet to access it.",
     "unitTitle": "Unit {unit}",
     "badge": "Case Study",
     "aofContext": "AOF Context",
@@ -587,6 +594,7 @@
     "guidedQuestions": "Guided Questions",
     "question": "Question {number}",
     "annotatedCorrection": "Annotated Correction",
+    "showCorrection": "Show correction",
     "sourceCitations": "Source Citations",
     "markComplete": "Mark as Complete",
     "completed": "Completed"

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -269,7 +269,8 @@
     "level": "Niveau",
     "cached": "En Cache",
     "totalQuestions": "Total Questions",
-    "quizCompleteScreenReader": "Quiz terminé avec {score}% de score. {correct} sur {total} questions correctes. Temps pris : {time}. {passed, select, true {Quiz réussi.} other {Quiz non réussi.}}"
+    "quizCompleteScreenReader": "Quiz terminé avec {score}% de score. {correct} sur {total} questions correctes. Temps pris : {time}. {passed, select, true {Quiz réussi.} other {Quiz non réussi.}}",
+    "offlineBanner": "Vous êtes hors-ligne — réponses validées localement et résultats en attente de synchronisation"
   },
   "ChatTutor": {
     "title": "Tuteur IA",
@@ -563,6 +564,9 @@
     "level": "Niveau {level}",
     "readingTime": "5-10 min de lecture",
     "cached": "En cache",
+    "offlineBadge": "Hors-ligne",
+    "offlineUnavailableTitle": "Contenu non disponible hors-ligne",
+    "offlineUnavailable": "Ce contenu n'a pas été téléchargé. Connectez-vous à Internet pour y accéder.",
     "unitTitle": "Unité {unit}",
     "introduction": "Introduction",
     "keyConcepts": "Concepts Clés",
@@ -580,6 +584,9 @@
     "level": "Niveau {level}",
     "estimatedTime": "40 min",
     "cached": "En cache",
+    "offlineBadge": "Hors-ligne",
+    "offlineUnavailableTitle": "Contenu non disponible hors-ligne",
+    "offlineUnavailable": "Cette étude de cas n'a pas été téléchargée. Connectez-vous à Internet pour y accéder.",
     "unitTitle": "Unité {unit}",
     "badge": "Étude de cas",
     "aofContext": "Contexte AOF",
@@ -587,6 +594,7 @@
     "guidedQuestions": "Questions guidées",
     "question": "Question {number}",
     "annotatedCorrection": "Correction annotée",
+    "showCorrection": "Voir la correction",
     "sourceCitations": "Sources citées",
     "markComplete": "Marquer comme Terminé",
     "completed": "Terminé"


### PR DESCRIPTION
## Summary

- Adds `frontend/lib/offline/content-loader.ts` — a zero-dependency IndexedDB abstraction (6 stores: lessons, quizzes, case_studies, flashcards, offline_actions, images) with helpers for content caching and offline action queuing
- Updates `lesson-viewer.tsx`, `case-study-viewer.tsx` to check IndexedDB first, fall back to API cache, then SSE streaming — saves content to IndexedDB after load
- Updates `quiz-interface.tsx` to validate answers client-side when offline, compute scores locally, and queue `quiz_result` in `offline_actions` for sync
- Updates `flashcard-deck.tsx` to queue `flashcard_review` in `offline_actions` when offline
- Adds "Hors-ligne" / "Offline" badge on content served from IndexedDB
- Adds "Contenu non disponible hors-ligne" / "Content not available offline" message for non-downloaded content
- Lesson reading time tracked locally and queued for sync
- All new strings added to `fr.json` and `en.json`

## Changes

- `frontend/lib/offline/content-loader.ts` — new: IndexedDB abstraction layer
- `frontend/components/learning/lesson-viewer.tsx` — offline-first loading, reading time sync queue
- `frontend/components/quiz/quiz-interface.tsx` — client-side answer validation + offline_actions queue
- `frontend/components/learning/case-study-viewer.tsx` — offline-first loading
- `frontend/components/learning/flashcard-deck.tsx` — review queuing when offline
- `frontend/messages/fr.json` — new offline i18n keys
- `frontend/messages/en.json` — new offline i18n keys

## Test plan

- [ ] Frontend lint passes (0 errors, pre-existing warnings only)
- [ ] Frontend build passes (`npm run build`)
- [ ] Lesson renders from IndexedDB when offline (after first online load)
- [ ] Quiz validates answers client-side when offline
- [ ] Quiz result queued in offline_actions
- [ ] Non-downloaded content shows "Contenu non disponible hors-ligne"
- [ ] Offline badge shown on content served from IndexedDB cache
- [ ] Flashcard reviews queued in offline_actions when offline
- [ ] All i18n strings present in FR and EN
- [ ] Manually verified on mobile viewport (320px)

Closes #296

Generated with [Claude Code](https://claude.ai/code)