### PR TITLE
fix: URGENT revert scroll blocking on all pages

### DIFF
--- a/frontend/app/[locale]/(app)/layout.tsx
+++ b/frontend/app/[locale]/(app)/layout.tsx
@@ -7,7 +7,7 @@ import { ChatLayout } from "@/components/chat/chat-layout";
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
     <ChatLayout>
-      <div className="flex h-dvh overflow-hidden flex-col md:flex-row">
+      <div className="flex min-h-dvh flex-col md:flex-row">
         <Sidebar />
         <div className="flex flex-1 flex-col min-h-0">
           <Header />

--- a/frontend/components/chat/chat-layout.tsx
+++ b/frontend/components/chat/chat-layout.tsx
@@ -34,7 +34,7 @@ interface ChatLayoutProps {
 export function ChatLayout({ children }: ChatLayoutProps) {
   return (
     <ChatProvider>
-      <div className="relative h-dvh overflow-hidden">
+      <div className="relative">
         {children}
         <ChatUIComponents />
       </div>


### PR DESCRIPTION
Reverts h-dvh overflow-hidden from root layout. Restores scrolling on all pages.