### PR TITLE
fix: global timezone fix — 40+ datetime.now(UTC) replaced across all services

### DIFF
--- a/backend/app/api/v1/quiz.py
+++ b/backend/app/api/v1/quiz.py
@@ -2,7 +2,6 @@
 
 import re
 import uuid
-from datetime import UTC
 from uuid import UUID
 
 import structlog
@@ -589,7 +588,7 @@ async def can_attempt_summative_assessment(
         # Check 24h cooldown
         from datetime import datetime
 
-        now = datetime.now(UTC)
+        now = datetime.utcnow()
         if latest_attempt.can_retry_at and now < latest_attempt.can_retry_at:
             return SummativeAssessmentAttemptCheck(
                 can_attempt=False,
@@ -763,7 +762,7 @@ async def submit_summative_assessment_attempt(
         # Set retry cooldown if failed (24 hours)
         from datetime import datetime, timedelta
 
-        can_retry_at = None if passed else datetime.now(UTC) + timedelta(hours=24)
+        can_retry_at = None if passed else datetime.utcnow() + timedelta(hours=24)
 
         # Check if module should be unlocked
         module_unlocked = False
@@ -789,7 +788,7 @@ async def submit_summative_assessment_attempt(
                     completion_pct=100.0,
                     quiz_score_avg=score,
                     time_spent_minutes=request.total_time_seconds // 60,
-                    last_accessed=datetime.now(UTC),
+                    last_accessed=datetime.utcnow(),
                 )
                 session.add(new_progress)
                 module_unlocked = True

--- a/backend/app/domain/services/auth_service.py
+++ b/backend/app/domain/services/auth_service.py
@@ -4,7 +4,7 @@ Handles user profile management and auth-related business logic.
 Works with local FastAPI auth (pyotp + python-jose).
 """
 
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import Any
 from uuid import UUID
 
@@ -92,7 +92,7 @@ class AuthService:
             professional_role=professional_role,
             current_level=1,  # Start at beginner level
             streak_days=0,
-            last_active=datetime.now(UTC),
+            last_active=datetime.utcnow(),
         )
 
         created_user = await self.user_repo.create(user)
@@ -148,7 +148,7 @@ class AuthService:
                 setattr(user, field, value)
 
         # Update last_active timestamp
-        user.last_active = datetime.now(UTC)
+        user.last_active = datetime.utcnow()
 
         updated_user = await self.user_repo.update(user)
 
@@ -174,8 +174,8 @@ class AuthService:
         if not user:
             raise ValueError(f"User {user_id} not found")
 
-        now = datetime.now(UTC)
-        last_active = user.last_active.replace(tzinfo=UTC)
+        now = datetime.utcnow()
+        last_active = user.last_active
 
         # Calculate days since last activity
         days_diff = (now.date() - last_active.date()).days

--- a/backend/app/domain/services/email_otp_service.py
+++ b/backend/app/domain/services/email_otp_service.py
@@ -1,7 +1,7 @@
 """Email OTP service for registration and login verification."""
 
 import secrets
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -71,7 +71,7 @@ class EmailOTPService:
 
             # Generate new OTP
             otp_code = self.generate_otp_code()
-            expires_at = datetime.now(UTC) + timedelta(minutes=self.otp_expiry_minutes)
+            expires_at = datetime.utcnow() + timedelta(minutes=self.otp_expiry_minutes)
 
             # Store OTP
             otp_record = EmailOTP(
@@ -82,7 +82,7 @@ class EmailOTPService:
                 purpose="registration",
                 attempts=0,
                 expires_at=expires_at,
-                created_at=datetime.now(UTC),
+                created_at=datetime.utcnow(),
                 ip_address=ip_address,
             )
             self.db.add(otp_record)
@@ -147,7 +147,7 @@ class EmailOTPService:
 
             # Generate new OTP
             otp_code = self.generate_otp_code()
-            expires_at = datetime.now(UTC) + timedelta(minutes=self.otp_expiry_minutes)
+            expires_at = datetime.utcnow() + timedelta(minutes=self.otp_expiry_minutes)
 
             # Store OTP
             otp_record = EmailOTP(
@@ -158,7 +158,7 @@ class EmailOTPService:
                 purpose="login",
                 attempts=0,
                 expires_at=expires_at,
-                created_at=datetime.now(UTC),
+                created_at=datetime.utcnow(),
                 ip_address=ip_address,
             )
             self.db.add(otp_record)
@@ -219,7 +219,7 @@ class EmailOTPService:
                 raise OTPError("OTP not found or already verified")
 
             # Check if expired
-            if otp_record.expires_at < datetime.now(UTC):
+            if otp_record.expires_at < datetime.utcnow():
                 raise OTPError("OTP has expired")
 
             # Check attempts
@@ -236,7 +236,7 @@ class EmailOTPService:
                 raise OTPError(f"Invalid OTP code. {attempts_left} attempts remaining.")
 
             # Mark as verified
-            otp_record.verified_at = datetime.now(UTC)
+            otp_record.verified_at = datetime.utcnow()
 
             # Get user info if available
             user_info = None
@@ -289,7 +289,7 @@ class EmailOTPService:
         """
         try:
             # Check rate limit by email
-            window_start = datetime.now(UTC) - timedelta(seconds=self.rate_limit_window)
+            window_start = datetime.utcnow() - timedelta(seconds=self.rate_limit_window)
 
             email_count = await self.db.scalar(
                 select(func.count(EmailOTP.id)).where(
@@ -332,7 +332,7 @@ class EmailOTPService:
         try:
             await self.db.execute(
                 select(EmailOTP).where(
-                    and_(EmailOTP.email == email, EmailOTP.expires_at < datetime.now(UTC))
+                    and_(EmailOTP.email == email, EmailOTP.expires_at < datetime.utcnow())
                 )
             )
             await self.db.commit()

--- a/backend/app/domain/services/jwt_auth_service.py
+++ b/backend/app/domain/services/jwt_auth_service.py
@@ -2,7 +2,7 @@
 
 import hashlib
 import secrets
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from typing import Any
 
 import jwt
@@ -33,7 +33,7 @@ class JWTAuthService:
         Returns:
             JWT access token
         """
-        now = datetime.now(UTC)
+        now = datetime.utcnow()
         expire = now + timedelta(minutes=self.access_token_expire_minutes)
 
         payload = {
@@ -113,7 +113,7 @@ class JWTAuthService:
         Returns:
             Expiration datetime
         """
-        now = datetime.now(UTC)
+        now = datetime.utcnow()
         if token_type == "access":
             return now + timedelta(minutes=self.access_token_expire_minutes)
         else:  # refresh
@@ -137,7 +137,7 @@ class JWTAuthService:
         Returns:
             JWT token for password reset
         """
-        now = datetime.now(UTC)
+        now = datetime.utcnow()
         expire = now + timedelta(hours=1)  # Magic links expire in 1 hour
 
         payload = {

--- a/backend/app/domain/services/local_auth_service.py
+++ b/backend/app/domain/services/local_auth_service.py
@@ -1,6 +1,6 @@
 """Local authentication service with TOTP MFA."""
 
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -73,8 +73,8 @@ class LocalAuthService:
                 professional_role=professional_role,
                 current_level=1,  # Will be set after placement test
                 streak_days=0,
-                last_active=datetime.now(UTC),
-                created_at=datetime.now(UTC),
+                last_active=datetime.utcnow(),
+                created_at=datetime.utcnow(),
             )
             self.db.add(user)
 
@@ -89,7 +89,7 @@ class LocalAuthService:
                 secret=totp_secret,
                 backup_codes=self.totp_service.hash_backup_codes(backup_codes),
                 is_verified=False,
-                created_at=datetime.now(UTC),
+                created_at=datetime.utcnow(),
             )
             self.db.add(totp_record)
 
@@ -151,7 +151,7 @@ class LocalAuthService:
 
             # Mark as verified
             totp_record.is_verified = True
-            totp_record.verified_at = datetime.now(UTC)
+            totp_record.verified_at = datetime.utcnow()
 
             # Create tokens
             access_token = self.jwt_service.create_access_token(
@@ -168,7 +168,7 @@ class LocalAuthService:
                 user_id=user.id,
                 token_hash=self.jwt_service.hash_token(refresh_token),
                 expires_at=self.jwt_service.get_token_expiry("refresh"),
-                created_at=datetime.now(UTC),
+                created_at=datetime.utcnow(),
             )
             self.db.add(refresh_record)
 
@@ -246,7 +246,7 @@ class LocalAuthService:
                 raise AuthenticationError("Invalid authentication code")
 
             # Update user activity
-            user.last_active = datetime.now(UTC)
+            user.last_active = datetime.utcnow()
 
             # Create tokens
             access_token = self.jwt_service.create_access_token(
@@ -263,8 +263,8 @@ class LocalAuthService:
                 user_id=user.id,
                 token_hash=self.jwt_service.hash_token(refresh_token),
                 expires_at=self.jwt_service.get_token_expiry("refresh"),
-                created_at=datetime.now(UTC),
-                last_used_at=datetime.now(UTC),
+                created_at=datetime.utcnow(),
+                last_used_at=datetime.utcnow(),
             )
             self.db.add(refresh_record)
 
@@ -322,15 +322,15 @@ class LocalAuthService:
                 id=uuid4(),
                 user_id=user.id,
                 token_hash=self.jwt_service.hash_token(magic_token),
-                expires_at=datetime.now(UTC) + timedelta(hours=1),
-                created_at=datetime.now(UTC),
+                expires_at=datetime.utcnow() + timedelta(hours=1),
+                created_at=datetime.utcnow(),
             )
             self.db.add(magic_link)
 
             # Clean up old magic links for this user
             await self.db.execute(
                 select(MagicLink).where(
-                    and_(MagicLink.user_id == user.id, MagicLink.expires_at < datetime.now(UTC))
+                    and_(MagicLink.user_id == user.id, MagicLink.expires_at < datetime.utcnow())
                 )
             )
 
@@ -368,7 +368,7 @@ class LocalAuthService:
                 select(MagicLink).where(
                     and_(
                         MagicLink.token_hash == token_hash,
-                        MagicLink.expires_at > datetime.now(UTC),
+                        MagicLink.expires_at > datetime.utcnow(),
                         MagicLink.used_at.is_(None),
                     )
                 )
@@ -383,7 +383,7 @@ class LocalAuthService:
                 raise AuthenticationError("User not found")
 
             # Mark magic link as used
-            magic_link.used_at = datetime.now(UTC)
+            magic_link.used_at = datetime.utcnow()
 
             # Remove existing TOTP setup
             await self.db.execute(select(TOTPSecret).where(TOTPSecret.user_id == user.id))
@@ -398,7 +398,7 @@ class LocalAuthService:
                 secret=totp_secret,
                 backup_codes=self.totp_service.hash_backup_codes(backup_codes),
                 is_verified=False,
-                created_at=datetime.now(UTC),
+                created_at=datetime.utcnow(),
             )
             self.db.add(totp_record)
 
@@ -446,7 +446,7 @@ class LocalAuthService:
                 select(RefreshToken).where(
                     and_(
                         RefreshToken.token_hash == token_hash,
-                        RefreshToken.expires_at > datetime.now(UTC),
+                        RefreshToken.expires_at > datetime.utcnow(),
                     )
                 )
             )
@@ -460,8 +460,8 @@ class LocalAuthService:
                 raise AuthenticationError("User not found")
 
             # Update refresh token usage
-            refresh_record.last_used_at = datetime.now(UTC)
-            user.last_active = datetime.now(UTC)
+            refresh_record.last_used_at = datetime.utcnow()
+            user.last_active = datetime.utcnow()
 
             # Create new access token
             access_token = self.jwt_service.create_access_token(
@@ -555,8 +555,8 @@ class LocalAuthService:
                 professional_role=professional_role,
                 current_level=1,  # Will be set after placement test
                 streak_days=0,
-                last_active=datetime.now(UTC),
-                created_at=datetime.now(UTC),
+                last_active=datetime.utcnow(),
+                created_at=datetime.utcnow(),
             )
             self.db.add(user)
             await self.db.commit()
@@ -635,7 +635,7 @@ class LocalAuthService:
                 user_id=user_obj.id,
                 token_hash=self.jwt_service.hash_token(refresh_token),
                 expires_at=self.jwt_service.get_token_expiry("refresh"),
-                created_at=datetime.now(UTC),
+                created_at=datetime.utcnow(),
             )
             self.db.add(refresh_record)
 
@@ -737,7 +737,7 @@ class LocalAuthService:
                 raise AuthenticationError("User not found")
 
             # Update user activity
-            user_obj.last_active = datetime.now(UTC)
+            user_obj.last_active = datetime.utcnow()
 
             # Create tokens
             access_token = self.jwt_service.create_access_token(
@@ -754,8 +754,8 @@ class LocalAuthService:
                 user_id=user_obj.id,
                 token_hash=self.jwt_service.hash_token(refresh_token),
                 expires_at=self.jwt_service.get_token_expiry("refresh"),
-                created_at=datetime.now(UTC),
-                last_used_at=datetime.now(UTC),
+                created_at=datetime.utcnow(),
+                last_used_at=datetime.utcnow(),
             )
             self.db.add(refresh_record)
 

--- a/backend/app/domain/services/progress_service.py
+++ b/backend/app/domain/services/progress_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import datetime
 from uuid import UUID
 
 import structlog
@@ -48,7 +48,7 @@ class ProgressService:
         Marks the module as in_progress if not already completed.
         Creates a lesson_reading record for streak and time tracking.
         """
-        now = datetime.now(UTC)
+        now = datetime.utcnow()
 
         # Upsert lesson reading record
         reading = LessonReading(
@@ -99,7 +99,7 @@ class ProgressService:
         Per FR-02.2: lesson completion requires passing the validation quiz (≥80%).
         Recalculates module completion_pct based on completed units.
         """
-        now = datetime.now(UTC)
+        now = datetime.utcnow()
 
         progress = await self._get_or_create_progress(user_id, module_id, now)
         progress.last_accessed = now


### PR DESCRIPTION
## Summary
Global replacement of datetime.now(UTC) with datetime.utcnow() across the entire backend. DB uses TIMESTAMP WITHOUT TIME ZONE — all datetime values must be naive.

This was causing crashes in: tutor chat, lesson tracking, progress tracking, auth, quiz, email OTP.

6 files, 40+ occurrences fixed.