### PR TITLE
feat(tutor): persist conversations to DB and cache offline (#299)

### DIFF
--- a/backend/tests/test_tutor_service.py
+++ b/backend/tests/test_tutor_service.py
@@ -283,3 +283,93 @@ async def test_send_message_never_yields_text_type(tutor_service, sample_user, s
     assert len(text_type_chunks) == 0, (
         "Bug #213 regression: type='text' chunks were yielded but frontend expects type='content'"
     )
+
+
+async def test_list_conversations_returns_expected_fields(
+    tutor_service, sample_user, sample_conversation
+):
+    """list_conversations returns dicts with required fields for the sidebar."""
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    from unittest.mock import MagicMock
+
+    mock_scalars = MagicMock()
+    mock_scalars.all.return_value = [sample_conversation]
+
+    mock_count_result = MagicMock()
+    mock_count_result.scalar.return_value = 1
+
+    execute_results = [MagicMock(), MagicMock()]
+    execute_results[0].scalars.return_value = mock_scalars
+    execute_results[1].scalar.return_value = 1
+
+    call_count = 0
+
+    async def fake_execute(_query):
+        nonlocal call_count
+        result = execute_results[call_count]
+        call_count += 1
+        return result
+
+    mock_session.execute = fake_execute
+
+    result = await tutor_service.list_conversations(
+        user_id=sample_user.id,
+        session=mock_session,
+    )
+
+    assert "conversations" in result
+    assert "total" in result
+    assert result["total"] == 1
+    assert len(result["conversations"]) == 1
+    conv = result["conversations"][0]
+    for field in ("id", "message_count", "last_message_at", "preview"):
+        assert field in conv, f"Missing field '{field}' in conversation summary"
+
+
+async def test_get_conversation_returns_none_for_wrong_user(
+    tutor_service, sample_user, sample_conversation
+):
+    """get_conversation returns None when conversation belongs to a different user."""
+    other_user_id = uuid.uuid4()
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    result = await tutor_service.get_conversation(
+        user_id=other_user_id,
+        conversation_id=sample_conversation.id,
+        session=mock_session,
+    )
+
+    assert result is None
+
+
+async def test_get_conversation_returns_messages(
+    tutor_service, sample_user, sample_conversation
+):
+    """get_conversation returns full conversation with messages list."""
+    from datetime import UTC, datetime
+
+    sample_conversation.messages = [
+        {"role": "user", "content": "Hello", "timestamp": datetime.now(UTC).isoformat()},
+        {"role": "assistant", "content": "Hi!", "timestamp": datetime.now(UTC).isoformat()},
+    ]
+
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = sample_conversation
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    result = await tutor_service.get_conversation(
+        user_id=sample_user.id,
+        conversation_id=sample_conversation.id,
+        session=mock_session,
+    )
+
+    assert result is not None
+    assert result["id"] == sample_conversation.id
+    assert "messages" in result
+    assert len(result["messages"]) == 2

--- a/frontend/app/[locale]/(app)/tutor/tutor-client.tsx
+++ b/frontend/app/[locale]/(app)/tutor/tutor-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import { Plus, MessageSquare } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -8,72 +8,64 @@ import { Card } from '@/components/ui/card';
 import { ChatPanel } from '@/components/chat';
 import { ChatProvider } from '@/components/chat';
 import { cn } from '@/lib/utils';
+import {
+  fetchConversations,
+  invalidateConversationsCache,
+  type ConversationSummary,
+} from '@/lib/tutor-api';
 
-interface Conversation {
-  id: string;
-  title: string;
-  lastMessage: string;
-  timestamp: Date;
-  messageCount: number;
-}
+const formatRelativeTime = (dateStr: string): string => {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffInMinutes = Math.floor((now.getTime() - date.getTime()) / (1000 * 60));
 
-const INITIAL_CONVERSATIONS: Conversation[] = [
-  {
-    id: '1',
-    title: 'Public Health Basics',
-    lastMessage: 'What are the main determinants of health?',
-    timestamp: new Date(2026, 2, 31, 14, 45),
-    messageCount: 5,
-  },
-  {
-    id: '2',
-    title: 'Epidemiology Questions',
-    lastMessage: 'Explain the difference between incidence and prevalence',
-    timestamp: new Date(2026, 2, 31, 13, 15),
-    messageCount: 12,
-  },
-  {
-    id: '3',
-    title: 'DHIS2 Data Analysis',
-    lastMessage: 'How do I create indicators in DHIS2?',
-    timestamp: new Date(2026, 2, 30, 15, 15),
-    messageCount: 8,
-  },
-];
+  if (diffInMinutes < 60) return `${diffInMinutes}m ago`;
+  if (diffInMinutes < 1440) return `${Math.floor(diffInMinutes / 60)}h ago`;
+  return `${Math.floor(diffInMinutes / 1440)}d ago`;
+};
 
 export function TutorPageClient() {
   const t = useTranslations('ChatTutor');
 
-  const [conversations, setConversations] = useState<Conversation[]>(INITIAL_CONVERSATIONS);
-  const [selectedConversation, setSelectedConversation] = useState<string | null>('1');
+  const [conversations, setConversations] = useState<ConversationSummary[]>([]);
+  const [selectedConversation, setSelectedConversation] = useState<string | null>(null);
+  const [isLoadingList, setIsLoadingList] = useState(true);
 
-  const formatRelativeTime = (date: Date) => {
-    const now = new Date();
-    const diffInMinutes = Math.floor((now.getTime() - date.getTime()) / (1000 * 60));
-
-    if (diffInMinutes < 60) {
-      return `${diffInMinutes}m ago`;
-    } else if (diffInMinutes < 1440) {
-      return `${Math.floor(diffInMinutes / 60)}h ago`;
-    } else {
-      return `${Math.floor(diffInMinutes / 1440)}d ago`;
-    }
-  };
+  useEffect(() => {
+    let cancelled = false;
+    fetchConversations()
+      .then((list) => {
+        if (cancelled) return;
+        setConversations(list);
+        if (list.length > 0) {
+          setSelectedConversation((prev) => (prev === null ? list[0].id : prev));
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setConversations([]);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingList(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleNewConversation = () => {
-    const newId = Date.now().toString();
-    const newConversation: Conversation = {
-      id: newId,
-      title: t('newConversationTitle'),
-      lastMessage: '',
-      timestamp: new Date(),
-      messageCount: 0,
-    };
-    setConversations(prev => [newConversation, ...prev]);
-    setSelectedConversation(newId);
+    setSelectedConversation(null);
   };
 
-  const selectedConvData = conversations.find(c => c.id === selectedConversation);
+  const handleConversationSaved = useCallback(
+    (newId: string) => {
+      setSelectedConversation(newId);
+      invalidateConversationsCache();
+      fetchConversations()
+        .then((list) => setConversations(list))
+        .catch(() => undefined);
+    },
+    [],
+  );
 
   return (
     <ChatProvider>
@@ -94,7 +86,17 @@ export function TutorPageClient() {
 
           {/* Conversations List */}
           <div className="flex-1 overflow-y-auto min-h-0">
-            {conversations.length === 0 ? (
+            {isLoadingList ? (
+              <div className="p-2 space-y-2">
+                {[1, 2, 3].map((i) => (
+                  <div key={i} className="p-3 rounded-lg border animate-pulse">
+                    <div className="h-4 w-3/4 mb-2 bg-muted rounded" />
+                    <div className="h-3 w-full mb-1 bg-muted rounded" />
+                    <div className="h-3 w-1/2 bg-muted rounded" />
+                  </div>
+                ))}
+              </div>
+            ) : conversations.length === 0 ? (
               <div className="flex flex-col items-center justify-center p-6 text-center">
                 <MessageSquare className="h-12 w-12 text-muted-foreground mb-4" />
                 <h3 className="font-medium mb-2">{t('noConversations')}</h3>
@@ -113,7 +115,7 @@ export function TutorPageClient() {
                     key={conversation.id}
                     className={cn(
                       'p-3 cursor-pointer transition-colors hover:bg-accent/50',
-                      selectedConversation === conversation.id && 'bg-accent border-primary'
+                      selectedConversation === conversation.id && 'bg-accent border-primary',
                     )}
                     onClick={() => setSelectedConversation(conversation.id)}
                     role="button"
@@ -128,20 +130,22 @@ export function TutorPageClient() {
                   >
                     <div className="flex justify-between items-start mb-2">
                       <h3 className="font-medium text-sm truncate pr-2">
-                        {conversation.title}
+                        {conversation.preview
+                          ? conversation.preview.slice(0, 40)
+                          : t('newConversationTitle')}
                       </h3>
                       <span className="text-xs text-muted-foreground shrink-0">
-                        {formatRelativeTime(conversation.timestamp)}
+                        {formatRelativeTime(conversation.last_message_at)}
                       </span>
                     </div>
-                    {conversation.lastMessage && (
+                    {conversation.preview && (
                       <p className="text-xs text-muted-foreground truncate mb-1">
-                        {conversation.lastMessage}
+                        {conversation.preview}
                       </p>
                     )}
                     <div className="flex justify-between items-center">
                       <span className="text-xs text-muted-foreground">
-                        {t('messageCount', { count: conversation.messageCount })}
+                        {t('messageCount', { count: conversation.message_count })}
                       </span>
                     </div>
                   </Card>
@@ -153,35 +157,15 @@ export function TutorPageClient() {
 
         {/* Main Chat Area */}
         <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
-          {selectedConversation ? (
-            <ChatPanel
-              isOpen={true}
-              onClose={() => {}}
-              embedded={true}
-              conversationId={selectedConversation}
-            />
-          ) : (
-            <div className="flex-1 flex flex-col items-center justify-center text-center p-6">
-              <MessageSquare className="h-16 w-16 text-muted-foreground mb-4" />
-              <h2 className="text-xl font-semibold mb-2">{t('selectConversation')}</h2>
-              <p className="text-muted-foreground mb-6 max-w-sm">
-                {t('selectConversationDescription')}
-              </p>
-              <Button onClick={handleNewConversation}>
-                <Plus className="h-4 w-4 mr-2" />
-                {t('newConversation')}
-              </Button>
-            </div>
-          )}
+          <ChatPanel
+            isOpen={true}
+            onClose={() => {}}
+            embedded={true}
+            conversationId={selectedConversation}
+            onConversationSaved={handleConversationSaved}
+          />
         </div>
       </div>
-
-      {/* Mobile: show conversation info if needed */}
-      {selectedConvData && (
-        <div className="sr-only" aria-live="polite">
-          {selectedConvData.title}
-        </div>
-      )}
     </ChatProvider>
   );
 }

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import { X, MoreVertical, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -29,6 +29,11 @@ import { ChatSkeleton } from './chat-skeleton';
 import { cn } from '@/lib/utils';
 import { authClient, AuthError } from '@/lib/auth';
 import { useRouter } from 'next/navigation';
+import {
+  fetchConversation,
+  cacheConversationDetail,
+  type ConversationDetail,
+} from '@/lib/tutor-api';
 
 interface ChatPanelProps {
   isOpen: boolean;
@@ -37,35 +42,96 @@ interface ChatPanelProps {
   conversationId?: string | null;
   className?: string;
   embedded?: boolean;
+  onConversationSaved?: (id: string) => void;
 }
 
-export function ChatPanel({ isOpen, onClose, moduleId, conversationId, className, embedded = false }: ChatPanelProps) {
+function messagesFromDetail(detail: ConversationDetail): ChatMessage[] {
+  return detail.messages
+    .filter((m) => m.role === 'user' || m.role === 'assistant')
+    .map((m, idx) => ({
+      id: `hist-${idx}`,
+      content: m.content,
+      isUser: m.role === 'user',
+      timestamp: new Date(m.timestamp),
+      sources: m.sources?.map((s, i) => ({
+        title: (s['source'] as string) ?? String(i + 1),
+        chapter: (s['chapter'] as number) ?? i + 1,
+        page: (s['page'] as number) ?? 0,
+      })),
+    }));
+}
+
+export function ChatPanel({
+  isOpen,
+  onClose,
+  moduleId,
+  conversationId,
+  className,
+  embedded = false,
+  onConversationSaved,
+}: ChatPanelProps) {
   const t = useTranslations('ChatTutor');
   const router = useRouter();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [isHistoryLoading, setIsHistoryLoading] = useState(false);
   const [isTyping, setIsTyping] = useState(false);
   const [showClearDialog, setShowClearDialog] = useState(false);
   const [currentUsage, setCurrentUsage] = useState(0);
+  const [activeConversationId, setActiveConversationId] = useState<string | null>(
+    conversationId ?? null,
+  );
   const scrollAreaRef = useRef<HTMLDivElement>(null);
 
   const maxDailyUsage = 50;
   const isLimitReached = currentUsage >= maxDailyUsage;
 
-  // Reset messages when conversation changes (including new conversation)
-  useEffect(() => {
-    setMessages([
-      {
-        id: 'welcome',
-        content: t('welcomeMessage'),
-        isUser: false,
-        timestamp: new Date(),
-      }
-    ]);
-    setCurrentUsage(0);
-  }, [conversationId, t]);
+  const makeWelcomeMessage = useCallback(
+    (): ChatMessage => ({
+      id: 'welcome',
+      content: t('welcomeMessage'),
+      isUser: false,
+      timestamp: new Date(),
+    }),
+    [t],
+  );
 
-  // Scroll to bottom when new messages are added
+  useEffect(() => {
+    setActiveConversationId(conversationId ?? null);
+  }, [conversationId]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!activeConversationId) {
+      setMessages([makeWelcomeMessage()]);
+      setCurrentUsage(0);
+      return;
+    }
+
+    setIsHistoryLoading(true);
+
+    fetchConversation(activeConversationId)
+      .then((detail) => {
+        if (cancelled) return;
+        const history = messagesFromDetail(detail);
+        setMessages(history.length > 0 ? history : [makeWelcomeMessage()]);
+        setCurrentUsage(history.filter((m) => m.isUser).length);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setMessages([makeWelcomeMessage()]);
+        setCurrentUsage(0);
+      })
+      .finally(() => {
+        if (!cancelled) setIsHistoryLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeConversationId, makeWelcomeMessage]);
+
   useEffect(() => {
     if (scrollAreaRef.current) {
       const scrollArea = scrollAreaRef.current;
@@ -83,13 +149,13 @@ export function ChatPanel({ isOpen, onClose, moduleId, conversationId, className
       timestamp: new Date(),
     };
 
-    setMessages(prev => [...prev, userMessage]);
-    setCurrentUsage(prev => prev + 1);
+    setMessages((prev) => [...prev, userMessage]);
+    setCurrentUsage((prev) => prev + 1);
     setIsLoading(true);
     setIsTyping(true);
 
     try {
-      const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+      const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
       let token: string;
       try {
         token = await authClient.getValidToken();
@@ -101,14 +167,15 @@ export function ChatPanel({ isOpen, onClose, moduleId, conversationId, className
         throw err;
       }
       const response = await fetch(`${API_BASE}/api/v1/tutor/chat`, {
-        method: "POST",
+        method: 'POST',
         headers: {
-          "Content-Type": "application/json",
+          'Content-Type': 'application/json',
           Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
           message: messageContent,
-          conversation_id: null,
+          conversation_id: activeConversationId,
+          module_id: moduleId ?? null,
         }),
       });
 
@@ -120,19 +187,21 @@ export function ChatPanel({ isOpen, onClose, moduleId, conversationId, className
         throw new Error(`API error: ${response.status}`);
       }
 
-      // Read SSE stream
       const reader = response.body?.getReader();
       const decoder = new TextDecoder();
-      let fullContent = "";
+      let fullContent = '';
       const aiMessageId = (Date.now() + 1).toString();
+      let newConversationId: string | null = null;
 
-      // Add placeholder message
-      setMessages(prev => [...prev, {
-        id: aiMessageId,
-        content: "",
-        isUser: false,
-        timestamp: new Date(),
-      }]);
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: aiMessageId,
+          content: '',
+          isUser: false,
+          timestamp: new Date(),
+        },
+      ]);
 
       if (reader) {
         while (true) {
@@ -140,47 +209,71 @@ export function ChatPanel({ isOpen, onClose, moduleId, conversationId, className
           if (done) break;
 
           const text = decoder.decode(value, { stream: true });
-          const lines = text.split("\n");
+          const lines = text.split('\n');
 
           for (const line of lines) {
-            if (!line.startsWith("data: ")) continue;
+            if (!line.startsWith('data: ')) continue;
             try {
               const chunk = JSON.parse(line.slice(6));
-              if (chunk.type === "content" && chunk.data?.text) {
-                fullContent += chunk.data.text;
-                setMessages(prev => prev.map(m =>
-                  m.id === aiMessageId ? { ...m, content: fullContent } : m
-                ));
-              } else if (chunk.type === "sources_cited" && chunk.data?.sources) {
-                setMessages(prev => prev.map(m =>
-                  m.id === aiMessageId ? {
-                    ...m,
-                    sources: chunk.data.sources.map((s: { source: string; chapter?: number; page?: number }, i: number) => ({
-                      title: s.source ?? String(i + 1), chapter: s.chapter ?? i + 1, page: s.page ?? 0,
-                    })),
-                  } : m
-                ));
-              } else if (chunk.type === "error") {
-                const errorCode = chunk.data?.code;
-                fullContent = errorCode === "limit_reached" ? t('errorLimitReached') : t('error');
-                setMessages(prev => prev.map(m =>
-                  m.id === aiMessageId ? { ...m, content: fullContent } : m
-                ));
+              if (chunk.type === 'conversation_id' && chunk.data?.conversation_id) {
+                newConversationId = chunk.data.conversation_id as string;
+                setActiveConversationId(newConversationId);
+                if (onConversationSaved) onConversationSaved(newConversationId);
+              } else if (chunk.type === 'content' && chunk.data?.text) {
+                fullContent += chunk.data.text as string;
+                setMessages((prev) =>
+                  prev.map((m) => (m.id === aiMessageId ? { ...m, content: fullContent } : m)),
+                );
+              } else if (chunk.type === 'sources_cited' && chunk.data?.sources) {
+                setMessages((prev) =>
+                  prev.map((m) =>
+                    m.id === aiMessageId
+                      ? {
+                          ...m,
+                          sources: (
+                            chunk.data.sources as { source: string; chapter?: number; page?: number }[]
+                          ).map((s, i) => ({
+                            title: s.source ?? String(i + 1),
+                            chapter: s.chapter ?? i + 1,
+                            page: s.page ?? 0,
+                          })),
+                        }
+                      : m,
+                  ),
+                );
+              } else if (chunk.type === 'finished') {
+                const savedId =
+                  (chunk.data?.conversation_id as string | undefined) ?? newConversationId;
+                if (savedId) {
+                  fetchConversation(savedId)
+                    .then((detail) => cacheConversationDetail(detail))
+                    .catch(() => undefined);
+                }
+              } else if (chunk.type === 'error') {
+                const errorCode = chunk.data?.code as string | undefined;
+                fullContent =
+                  errorCode === 'limit_reached' ? t('errorLimitReached') : t('error');
+                setMessages((prev) =>
+                  prev.map((m) => (m.id === aiMessageId ? { ...m, content: fullContent } : m)),
+                );
               }
             } catch {
-              // Skip unparseable lines
+              // skip unparseable lines
             }
           }
         }
       }
     } catch (error) {
       console.error('Failed to send message:', error);
-      setMessages(prev => [...prev, {
-        id: (Date.now() + 1).toString(),
-        content: t('error'),
-        isUser: false,
-        timestamp: new Date(),
-      }]);
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: (Date.now() + 1).toString(),
+          content: t('error'),
+          isUser: false,
+          timestamp: new Date(),
+        },
+      ]);
     } finally {
       setIsLoading(false);
       setIsTyping(false);
@@ -194,14 +287,7 @@ export function ChatPanel({ isOpen, onClose, moduleId, conversationId, className
   };
 
   const handleClearHistory = () => {
-    setMessages([
-      {
-        id: 'welcome',
-        content: t('welcomeMessage'),
-        isUser: false,
-        timestamp: new Date(),
-      }
-    ]);
+    setMessages([makeWelcomeMessage()]);
     setShowClearDialog(false);
   };
 
@@ -209,20 +295,17 @@ export function ChatPanel({ isOpen, onClose, moduleId, conversationId, className
 
   return (
     <>
-      <div 
+      <div
         className={cn(
           embedded
             ? 'flex flex-col h-full w-full bg-background'
             : cn(
-                // Mobile: Full screen overlay
                 'fixed inset-0 z-50 flex flex-col bg-background',
-                // Desktop: Side panel
                 'md:relative md:inset-auto md:w-96 md:border-l',
-                // Animation
                 'transition-transform duration-300 ease-in-out',
-                isOpen ? 'translate-x-0' : 'translate-x-full md:translate-x-0'
+                isOpen ? 'translate-x-0' : 'translate-x-full md:translate-x-0',
               ),
-          className
+          className,
         )}
       >
         {/* Header */}
@@ -254,19 +337,16 @@ export function ChatPanel({ isOpen, onClose, moduleId, conversationId, className
         </div>
 
         {/* Usage Counter */}
-        <UsageCounter 
-          currentUsage={currentUsage} 
+        <UsageCounter
+          currentUsage={currentUsage}
           maxUsage={maxDailyUsage}
           className="p-4 pb-2"
         />
 
         {/* Messages */}
         <div className="flex-1 flex flex-col min-h-0">
-          <div
-            ref={scrollAreaRef}
-            className="flex-1 overflow-y-auto px-4 py-2"
-          >
-            {isLoading && messages.length <= 1 ? (
+          <div ref={scrollAreaRef} className="flex-1 overflow-y-auto px-4 py-2">
+            {isHistoryLoading ? (
               <ChatSkeleton />
             ) : (
               <>
@@ -277,43 +357,27 @@ export function ChatPanel({ isOpen, onClose, moduleId, conversationId, className
               </>
             )}
 
-            {/* Empty state */}
-            {messages.length === 0 && !isLoading && (
+            {messages.length === 0 && !isLoading && !isHistoryLoading && (
               <div className="flex flex-col items-center justify-center h-full text-center p-6">
-                <div className="text-muted-foreground mb-2">
-                  {t('emptyState')}
-                </div>
-                <div className="text-sm text-muted-foreground">
-                  {t('emptyStateDescription')}
-                </div>
+                <div className="text-muted-foreground mb-2">{t('emptyState')}</div>
+                <div className="text-sm text-muted-foreground">{t('emptyStateDescription')}</div>
               </div>
             )}
           </div>
 
-          {/* Suggestions */}
           {!isLimitReached && (
-            <ChatSuggestions
-              onSuggestionClick={handleSuggestionClick}
-              disabled={isLoading}
-            />
+            <ChatSuggestions onSuggestionClick={handleSuggestionClick} disabled={isLoading} />
           )}
 
-          {/* Input */}
-          <ChatInput
-            onSendMessage={handleSendMessage}
-            disabled={isLimitReached || isLoading}
-          />
+          <ChatInput onSendMessage={handleSendMessage} disabled={isLimitReached || isLoading} />
         </div>
       </div>
 
-      {/* Clear History Dialog */}
       <AlertDialog open={showClearDialog} onOpenChange={setShowClearDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>{t('confirmClearHistory')}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {t('confirmClearHistoryDescription')}
-            </AlertDialogDescription>
+            <AlertDialogDescription>{t('confirmClearHistoryDescription')}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>{t('cancel')}</AlertDialogCancel>

--- a/frontend/lib/tutor-api.ts
+++ b/frontend/lib/tutor-api.ts
@@ -1,0 +1,120 @@
+import { authClient, AuthError } from '@/lib/auth';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+const CACHE_KEY = 'tutor_conversations_cache';
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+export interface ConversationSummary {
+  id: string;
+  module_id: string | null;
+  message_count: number;
+  last_message_at: string;
+  preview: string;
+}
+
+export interface ConversationMessage {
+  role: string;
+  content: string;
+  sources: Record<string, unknown>[];
+  timestamp: string;
+  activity_suggestions: Record<string, string>[];
+}
+
+export interface ConversationDetail {
+  id: string;
+  module_id: string | null;
+  messages: ConversationMessage[];
+  created_at: string;
+}
+
+export interface ConversationListResponse {
+  conversations: ConversationSummary[];
+  total: number;
+}
+
+interface CacheEntry<T> {
+  data: T;
+  ts: number;
+}
+
+function readCache<T>(key: string): T | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+    const entry: CacheEntry<T> = JSON.parse(raw);
+    if (Date.now() - entry.ts > CACHE_TTL_MS) return null;
+    return entry.data;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache<T>(key: string, data: T): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const entry: CacheEntry<T> = { data, ts: Date.now() };
+    localStorage.setItem(key, JSON.stringify(entry));
+  } catch {
+    // quota exceeded — silently skip
+  }
+}
+
+function convDetailKey(id: string): string {
+  return `tutor_conv_${id}`;
+}
+
+async function getToken(): Promise<string> {
+  return authClient.getValidToken();
+}
+
+export async function fetchConversations(): Promise<ConversationSummary[]> {
+  const cached = readCache<ConversationSummary[]>(CACHE_KEY);
+
+  try {
+    const token = await getToken();
+    const res = await fetch(`${API_BASE}/api/v1/tutor/conversations?limit=30`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) throw new AuthError(`HTTP ${res.status}`, res.status);
+    const data: ConversationListResponse = await res.json();
+    writeCache(CACHE_KEY, data.conversations);
+    return data.conversations;
+  } catch (err) {
+    if (cached) return cached;
+    throw err;
+  }
+}
+
+export async function fetchConversation(id: string): Promise<ConversationDetail> {
+  const cacheKey = convDetailKey(id);
+  const cached = readCache<ConversationDetail>(cacheKey);
+
+  try {
+    const token = await getToken();
+    const res = await fetch(`${API_BASE}/api/v1/tutor/conversations/${id}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) throw new AuthError(`HTTP ${res.status}`, res.status);
+    const data: ConversationDetail = await res.json();
+    writeCache(cacheKey, data);
+    return data;
+  } catch (err) {
+    if (cached) return cached;
+    throw err;
+  }
+}
+
+export function invalidateConversationsCache(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.removeItem(CACHE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+export function cacheConversationDetail(detail: ConversationDetail): void {
+  writeCache(convDetailKey(detail.id), detail);
+}


### PR DESCRIPTION
## Summary

- **Root cause 1**: `chat-panel.tsx` always sent `conversation_id: null`, creating a new conversation on every message instead of continuing the existing one
- **Root cause 2**: `tutor-client.tsx` used hardcoded fake conversations, never loading from the API
- **Root cause 3**: No localStorage cache for offline access
- Backend was already saving correctly — bug was entirely frontend-side

## Changes

| File | Change |
|------|--------|
| `frontend/lib/tutor-api.ts` | **New** — `fetchConversations`, `fetchConversation` with 5-min localStorage cache + offline fallback |
| `frontend/components/chat/chat-panel.tsx` | Load message history from server on mount; pass real `conversation_id`; refresh cache on `finished` event |
| `frontend/app/[locale]/(app)/tutor/tutor-client.tsx` | Real API data instead of hardcoded fakes; skeleton loading; sidebar updates live |
| `backend/tests/test_tutor_service.py` | 3 new tests: `list_conversations` fields, `get_conversation` wrong user → None, `get_conversation` returns messages |

## Test plan

- [ ] Backend tests pass (`uv run pytest backend/tests/test_tutor_service.py`)
- [ ] Frontend lint passes (`npm run lint`)
- [ ] Conversations persist after browser reload
- [ ] Sidebar shows real saved conversations
- [ ] Switching conversations loads correct messages
- [ ] Offline: cached conversations visible when server unreachable

Closes #299

Generated with [Claude Code](https://claude.ai/code)