### PR TITLE
feat(tutor): agentic tool_use loop with 5 tools and learner_memory

### DIFF
--- a/backend/app/ai/prompts/tutor.py
+++ b/backend/app/ai/prompts/tutor.py
@@ -111,6 +111,45 @@ vers la compréhension plutôt que de donner des réponses directes.
 ## SOURCES DISPONIBLES
 {sources_context}
 
+## OUTILS DISPONIBLES (tool_use)
+
+Tu as accès à 5 outils que tu peux appeler de manière autonome:
+
+### `search_knowledge_base(query, module_id?)`
+Utilise cet outil CHAQUE FOIS que tu dois:
+- Citer une source ou vérifier un concept
+- Trouver des informations précises sur un sujet de santé publique
+- Appuyer ta guidance Socratique sur des références bibliographiques
+- Répondre à des questions nécessitant des données factuelles
+
+### `get_learner_progress(user_id)`
+Utilise cet outil quand tu dois:
+- Personnaliser tes conseils selon le niveau et les forces/faiblesses de l'apprenant
+- Adapter la difficulté des questions Socratiques
+- Référencer les modules que l'apprenant a déjà complétés
+- Identifier les domaines nécessitant un renforcement
+
+### `generate_mini_quiz(topic, num_questions, difficulty)`
+Utilise cet outil après avoir exploré un concept difficile:
+- Proposer 2-3 questions de vérification de compréhension
+- Renforcer l'apprentissage par la pratique active
+- Évaluer si l'apprenant a intégré le concept avant de passer à la suite
+
+### `search_flashcards(concept, module_id?)`
+Utilise cet outil pour:
+- Suggérer des flashcards pertinentes après avoir couvert un concept clé
+- Proposer du matériel de révision en répétition espacée
+- Renforcer la mémorisation des termes importants
+
+### `save_learner_preference(preference_type, value)`
+Utilise cet outil quand tu détectes un pattern récurrent:
+- L'apprenant répond mieux aux analogies qu'aux définitions formelles
+- L'apprenant préfère les exemples concrets du contexte AOF
+- L'apprenant a des difficultés avec certains types de concepts
+- L'apprenant préfère une approche plus directe ou plus Socratique
+
+**IMPORTANT:** Tu peux enchaîner jusqu'à 3 appels d'outils par message. Utilise les outils intelligemment selon le contexte — ne les appelle pas tous systématiquement.
+
 ## INSTRUCTIONS SPÉCIALES
 
 ### RÉPONSES INTERDITES
@@ -124,7 +163,8 @@ vers la compréhension plutôt que de donner des réponses directes.
 - Analogies contextualisées
 - Encouragements personnalisés
 - Indices progressifs
-- Sources citées
+- Sources citées (via search_knowledge_base)
+- Mini-quizzes après les concepts difficiles (via generate_mini_quiz)
 
 ### GESTION DES ERREURS
 - Reformule positivement: "Intéressant, et si on regardait sous un autre angle ?"
@@ -136,7 +176,7 @@ Chaque réponse doit contenir:
 1. Un encouragement ou validation
 2. Une question guidante principale
 3. Un indice si nécessaire
-4. Une citation de source
+4. Une citation de source (recherchée via search_knowledge_base)
 5. Une suggestion d'activité si pertinente
 
 ## EXEMPLE DE RÉPONSE CONFORME

--- a/backend/app/domain/models/__init__.py
+++ b/backend/app/domain/models/__init__.py
@@ -4,6 +4,7 @@ from app.domain.models.content import GeneratedContent
 from app.domain.models.conversation import TutorConversation
 from app.domain.models.document_chunk import DocumentChunk
 from app.domain.models.flashcard import FlashcardReview
+from app.domain.models.learner_memory import LearnerMemory
 from app.domain.models.module import Module
 from app.domain.models.module_unit import ModuleUnit
 from app.domain.models.progress import UserModuleProgress
