### PR TITLE
fix(quiz): complete quiz validation flow — scoring, results, module validation

### DIFF
--- a/backend/app/api/v1/quiz.py
+++ b/backend/app/api/v1/quiz.py
@@ -340,8 +340,9 @@ async def submit_quiz_attempt(
 
         # Calculate final score
         score = round((correct_count / len(questions)) * 100, 1)
-        passing_score = quiz_data.get("passing_score", 70.0)
+        passing_score = quiz_data.get("passing_score", 80.0)
         passed = score >= passing_score
+        lesson_validated = score >= 80.0
 
         # Store attempt in database
         attempt = QuizAttempt(
@@ -375,8 +376,8 @@ async def submit_quiz_attempt(
         await session.commit()
         await session.refresh(attempt)
 
-        # Update module progress when quiz is passed (≥80%) — FR-02.2
-        if passed:
+        # Update module progress when lesson is validated (≥80%) — FR-02.2, FR-03.3
+        if lesson_validated:
             try:
                 unit_id = quiz_data.get("unit_id", "")
                 if unit_id:
@@ -386,7 +387,7 @@ async def submit_quiz_attempt(
                         module_id=quiz_content.module_id,
                         unit_id=unit_id,
                         score=score,
-                        passed=passed,
+                        passed=True,
                     )
             except Exception as progress_err:
                 logger.warning(
@@ -402,6 +403,7 @@ async def submit_quiz_attempt(
             correct_answers=correct_count,
             total_time_seconds=request.total_time_seconds,
             passed=passed,
+            lesson_validated=lesson_validated,
             results=results,
             attempted_at=attempt.attempted_at.isoformat(),
         )

--- a/backend/app/api/v1/schemas/quiz.py
+++ b/backend/app/api/v1/schemas/quiz.py
@@ -151,6 +151,10 @@ class QuizAttemptResponse(BaseModel):
     correct_answers: int = Field(description="Number of correct answers")
     total_time_seconds: int = Field(description="Total time taken")
     passed: bool = Field(description="Whether user passed based on passing score")
+    lesson_validated: bool = Field(
+        description="Whether lesson is validated (score ≥80%) — marks lesson complete in user_module_progress",
+        default=False,
+    )
     results: list[QuizAttemptResult] = Field(description="Per-question results")
     attempted_at: str = Field(description="ISO timestamp when attempt was submitted")
 

--- a/backend/app/domain/services/quiz_service.py
+++ b/backend/app/domain/services/quiz_service.py
@@ -53,24 +53,13 @@ class QuizService:
             Exception: If quiz generation fails
         """
         try:
-            # Check cache first
+            # Cache lookup: match module, unit, language, and level
             query = select(GeneratedContent).where(
                 GeneratedContent.module_id == module_id,
                 GeneratedContent.content_type == "quiz",
                 GeneratedContent.language == language,
                 GeneratedContent.level == level,
                 GeneratedContent.content["unit_id"].astext == unit_id,
-                GeneratedContent.content["questions"]
-                .as_("json")
-                .op("@>")('[{"questions": [{}] for _ in range(num_questions)}]'),
-            )
-
-            # Simplified cache lookup - look for any quiz for this module/unit/language/level
-            query = select(GeneratedContent).where(
-                GeneratedContent.module_id == module_id,
-                GeneratedContent.content_type == "quiz",
-                GeneratedContent.language == language,
-                GeneratedContent.level == level,
             )
 
             result = await session.execute(query)
@@ -280,7 +269,7 @@ RESPONSE FORMAT (JSON):
     }}
   ],
   "time_limit_minutes": {max(10, num_questions * 1.5)},
-  "passing_score": 70.0
+  "passing_score": 80.0
 }}
 
 Generate the quiz now, ensuring all questions are relevant to public health practice in West Africa."""
@@ -324,8 +313,17 @@ Generate the quiz now, ensuring all questions are relevant to public health prac
                     raise ValueError(f"Missing required field: {field}")
 
             questions = quiz_data["questions"]
-            if not isinstance(questions, list) or len(questions) != expected_questions:
-                raise ValueError(f"Expected {expected_questions} questions, got {len(questions)}")
+            if not isinstance(questions, list) or len(questions) == 0:
+                raise ValueError("Quiz must have at least one question")
+            if (
+                len(questions) < max(1, expected_questions - 2)
+                or len(questions) > expected_questions + 2
+            ):
+                logger.warning(
+                    "Question count mismatch",
+                    expected=expected_questions,
+                    got=len(questions),
+                )
 
             # Validate each question
             for i, question in enumerate(questions):
@@ -333,7 +331,9 @@ Generate the quiz now, ensuring all questions are relevant to public health prac
 
             # Set defaults for optional fields
             quiz_data.setdefault("time_limit_minutes", max(10, len(questions) * 2))
-            quiz_data.setdefault("passing_score", 70.0)
+            quiz_data.setdefault("passing_score", 80.0)
+            if quiz_data.get("passing_score", 80.0) < 80.0:
+                quiz_data["passing_score"] = 80.0
 
             # Add unit_id to content
             quiz_data["unit_id"] = unit_id

--- a/backend/tests/test_quiz_service.py
+++ b/backend/tests/test_quiz_service.py
@@ -1,0 +1,305 @@
+"""Tests for the quiz generation service."""
+
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.domain.services.quiz_service import QuizService
+
+SAMPLE_QUIZ_JSON = json.dumps(
+    {
+        "title": "Public Health Foundations Quiz",
+        "description": "Test your knowledge of public health fundamentals.",
+        "questions": [
+            {
+                "id": f"q{i}",
+                "question": f"Sample question {i}?",
+                "options": ["Option A", "Option B", "Option C", "Option D"],
+                "correct_answer": 0,
+                "explanation": f"Explanation {i}.",
+                "sources_cited": ["Donaldson Ch.1, p.10"],
+                "difficulty": "medium",
+            }
+            for i in range(1, 11)
+        ],
+        "time_limit_minutes": 15,
+        "passing_score": 80.0,
+    }
+)
+
+
+@pytest.fixture
+def mock_claude_service():
+    service = AsyncMock()
+    service.generate_content = AsyncMock(return_value=SAMPLE_QUIZ_JSON)
+    return service
+
+
+@pytest.fixture
+def mock_retriever():
+    retriever = AsyncMock()
+    chunk = MagicMock()
+    chunk.source_reference = "Donaldson Ch.1"
+    chunk.content = "Public health content chunk."
+    retriever.retrieve_chunks = AsyncMock(return_value=[chunk])
+    return retriever
+
+
+@pytest.fixture
+def quiz_service(mock_claude_service, mock_retriever):
+    return QuizService(mock_claude_service, mock_retriever)
+
+
+class TestParseQuizResponse:
+    def test_parses_valid_json_response(self, quiz_service):
+        result = quiz_service._parse_quiz_response(SAMPLE_QUIZ_JSON, "M01-U04", 10)
+        assert result["title"] == "Public Health Foundations Quiz"
+        assert len(result["questions"]) == 10
+        assert result["unit_id"] == "M01-U04"
+
+    def test_parses_json_wrapped_in_markdown_code_block(self, quiz_service):
+        wrapped = f"```json\n{SAMPLE_QUIZ_JSON}\n```"
+        result = quiz_service._parse_quiz_response(wrapped, "M01-U04", 10)
+        assert len(result["questions"]) == 10
+
+    def test_parses_json_wrapped_in_generic_code_block(self, quiz_service):
+        wrapped = f"```\n{SAMPLE_QUIZ_JSON}\n```"
+        result = quiz_service._parse_quiz_response(wrapped, "M01-U04", 10)
+        assert len(result["questions"]) == 10
+
+    def test_raises_on_invalid_json(self, quiz_service):
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            quiz_service._parse_quiz_response("not valid json", "M01-U04", 10)
+
+    def test_raises_on_missing_title_field(self, quiz_service):
+        data = json.loads(SAMPLE_QUIZ_JSON)
+        del data["title"]
+        with pytest.raises(ValueError, match="Missing required field"):
+            quiz_service._parse_quiz_response(json.dumps(data), "M01-U04", 10)
+
+    def test_raises_on_empty_questions_list(self, quiz_service):
+        data = json.loads(SAMPLE_QUIZ_JSON)
+        data["questions"] = []
+        with pytest.raises(ValueError, match="at least one question"):
+            quiz_service._parse_quiz_response(json.dumps(data), "M01-U04", 10)
+
+    def test_sets_default_passing_score_to_80(self, quiz_service):
+        data = json.loads(SAMPLE_QUIZ_JSON)
+        del data["passing_score"]
+        result = quiz_service._parse_quiz_response(json.dumps(data), "M01-U04", 10)
+        assert result["passing_score"] == 80.0
+
+    def test_enforces_minimum_passing_score_of_80(self, quiz_service):
+        data = json.loads(SAMPLE_QUIZ_JSON)
+        data["passing_score"] = 60.0
+        result = quiz_service._parse_quiz_response(json.dumps(data), "M01-U04", 10)
+        assert result["passing_score"] == 80.0
+
+    def test_accepts_slightly_fewer_questions_than_requested(self, quiz_service):
+        data = json.loads(SAMPLE_QUIZ_JSON)
+        data["questions"] = data["questions"][:8]
+        result = quiz_service._parse_quiz_response(json.dumps(data), "M01-U04", 10)
+        assert len(result["questions"]) == 8
+
+    def test_unit_id_added_to_result(self, quiz_service):
+        result = quiz_service._parse_quiz_response(SAMPLE_QUIZ_JSON, "M01-U04", 10)
+        assert result["unit_id"] == "M01-U04"
+
+
+class TestValidateQuestion:
+    def test_valid_question_passes(self, quiz_service):
+        question = {
+            "id": "q1",
+            "question": "What is epidemiology?",
+            "options": ["A", "B", "C", "D"],
+            "correct_answer": 0,
+            "explanation": "Epidemiology studies disease distribution.",
+        }
+        quiz_service._validate_question(question, "q1")
+
+    def test_raises_on_missing_id(self, quiz_service):
+        question = {
+            "question": "What is epidemiology?",
+            "options": ["A", "B", "C", "D"],
+            "correct_answer": 0,
+            "explanation": "Explanation.",
+        }
+        with pytest.raises(ValueError, match="Missing required field 'id'"):
+            quiz_service._validate_question(question, "q1")
+
+    def test_raises_on_wrong_option_count(self, quiz_service):
+        question = {
+            "id": "q1",
+            "question": "What is epidemiology?",
+            "options": ["A", "B", "C"],
+            "correct_answer": 0,
+            "explanation": "Explanation.",
+        }
+        with pytest.raises(ValueError, match="exactly 4 options"):
+            quiz_service._validate_question(question, "q1")
+
+    def test_raises_on_invalid_correct_answer(self, quiz_service):
+        question = {
+            "id": "q1",
+            "question": "What is epidemiology?",
+            "options": ["A", "B", "C", "D"],
+            "correct_answer": 5,
+            "explanation": "Explanation.",
+        }
+        with pytest.raises(ValueError, match="correct_answer must be 0, 1, 2, or 3"):
+            quiz_service._validate_question(question, "q1")
+
+    def test_sets_default_sources_and_difficulty(self, quiz_service):
+        question = {
+            "id": "q1",
+            "question": "Test?",
+            "options": ["A", "B", "C", "D"],
+            "correct_answer": 1,
+            "explanation": "Explanation.",
+        }
+        quiz_service._validate_question(question, "q1")
+        assert question["sources_cited"] == []
+        assert question["difficulty"] == "medium"
+
+
+class TestExtractSourcesFromQuiz:
+    def test_extracts_unique_sources(self, quiz_service):
+        from app.api.v1.schemas.quiz import QuizContent, QuizQuestion
+
+        questions = [
+            QuizQuestion(
+                id="q1",
+                question="Q1?",
+                options=["A", "B", "C", "D"],
+                correct_answer=0,
+                explanation="Exp.",
+                sources_cited=["Source A", "Source B"],
+            ),
+            QuizQuestion(
+                id="q2",
+                question="Q2?",
+                options=["A", "B", "C", "D"],
+                correct_answer=1,
+                explanation="Exp.",
+                sources_cited=["Source B", "Source C"],
+            ),
+        ]
+        content = QuizContent(
+            title="Test",
+            description="Desc",
+            questions=questions,
+            passing_score=80.0,
+        )
+        sources = quiz_service._extract_sources_from_quiz(content)
+        assert set(sources) == {"Source A", "Source B", "Source C"}
+
+    def test_returns_empty_list_when_no_sources(self, quiz_service):
+        from app.api.v1.schemas.quiz import QuizContent, QuizQuestion
+
+        question = QuizQuestion(
+            id="q1",
+            question="Q1?",
+            options=["A", "B", "C", "D"],
+            correct_answer=0,
+            explanation="Exp.",
+            sources_cited=[],
+        )
+        content = QuizContent(
+            title="Test",
+            description="Desc",
+            questions=[question],
+            passing_score=80.0,
+        )
+        sources = quiz_service._extract_sources_from_quiz(content)
+        assert sources == []
+
+
+class TestGenerateQuizContent:
+    async def test_calls_retriever_and_claude(
+        self, quiz_service, mock_retriever, mock_claude_service
+    ):
+        module_id = uuid.uuid4()
+        result = await quiz_service._generate_quiz_content(
+            module_id=module_id,
+            unit_id="M01-U04",
+            language="fr",
+            country="senegal",
+            level=1,
+            num_questions=10,
+        )
+        mock_retriever.retrieve_chunks.assert_called_once()
+        mock_claude_service.generate_content.assert_called_once()
+        assert len(result.questions) == 10
+
+    async def test_generated_content_has_passing_score_80(self, quiz_service, mock_claude_service):
+        module_id = uuid.uuid4()
+        result = await quiz_service._generate_quiz_content(
+            module_id=module_id,
+            unit_id="M01-U04",
+            language="fr",
+            country="senegal",
+            level=1,
+            num_questions=10,
+        )
+        assert result.passing_score == 80.0
+
+    async def test_raises_on_claude_error(self, quiz_service, mock_claude_service):
+        mock_claude_service.generate_content.side_effect = Exception("API error")
+        module_id = uuid.uuid4()
+        with pytest.raises(Exception, match="API error"):
+            await quiz_service._generate_quiz_content(
+                module_id=module_id,
+                unit_id="M01-U04",
+                language="fr",
+                country="senegal",
+                level=1,
+                num_questions=10,
+            )
+
+
+class TestBuildQuizPrompt:
+    def test_prompt_contains_unit_id(self, quiz_service):
+        prompt = quiz_service._build_quiz_prompt(
+            context="Some context",
+            unit_id="M01-U04",
+            language="fr",
+            country="senegal",
+            level=1,
+            num_questions=10,
+        )
+        assert "M01-U04" in prompt
+
+    def test_prompt_uses_french_instruction(self, quiz_service):
+        prompt = quiz_service._build_quiz_prompt(
+            context="context",
+            unit_id="M01-U04",
+            language="fr",
+            country="senegal",
+            level=1,
+            num_questions=5,
+        )
+        assert "in French" in prompt
+
+    def test_prompt_uses_english_instruction(self, quiz_service):
+        prompt = quiz_service._build_quiz_prompt(
+            context="context",
+            unit_id="M01-U04",
+            language="en",
+            country="ghana",
+            level=2,
+            num_questions=5,
+        )
+        assert "in English" in prompt
+
+    def test_prompt_includes_passing_score_80(self, quiz_service):
+        prompt = quiz_service._build_quiz_prompt(
+            context="context",
+            unit_id="M01-U04",
+            language="fr",
+            country="senegal",
+            level=1,
+            num_questions=10,
+        )
+        assert "80.0" in prompt

--- a/frontend/components/quiz/quiz-container.tsx
+++ b/frontend/components/quiz/quiz-container.tsx
@@ -112,7 +112,8 @@ export function QuizContainer({
   
   const handleRetry = () => {
     setResult(null);
-    setState('in-progress');
+    setQuiz(null);
+    void loadQuiz();
   };
   
   const handleContinue = () => {

--- a/frontend/components/quiz/quiz-results.tsx
+++ b/frontend/components/quiz/quiz-results.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
-import { Clock, CheckCircle, XCircle, RotateCcw, ArrowRight, Trophy, Target } from 'lucide-react';
+import { Clock, CheckCircle, XCircle, RotateCcw, ArrowRight, Trophy, Target, BookCheck } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -22,6 +22,7 @@ export function QuizResults({ quiz, result, onRetry, onContinue }: QuizResultsPr
   const passingScore = quiz.content.passing_score;
   const scorePercent = result.score;
   const isPassed = result.passed;
+  const lessonValidated = result.lesson_validated ?? result.score >= 80;
   
   // Format time spent
   const formatTime = (seconds: number): string => {
@@ -56,6 +57,33 @@ export function QuizResults({ quiz, result, onRetry, onContinue }: QuizResultsPr
           {isPassed ? t('congratulations') : t('needsImprovement')}
         </p>
       </div>
+      
+      {/* Lesson Validation Banner — FR-03.3 */}
+      {lessonValidated ? (
+        <Card className="bg-teal-50 border-teal-300">
+          <CardContent className="p-4">
+            <div className="flex items-center gap-3">
+              <BookCheck className="w-6 h-6 text-teal-600 flex-shrink-0" />
+              <div>
+                <p className="font-semibold text-teal-900">{t('lessonCompleted')}</p>
+                <p className="text-sm text-teal-700">{t('lessonCompletedDesc')}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card className="bg-amber-50 border-amber-300">
+          <CardContent className="p-4">
+            <div className="flex items-center gap-3">
+              <Target className="w-6 h-6 text-amber-600 flex-shrink-0" />
+              <div>
+                <p className="font-semibold text-amber-900">{t('lessonNotValidated')}</p>
+                <p className="text-sm text-amber-700">{t('lessonNotValidatedDesc', { score: 80 })}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
       
       {/* Score Summary Card */}
       <Card className={`${isPassed ? 'bg-green-50 border-green-200' : 'bg-amber-50 border-amber-200'}`}>
@@ -212,24 +240,28 @@ export function QuizResults({ quiz, result, onRetry, onContinue }: QuizResultsPr
         </CardContent>
       </Card>
       
-      {/* Action Buttons */}
+      {/* Action Buttons — per SRS: no skip; retry regenerates quiz */}
       <div className="flex flex-col sm:flex-row gap-4 justify-center">
-        <Button
-          variant="outline"
-          onClick={onRetry}
-          className="min-h-11"
-        >
-          <RotateCcw className="w-4 h-4 mr-2" />
-          {t('retryQuiz')}
-        </Button>
+        {!lessonValidated && (
+          <Button
+            variant="outline"
+            onClick={onRetry}
+            className="min-h-11"
+          >
+            <RotateCcw className="w-4 h-4 mr-2" />
+            {t('retryQuiz')}
+          </Button>
+        )}
         
-        <Button
-          onClick={onContinue}
-          className="min-h-11"
-        >
-          {t('continueToNextUnit')}
-          <ArrowRight className="w-4 h-4 ml-2" />
-        </Button>
+        {lessonValidated && (
+          <Button
+            onClick={onContinue}
+            className="min-h-11"
+          >
+            {t('continueToNextUnit')}
+            <ArrowRight className="w-4 h-4 ml-2" />
+          </Button>
+        )}
       </div>
       
       {/* Summary Stats for Screen Readers */}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -225,6 +225,7 @@ export interface QuizAttemptResponse {
   correct_answers: number;
   total_time_seconds: number;
   passed: boolean;
+  lesson_validated: boolean;
   results: QuizAttemptResult[];
   attempted_at: string;
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -269,7 +269,11 @@
     "level": "Level",
     "cached": "Cached",
     "totalQuestions": "Total Questions",
-    "quizCompleteScreenReader": "Quiz completed with {score}% score. {correct} out of {total} questions correct. Time taken: {time}. {passed, select, true {Quiz passed.} other {Quiz not passed.}}"
+    "quizCompleteScreenReader": "Quiz completed with {score}% score. {correct} out of {total} questions correct. Time taken: {time}. {passed, select, true {Quiz passed.} other {Quiz not passed.}}",
+    "lessonCompleted": "Lesson validated!",
+    "lessonCompletedDesc": "You scored ≥80%. This lesson is now marked as complete in your progress.",
+    "lessonNotValidated": "Lesson not validated",
+    "lessonNotValidatedDesc": "You need at least {score}% to validate this lesson. Try again!"
   },
   "ChatTutor": {
     "title": "AI Tutor",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -269,7 +269,11 @@
     "level": "Niveau",
     "cached": "En Cache",
     "totalQuestions": "Total Questions",
-    "quizCompleteScreenReader": "Quiz terminé avec {score}% de score. {correct} sur {total} questions correctes. Temps pris : {time}. {passed, select, true {Quiz réussi.} other {Quiz non réussi.}}"
+    "quizCompleteScreenReader": "Quiz terminé avec {score}% de score. {correct} sur {total} questions correctes. Temps pris : {time}. {passed, select, true {Quiz réussi.} other {Quiz non réussi.}}",
+    "lessonCompleted": "Leçon validée !",
+    "lessonCompletedDesc": "Vous avez obtenu un score ≥ 80%. Cette leçon est maintenant marquée comme terminée dans votre progression.",
+    "lessonNotValidated": "Leçon non validée",
+    "lessonNotValidatedDesc": "Vous devez obtenir au moins {score}% pour valider cette leçon. Réessayez !"
   },
   "ChatTutor": {
     "title": "Tuteur IA",


### PR DESCRIPTION
## Summary

Fixes quiz validation flow per SRS FR-02.2 and FR-03.3. The quiz at `/[locale]/modules/[moduleId]/quiz` was functionally broken due to multiple issues in both the backend scoring logic and frontend result presentation.

## Root causes fixed

1. **`quiz_service.py`** — passing_score defaulted to 70% instead of 80%; cache query did not filter by `unit_id` (returned wrong quiz); strict question count validation caused failures when Claude returned ±1-2 questions
2. **`quiz.py` API** — module progress update was tied to `quiz.passing_score` (70%) instead of hardcoded 80% per SRS FR-03.3; `lesson_validated` field missing from response
3. **`quiz-container.tsx`** — retry reused cached quiz (allowed memorisation); SRS requires quiz regeneration on retry
4. **`quiz-results.tsx`** — no lesson validation feedback shown; retry button shown even after successful validation; no "Continue" button shown after validation

## Changes

### Backend
- `backend/app/domain/services/quiz_service.py` — fix cache query (unit_id filter), enforce passing_score ≥80%, relax question count validation to ±2 tolerance
- `backend/app/api/v1/quiz.py` — use hardcoded 80% threshold for `lesson_validated`; add `lesson_validated` field to response
- `backend/app/api/v1/schemas/quiz.py` — add `lesson_validated: bool` to `QuizAttemptResponse`
- `backend/tests/test_quiz_service.py` — 24 new unit tests (100% pass)

### Frontend
- `frontend/lib/api.ts` — add `lesson_validated: boolean` to `QuizAttemptResponse` type
- `frontend/components/quiz/quiz-container.tsx` — retry regenerates quiz (clears cache, re-fetches)
- `frontend/components/quiz/quiz-results.tsx` — lesson validation banner (teal=validated, amber=not); show retry only when not validated; show Continue only after validation
- `frontend/messages/fr.json` + `frontend/messages/en.json` — add `lessonCompleted`, `lessonCompletedDesc`, `lessonNotValidated`, `lessonNotValidatedDesc` keys

## Test plan

- [x] 24 backend unit tests pass (`pytest tests/test_quiz_service.py`)
- [x] Frontend lint passes (0 errors)
- [x] Frontend build passes
- [ ] Manually verify quiz flow at `/fr/modules/M01/quiz?unit=M01-U04`
- [ ] Verify score ≥80% shows green "Lesson validated" banner and Continue button
- [ ] Verify score <80% shows amber "Not validated" banner and Retry button
- [ ] Verify Retry regenerates a new quiz (different questions)

Closes #316

🤖 Generated with [Claude Code](https://claude.ai/code)