### PR TITLE
fix(quiz): replace retrieve_chunks() with search_for_module() (#332)

### DIFF
--- a/backend/app/domain/services/quiz_service.py
+++ b/backend/app/domain/services/quiz_service.py
@@ -173,15 +173,19 @@ class QuizService:
         try:
             # Retrieve relevant content chunks using RAG
             search_query = f"module {module_id} unit {unit_id} public health epidemiology concepts"
-            retrieved_chunks = await self.semantic_retriever.retrieve_chunks(
+            search_results = await self.semantic_retriever.search_for_module(
                 query=search_query,
-                top_k=8,  # Get more chunks for quiz questions
-                module_filter=str(module_id) if module_id else None,
+                user_level=level,
+                user_language=language,
+                top_k=8,
             )
 
             # Build context from retrieved chunks
             context_text = "\n\n".join(
-                [f"Source: {chunk.source_reference}\n{chunk.content}" for chunk in retrieved_chunks]
+                [
+                    f"Source: {result.chunk.source}\n{result.chunk.content}"
+                    for result in search_results
+                ]
             )
 
             # Generate quiz using Claude API with structured prompt


### PR DESCRIPTION
## Summary

Fixes the quiz generation crash caused by calling a non-existent method on `SemanticRetriever`.

## Changes

- `backend/app/domain/services/quiz_service.py`: Replace `self.semantic_retriever.retrieve_chunks(query=..., top_k=8, module_filter=...)` with `self.semantic_retriever.search_for_module(query=..., user_level=level, user_language=language, top_k=8)`
- Fix `chunk.source_reference` → `result.chunk.source` to match the `SearchResult` dataclass returned by `search_for_module()`

## Test plan
- [ ] Backend tests pass
- [ ] Quiz generation no longer raises `AttributeError: 'SemanticRetriever' object has no attribute 'retrieve_chunks'`
- [ ] Manually verified on mobile viewport

Closes #332

Generated with [Claude Code](https://claude.ai/code)