@@ -14,6 +15,7 @@ __all__ = [
     "Base",
     "DocumentChunk",
     "GeneratedContent",
+    "LearnerMemory",
     "TutorConversation",
     "FlashcardReview",
     "MagicLink",

--- a/backend/app/domain/models/learner_memory.py
+++ b/backend/app/domain/models/learner_memory.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, String, func
+from sqlalchemy.dialects.postgresql import JSON
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.domain.models.base import Base
+
+if TYPE_CHECKING:
+    from app.domain.models.user import User
+
+
+class LearnerMemory(Base):
+    __tablename__ = "learner_memory"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), index=True)
+    preference_type: Mapped[str] = mapped_column(String(100), index=True)
+    value: Mapped[dict] = mapped_column(JSON)
+    created_at: Mapped[datetime] = mapped_column(server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(server_default=func.now(), onupdate=func.now())
+
+    user: Mapped[User] = relationship(back_populates="learner_memories")

--- a/backend/app/domain/models/user.py
+++ b/backend/app/domain/models/user.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from app.domain.models.auth import EmailOTP, MagicLink, RefreshToken, TOTPSecret
     from app.domain.models.conversation import TutorConversation
     from app.domain.models.flashcard import FlashcardReview
+    from app.domain.models.learner_memory import LearnerMemory
     from app.domain.models.lesson_reading import LessonReading
     from app.domain.models.progress import UserModuleProgress
     from app.domain.models.quiz import PlacementTestAttempt, QuizAttempt, SummativeAssessmentAttempt
@@ -51,3 +52,4 @@ class User(Base):
     flashcard_reviews: Mapped[list[FlashcardReview]] = relationship(back_populates="user")
     lesson_readings: Mapped[list[LessonReading]] = relationship(back_populates="user")
     tutor_conversations: Mapped[list[TutorConversation]] = relationship(back_populates="user")
+    learner_memories: Mapped[list[LearnerMemory]] = relationship(back_populates="user")

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -1,4 +1,4 @@
-"""Service for AI tutor functionality with Socratic pedagogical approach."""
+"""Service for AI tutor functionality with agentic tool_use and Socratic pedagogical approach."""
 
 import uuid
 from collections.abc import AsyncGenerator
@@ -7,6 +7,7 @@ from typing import Any
 
 import structlog
 from anthropic import AsyncAnthropic
+from anthropic.types import MessageParam, ToolResultBlockParam, ToolUseBlock
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -16,13 +17,16 @@ from app.ai.rag.retriever import SemanticRetriever
 from app.domain.models.conversation import TutorConversation
 from app.domain.models.module import Module
 from app.domain.models.user import User
+from app.domain.services.tutor_tools import TOOL_DEFINITIONS, TutorToolExecutor
 from app.infrastructure.config.settings import get_settings
 
 logger = structlog.get_logger()
 
+MAX_TOOL_CALLS = 3
+
 
 class TutorService:
-    """Service for managing AI tutor conversations with Socratic approach."""
+    """Service for managing AI tutor conversations with agentic tool_use and Socratic approach."""
 
     def __init__(
         self,
@@ -34,7 +38,7 @@ class TutorService:
         self.retriever = semantic_retriever
         self.embedding_service = embedding_service
         self.settings = get_settings()
-        self.daily_message_limit = 50  # Free tier limit
+        self.daily_message_limit = 50
 
     async def send_message(
         self,
@@ -47,7 +51,10 @@ class TutorService:
         conversation_id: uuid.UUID | None = None,
     ) -> AsyncGenerator[dict[str, Any], None]:
         """
-        Send a message to the AI tutor and stream the response.
+        Send a message to the AI tutor and stream the response using agentic tool_use.
+
+        Claude autonomously decides when to call tools (RAG search, progress lookup, etc.)
+        The tool loop runs server-side; only text chunks are streamed to the client.
 
         Args:
             user_id: User ID
@@ -61,11 +68,9 @@ class TutorService:
         Yields:
             Stream chunks with tutor response data
         """
-        # Convert user_id to UUID if it's a string
         if isinstance(user_id, str):
             user_id = uuid.UUID(user_id)
 
-        # Check daily message limit
         messages_used = await self._check_daily_limit(user_id, session)
         if messages_used >= self.daily_message_limit:
             yield {
@@ -78,14 +83,12 @@ class TutorService:
             }
             return
 
-        # Get user context
         user = await session.get(User, user_id)
         if not user:
             yield {"type": "error", "data": {"message": "User not found"}}
             return
 
         try:
-            # Get or create conversation
             conversation = await self._get_or_create_conversation(
                 user_id, module_id, conversation_id, session
             )
@@ -95,101 +98,191 @@ class TutorService:
                 "data": {"conversation_id": str(conversation.id)},
             }
 
-            # Build context
             context = TutorContext(
                 user_level=user.current_level,
                 user_language=user.preferred_language,
-                user_country=user.country,
+                user_country=user.country or "SN",
                 module_id=str(module_id) if module_id else None,
                 context_type=context_type,
                 context_id=str(context_id) if context_id else None,
             )
 
-            # Perform RAG retrieval
-            rag_chunks = await self._retrieve_relevant_context(message, user, module_id, session)
+            system_prompt = get_socratic_system_prompt(context, [])
 
-            yield {
-                "type": "sources_retrieved",
-                "data": {
-                    "chunk_count": len(rag_chunks),
-                    "sources": [chunk.chunk.source for chunk in rag_chunks],
-                },
-            }
-
-            # Generate system prompt
-            chunks_dict = [
-                {
-                    "content": chunk.chunk.content,
-                    "source": chunk.chunk.source,
-                    "chapter": chunk.chunk.chapter,
-                    "page": chunk.chunk.page,
-                    "similarity": chunk.similarity_score,
-                }
-                for chunk in rag_chunks
-            ]
-
-            system_prompt = get_socratic_system_prompt(context, chunks_dict)
-
-            # Prepare conversation history
             conversation_history = await self._prepare_conversation_history(conversation)
 
-            # Add user message
-            user_msg = {
+            user_msg_stored = {
                 "role": "user",
                 "content": message,
                 "timestamp": datetime.utcnow().isoformat(),
             }
-            conversation_history.append(user_msg)
+            conversation_history.append({"role": "user", "content": message})
 
-            # Stream Claude response
+            tool_executor = TutorToolExecutor(
+                retriever=self.retriever,
+                anthropic_client=self.anthropic,
+                user_id=user_id,
+                user_level=user.current_level,
+                user_language=user.preferred_language,
+            )
+
+            tool_call_count = 0
             full_response = ""
-            sources_cited = []
-            activity_suggestions = []
+            all_tool_calls: list[dict[str, Any]] = []
+            sources_cited: list[dict[str, Any]] = []
+            api_messages: list[MessageParam] = list(conversation_history)
 
-            async with self.anthropic.messages.stream(
-                model="claude-sonnet-4-6",
-                system=system_prompt,
-                messages=[
-                    {"role": msg["role"], "content": msg["content"]} for msg in conversation_history
-                ],
-                max_tokens=1000,
-                temperature=0.7,
-            ) as stream:
-                async for event in stream:
-                    if event.type == "content_block_delta" and hasattr(event.delta, "text"):
-                        chunk_text = event.delta.text
-                        full_response += chunk_text
+            while tool_call_count <= MAX_TOOL_CALLS:
+                response = await self.anthropic.messages.create(
+                    model="claude-sonnet-4-6",
+                    system=system_prompt,
+                    messages=api_messages,
+                    tools=TOOL_DEFINITIONS,
+                    max_tokens=1500,
+                    temperature=0.7,
+                )
+
+                tool_use_blocks = [
+                    block for block in response.content if isinstance(block, ToolUseBlock)
+                ]
+
+                if not tool_use_blocks:
+                    text_parts = [
+                        block.text
+                        for block in response.content
+                        if hasattr(block, "text") and block.text
+                    ]
+                    full_response = "".join(text_parts)
+
+                    for chunk_text in _split_into_chunks(full_response):
                         yield {
                             "type": "content",
                             "data": {"text": chunk_text},
                             "conversation_id": str(conversation.id),
                         }
+                    break
 
-            # Extract sources and activity suggestions from response
-            sources_cited = self._extract_sources_from_response(full_response, chunks_dict)
+                if tool_call_count >= MAX_TOOL_CALLS:
+                    logger.warning(
+                        "Max tool calls reached, forcing final response",
+                        user_id=str(user_id),
+                        tool_call_count=tool_call_count,
+                    )
+                    text_parts = [
+                        block.text
+                        for block in response.content
+                        if hasattr(block, "text") and block.text
+                    ]
+                    full_response = "".join(text_parts)
+                    if full_response:
+                        for chunk_text in _split_into_chunks(full_response):
+                            yield {
+                                "type": "content",
+                                "data": {"text": chunk_text},
+                                "conversation_id": str(conversation.id),
+                            }
+                    break
+
+                assistant_content: list[Any] = list(response.content)
+                api_messages.append({"role": "assistant", "content": assistant_content})
+
+                tool_results: list[ToolResultBlockParam] = []
+                for tool_block in tool_use_blocks:
+                    tool_call_count += 1
+
+                    logger.info(
+                        "Tutor tool call",
+                        tool_name=tool_block.name,
+                        tool_id=tool_block.id,
+                        user_id=str(user_id),
+                        call_number=tool_call_count,
+                    )
+
+                    yield {
+                        "type": "tool_call",
+                        "data": {
+                            "tool_name": tool_block.name,
+                            "call_number": tool_call_count,
+                        },
+                        "conversation_id": str(conversation.id),
+                    }
+
+                    tool_result_str = await tool_executor.execute(
+                        tool_name=tool_block.name,
+                        tool_input=tool_block.input,
+                        session=session,
+                    )
+
+                    all_tool_calls.append(
+                        {
+                            "tool_name": tool_block.name,
+                            "tool_id": tool_block.id,
+                            "input": tool_block.input,
+                            "result_preview": tool_result_str[:200],
+                        }
+                    )
+
+                    if tool_block.name == "search_knowledge_base":
+                        import json
+
+                        try:
+                            rag_result = json.loads(tool_result_str)
+                            for chunk in rag_result.get("results", []):
+                                source_info: dict[str, Any] = {
+                                    "source": chunk.get("source", ""),
+                                    "content_preview": chunk.get("content", "")[:100] + "...",
+                                    "similarity_score": chunk.get("similarity", 0),
+                                }
+                                if chunk.get("chapter"):
+                                    source_info["chapter"] = chunk["chapter"]
+                                if chunk.get("page"):
+                                    source_info["page"] = chunk["page"]
+                                sources_cited.append(source_info)
+                        except Exception:
+                            pass
+
+                    tool_results.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": tool_block.id,
+                            "content": tool_result_str,
+                        }
+                    )
+
+                api_messages.append({"role": "user", "content": tool_results})
+
+            unique_sources = _deduplicate_sources(sources_cited)
+
             activity_suggestions = self._extract_activity_suggestions(
                 full_response, context_type, user.current_level
             )
 
-            # Save messages to conversation
-            assistant_msg = {
+            assistant_msg_stored = {
                 "role": "assistant",
                 "content": full_response,
-                "sources": sources_cited,
+                "sources": unique_sources,
                 "timestamp": datetime.utcnow().isoformat(),
                 "activity_suggestions": activity_suggestions,
+                "tool_calls_count": tool_call_count,
             }
 
-            # Update conversation
-            updated_messages = conversation.messages + [user_msg, assistant_msg]
+            updated_messages = conversation.messages + [user_msg_stored, assistant_msg_stored]
             conversation.messages = updated_messages
             session.add(conversation)
             await session.commit()
 
-            # Send final metadata
+            yield {
+                "type": "sources_retrieved",
+                "data": {
+                    "chunk_count": len(unique_sources),
+                    "sources": [s.get("source", "") for s in unique_sources],
+                },
+                "conversation_id": str(conversation.id),
+            }
+
             yield {
                 "type": "sources_cited",
-                "data": {"sources": sources_cited},
+                "data": {"sources": unique_sources},
                 "conversation_id": str(conversation.id),
             }
 
@@ -204,6 +297,7 @@ class TutorService:
                 "data": {
                     "remaining_messages": self.daily_message_limit - messages_used - 1,
                     "conversation_id": str(conversation.id),
+                    "tool_calls_made": tool_call_count,
                 },
                 "finished": True,
             }
@@ -219,7 +313,6 @@ class TutorService:
         self, user_id: str | uuid.UUID, conversation_id: uuid.UUID, session: AsyncSession
     ) -> dict[str, Any] | None:
         """Get a specific conversation."""
-        # Convert user_id to UUID if it's a string
         if isinstance(user_id, str):
             user_id = uuid.UUID(user_id)
 
