### PR TITLE
fix(tutor): pin chat input with h-dvh viewport layout (#321)

### DIFF
--- a/frontend/app/[locale]/(app)/layout.tsx
+++ b/frontend/app/[locale]/(app)/layout.tsx
@@ -7,7 +7,7 @@ import { ChatLayout } from "@/components/chat/chat-layout";
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
     <ChatLayout>
-      <div className="flex min-h-dvh flex-col md:flex-row">
+      <div className="flex h-dvh overflow-hidden flex-col md:flex-row">
         <Sidebar />
         <div className="flex flex-1 flex-col min-h-0">
           <Header />

--- a/frontend/components/chat/chat-layout.tsx
+++ b/frontend/components/chat/chat-layout.tsx
@@ -34,7 +34,7 @@ interface ChatLayoutProps {
 export function ChatLayout({ children }: ChatLayoutProps) {
   return (
     <ChatProvider>
-      <div className="relative">
+      <div className="relative h-dvh overflow-hidden">
         {children}
         <ChatUIComponents />
       </div>


### PR DESCRIPTION
## Summary

Fixes regression where tutor chat input scrolls off screen when messages accumulate.

Two root-cause changes (2 lines total):

| File | Before | After |
|------|--------|-------|
| `frontend/app/[locale]/(app)/layout.tsx` | `flex min-h-dvh` | `flex h-dvh overflow-hidden` |
| `frontend/components/chat/chat-layout.tsx` | `relative` | `relative h-dvh overflow-hidden` |

`min-h-dvh` allows the page to grow taller than the viewport. With `h-dvh overflow-hidden`, the flex height chain is intact: the messages area (`flex-1 overflow-y-auto`) is constrained and scrolls internally — the input and quick-actions are fixed siblings below it and never move.

## Changes

- `frontend/app/[locale]/(app)/layout.tsx` — `min-h-dvh` → `h-dvh overflow-hidden`
- `frontend/components/chat/chat-layout.tsx` — add `h-dvh overflow-hidden` to wrapper

## Test plan
- [ ] `npm run lint` — passes (0 errors)
- [ ] `npm run build` — passes
- [ ] Messages scroll within container; input always visible at bottom
- [ ] Works on mobile 320px with bottom nav
- [ ] New messages auto-scroll to bottom

Closes #321

Generated with [Claude Code](https://claude.ai/code)