### PR TITLE
feat(progression): module validation and auto-unlock (#337)

### DIFF
--- a/backend/app/api/v1/progress.py
+++ b/backend/app/api/v1/progress.py
@@ -134,13 +134,30 @@ async def get_all_module_progress(
     current_user: Annotated[User, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> list[ModuleProgressResponse]:
-    """Get current user's progress for all modules."""
+    """
+    Get current user's progress for all modules.
+
+    Returns ALL modules (including locked ones), ordered by module_number.
+    Locked modules with no progress record have status 'locked' and 0% completion.
+    """
     try:
         user_id = UUID(str(current_user.id))
         service = ProgressService(db)
-        all_progress = await service.get_all_module_progress(user_id)
+        all_modules = await service.get_all_modules_with_progress(user_id)
 
-        return [_make_module_progress_response(user_id, p.module_id, p) for p in all_progress]
+        return [
+            ModuleProgressResponse(
+                module_id=m["module_id"],
+                user_id=m["user_id"],
+                module_number=m["module_number"],
+                status=m["status"],
+                completion_pct=m["completion_pct"],
+                quiz_score_avg=m["quiz_score_avg"],
+                time_spent_minutes=m["time_spent_minutes"],
+                last_accessed=m["last_accessed"],
+            )
+            for m in all_modules
+        ]
 
     except Exception as e:
         logger.error("Failed to get all module progress", error=str(e), exc_info=True)

--- a/backend/app/api/v1/schemas/progress.py
+++ b/backend/app/api/v1/schemas/progress.py
@@ -26,6 +26,7 @@ class ModuleProgressResponse(BaseModel):
 
     module_id: UUID = Field(description="Module UUID")
     user_id: UUID = Field(description="User UUID")
+    module_number: int | None = Field(default=None, description="Module number (1-15)")
     status: str = Field(description="locked | in_progress | completed")
     completion_pct: float = Field(description="Completion percentage (0-100)")
     quiz_score_avg: float | None = Field(description="Average quiz score (0-100)")

--- a/backend/app/domain/services/progress_service.py
+++ b/backend/app/domain/services/progress_service.py
@@ -17,6 +17,9 @@ from app.domain.models.progress import UserModuleProgress
 
 logger = structlog.get_logger()
 
+_UNLOCK_THRESHOLD_PCT = 80.0
+_UNLOCK_THRESHOLD_SCORE = 80.0
+
 
 class ProgressService:
     def __init__(self, db: AsyncSession) -> None:
@@ -98,6 +101,8 @@ class ProgressService:
 
         Per FR-02.2: lesson completion requires passing the validation quiz (≥80%).
         Recalculates module completion_pct based on completed units.
+        When completion_pct >= 80 AND quiz_score_avg >= 80, marks module completed
+        and unlocks the next module (N+1).
         """
         now = datetime.utcnow()
 
@@ -127,6 +132,14 @@ class ProgressService:
 
         await self.db.commit()
         await self.db.refresh(progress)
+
+        # After commit, check whether N+1 unlock conditions are met
+        if (
+            progress.completion_pct >= _UNLOCK_THRESHOLD_PCT
+            and progress.quiz_score_avg is not None
+            and progress.quiz_score_avg >= _UNLOCK_THRESHOLD_SCORE
+        ):
+            await self._unlock_next_module(user_id, module_id)
 
         logger.info(
             "Progress updated after quiz",
@@ -158,6 +171,44 @@ class ProgressService:
             select(UserModuleProgress).where(UserModuleProgress.user_id == user_id)
         )
         return list(result.scalars().all())
+
+    async def get_all_modules_with_progress(self, user_id: UUID) -> list[dict]:
+        """
+        Return ALL modules with their real lock/unlock status for the user.
+
+        Modules without a progress record default to 'locked'.
+        Returns data ordered by module_number.
+        """
+        modules_result = await self.db.execute(select(Module).order_by(Module.module_number))
+        modules = list(modules_result.scalars().all())
+
+        progress_result = await self.db.execute(
+            select(UserModuleProgress).where(UserModuleProgress.user_id == user_id)
+        )
+        progress_map: dict[uuid.UUID, UserModuleProgress] = {
+            p.module_id: p for p in progress_result.scalars().all()
+        }
+
+        result = []
+        for module in modules:
+            progress = progress_map.get(module.id)
+            result.append(
+                {
+                    "module_id": module.id,
+                    "module_number": module.module_number,
+                    "user_id": user_id,
+                    "status": progress.status if progress else "locked",
+                    "completion_pct": progress.completion_pct if progress else 0.0,
+                    "quiz_score_avg": progress.quiz_score_avg if progress else None,
+                    "time_spent_minutes": progress.time_spent_minutes if progress else 0,
+                    "last_accessed": (
+                        progress.last_accessed.isoformat()
+                        if progress and progress.last_accessed
+                        else None
+                    ),
+                }
+            )
+        return result
 
     async def get_module_with_progress(self, user_id: UUID, module_id: UUID) -> dict:
         """
@@ -230,6 +281,63 @@ class ProgressService:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    async def _unlock_next_module(self, user_id: UUID, completed_module_id: UUID) -> None:
+        """
+        Unlock the module with module_number = N+1 when module N meets threshold.
+
+        Per FR-02.2: creates an in_progress progress record for the next module
+        if it doesn't already have one (i.e. is still locked).
+        """
+        module_result = await self.db.execute(
+            select(Module).where(Module.id == completed_module_id)
+        )
+        module = module_result.scalar_one_or_none()
+        if not module:
+            return
+
+        next_result = await self.db.execute(
+            select(Module).where(Module.module_number == module.module_number + 1)
+        )
+        next_module = next_result.scalar_one_or_none()
+        if not next_module:
+            return
+
+        existing = await self.db.execute(
+            select(UserModuleProgress).where(
+                UserModuleProgress.user_id == user_id,
+                UserModuleProgress.module_id == next_module.id,
+            )
+        )
+        next_progress = existing.scalar_one_or_none()
+
+        if next_progress is None:
+            now = datetime.utcnow()
+            next_progress = UserModuleProgress(
+                user_id=user_id,
+                module_id=next_module.id,
+                status="in_progress",
+                completion_pct=0.0,
+                quiz_score_avg=None,
+                time_spent_minutes=0,
+                last_accessed=now,
+            )
+            self.db.add(next_progress)
+            await self.db.commit()
+            logger.info(
+                "Next module unlocked",
+                user_id=str(user_id),
+                unlocked_module_number=next_module.module_number,
+                unlocked_module_id=str(next_module.id),
+            )
+        elif next_progress.status == "locked":
+            next_progress.status = "in_progress"
+            await self.db.commit()
+            logger.info(
+                "Next module status updated to in_progress",
+                user_id=str(user_id),
+                module_number=next_module.module_number,
+            )
 
     async def _get_or_create_progress(
         self, user_id: UUID, module_id: UUID, now: datetime

--- a/backend/tests/test_progress_service.py
+++ b/backend/tests/test_progress_service.py
@@ -419,3 +419,272 @@ class TestProgressServiceIntegration:
         )
 
         assert result.last_accessed is not None
+
+
+class TestUnlockNextModule:
+    async def test_unlock_threshold_triggers_next_module_unlock(
+        self, progress_service, mock_db, user_id, module_id
+    ):
+        from app.domain.models.module import Module
+
+        next_module_id = uuid.uuid4()
+        current_module = Module(
+            id=module_id,
+            module_number=1,
+            level=1,
+            title_fr="M01",
+            title_en="M01",
+            estimated_hours=20,
+        )
+        next_module = Module(
+            id=next_module_id,
+            module_number=2,
+            level=1,
+            title_fr="M02",
+            title_en="M02",
+            estimated_hours=20,
+        )
+        existing_progress = UserModuleProgress(
+            user_id=user_id,
+            module_id=module_id,
+            status="in_progress",
+            completion_pct=0.0,
+            quiz_score_avg=None,
+            time_spent_minutes=0,
+            last_accessed=None,
+        )
+        added_objects = []
+
+        def capture_add(obj):
+            added_objects.append(obj)
+
+        mock_db.add = MagicMock(side_effect=capture_add)
+
+        call_count = 0
+
+        async def mock_execute(query):
+            nonlocal call_count
+            call_count += 1
+            mock_result = MagicMock()
+            if call_count == 1:
+                # _get_or_create_progress
+                mock_result.scalar_one_or_none = MagicMock(return_value=existing_progress)
+            elif call_count == 2:
+                # _calculate_completion_pct: total units
+                mock_result.scalar = MagicMock(return_value=1)
+            elif call_count == 3:
+                # _get_completed_units: quiz contents
+                mock_result.all = MagicMock(return_value=[])
+            elif call_count == 4:
+                # _unlock_next_module: current module lookup
+                mock_result.scalar_one_or_none = MagicMock(return_value=current_module)
+            elif call_count == 5:
+                # _unlock_next_module: next module lookup
+                mock_result.scalar_one_or_none = MagicMock(return_value=next_module)
+            elif call_count == 6:
+                # _unlock_next_module: check existing progress for next module
+                mock_result.scalar_one_or_none = MagicMock(return_value=None)
+            else:
+                mock_result.scalar_one_or_none = MagicMock(return_value=None)
+                mock_result.scalar = MagicMock(return_value=None)
+                mock_result.all = MagicMock(return_value=[])
+            return mock_result
+
+        mock_db.execute = mock_execute
+
+        result = await progress_service.update_progress_after_quiz(
+            user_id=user_id,
+            module_id=module_id,
+            unit_id="M01-U01",
+            score=90.0,
+            passed=True,
+        )
+
+        assert result.quiz_score_avg == 90.0
+        assert result.completion_pct == 100.0
+        assert result.status == "completed"
+
+        unlocked = [
+            obj
+            for obj in added_objects
+            if isinstance(obj, UserModuleProgress) and obj.module_id == next_module_id
+        ]
+        assert len(unlocked) == 1
+        assert unlocked[0].status == "in_progress"
+
+    async def test_no_unlock_when_score_below_threshold(
+        self, progress_service, mock_db, user_id, module_id
+    ):
+        existing_progress = UserModuleProgress(
+            user_id=user_id,
+            module_id=module_id,
+            status="in_progress",
+            completion_pct=0.0,
+            quiz_score_avg=None,
+            time_spent_minutes=0,
+            last_accessed=None,
+        )
+
+        call_count = 0
+
+        async def mock_execute(query):
+            nonlocal call_count
+            call_count += 1
+            mock_result = MagicMock()
+            if call_count == 1:
+                mock_result.scalar_one_or_none = MagicMock(return_value=existing_progress)
+            else:
+                mock_result.scalar_one_or_none = MagicMock(return_value=None)
+                mock_result.scalar = MagicMock(return_value=None)
+            return mock_result
+
+        mock_db.execute = mock_execute
+
+        result = await progress_service.update_progress_after_quiz(
+            user_id=user_id,
+            module_id=module_id,
+            unit_id="M01-U01",
+            score=70.0,
+            passed=False,
+        )
+
+        assert result.quiz_score_avg == 70.0
+        # No unlock should happen — execute should only have been called twice
+        # (once for get_or_create_progress, no further calls for unlock)
+        assert call_count == 1
+
+    async def test_unlock_updates_existing_locked_next_module(
+        self, progress_service, mock_db, user_id, module_id
+    ):
+        from app.domain.models.module import Module
+
+        next_module_id = uuid.uuid4()
+        current_module = Module(
+            id=module_id,
+            module_number=3,
+            level=1,
+            title_fr="M03",
+            title_en="M03",
+            estimated_hours=20,
+        )
+        next_module = Module(
+            id=next_module_id,
+            module_number=4,
+            level=2,
+            title_fr="M04",
+            title_en="M04",
+            estimated_hours=25,
+        )
+        locked_next_progress = UserModuleProgress(
+            user_id=user_id,
+            module_id=next_module_id,
+            status="locked",
+            completion_pct=0.0,
+            quiz_score_avg=None,
+            time_spent_minutes=0,
+            last_accessed=None,
+        )
+        existing_progress = UserModuleProgress(
+            user_id=user_id,
+            module_id=module_id,
+            status="in_progress",
+            completion_pct=0.0,
+            quiz_score_avg=None,
+            time_spent_minutes=0,
+            last_accessed=None,
+        )
+        call_count = 0
+
+        async def mock_execute(query):
+            nonlocal call_count
+            call_count += 1
+            mock_result = MagicMock()
+            if call_count == 1:
+                mock_result.scalar_one_or_none = MagicMock(return_value=existing_progress)
+            elif call_count == 2:
+                mock_result.scalar = MagicMock(return_value=1)
+            elif call_count == 3:
+                mock_result.all = MagicMock(return_value=[])
+            elif call_count == 4:
+                mock_result.scalar_one_or_none = MagicMock(return_value=current_module)
+            elif call_count == 5:
+                mock_result.scalar_one_or_none = MagicMock(return_value=next_module)
+            elif call_count == 6:
+                mock_result.scalar_one_or_none = MagicMock(return_value=locked_next_progress)
+            else:
+                mock_result.scalar_one_or_none = MagicMock(return_value=None)
+            return mock_result
+
+        mock_db.execute = mock_execute
+
+        await progress_service.update_progress_after_quiz(
+            user_id=user_id,
+            module_id=module_id,
+            unit_id="M03-U01",
+            score=85.0,
+            passed=True,
+        )
+
+        assert locked_next_progress.status == "in_progress"
+
+    async def test_no_unlock_when_no_next_module(
+        self, progress_service, mock_db, user_id, module_id
+    ):
+        from app.domain.models.module import Module
+
+        last_module = Module(
+            id=module_id,
+            module_number=15,
+            level=4,
+            title_fr="M15",
+            title_en="M15",
+            estimated_hours=20,
+        )
+        existing_progress = UserModuleProgress(
+            user_id=user_id,
+            module_id=module_id,
+            status="in_progress",
+            completion_pct=0.0,
+            quiz_score_avg=None,
+            time_spent_minutes=0,
+            last_accessed=None,
+        )
+        call_count = 0
+
+        async def mock_execute(query):
+            nonlocal call_count
+            call_count += 1
+            mock_result = MagicMock()
+            if call_count == 1:
+                mock_result.scalar_one_or_none = MagicMock(return_value=existing_progress)
+            elif call_count == 2:
+                mock_result.scalar = MagicMock(return_value=1)
+            elif call_count == 3:
+                mock_result.all = MagicMock(return_value=[])
+            elif call_count == 4:
+                mock_result.scalar_one_or_none = MagicMock(return_value=last_module)
+            elif call_count == 5:
+                # No next module
+                mock_result.scalar_one_or_none = MagicMock(return_value=None)
+            else:
+                mock_result.scalar_one_or_none = MagicMock(return_value=None)
+            return mock_result
+
+        mock_db.execute = mock_execute
+        added_objects = []
+        mock_db.add = MagicMock(side_effect=lambda obj: added_objects.append(obj))
+
+        await progress_service.update_progress_after_quiz(
+            user_id=user_id,
+            module_id=module_id,
+            unit_id="M15-U01",
+            score=90.0,
+            passed=True,
+        )
+
+        new_progress_rows = [
+            obj
+            for obj in added_objects
+            if isinstance(obj, UserModuleProgress) and obj.module_id != module_id
+        ]
+        assert len(new_progress_rows) == 0

--- a/frontend/components/learning/module-map.tsx
+++ b/frontend/components/learning/module-map.tsx
@@ -1,35 +1,124 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import { useTranslations, useLocale } from 'next-intl';
 import { ModuleCard } from './module-card';
-import { 
-  CURRICULUM_MODULES, 
-  LEVEL_INFO, 
-  getModulesByLevel, 
-  isModuleUnlocked, 
-  getLevelProgress 
+import {
+  CURRICULUM_MODULES,
+  LEVEL_INFO,
+  getModulesByLevel,
+  type Module,
 } from '@/lib/modules';
+import { getAllModuleProgress, type ModuleProgressResponse } from '@/lib/api';
 
 interface ModuleMapProps {
   onModuleClick: (moduleId: string) => void;
 }
 
+function mergeProgressIntoModules(
+  apiProgress: ModuleProgressResponse[]
+): Module[] {
+  const progressByNumber = new Map<number, ModuleProgressResponse>();
+  for (const p of apiProgress) {
+    if (p.module_number != null) {
+      progressByNumber.set(p.module_number, p);
+    }
+  }
+
+  return CURRICULUM_MODULES.map((mod) => {
+    const progress = progressByNumber.get(mod.number);
+    if (!progress) return mod;
+
+    const apiStatus = progress.status;
+    const mappedStatus: Module['status'] =
+      apiStatus === 'completed'
+        ? 'completed'
+        : apiStatus === 'in_progress'
+        ? 'in-progress'
+        : 'locked';
+
+    return {
+      ...mod,
+      status: mappedStatus,
+      completionPercentage: progress.completion_pct,
+    };
+  });
+}
+
 export function ModuleMap({ onModuleClick }: ModuleMapProps) {
   const t = useTranslations('ModuleMap');
   const locale = useLocale() as 'en' | 'fr';
-  
+
+  const [modules, setModules] = useState<Module[]>(CURRICULUM_MODULES);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getAllModuleProgress()
+      .then((data) => {
+        if (!cancelled) {
+          setModules(mergeProgressIntoModules(data));
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setError(true);
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const levels = [1, 2, 3, 4] as const;
-  
+
+  const getLevelProgress = (level: 1 | 2 | 3 | 4) => {
+    const levelModules = modules.filter((m) => m.level === level);
+    const completedModules = levelModules.filter((m) => m.status === 'completed').length;
+    const totalModules = levelModules.length;
+    const averageCompletion =
+      totalModules > 0
+        ? levelModules.reduce((sum, m) => sum + m.completionPercentage, 0) / totalModules
+        : 0;
+    return { completedModules, totalModules, averageCompletion: Math.round(averageCompletion) };
+  };
+
+  const isModuleUnlocked = (module: Module): boolean => {
+    if (module.status !== 'locked') return true;
+    if (module.prerequisites.length === 0) return true;
+    return false;
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <p className="text-stone-500 text-sm">{t('loading')}</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <p className="text-red-500 text-sm">{t('error')}</p>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-8">
       {levels.map((level) => {
-        const levelModules = getModulesByLevel(level);
+        const levelModules = getModulesByLevel(level).map(
+          (m) => modules.find((mod) => mod.id === m.id) ?? m
+        );
         const levelProgress = getLevelProgress(level);
         const levelInfo = LEVEL_INFO[level];
-        
+
         return (
           <div key={level} className="space-y-4">
-            {/* Level Header */}
             <div className="border-b border-stone-200 pb-4">
               <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
                 <div>
@@ -42,14 +131,14 @@ export function ModuleMap({ onModuleClick }: ModuleMapProps) {
                 </div>
                 <div className="flex flex-col sm:items-end gap-1">
                   <div className="text-sm text-stone-600">
-                    {t('progress', { 
+                    {t('progress', {
                       completed: levelProgress.completedModules,
-                      total: levelProgress.totalModules 
+                      total: levelProgress.totalModules,
                     })}
                   </div>
                   <div className="flex items-center gap-2">
                     <div className="h-2 w-20 rounded-full bg-stone-200">
-                      <div 
+                      <div
                         className="h-2 rounded-full bg-teal-500 transition-all duration-500"
                         style={{ width: `${levelProgress.averageCompletion}%` }}
                       />
@@ -61,12 +150,11 @@ export function ModuleMap({ onModuleClick }: ModuleMapProps) {
                 </div>
               </div>
             </div>
-            
-            {/* Module Grid */}
+
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
               {levelModules.map((module) => {
-                const unlocked = isModuleUnlocked(module, CURRICULUM_MODULES);
-                
+                const unlocked = isModuleUnlocked(module);
+
                 return (
                   <ModuleCard
                     key={module.id}
@@ -80,8 +168,7 @@ export function ModuleMap({ onModuleClick }: ModuleMapProps) {
           </div>
         );
       })}
-      
-      {/* Overall Progress Summary */}
+
       <div className="mt-8 rounded-lg bg-teal-50 p-6 text-center">
         <h3 className="text-lg font-semibold text-teal-900">
           {t('overallProgress')}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -4,6 +4,7 @@ export const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:800
 export interface ModuleProgressResponse {
   module_id: string;
   user_id: string;
+  module_number: number | null;
   status: "locked" | "in_progress" | "completed";
   completion_pct: number;
   quiz_score_avg: number | null;

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -188,7 +188,9 @@
     "overallProgress": "Overall Progress",
     "modulesCompleted": "modules completed",
     "totalHours": "{count} total hours",
-    "estimatedCompletion": "Estimated 6-12 months to complete"
+    "estimatedCompletion": "Estimated 6-12 months to complete",
+    "loading": "Loading modules...",
+    "error": "Could not load module progress. Please try again."
   },
   "ModuleOverview": {
     "backToModules": "Back to Modules",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -188,7 +188,9 @@
     "overallProgress": "Progression globale",
     "modulesCompleted": "modules terminés",
     "totalHours": "{count} heures au total",
-    "estimatedCompletion": "Durée estimée : 6-12 mois"
+    "estimatedCompletion": "Durée estimée : 6-12 mois",
+    "loading": "Chargement des modules...",
+    "error": "Impossible de charger la progression. Veuillez réessayer."
   },
   "ModuleOverview": {
     "backToModules": "Retour aux modules",


### PR DESCRIPTION
## Summary

- Passing a quiz (≥80%) now recalculates `completion_pct` for the module
- When `completion_pct ≥ 80` AND `quiz_score_avg ≥ 80`, module N+1 is automatically unlocked (status → `in_progress`)
- `GET /progress/modules` now returns ALL 15 modules (including locked ones with no progress record), ordered by `module_number`
- `/modules` page fetches real lock/unlock status from the API instead of static hardcoded data

## Changes

- `backend/app/domain/services/progress_service.py` — added `_unlock_next_module()`, `get_all_modules_with_progress()`; unlock called after quiz commit
- `backend/app/api/v1/schemas/progress.py` — added `module_number` field to `ModuleProgressResponse`
- `backend/app/api/v1/progress.py` — `GET /modules` uses new service method, includes `module_number` in response
- `backend/tests/test_progress_service.py` — 4 new tests for unlock logic (133 total, all passing)
- `frontend/lib/api.ts` — added `module_number` to `ModuleProgressResponse` type
- `frontend/components/learning/module-map.tsx` — fetches real API data, merges with static metadata, loading/error states
- `frontend/messages/en.json` + `fr.json` — added `loading`/`error` keys to `ModuleMap`

## Test plan

- [x] Backend tests pass (`133 passed`)
- [x] Frontend lint passes (0 errors)
- [x] `_unlock_next_module` creates `in_progress` progress row for N+1 module
- [x] No unlock when quiz score below threshold
- [x] No unlock when already at last module (M15)
- [x] `GET /progress/modules` returns all 15 modules with real status
- [x] Locked modules show lock icon and button disabled in `/modules` page

Closes #337

Generated with [Claude Code](https://claude.ai/code)