@@ -243,7 +336,6 @@ class TutorService:
         self, user_id: str | uuid.UUID, session: AsyncSession, limit: int = 20, offset: int = 0
     ) -> dict[str, Any]:
         """List user's tutor conversations."""
-        # Convert user_id to UUID if it's a string
         if isinstance(user_id, str):
             user_id = uuid.UUID(user_id)
 
@@ -257,7 +349,6 @@ class TutorService:
         result = await session.execute(query)
         conversations = result.scalars().all()
 
-        # Count total conversations
         count_query = select(func.count(TutorConversation.id)).where(
             TutorConversation.user_id == user_id
         )
@@ -299,23 +390,18 @@ class TutorService:
         self, user_id: str | uuid.UUID, session: AsyncSession
     ) -> dict[str, Any]:
         """Get tutor usage statistics for a user."""
-        # Convert user_id to UUID if it's a string
         if isinstance(user_id, str):
             user_id = uuid.UUID(user_id)
 
-        # Count daily messages
         daily_messages = await self._check_daily_limit(user_id, session)
 
-        # Count total conversations
         count_query = select(func.count(TutorConversation.id)).where(
             TutorConversation.user_id == user_id
         )
         count_result = await session.execute(count_query)
         total_conversations = count_result.scalar() or 0
 
-        # For now, return basic stats
-        # TODO: Implement topic extraction and frequency analysis
-        most_discussed_topics = []
+        most_discussed_topics: list[Any] = []
 
         return {
             "daily_messages_used": daily_messages,
@@ -326,7 +412,6 @@ class TutorService:
 
     async def _check_daily_limit(self, user_id: str | uuid.UUID, session: AsyncSession) -> int:
         """Check how many messages user has sent today."""
-        # Convert user_id to UUID if it's a string
         if isinstance(user_id, str):
             user_id = uuid.UUID(user_id)
 
@@ -341,7 +426,6 @@ class TutorService:
 
         message_count = 0
         for conv in conversations:
-            # Count user messages only
             user_messages = [msg for msg in conv.messages if msg.get("role") == "user"]
             message_count += len(user_messages)
 
@@ -355,7 +439,6 @@ class TutorService:
         session: AsyncSession,
     ) -> TutorConversation:
         """Get existing conversation or create a new one."""
-        # Convert user_id to UUID if it's a string
         if isinstance(user_id, str):
             user_id = uuid.UUID(user_id)
 
@@ -369,7 +452,6 @@ class TutorService:
             if conversation:
                 return conversation
 
-        # Create new conversation
         conversation = TutorConversation(
             id=uuid.uuid4(),
             user_id=user_id,
@@ -378,22 +460,20 @@ class TutorService:
             created_at=datetime.utcnow(),
         )
         session.add(conversation)
-        await session.flush()  # Get the ID
+        await session.flush()
 
         return conversation
 
     async def _retrieve_relevant_context(
         self, query: str, user: User, module_id: uuid.UUID | None, session: AsyncSession
     ) -> list[Any]:
-        """Retrieve relevant context using RAG."""
-        # Get module context if available
+        """Retrieve relevant context using RAG (kept for backward compatibility)."""
         books_sources = None
         if module_id:
             module = await session.get(Module, module_id)
             if module:
                 books_sources = module.books_sources
 
-        # Search for relevant chunks
         search_results = await self.retriever.search_for_module(
             query=query,
             user_level=user.current_level,
@@ -417,14 +497,12 @@ class TutorService:
         self, conversation: TutorConversation
     ) -> list[dict[str, str]]:
         """Prepare conversation history for Claude API."""
-        # Limit to last 10 messages to stay within context limits
         messages = (
             conversation.messages[-10:]
             if len(conversation.messages) > 10
             else conversation.messages
         )
 
-        # Convert to Claude format (role and content only)
         claude_messages = []
         for msg in messages:
             if msg.get("role") and msg.get("content"):
@@ -437,51 +515,10 @@ class TutorService:
 
         return claude_messages
 
-    def _extract_sources_from_response(
-        self, response: str, available_chunks: list[dict[str, Any]]
-    ) -> list[dict[str, Any]]:
-        """Extract source citations from the tutor response."""
-        sources = []
-
-        # Look for citation patterns in the response
-        for chunk in available_chunks:
-            source_name = chunk.get("source", "")
-            chapter = chunk.get("chapter")
-            page = chunk.get("page")
-
-            # Simple matching - look for source name in response
-            if source_name.lower() in response.lower():
-                source_info = {
-                    "source": source_name,
-                    "content_preview": chunk.get("content", "")[:100] + "...",
-                    "similarity_score": chunk.get("similarity", 0),
-                }
-                if chapter:
-                    source_info["chapter"] = chapter
-                if page:
-                    source_info["page"] = page
-
-                sources.append(source_info)
-
-        # Remove duplicates based on source name
-        seen_sources = set()
-        unique_sources = []
-        for source in sources:
-            source_key = f"{source['source']}-{source.get('chapter', '')}-{source.get('page', '')}"
-            if source_key not in seen_sources:
-                seen_sources.add(source_key)
-                unique_sources.append(source)
-
-        return unique_sources[:5]  # Limit to 5 sources
-
     def _extract_activity_suggestions(
         self, response: str, context_type: str | None, user_level: int
     ) -> list[dict[str, str]]:
         """Extract activity suggestions from the response or generate them."""
-        # For now, generate basic suggestions
-        # TODO: Implement NLP to extract suggestions from response
-
-        # Look for key health topics
         health_topics = [
             "surveillance",
             "épidémiologie",
@@ -493,10 +530,32 @@ class TutorService:
             "hygiène",
         ]
 
-        topic = "santé publique"  # default
+        topic = "santé publique"
         for health_topic in health_topics:
             if health_topic in response.lower():
                 topic = health_topic
                 break
 
         return get_activity_suggestions(context_type, user_level, topic)
