### PR TITLE
fix(tutor): pin chat input at bottom with fixed viewport layout

### DIFF
--- a/frontend/app/[locale]/(app)/layout.tsx
+++ b/frontend/app/[locale]/(app)/layout.tsx
@@ -7,7 +7,7 @@ import { ChatLayout } from "@/components/chat/chat-layout";
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
     <ChatLayout>
-      <div className="flex min-h-dvh flex-col md:flex-row">
+      <div className="flex h-dvh overflow-hidden flex-col md:flex-row">
         <Sidebar />
         <div className="flex flex-1 flex-col min-h-0">
           <Header />

--- a/frontend/components/chat/chat-layout.tsx
+++ b/frontend/components/chat/chat-layout.tsx
@@ -34,7 +34,7 @@ interface ChatLayoutProps {
 export function ChatLayout({ children }: ChatLayoutProps) {
   return (
     <ChatProvider>
-      <div className="relative">
+      <div className="relative h-dvh overflow-hidden">
         {children}
         <ChatUIComponents />
       </div>


### PR DESCRIPTION
## Summary

- Fixes regression where tutor chat input scrolls off screen as messages accumulate
- Replaces `min-h-dvh` with `h-dvh overflow-hidden` in `(app)/layout.tsx` — this caps the app shell to exactly the viewport height so the flex chain can constrain child heights properly
- Adds `h-dvh overflow-hidden` to the `ChatLayout` wrapper div so it doesn't escape the height budget

## Changes

- `frontend/app/[locale]/(app)/layout.tsx` — `min-h-dvh` → `h-dvh overflow-hidden`
- `frontend/components/chat/chat-layout.tsx` — `relative` → `relative h-dvh overflow-hidden`

The inner `chat-panel.tsx` layout was already correct (`flex-1 overflow-y-auto` for messages, siblings for suggestions + input). Only the outer containers were missing the hard height cap.

## Test plan

- [x] `npm run lint` — passes (0 errors, pre-existing warnings only)
- [x] `npm run build` — passes
- [ ] Manually verify on mobile 320px: messages scroll, input stays pinned
- [ ] Verify conversation sidebar hidden on mobile, visible on desktop

Closes #321

Generated with [Claude Code](https://claude.ai/code)