+
+
+def _split_into_chunks(text: str, chunk_size: int = 50) -> list[str]:
+    """Split text into smaller chunks for streaming simulation."""
+    if not text:
+        return []
+    chunks = []
+    for i in range(0, len(text), chunk_size):
+        chunks.append(text[i : i + chunk_size])
+    return chunks
+
+
+def _deduplicate_sources(sources: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Remove duplicate sources by source+chapter+page."""
+    seen: set[str] = set()
+    unique: list[dict[str, Any]] = []
+    for source in sources:
+        key = f"{source.get('source', '')}-{source.get('chapter', '')}-{source.get('page', '')}"
+        if key not in seen:
+            seen.add(key)
+            unique.append(source)
+    return unique[:5]

--- a/backend/app/domain/services/tutor_tools.py
+++ b/backend/app/domain/services/tutor_tools.py
@@ -1,0 +1,495 @@
+"""Tool definitions and execution handlers for the agentic AI tutor."""
+
+import json
+import uuid
+from typing import Any
+
+import structlog
+from anthropic.types import ToolParam
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.ai.rag.retriever import SemanticRetriever
+from app.domain.models.content import GeneratedContent
+from app.domain.models.learner_memory import LearnerMemory
+from app.domain.models.module import Module
+from app.domain.models.progress import UserModuleProgress
+from app.domain.models.quiz import PlacementTestAttempt, QuizAttempt
+
+logger = structlog.get_logger()
+
+TOOL_DEFINITIONS: list[ToolParam] = [
+    {
+        "name": "search_knowledge_base",
+        "description": (
+            "Search the knowledge base (reference textbooks on public health) for relevant information. "
+            "Use this when you need to cite sources, verify a concept, or find supporting material "
+            "for your Socratic guidance. Returns relevant text chunks with source citations."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "The search query to find relevant knowledge base content.",
+                },
+                "module_id": {
+                    "type": "string",
+                    "description": "Optional UUID of the current module to narrow source filtering.",
+                },
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "get_learner_progress",
+        "description": (
+            "Retrieve the learner's current progress, quiz scores, completed modules, "
+            "weak domains, and placement test results. Use this to personalize your guidance, "
+            "adapt difficulty, and address knowledge gaps."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string",
+                    "description": "UUID of the learner.",
+                },
+            },
+            "required": ["user_id"],
+        },
+    },
+    {
+        "name": "generate_mini_quiz",
+        "description": (
+            "Generate an inline mini quiz (2-3 questions) to test the learner's comprehension "
+            "of a specific topic. Use this after explaining a difficult concept to reinforce learning. "
+            "Returns structured quiz questions with options."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "topic": {
+                    "type": "string",
+                    "description": "The topic or concept to quiz the learner on.",
+                },
+                "num_questions": {
+                    "type": "integer",
+                    "description": "Number of questions to generate (2-3 recommended).",
+                    "minimum": 1,
+                    "maximum": 3,
+                },
+                "difficulty": {
+                    "type": "string",
+                    "enum": ["easy", "medium", "hard"],
+                    "description": "Difficulty level of the quiz questions.",
+                },
+            },
+            "required": ["topic", "num_questions", "difficulty"],
+        },
+    },
+    {
+        "name": "search_flashcards",
+        "description": (
+            "Find relevant flashcards for a concept to suggest to the learner for review. "
+            "Use this to recommend spaced repetition material after covering a topic."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "concept": {
+                    "type": "string",
+                    "description": "The concept or term to search flashcards for.",
+                },
+                "module_id": {
+                    "type": "string",
+                    "description": "Optional UUID of the module to filter flashcards.",
+                },
+            },
+            "required": ["concept"],
+        },
+    },
+    {
+        "name": "save_learner_preference",
+        "description": (
+            "Save a detected learner preference or learning pattern to personalize future interactions. "
+            "Use this when you detect consistent patterns such as: the learner prefers analogies, "
+            "responds well to examples, prefers a specific language, struggles with statistics, etc."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "preference_type": {
+                    "type": "string",
+                    "description": (
+                        "Category of the preference (e.g., 'learning_style', 'difficulty_preference', "
+                        "'language_preference', 'topic_strength', 'topic_weakness')."
+                    ),
+                },
+                "value": {
+                    "type": "object",
+                    "description": (
+                        "The preference value as a JSON object with relevant details. "
+                        'Example: {"style": "analogies", "confidence": 0.9}'
+                    ),
+                },
+            },
+            "required": ["preference_type", "value"],
+        },
+    },
+]
+
+
+class TutorToolExecutor:
+    """Executes tool calls made by Claude in the agentic tutor loop."""
+
+    def __init__(
+        self,
+        retriever: SemanticRetriever,
+        anthropic_client: Any,
+        user_id: uuid.UUID,
+        user_level: int,
+        user_language: str,
+    ):
+        self.retriever = retriever
+        self.anthropic = anthropic_client
+        self.user_id = user_id
+        self.user_level = user_level
+        self.user_language = user_language
+
+    async def execute(
+        self,
+        tool_name: str,
+        tool_input: dict[str, Any],
+        session: AsyncSession,
+    ) -> str:
+        """
+        Execute a tool call and return the result as a JSON string.
+
+        Args:
+            tool_name: Name of the tool to execute
+            tool_input: Tool input parameters
+            session: Database session
+
+        Returns:
+            JSON string with tool result
+        """
+        logger.info(
+            "Executing tutor tool",
+            tool_name=tool_name,
+            user_id=str(self.user_id),
+            tool_input_keys=list(tool_input.keys()),
+        )
+
+        try:
+            if tool_name == "search_knowledge_base":
+                return await self._search_knowledge_base(tool_input, session)
+            elif tool_name == "get_learner_progress":
+                return await self._get_learner_progress(tool_input, session)
+            elif tool_name == "generate_mini_quiz":
+                return await self._generate_mini_quiz(tool_input)
+            elif tool_name == "search_flashcards":
+                return await self._search_flashcards(tool_input, session)
+            elif tool_name == "save_learner_preference":
+                return await self._save_learner_preference(tool_input, session)
+            else:
+                logger.warning("Unknown tool called", tool_name=tool_name)
+                return json.dumps({"error": f"Unknown tool: {tool_name}"})
+        except Exception as e:
+            logger.error(
+                "Tool execution failed",
+                tool_name=tool_name,
+                error=str(e),
+                user_id=str(self.user_id),
+            )
+            return json.dumps({"error": f"Tool execution failed: {str(e)}"})
+
+    async def _search_knowledge_base(
+        self, tool_input: dict[str, Any], session: AsyncSession
+    ) -> str:
+        """Execute search_knowledge_base tool."""
+        query = tool_input["query"]
+        module_id_str = tool_input.get("module_id")
+
+        books_sources = None
+        if module_id_str:
+            try:
+                module_id = uuid.UUID(module_id_str)
+                module = await session.get(Module, module_id)
+                if module:
+                    books_sources = module.books_sources
+            except (ValueError, TypeError):
+                pass
+
+        results = await self.retriever.search_for_module(
+            query=query,
+            user_level=self.user_level,
+            user_language=self.user_language,
+            books_sources=books_sources,
+            top_k=5,
+            session=session,
+        )
+
+        chunks = []
+        for result in results:
+            chunks.append(
+                {
+                    "content": result.chunk.content,
+                    "source": result.chunk.source,
+                    "chapter": result.chunk.chapter,
+                    "page": result.chunk.page,
+                    "similarity": round(result.similarity_score, 3),
+                }
+            )
+
+        logger.info(
+            "search_knowledge_base tool completed",
+            query=query,
+            results_count=len(chunks),
+            user_id=str(self.user_id),
+        )
+        return json.dumps({"query": query, "results": chunks, "count": len(chunks)})
+
+    async def _get_learner_progress(self, tool_input: dict[str, Any], session: AsyncSession) -> str:
+        """Execute get_learner_progress tool."""
+        progress_query = select(UserModuleProgress).where(
+            UserModuleProgress.user_id == self.user_id
+        )
+        progress_result = await session.execute(progress_query)
+        progress_rows = progress_result.scalars().all()
+
+        modules_progress = []
+        completed_modules = []
+        weak_domains = []
+
+        for row in progress_rows:
+            module_data = {
+                "module_id": str(row.module_id),
+                "status": row.status,
+                "completion_pct": row.completion_pct,
+                "quiz_score_avg": row.quiz_score_avg,
+                "time_spent_minutes": row.time_spent_minutes,
+            }
+            modules_progress.append(module_data)
+
+            if row.status == "completed":
+                completed_modules.append(str(row.module_id))
+
+            if row.quiz_score_avg is not None and row.quiz_score_avg < 60:
+                weak_domains.append(
+                    {"module_id": str(row.module_id), "quiz_score_avg": row.quiz_score_avg}
+                )
+
+        quiz_query = (
+            select(QuizAttempt)
+            .where(QuizAttempt.user_id == self.user_id)
+            .order_by(QuizAttempt.attempted_at.desc())
+            .limit(5)
+        )
+        quiz_result = await session.execute(quiz_query)
+        recent_quizzes = quiz_result.scalars().all()
+
+        recent_scores = [
+            {"quiz_id": str(q.quiz_id), "score": q.score, "attempted_at": str(q.attempted_at)}
+            for q in recent_quizzes
+        ]
+
+        placement_query = (
+            select(PlacementTestAttempt)
+            .where(PlacementTestAttempt.user_id == self.user_id)
+            .order_by(PlacementTestAttempt.attempted_at.desc())
+            .limit(1)
+        )
+        placement_result = await session.execute(placement_query)
+        placement = placement_result.scalar_one_or_none()
+
+        placement_data = None
+        if placement:
+            placement_data = {
+                "assigned_level": placement.assigned_level,
+                "raw_score": placement.raw_score,
+                "domain_scores": placement.domain_scores,
+                "competency_areas": placement.competency_areas,
+            }
+
+        result = {
+            "user_id": str(self.user_id),
+            "current_level": self.user_level,
+            "modules_progress": modules_progress,
+            "completed_modules_count": len(completed_modules),
+            "weak_domains": weak_domains,
+            "recent_quiz_scores": recent_scores,
+            "placement_test": placement_data,
+        }
+
+        logger.info(
+            "get_learner_progress tool completed",
+            user_id=str(self.user_id),
+            modules_count=len(modules_progress),
+        )
+        return json.dumps(result)
+
+    async def _generate_mini_quiz(self, tool_input: dict[str, Any]) -> str:
+        """Execute generate_mini_quiz tool via a separate Claude call."""
+        topic = tool_input["topic"]
+        num_questions = min(int(tool_input.get("num_questions", 2)), 3)
+        difficulty = tool_input.get("difficulty", "medium")
+
+        language_instruction = "en français" if self.user_language == "fr" else "in English"
+        difficulty_map = {
+            "easy": "simples, définitions et reconnaissance",
+            "medium": "application de concepts",
+            "hard": "analyse et évaluation critique",
+        }
+        difficulty_desc = difficulty_map.get(difficulty, "application de concepts")
+
+        prompt = f"""Generate a mini quiz {language_instruction} on the topic: "{topic}"
+
+Requirements:
+- {num_questions} multiple-choice questions
+- Difficulty: {difficulty_desc}
+- Each question has 4 options (A, B, C, D)
+- One correct answer per question
+- Brief explanation for the correct answer
+- Context: West African public health setting
+
+Respond ONLY with valid JSON in this exact format:
+{{
+  "topic": "{topic}",
+  "questions": [
+    {{
+      "question": "Question text here?",
+      "options": {{
+        "A": "Option A text",
+        "B": "Option B text",
+        "C": "Option C text",
+        "D": "Option D text"
+      }},
+      "correct_answer": "A",
+      "explanation": "Brief explanation why A is correct."
+    }}
+  ]
+}}"""
+
+        response = await self.anthropic.messages.create(
+            model="claude-sonnet-4-6",
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=800,
+            temperature=0.5,
+        )
+
+        quiz_text = response.content[0].text.strip()
+
+        try:
+            if "```json" in quiz_text:
+                quiz_text = quiz_text.split("```json")[1].split("```")[0].strip()
+            elif "```" in quiz_text:
+                quiz_text = quiz_text.split("```")[1].split("```")[0].strip()
+            quiz_data = json.loads(quiz_text)
+        except (json.JSONDecodeError, IndexError):
+            quiz_data = {"topic": topic, "raw": quiz_text, "parse_error": True}
+
+        logger.info(
+            "generate_mini_quiz tool completed",
+            topic=topic,
+            num_questions=num_questions,
+            user_id=str(self.user_id),
+        )
+        return json.dumps(quiz_data)
+
+    async def _search_flashcards(self, tool_input: dict[str, Any], session: AsyncSession) -> str:
+        """Execute search_flashcards tool."""
+        concept = tool_input["concept"]
+        module_id_str = tool_input.get("module_id")
+
+        query = select(GeneratedContent).where(GeneratedContent.content_type == "flashcard")
+
+        if module_id_str:
+            try:
+                module_id = uuid.UUID(module_id_str)
+                query = query.where(GeneratedContent.module_id == module_id)
+            except (ValueError, TypeError):
+                pass
+
+        query = query.limit(20)
+        result = await session.execute(query)
+        all_flashcards = result.scalars().all()
+
+        concept_lower = concept.lower()
+        matching = []
+
+        for card in all_flashcards:
+            content = card.content or {}
+            term_fr = str(content.get("term_fr", "")).lower()
+            term_en = str(content.get("term_en", "")).lower()
+            definition_fr = str(content.get("definition_fr", "")).lower()
+
+            if (
+                concept_lower in term_fr
+                or concept_lower in term_en
+                or concept_lower in definition_fr
+            ):
+                matching.append(
+                    {
+                        "id": str(card.id),
+                        "module_id": str(card.module_id),
+                        "term_fr": content.get("term_fr"),
+                        "term_en": content.get("term_en"),
+                        "definition_fr": content.get("definition_fr"),
+                        "definition_en": content.get("definition_en"),
+                    }
+                )
+
+            if len(matching) >= 5:
+                break
+
+        logger.info(
+            "search_flashcards tool completed",
+            concept=concept,
+            results_count=len(matching),
+            user_id=str(self.user_id),
+        )
+        return json.dumps({"concept": concept, "flashcards": matching, "count": len(matching)})
+
+    async def _save_learner_preference(
+        self, tool_input: dict[str, Any], session: AsyncSession
+    ) -> str:
+        """Execute save_learner_preference tool."""
+        preference_type = tool_input["preference_type"]
+        value = tool_input["value"]
+
+        existing_query = select(LearnerMemory).where(
+            LearnerMemory.user_id == self.user_id,
+            LearnerMemory.preference_type == preference_type,
+        )
+        existing_result = await session.execute(existing_query)
+        existing = existing_result.scalar_one_or_none()
+
+        if existing:
+            existing.value = value
+            session.add(existing)
+        else:
+            memory = LearnerMemory(
+                id=uuid.uuid4(),
+                user_id=self.user_id,
+                preference_type=preference_type,
+                value=value,
+            )
+            session.add(memory)
+
+        await session.flush()
+
+        logger.info(
+            "save_learner_preference tool completed",
+            preference_type=preference_type,
+            user_id=str(self.user_id),
+            updated=existing is not None,
+        )
+        return json.dumps(
+            {
+                "saved": True,
+                "preference_type": preference_type,
+                "value": value,
+                "updated": existing is not None,
+            }
+        )

--- a/backend/migrations/versions/013_add_learner_memory_table.py
+++ b/backend/migrations/versions/013_add_learner_memory_table.py
@@ -1,0 +1,38 @@
+"""Add learner_memory table for AI tutor preference storage
+
+Revision ID: 013_add_learner_memory_table
+Revises: 012_invalidate_m01_m03_cached_lessons
+Create Date: 2026-04-02
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "013_add_learner_memory_table"
+down_revision: str | None = "012_invalidate_m01_m03_cached_lessons"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "learner_memory",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("preference_type", sa.String(100), nullable=False),
+        sa.Column("value", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_learner_memory_user_id", "learner_memory", ["user_id"])
+    op.create_index("ix_learner_memory_preference_type", "learner_memory", ["preference_type"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_learner_memory_preference_type", table_name="learner_memory")
+    op.drop_index("ix_learner_memory_user_id", table_name="learner_memory")
+    op.drop_table("learner_memory")

--- a/backend/tests/test_tutor_service.py
+++ b/backend/tests/test_tutor_service.py
@@ -91,26 +91,13 @@ async def test_send_message_yields_content_type_chunks(
     mock_session = AsyncMock(spec=AsyncSession)
     mock_session.get = AsyncMock(return_value=sample_user)
 
-    mock_event = MagicMock()
-    mock_event.type = "content_block_delta"
-    mock_event.delta = MagicMock()
-    mock_event.delta.text = "Bonjour! "
+    class FakeTextBlock:
+        def __init__(self, text):
+            self.text = text
 
-    mock_event2 = MagicMock()
-    mock_event2.type = "content_block_delta"
-    mock_event2.delta = MagicMock()
-    mock_event2.delta.text = "Comment puis-je vous aider?"
-
-    async def mock_stream_iter():
-        yield mock_event
-        yield mock_event2
-
-    mock_stream = MagicMock()
-    mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
-    mock_stream.__aexit__ = AsyncMock(return_value=None)
-    mock_stream.__aiter__ = lambda self: mock_stream_iter()
-
-    tutor_service.anthropic.messages.stream = MagicMock(return_value=mock_stream)
+    mock_response = MagicMock()
+    mock_response.content = [FakeTextBlock("Bonjour! Comment puis-je vous aider?")]
+    tutor_service.anthropic.messages.create = AsyncMock(return_value=mock_response)
 
     with (
         patch.object(
@@ -124,12 +111,6 @@ async def test_send_message_yields_content_type_chunks(
             "_get_or_create_conversation",
             new_callable=AsyncMock,
             return_value=sample_conversation,
-        ),
-        patch.object(
-            tutor_service,
-            "_retrieve_relevant_context",
-            new_callable=AsyncMock,
-            return_value=[],
         ),
     ):
         mock_session.add = MagicMock()
@@ -148,9 +129,8 @@ async def test_send_message_yields_content_type_chunks(
     assert "content" in chunk_types, f"Expected 'content' type in chunks but got: {chunk_types}"
 
     content_chunks = [c for c in chunks if c["type"] == "content"]
-    assert len(content_chunks) == 2
-    assert content_chunks[0]["data"]["text"] == "Bonjour! "
-    assert content_chunks[1]["data"]["text"] == "Comment puis-je vous aider?"
+    full_text = "".join(c["data"]["text"] for c in content_chunks)
+    assert "Bonjour!" in full_text
 
 
 async def test_send_message_yields_sources_cited_type(
@@ -160,16 +140,13 @@ async def test_send_message_yields_sources_cited_type(
     mock_session = AsyncMock(spec=AsyncSession)
     mock_session.get = AsyncMock(return_value=sample_user)
 
-    async def mock_stream_iter():
-        return
-        yield  # make it an async generator
+    class FakeTextBlock:
+        def __init__(self, text):
+            self.text = text
 
-    mock_stream = MagicMock()
-    mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
-    mock_stream.__aexit__ = AsyncMock(return_value=None)
-    mock_stream.__aiter__ = lambda self: mock_stream_iter()
-
-    tutor_service.anthropic.messages.stream = MagicMock(return_value=mock_stream)
+    mock_response = MagicMock()
+    mock_response.content = [FakeTextBlock("Test response")]
+    tutor_service.anthropic.messages.create = AsyncMock(return_value=mock_response)
 
     with (
         patch.object(
@@ -183,12 +160,6 @@ async def test_send_message_yields_sources_cited_type(
             "_get_or_create_conversation",
             new_callable=AsyncMock,
             return_value=sample_conversation,
-        ),
-        patch.object(
-            tutor_service,
-            "_retrieve_relevant_context",
-            new_callable=AsyncMock,
-            return_value=[],
         ),
     ):
         mock_session.add = MagicMock()
@@ -274,20 +245,13 @@ async def test_send_message_never_yields_text_type(tutor_service, sample_user, s
     mock_session = AsyncMock(spec=AsyncSession)
     mock_session.get = AsyncMock(return_value=sample_user)
 
-    mock_event = MagicMock()
-    mock_event.type = "content_block_delta"
-    mock_event.delta = MagicMock()
-    mock_event.delta.text = "Test response"
+    class FakeTextBlock:
+        def __init__(self, text):
+            self.text = text
 
-    async def mock_stream_iter():
-        yield mock_event
-
-    mock_stream = MagicMock()
-    mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
-    mock_stream.__aexit__ = AsyncMock(return_value=None)
-    mock_stream.__aiter__ = lambda self: mock_stream_iter()
-
-    tutor_service.anthropic.messages.stream = MagicMock(return_value=mock_stream)
+    mock_response = MagicMock()
+    mock_response.content = [FakeTextBlock("Test response")]
+    tutor_service.anthropic.messages.create = AsyncMock(return_value=mock_response)
 
     with (
         patch.object(
@@ -301,12 +265,6 @@ async def test_send_message_never_yields_text_type(tutor_service, sample_user, s
             "_get_or_create_conversation",
             new_callable=AsyncMock,
             return_value=sample_conversation,
-        ),
-        patch.object(
-            tutor_service,
-            "_retrieve_relevant_context",
-            new_callable=AsyncMock,
-            return_value=[],
         ),
     ):
         mock_session.add = MagicMock()

--- a/backend/tests/test_tutor_tools.py
+++ b/backend/tests/test_tutor_tools.py
@@ -1,0 +1,684 @@
+"""Tests for agentic tutor tools (tool_use loop, each tool handler, max limit)."""
+
+import json
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.ai.rag.retriever import SemanticRetriever
+from app.domain.models.content import GeneratedContent
+from app.domain.models.conversation import TutorConversation
+from app.domain.models.learner_memory import LearnerMemory
+from app.domain.models.user import User
+from app.domain.services.tutor_service import (
+    MAX_TOOL_CALLS,
+    TutorService,
+    _deduplicate_sources,
+    _split_into_chunks,
+)
+from app.domain.services.tutor_tools import TOOL_DEFINITIONS, TutorToolExecutor
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def collect_chunks(generator) -> list[dict]:
+    chunks = []
+    async for chunk in generator:
+        chunks.append(chunk)
+    return chunks
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_user():
+    return User(
+        id=uuid.uuid4(),
+        email="test@example.com",
+        name="Test User",
+        preferred_language="fr",
+        country="SN",
+        professional_role="nurse",
+        current_level=2,
+        streak_days=0,
+        last_active=datetime.now(UTC),
+        created_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def sample_conversation(sample_user):
+    return TutorConversation(
+        id=uuid.uuid4(),
+        user_id=sample_user.id,
+        module_id=None,
+        messages=[],
+        created_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def mock_retriever():
+    retriever = AsyncMock(spec=SemanticRetriever)
+    retriever.search_for_module = AsyncMock(return_value=[])
+    return retriever
+
+
+@pytest.fixture
+def mock_anthropic():
+    return MagicMock()
+
+
+@pytest.fixture
+def tool_executor(mock_retriever, mock_anthropic, sample_user):
+    return TutorToolExecutor(
+        retriever=mock_retriever,
+        anthropic_client=mock_anthropic,
+        user_id=sample_user.id,
+        user_level=sample_user.current_level,
+        user_language=sample_user.preferred_language,
+    )
+
+
+@pytest.fixture
+def tutor_service(mock_retriever, mock_anthropic):
+    from app.ai.rag.embeddings import EmbeddingService
+
+    embedding_service = AsyncMock(spec=EmbeddingService)
+    return TutorService(
+        anthropic_client=mock_anthropic,
+        semantic_retriever=mock_retriever,
+        embedding_service=embedding_service,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool definitions
+# ---------------------------------------------------------------------------
+
+
+def test_tool_definitions_count():
+    assert len(TOOL_DEFINITIONS) == 5
+
+
+def test_tool_names():
+    names = {t["name"] for t in TOOL_DEFINITIONS}
+    assert names == {
+        "search_knowledge_base",
+        "get_learner_progress",
+        "generate_mini_quiz",
+        "search_flashcards",
+        "save_learner_preference",
+    }
+
+
+def test_each_tool_has_input_schema():
+    for tool in TOOL_DEFINITIONS:
+        assert "input_schema" in tool
+        assert "properties" in tool["input_schema"]
+        assert "required" in tool["input_schema"]
+
+
+def test_search_knowledge_base_requires_query():
+    tool = next(t for t in TOOL_DEFINITIONS if t["name"] == "search_knowledge_base")
+    assert "query" in tool["input_schema"]["required"]
+
+
+def test_get_learner_progress_requires_user_id():
+    tool = next(t for t in TOOL_DEFINITIONS if t["name"] == "get_learner_progress")
+    assert "user_id" in tool["input_schema"]["required"]
+
+
+def test_generate_mini_quiz_required_fields():
+    tool = next(t for t in TOOL_DEFINITIONS if t["name"] == "generate_mini_quiz")
+    required = set(tool["input_schema"]["required"])
+    assert {"topic", "num_questions", "difficulty"}.issubset(required)
+
+
+def test_save_learner_preference_required_fields():
+    tool = next(t for t in TOOL_DEFINITIONS if t["name"] == "save_learner_preference")
+    required = set(tool["input_schema"]["required"])
+    assert {"preference_type", "value"}.issubset(required)
+
+
+# ---------------------------------------------------------------------------
+# search_knowledge_base tool
+# ---------------------------------------------------------------------------
+
+
+async def test_search_knowledge_base_returns_results(tool_executor, mock_retriever):
+    mock_chunk = MagicMock()
+    mock_chunk.content = "Public health surveillance involves..."
+    mock_chunk.source = "donaldson"
+    mock_chunk.chapter = "4"
+    mock_chunk.page = "89"
+
+    mock_result = MagicMock()
+    mock_result.chunk = mock_chunk
+    mock_result.similarity_score = 0.85
+
+    mock_retriever.search_for_module = AsyncMock(return_value=[mock_result])
+
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_session.get = AsyncMock(return_value=None)
+
+    result_str = await tool_executor._search_knowledge_base({"query": "surveillance"}, mock_session)
+    result = json.loads(result_str)
+
+    assert result["query"] == "surveillance"
+    assert result["count"] == 1
+    assert result["results"][0]["source"] == "donaldson"
+    assert result["results"][0]["similarity"] == 0.85
+
+
+async def test_search_knowledge_base_empty_results(tool_executor, mock_retriever):
+    mock_retriever.search_for_module = AsyncMock(return_value=[])
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_session.get = AsyncMock(return_value=None)
+
+    result_str = await tool_executor._search_knowledge_base({"query": "xyz"}, mock_session)
+    result = json.loads(result_str)
+
+    assert result["count"] == 0
+    assert result["results"] == []
+
+
+# ---------------------------------------------------------------------------
+# get_learner_progress tool
+# ---------------------------------------------------------------------------
+
+
+async def test_get_learner_progress_returns_structure(tool_executor):
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    mock_progress_result = MagicMock()
+    mock_progress_result.scalars.return_value.all.return_value = []
+
+    mock_quiz_result = MagicMock()
+    mock_quiz_result.scalars.return_value.all.return_value = []
+
+    mock_placement_result = MagicMock()
+    mock_placement_result.scalar_one_or_none.return_value = None
+
+    mock_session.execute = AsyncMock(
+        side_effect=[mock_progress_result, mock_quiz_result, mock_placement_result]
+    )
+
+    result_str = await tool_executor._get_learner_progress(
+        {"user_id": str(tool_executor.user_id)}, mock_session
+    )
+    result = json.loads(result_str)
+
+    assert "user_id" in result
+    assert "current_level" in result
+    assert "modules_progress" in result
+    assert "completed_modules_count" in result
+    assert "weak_domains" in result
+    assert "recent_quiz_scores" in result
+    assert result["current_level"] == 2
+
+
+# ---------------------------------------------------------------------------
+# generate_mini_quiz tool
+# ---------------------------------------------------------------------------
+
+
+async def test_generate_mini_quiz_returns_valid_json(tool_executor, mock_anthropic):
+    quiz_json = json.dumps(
+        {
+            "topic": "surveillance",
+            "questions": [
+                {
+                    "question": "What is epidemiological surveillance?",
+                    "options": {"A": "Option A", "B": "Option B", "C": "Option C", "D": "Option D"},
+                    "correct_answer": "A",
+                    "explanation": "Surveillance is systematic data collection.",
+                }
+            ],
+        }
+    )
+
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text=quiz_json)]
+    mock_anthropic.messages.create = AsyncMock(return_value=mock_response)
+
+    result_str = await tool_executor._generate_mini_quiz(
+        {"topic": "surveillance", "num_questions": 1, "difficulty": "medium"}
+    )
+    result = json.loads(result_str)
+
+    assert result["topic"] == "surveillance"
+    assert "questions" in result
+    assert len(result["questions"]) == 1
+
+
+async def test_generate_mini_quiz_handles_parse_error(tool_executor, mock_anthropic):
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text="Not valid JSON here")]
+    mock_anthropic.messages.create = AsyncMock(return_value=mock_response)
+
+    result_str = await tool_executor._generate_mini_quiz(
+        {"topic": "test", "num_questions": 2, "difficulty": "easy"}
+    )
+    result = json.loads(result_str)
+
+    assert result["topic"] == "test"
+    assert "parse_error" in result
+
+
+# ---------------------------------------------------------------------------
+# search_flashcards tool
+# ---------------------------------------------------------------------------
+
+
+async def test_search_flashcards_matches_concept(tool_executor):
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    mock_card = MagicMock(spec=GeneratedContent)
+    mock_card.id = uuid.uuid4()
+    mock_card.module_id = uuid.uuid4()
+    mock_card.content = {
+        "term_fr": "surveillance épidémiologique",
+        "term_en": "epidemiological surveillance",
+        "definition_fr": "Collecte systématique de données sanitaires",
+        "definition_en": "Systematic collection of health data",
+    }
+
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [mock_card]
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    result_str = await tool_executor._search_flashcards({"concept": "surveillance"}, mock_session)
+    result = json.loads(result_str)
+
+    assert result["concept"] == "surveillance"
+    assert result["count"] == 1
+    assert result["flashcards"][0]["term_fr"] == "surveillance épidémiologique"
+
+
+async def test_search_flashcards_no_match(tool_executor):
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    mock_card = MagicMock(spec=GeneratedContent)
+    mock_card.id = uuid.uuid4()
+    mock_card.module_id = uuid.uuid4()
+    mock_card.content = {
+        "term_fr": "paludisme",
+        "term_en": "malaria",
+        "definition_fr": "Maladie parasitaire",
+        "definition_en": "Parasitic disease",
+    }
+
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [mock_card]
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    result_str = await tool_executor._search_flashcards({"concept": "vaccination"}, mock_session)
+    result = json.loads(result_str)
+
+    assert result["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# save_learner_preference tool
+# ---------------------------------------------------------------------------
+
+
+async def test_save_learner_preference_creates_new(tool_executor):
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.add = MagicMock()
+    mock_session.flush = AsyncMock()
+
+    result_str = await tool_executor._save_learner_preference(
+        {
+            "preference_type": "learning_style",
+            "value": {"style": "analogies", "confidence": 0.9},
+        },
+        mock_session,
+    )
+    result = json.loads(result_str)
+
+    assert result["saved"] is True
+    assert result["preference_type"] == "learning_style"
+    assert result["updated"] is False
+    mock_session.add.assert_called_once()
+
+
+async def test_save_learner_preference_updates_existing(tool_executor):
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    existing = MagicMock(spec=LearnerMemory)
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = existing
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.add = MagicMock()
+    mock_session.flush = AsyncMock()
+
+    result_str = await tool_executor._save_learner_preference(
+        {
+            "preference_type": "learning_style",
+            "value": {"style": "examples", "confidence": 0.8},
+        },
+        mock_session,
+    )
+    result = json.loads(result_str)
+
+    assert result["saved"] is True
+    assert result["updated"] is True
+    assert existing.value == {"style": "examples", "confidence": 0.8}
+
+
+# ---------------------------------------------------------------------------
+# tool_use loop in TutorService
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_use_loop_executes_tool_and_gets_final_response(
+    tutor_service, sample_user, sample_conversation, mock_anthropic
+):
+    """Test that Claude returning tool_use blocks triggers tool execution and retry."""
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_session.get = AsyncMock(return_value=sample_user)
+
+    tool_use_block = MagicMock()
+    tool_use_block.__class__ = __import__("anthropic.types", fromlist=["ToolUseBlock"]).ToolUseBlock
+    tool_use_block.name = "search_knowledge_base"
+    tool_use_block.id = "tool_123"
+    tool_use_block.input = {"query": "surveillance épidémiologique"}
+
+    text_block = MagicMock()
+    text_block.text = "Excellente réflexion! Que penses-tu..."
+    del tool_use_block.__class__
+
+    from anthropic.types import ToolUseBlock
+
+    real_tool_use_block = MagicMock(spec=ToolUseBlock)
+    real_tool_use_block.name = "search_knowledge_base"
+    real_tool_use_block.id = "tool_123"
+    real_tool_use_block.input = {"query": "surveillance"}
+
+    first_response = MagicMock()
+    first_response.content = [real_tool_use_block]
+
+    second_response = MagicMock()
+    final_text = MagicMock()
+    final_text.text = "Excellente question!"
+    del final_text.__class__
+
+    class FakeTextBlock:
+        def __init__(self, text):
+            self.text = text
+
+    second_response.content = [FakeTextBlock("Excellente question! Penses-tu que...")]
+
+    mock_anthropic.messages.create = AsyncMock(side_effect=[first_response, second_response])
+
+    with (
+        patch.object(
+            tutor_service,
+            "_check_daily_limit",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch.object(
+            tutor_service,
+            "_get_or_create_conversation",
+            new_callable=AsyncMock,
+            return_value=sample_conversation,
+        ),
+        patch("app.domain.services.tutor_service.TutorToolExecutor") as mock_executor_cls,
+    ):
+        mock_executor = AsyncMock()
+        mock_executor.execute = AsyncMock(
+            return_value=json.dumps({"query": "surveillance", "results": [], "count": 0})
+        )
+        mock_executor_cls.return_value = mock_executor
+
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.flush = AsyncMock()
+
+        chunks = await collect_chunks(
+            tutor_service.send_message(
+                user_id=sample_user.id,
+                message="Qu'est-ce que la surveillance?",
+                session=mock_session,
+            )
+        )
+
+    chunk_types = [c["type"] for c in chunks]
+    assert "tool_call" in chunk_types, f"Expected tool_call chunk, got: {chunk_types}"
+    assert "content" in chunk_types, f"Expected content chunk, got: {chunk_types}"
+
+
+async def test_max_tool_calls_enforced(
+    tutor_service, sample_user, sample_conversation, mock_anthropic
+):
+    """Test that tool call loop stops at MAX_TOOL_CALLS."""
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_session.get = AsyncMock(return_value=sample_user)
+
+    from anthropic.types import ToolUseBlock
+
+    def make_tool_response():
+        tool_block = MagicMock(spec=ToolUseBlock)
+        tool_block.name = "search_knowledge_base"
+        tool_block.id = f"tool_{uuid.uuid4().hex[:8]}"
+        tool_block.input = {"query": "test"}
+        resp = MagicMock()
+        resp.content = [tool_block]
+        return resp
+
+    responses = [make_tool_response() for _ in range(MAX_TOOL_CALLS + 2)]
+    mock_anthropic.messages.create = AsyncMock(side_effect=responses)
+
+    with (
+        patch.object(
+            tutor_service,
+            "_check_daily_limit",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch.object(
+            tutor_service,
+            "_get_or_create_conversation",
+            new_callable=AsyncMock,
+            return_value=sample_conversation,
+        ),
+        patch("app.domain.services.tutor_service.TutorToolExecutor") as mock_executor_cls,
+    ):
+        mock_executor = AsyncMock()
+        mock_executor.execute = AsyncMock(
+            return_value=json.dumps({"results": [], "count": 0, "query": "test"})
+        )
+        mock_executor_cls.return_value = mock_executor
+
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.flush = AsyncMock()
+
+        chunks = await collect_chunks(
+            tutor_service.send_message(
+                user_id=sample_user.id,
+                message="Test",
+                session=mock_session,
+            )
+        )
+
+    tool_call_chunks = [c for c in chunks if c["type"] == "tool_call"]
+    assert len(tool_call_chunks) <= MAX_TOOL_CALLS, (
+        f"Expected at most {MAX_TOOL_CALLS} tool calls, got {len(tool_call_chunks)}"
+    )
+    assert mock_anthropic.messages.create.call_count <= MAX_TOOL_CALLS + 1
+
+
+async def test_no_tool_use_yields_content_chunks(
+    tutor_service, sample_user, sample_conversation, mock_anthropic
+):
+    """Test that when Claude returns no tool_use blocks, content is streamed."""
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_session.get = AsyncMock(return_value=sample_user)
+
+    class FakeTextBlock:
+        def __init__(self, text):
+            self.text = text
+
+    response = MagicMock()
+    response.content = [FakeTextBlock("Excellente question! Penses-tu que la surveillance...")]
+    mock_anthropic.messages.create = AsyncMock(return_value=response)
+
+    with (
+        patch.object(
+            tutor_service,
+            "_check_daily_limit",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch.object(
+            tutor_service,
+            "_get_or_create_conversation",
+            new_callable=AsyncMock,
+            return_value=sample_conversation,
+        ),
+    ):
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.flush = AsyncMock()
+
+        chunks = await collect_chunks(
+            tutor_service.send_message(
+                user_id=sample_user.id,
+                message="Test message",
+                session=mock_session,
+            )
+        )
+
+    chunk_types = [c["type"] for c in chunks]
+    assert "content" in chunk_types
+    assert "text" not in chunk_types
+
+    content_chunks = [c for c in chunks if c["type"] == "content"]
+    full_text = "".join(c["data"]["text"] for c in content_chunks)
+    assert "Excellente question!" in full_text
+
+
+async def test_finished_chunk_includes_tool_calls_made(
+    tutor_service, sample_user, sample_conversation, mock_anthropic
+):
+    """Test that finished chunk includes tool_calls_made count."""
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_session.get = AsyncMock(return_value=sample_user)
+
+    class FakeTextBlock:
+        def __init__(self, text):
+            self.text = text
+
+    response = MagicMock()
+    response.content = [FakeTextBlock("Test response")]
+    mock_anthropic.messages.create = AsyncMock(return_value=response)
+
+    with (
+        patch.object(
+            tutor_service,
+            "_check_daily_limit",
+            new_callable=AsyncMock,
+            return_value=5,
+        ),
+        patch.object(
+            tutor_service,
+            "_get_or_create_conversation",
+            new_callable=AsyncMock,
+            return_value=sample_conversation,
+        ),
+    ):
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.flush = AsyncMock()
+
+        chunks = await collect_chunks(
+            tutor_service.send_message(
+                user_id=sample_user.id,
+                message="Test",
+                session=mock_session,
+            )
+        )
+
+    finished_chunks = [c for c in chunks if c["type"] == "finished"]
+    assert len(finished_chunks) == 1
+    assert "tool_calls_made" in finished_chunks[0]["data"]
+    assert finished_chunks[0]["data"]["remaining_messages"] == 44
+
+
+# ---------------------------------------------------------------------------
+# Utility functions
+# ---------------------------------------------------------------------------
+
+
+def test_split_into_chunks_empty():
+    assert _split_into_chunks("") == []
+
+
+def test_split_into_chunks_small_text():
+    result = _split_into_chunks("Hello", chunk_size=50)
+    assert result == ["Hello"]
+    assert "".join(result) == "Hello"
+
+
+def test_split_into_chunks_large_text():
+    text = "A" * 120
+    chunks = _split_into_chunks(text, chunk_size=50)
+    assert len(chunks) == 3
+    assert "".join(chunks) == text
+
+
+def test_deduplicate_sources_removes_duplicates():
+    sources = [
+        {"source": "donaldson", "chapter": "4", "page": "89"},
+        {"source": "donaldson", "chapter": "4", "page": "89"},
+        {"source": "triola", "chapter": "2", "page": "45"},
+    ]
+    unique = _deduplicate_sources(sources)
+    assert len(unique) == 2
+
+
+def test_deduplicate_sources_respects_limit():
+    sources = [{"source": f"book_{i}", "chapter": str(i), "page": str(i)} for i in range(10)]
+    unique = _deduplicate_sources(sources)
+    assert len(unique) == 5
+
+
+# ---------------------------------------------------------------------------
+# Tool executor error handling
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_executor_unknown_tool(tool_executor):
+    mock_session = AsyncMock(spec=AsyncSession)
+    result_str = await tool_executor.execute("unknown_tool", {}, mock_session)
+    result = json.loads(result_str)
+    assert "error" in result
+    assert "Unknown tool" in result["error"]
+
+
+async def test_tool_executor_handles_exception(tool_executor, mock_retriever):
+    mock_retriever.search_for_module = AsyncMock(side_effect=RuntimeError("DB error"))
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_session.get = AsyncMock(return_value=None)
+
+    result_str = await tool_executor.execute(
+        "search_knowledge_base", {"query": "test"}, mock_session
+    )
+    result = json.loads(result_str)
+    assert "error" in result


### PR DESCRIPTION
## Summary

- Refactor `TutorService` from simple chat relay to agentic system using Claude `tool_use` API
- Claude autonomously decides when to call 5 registered tools based on conversation context
- Tool execution loop runs server-side (max 3 calls/message); only text chunks streamed to client

## Changes

### New files
- `backend/app/domain/services/tutor_tools.py` — 5 tool definitions (JSON Schema) + `TutorToolExecutor` with all handlers
- `backend/app/domain/models/learner_memory.py` — `LearnerMemory` SQLAlchemy model for preference storage
- `backend/migrations/versions/013_add_learner_memory_table.py` — Alembic migration for `learner_memory` table
- `backend/tests/test_tutor_tools.py` — 27 new unit tests for tools, loop, and edge cases

### Modified files
- `backend/app/domain/services/tutor_service.py` — Major refactor: `messages.create()` with `tools=`, tool_use loop, `MAX_TOOL_CALLS=3` guard
- `backend/app/ai/prompts/tutor.py` — Enhanced system prompt with tool usage instructions for each of the 5 tools
- `backend/app/domain/models/__init__.py` — Register `LearnerMemory` model
- `backend/app/domain/models/user.py` — Add `learner_memories` relationship
- `backend/tests/test_tutor_service.py` — Updated 3 tests to use `messages.create()` instead of `messages.stream()`

## Tools registered

| Tool | Purpose |
|------|---------|
| `search_knowledge_base` | RAG via `SemanticRetriever.search_for_module()` |
| `get_learner_progress` | Queries `UserModuleProgress`, `QuizAttempt`, `PlacementTestAttempt` |
| `generate_mini_quiz` | Generates 2-3 inline quiz questions via separate Claude call |
| `search_flashcards` | Queries `generated_content` where `content_type='flashcard'` |
| `save_learner_preference` | Upserts to `learner_memory` table |

## Test plan
- [x] 27 new tests in `test_tutor_tools.py` pass
- [x] 4 existing tutor service tests updated and passing
- [x] Full test suite: 141 passed, 0 failed
- [x] `ruff check --fix` and `ruff format` clean
- [ ] Manually test on mobile viewport (deferred to maintainer review)

Closes #328

Generated with [Claude Code](https://claude.ai/code)