### PR TITLE
feat(tutor): session manager — cross-session context with memory + compact history

### DIFF
--- a/backend/app/ai/prompts/tutor.py
+++ b/backend/app/ai/prompts/tutor.py
@@ -15,6 +15,8 @@ class TutorContext:
     context_type: str | None = None  # "module" | "lesson" | "quiz" | None
     context_id: str | None = None
     learner_memory: str | None = None  # Pre-formatted memory text for system prompt
+    previous_session_context: str | None = None  # Compacted context from prior session
+    progress_snapshot: str | None = None  # Short learner progress summary
 
 
 def get_socratic_system_prompt(context: TutorContext, rag_chunks: list[dict[str, Any]]) -> str:
@@ -54,7 +56,7 @@ vers la compréhension plutôt que de donner des réponses directes.
 - Langue: {language_instruction}
 - Pays: {country_context}
 - Module actuel: {context.module_id or "Non spécifié"}
-{_format_memory_section(context.learner_memory)}
+{_format_progress_section(context.progress_snapshot)}{_format_memory_section(context.learner_memory)}{_format_previous_session_section(context.previous_session_context)}
 
 ## LES 10 RÈGLES PÉDAGOGIQUES OBLIGATOIRES
 
@@ -207,6 +209,20 @@ def _format_memory_section(learner_memory: str | None) -> str:
     if not learner_memory:
         return ""
     return f"\n## MÉMOIRE DE L'APPRENANT\n{learner_memory}"
+
+
+def _format_previous_session_section(previous_session_context: str | None) -> str:
+    """Format previous session context as a section for the system prompt."""
+    if not previous_session_context:
+        return ""
+    return f'\n## CONTEXTE DE LA SESSION PRÉCÉDENTE\n{previous_session_context}\n(Utilise ce contexte pour assurer la continuité. Tu peux référencer naturellement les discussions précédentes: "Comme nous avons vu lors de notre dernière session...")'
+
+
+def _format_progress_section(progress_snapshot: str | None) -> str:
+    """Format learner progress snapshot as a section for the system prompt."""
+    if not progress_snapshot:
+        return ""
+    return f"\n## PROGRESSION ACTUELLE\n{progress_snapshot}"
 
 
 def _get_language_instruction(language: str) -> str:

--- a/backend/app/api/v1/schemas/tutor.py
+++ b/backend/app/api/v1/schemas/tutor.py
@@ -53,6 +53,9 @@ class ConversationSummary(BaseModel):
     message_count: int = Field(..., description="Number of messages")
     last_message_at: datetime = Field(..., description="Timestamp of last message")
     preview: str = Field(..., description="First few words of conversation")
+    has_context: bool = Field(
+        False, description="Whether this conversation has prior compacted context"
+    )
 
 
 class TutorConversationListResponse(BaseModel):

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -3,6 +3,7 @@
 import asyncio
 import uuid
 from collections.abc import AsyncGenerator
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
@@ -34,6 +35,153 @@ COMPACT_TRIGGER = 20
 COMPACT_KEEP_RECENT = 5
 COMPACT_SUMMARIZE_UP_TO = 15
 
+SESSION_CONTEXT_TOKEN_BUDGET = 1500
+
+
+@dataclass
+class SessionContext:
+    """Composed session context for a tutor conversation."""
+
+    learner_memory: str = ""
+    previous_compact: str = ""
+    current_compact: str = ""
+    progress_snapshot: str = ""
+    is_new_conversation: bool = True
+
+    @property
+    def has_prior_context(self) -> bool:
+        """Return True if any prior context was loaded."""
+        return bool(self.learner_memory or self.previous_compact or self.current_compact)
+
+    def total_text(self) -> str:
+        """Return concatenated context text for token estimation."""
+        parts = [
+            self.learner_memory,
+            self.previous_compact,
+            self.current_compact,
+            self.progress_snapshot,
+        ]
+        return "\n".join(p for p in parts if p)
+
+    def estimated_tokens(self) -> int:
+        """Rough estimate: ~4 chars per token."""
+        return len(self.total_text()) // 4
+
+
+class SessionManager:
+    """Composes full session context for a tutor conversation.
+
+    Loads learner memory + compacted history + progress snapshot and enforces
+    the SESSION_CONTEXT_TOKEN_BUDGET so injected context stays ≤1500 tokens.
+    """
+
+    def __init__(self, learner_memory_service: LearnerMemoryService) -> None:
+        self.learner_memory_service = learner_memory_service
+
+    async def build_session_context(
+        self,
+        user: User,
+        conversation: TutorConversation,
+        is_new_conversation: bool,
+        session: AsyncSession,
+    ) -> SessionContext:
+        """Build full session context respecting the token budget.
+
+        For a new conversation: loads learner_memory + last conversation's compacted_context.
+        For a continuing conversation: loads learner_memory + current compacted_context.
+        Progress snapshot is derived from the User model (level, country).
+        """
+        ctx = SessionContext(is_new_conversation=is_new_conversation)
+
+        ctx.learner_memory = await self.learner_memory_service.format_for_prompt(user.id, session)
+
+        if is_new_conversation:
+            prior = await self._get_previous_compact(user.id, conversation.id, session)
+            if prior:
+                ctx.previous_compact = prior
+        else:
+            if conversation.compacted_context:
+                ctx.current_compact = conversation.compacted_context
+
+        ctx.progress_snapshot = _build_progress_snapshot(user)
+
+        ctx = _trim_to_budget(ctx)
+
+        logger.info(
+            "Session context built",
+            user_id=str(user.id),
+            conversation_id=str(conversation.id),
+            is_new=is_new_conversation,
+            estimated_tokens=ctx.estimated_tokens(),
+            has_prior_context=ctx.has_prior_context,
+        )
+
+        return ctx
+
+    async def _get_previous_compact(
+        self,
+        user_id: uuid.UUID,
+        current_conversation_id: uuid.UUID,
+        session: AsyncSession,
+    ) -> str | None:
+        """Return compacted_context from the most recent prior conversation."""
+        result = await session.execute(
+            select(TutorConversation)
+            .where(
+                TutorConversation.user_id == user_id,
+                TutorConversation.id != current_conversation_id,
+                TutorConversation.compacted_context.isnot(None),
+            )
+            .order_by(TutorConversation.created_at.desc())
+            .limit(1)
+        )
+        prev = result.scalar_one_or_none()
+        return prev.compacted_context if prev else None
+
+
+def _build_progress_snapshot(user: User) -> str:
+    """Build a short progress snapshot from the user model."""
+    level_labels = {
+        1: "Beginner (L1)",
+        2: "Intermediate (L2)",
+        3: "Advanced (L3)",
+        4: "Expert (L4)",
+    }
+    level_label = level_labels.get(user.current_level, f"Level {user.current_level}")
+    parts = [f"Level: {level_label}", f"Country: {user.country or 'SN'}"]
+    if hasattr(user, "streak_days") and user.streak_days:
+        parts.append(f"Streak: {user.streak_days} days")
+    return ", ".join(parts)
+
+
+def _trim_to_budget(ctx: SessionContext) -> SessionContext:
+    """Trim context fields to stay within SESSION_CONTEXT_TOKEN_BUDGET.
+
+    Priority order (least to most likely trimmed):
+    progress_snapshot > learner_memory > previous_compact/current_compact
+    """
+    if ctx.estimated_tokens() <= SESSION_CONTEXT_TOKEN_BUDGET:
+        return ctx
+
+    budget_chars = SESSION_CONTEXT_TOKEN_BUDGET * 4
+
+    if ctx.previous_compact:
+        available = budget_chars - len(ctx.learner_memory) - len(ctx.progress_snapshot)
+        if available < len(ctx.previous_compact):
+            ctx.previous_compact = ctx.previous_compact[: max(0, available)]
+
+    if ctx.current_compact:
+        available = budget_chars - len(ctx.learner_memory) - len(ctx.progress_snapshot)
+        if available < len(ctx.current_compact):
+            ctx.current_compact = ctx.current_compact[: max(0, available)]
+
+    if ctx.estimated_tokens() > SESSION_CONTEXT_TOKEN_BUDGET:
+        available = budget_chars - len(ctx.progress_snapshot)
+        if available < len(ctx.learner_memory):
+            ctx.learner_memory = ctx.learner_memory[: max(0, available)]
+
+    return ctx
+
 
 class TutorService:
     """Service for managing AI tutor conversations with agentic tool_use and Socratic approach."""
@@ -49,6 +197,7 @@ class TutorService:
         self.retriever = semantic_retriever
         self.embedding_service = embedding_service
         self.learner_memory_service = learner_memory_service or LearnerMemoryService()
+        self.session_manager = SessionManager(self.learner_memory_service)
         self.settings = get_settings()
         self.daily_message_limit = 50
 
@@ -101,25 +250,31 @@ class TutorService:
             return
 
         try:
+            is_new_conversation = conversation_id is None
             conversation = await self._get_or_create_conversation(
                 user_id, module_id, conversation_id, session
             )
 
-            if not conversation_id and not conversation.compacted_context:
-                prior_compact = await self._get_previous_compact(user_id, conversation.id, session)
-                if prior_compact:
-                    conversation.compacted_context = prior_compact
-                    session.add(conversation)
-                    await session.flush()
+            session_ctx = await self.session_manager.build_session_context(
+                user=user,
+                conversation=conversation,
+                is_new_conversation=is_new_conversation,
+                session=session,
+            )
+
+            if (
+                is_new_conversation
+                and session_ctx.previous_compact
+                and not conversation.compacted_context
+            ):
+                conversation.compacted_context = session_ctx.previous_compact
+                session.add(conversation)
+                await session.flush()
 
             yield {
                 "type": "conversation_id",
                 "data": {"conversation_id": str(conversation.id)},
             }
-
-            learner_memory_text = await self.learner_memory_service.format_for_prompt(
-                user_id, session
-            )
 
             context = TutorContext(
                 user_level=user.current_level,
@@ -128,7 +283,9 @@ class TutorService:
                 module_id=str(module_id) if module_id else None,
                 context_type=context_type,
                 context_id=str(context_id) if context_id else None,
-                learner_memory=learner_memory_text,
+                learner_memory=session_ctx.learner_memory,
+                previous_session_context=session_ctx.previous_compact,
+                progress_snapshot=session_ctx.progress_snapshot,
             )
 
             system_prompt = get_socratic_system_prompt(context, [])
@@ -414,6 +571,7 @@ class TutorService:
                     "message_count": len(conv.messages),
                     "last_message_at": last_message_at,
                     "preview": preview,
+                    "has_context": bool(conv.compacted_context),
                 }
             )
 

--- a/backend/tests/test_session_manager.py
+++ b/backend/tests/test_session_manager.py
@@ -1,0 +1,369 @@
+"""Tests for SessionManager — cross-session context with memory + compact history."""
+
+import time
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.models.conversation import TutorConversation
+from app.domain.models.user import User
+from app.domain.services.learner_memory_service import LearnerMemoryService
+from app.domain.services.tutor_service import (
+    SESSION_CONTEXT_TOKEN_BUDGET,
+    SessionContext,
+    SessionManager,
+    _build_progress_snapshot,
+    _trim_to_budget,
+)
+
+
+@pytest.fixture
+def sample_user():
+    return User(
+        id=uuid.uuid4(),
+        email="test@example.com",
+        name="Test User",
+        preferred_language="fr",
+        country="SN",
+        professional_role="nurse",
+        current_level=2,
+        streak_days=5,
+        last_active=datetime.now(UTC),
+        created_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def new_conversation(sample_user):
+    return TutorConversation(
+        id=uuid.uuid4(),
+        user_id=sample_user.id,
+        module_id=None,
+        messages=[],
+        message_count=0,
+        created_at=datetime.now(UTC),
+        compacted_context=None,
+        compacted_at=None,
+    )
+
+
+@pytest.fixture
+def conversation_with_compact(sample_user):
+    return TutorConversation(
+        id=uuid.uuid4(),
+        user_id=sample_user.id,
+        module_id=None,
+        messages=[{"role": "user", "content": "Hello", "timestamp": datetime.now(UTC).isoformat()}],
+        message_count=1,
+        created_at=datetime.now(UTC),
+        compacted_context="Previous compact summary about malaria surveillance.",
+        compacted_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def mock_memory_service():
+    svc = AsyncMock(spec=LearnerMemoryService)
+    svc.format_for_prompt = AsyncMock(return_value="Style: analogies\nCountry: SN\nGoal: pass exam")
+    return svc
+
+
+@pytest.fixture
+def session_manager(mock_memory_service):
+    return SessionManager(learner_memory_service=mock_memory_service)
+
+
+async def test_new_conversation_loads_learner_memory(
+    session_manager, sample_user, new_conversation, mock_memory_service
+):
+    """New conversation: learner_memory is loaded from memory service."""
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    ctx = await session_manager.build_session_context(
+        user=sample_user,
+        conversation=new_conversation,
+        is_new_conversation=True,
+        session=mock_session,
+    )
+
+    assert ctx.learner_memory == "Style: analogies\nCountry: SN\nGoal: pass exam"
+    mock_memory_service.format_for_prompt.assert_awaited_once_with(sample_user.id, mock_session)
+
+
+async def test_new_conversation_loads_previous_compact(
+    session_manager, sample_user, new_conversation
+):
+    """New conversation: previous conversation's compacted_context is loaded as previous_compact."""
+    prior_conv = TutorConversation(
+        id=uuid.uuid4(),
+        user_id=sample_user.id,
+        module_id=None,
+        messages=[],
+        message_count=0,
+        created_at=datetime.now(UTC),
+        compacted_context="Summary of the last session about epidemiology.",
+        compacted_at=datetime.now(UTC),
+    )
+
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = prior_conv
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    ctx = await session_manager.build_session_context(
+        user=sample_user,
+        conversation=new_conversation,
+        is_new_conversation=True,
+        session=mock_session,
+    )
+
+    assert ctx.previous_compact == "Summary of the last session about epidemiology."
+    assert ctx.current_compact == ""
+    assert ctx.is_new_conversation is True
+
+
+async def test_new_conversation_no_prior_compact_when_none_exists(
+    session_manager, sample_user, new_conversation
+):
+    """New conversation: previous_compact is empty when no prior conversation exists."""
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    ctx = await session_manager.build_session_context(
+        user=sample_user,
+        conversation=new_conversation,
+        is_new_conversation=True,
+        session=mock_session,
+    )
+
+    assert ctx.previous_compact == ""
+
+
+async def test_continuing_conversation_loads_current_compact(
+    session_manager, sample_user, conversation_with_compact
+):
+    """Continuing conversation: loads current compacted_context, not previous."""
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    ctx = await session_manager.build_session_context(
+        user=sample_user,
+        conversation=conversation_with_compact,
+        is_new_conversation=False,
+        session=mock_session,
+    )
+
+    assert ctx.current_compact == "Previous compact summary about malaria surveillance."
+    assert ctx.previous_compact == ""
+    assert ctx.is_new_conversation is False
+
+
+async def test_continuing_conversation_without_compact(
+    session_manager, sample_user, new_conversation
+):
+    """Continuing conversation with no compacted_context: current_compact is empty."""
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    ctx = await session_manager.build_session_context(
+        user=sample_user,
+        conversation=new_conversation,
+        is_new_conversation=False,
+        session=mock_session,
+    )
+
+    assert ctx.current_compact == ""
+    assert ctx.previous_compact == ""
+
+
+async def test_progress_snapshot_included(session_manager, sample_user, new_conversation):
+    """Session context always includes a progress_snapshot from the User model."""
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    ctx = await session_manager.build_session_context(
+        user=sample_user,
+        conversation=new_conversation,
+        is_new_conversation=True,
+        session=mock_session,
+    )
+
+    assert ctx.progress_snapshot != ""
+    assert "L2" in ctx.progress_snapshot or "Intermediate" in ctx.progress_snapshot
+    assert "SN" in ctx.progress_snapshot
+
+
+def test_build_progress_snapshot_level_labels(sample_user):
+    """_build_progress_snapshot renders correct level labels."""
+    for level, label in [(1, "L1"), (2, "L2"), (3, "L3"), (4, "L4")]:
+        sample_user.current_level = level
+        snapshot = _build_progress_snapshot(sample_user)
+        assert label in snapshot
+
+
+def test_build_progress_snapshot_includes_country(sample_user):
+    """_build_progress_snapshot includes country code."""
+    sample_user.country = "BF"
+    snapshot = _build_progress_snapshot(sample_user)
+    assert "BF" in snapshot
+
+
+def test_build_progress_snapshot_includes_streak(sample_user):
+    """_build_progress_snapshot includes streak days when present."""
+    sample_user.streak_days = 10
+    snapshot = _build_progress_snapshot(sample_user)
+    assert "10" in snapshot
+
+
+async def test_total_context_stays_within_budget(session_manager, sample_user, new_conversation):
+    """Session context estimated_tokens() stays ≤ SESSION_CONTEXT_TOKEN_BUDGET."""
+    big_compact = "A" * (SESSION_CONTEXT_TOKEN_BUDGET * 8)
+    prior_conv = TutorConversation(
+        id=uuid.uuid4(),
+        user_id=sample_user.id,
+        module_id=None,
+        messages=[],
+        message_count=0,
+        created_at=datetime.now(UTC),
+        compacted_context=big_compact,
+        compacted_at=datetime.now(UTC),
+    )
+
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = prior_conv
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    ctx = await session_manager.build_session_context(
+        user=sample_user,
+        conversation=new_conversation,
+        is_new_conversation=True,
+        session=mock_session,
+    )
+
+    assert ctx.estimated_tokens() <= SESSION_CONTEXT_TOKEN_BUDGET
+
+
+def test_trim_to_budget_no_op_when_under_budget():
+    """_trim_to_budget returns context unchanged when already within budget."""
+    ctx = SessionContext(
+        learner_memory="short memory",
+        previous_compact="short compact",
+        progress_snapshot="Level 2",
+    )
+    original_memory = ctx.learner_memory
+    original_compact = ctx.previous_compact
+    result = _trim_to_budget(ctx)
+    assert result.learner_memory == original_memory
+    assert result.previous_compact == original_compact
+
+
+def test_trim_to_budget_trims_oversize_compact():
+    """_trim_to_budget trims previous_compact when it exceeds budget."""
+    oversized = "X" * (SESSION_CONTEXT_TOKEN_BUDGET * 6)
+    ctx = SessionContext(
+        learner_memory="memory",
+        previous_compact=oversized,
+        progress_snapshot="Level 2",
+    )
+    result = _trim_to_budget(ctx)
+    assert result.estimated_tokens() <= SESSION_CONTEXT_TOKEN_BUDGET
+
+
+def test_session_context_has_prior_context_true():
+    """has_prior_context is True when any context field is set."""
+    ctx = SessionContext(previous_compact="some summary")
+    assert ctx.has_prior_context is True
+
+
+def test_session_context_has_prior_context_false():
+    """has_prior_context is False when all context fields are empty."""
+    ctx = SessionContext()
+    assert ctx.has_prior_context is False
+
+
+async def test_session_init_latency_under_200ms(session_manager, sample_user, new_conversation):
+    """Session context initialization must complete in < 200ms with mocked DB."""
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    start = time.perf_counter()
+    await session_manager.build_session_context(
+        user=sample_user,
+        conversation=new_conversation,
+        is_new_conversation=True,
+        session=mock_session,
+    )
+    elapsed_ms = (time.perf_counter() - start) * 1000
+
+    assert elapsed_ms < 200, f"Session init took {elapsed_ms:.1f}ms, must be < 200ms"
+
+
+async def test_list_conversations_has_context_field():
+    """list_conversations result includes has_context for each conversation."""
+
+    from app.ai.rag.embeddings import EmbeddingService
+    from app.ai.rag.retriever import SemanticRetriever
+    from app.domain.services.tutor_service import TutorService
+
+    mock_anthropic = MagicMock()
+    mock_retriever = AsyncMock(spec=SemanticRetriever)
+    mock_embedding = AsyncMock(spec=EmbeddingService)
+    mock_memory_svc = AsyncMock(spec=LearnerMemoryService)
+    mock_memory_svc.format_for_prompt = AsyncMock(return_value="")
+
+    service = TutorService(
+        anthropic_client=mock_anthropic,
+        semantic_retriever=mock_retriever,
+        embedding_service=mock_embedding,
+        learner_memory_service=mock_memory_svc,
+    )
+
+    user_id = uuid.uuid4()
+    conv_with_context = TutorConversation(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        module_id=None,
+        messages=[{"role": "user", "content": "Hi", "timestamp": datetime.now(UTC).isoformat()}],
+        message_count=1,
+        created_at=datetime.now(UTC),
+        compacted_context="Some prior context",
+        compacted_at=datetime.now(UTC),
+    )
+    conv_without_context = TutorConversation(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        module_id=None,
+        messages=[],
+        message_count=0,
+        created_at=datetime.now(UTC),
+        compacted_context=None,
+        compacted_at=None,
+    )
+
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_list_result = MagicMock()
+    mock_list_result.scalars.return_value.all.return_value = [
+        conv_with_context,
+        conv_without_context,
+    ]
+    mock_count_result = MagicMock()
+    mock_count_result.scalar.return_value = 2
+    mock_session.execute = AsyncMock(side_effect=[mock_list_result, mock_count_result])
+
+    result = await service.list_conversations(user_id=user_id, session=mock_session)
+
+    convs = result["conversations"]
+    assert len(convs) == 2
+    assert convs[0]["has_context"] is True
+    assert convs[1]["has_context"] is False

--- a/backend/tests/test_tutor_compaction.py
+++ b/backend/tests/test_tutor_compaction.py
@@ -13,6 +13,7 @@ from app.domain.services.tutor_service import (
     COMPACT_KEEP_RECENT,
     COMPACT_SUMMARIZE_UP_TO,
     COMPACT_TRIGGER,
+    SessionContext,
     TutorService,
 )
 
@@ -41,11 +42,15 @@ def mock_embedding_service():
 
 @pytest.fixture
 def tutor_service(mock_anthropic_client, mock_semantic_retriever, mock_embedding_service):
-    return TutorService(
+    svc = TutorService(
         anthropic_client=mock_anthropic_client,
         semantic_retriever=mock_semantic_retriever,
         embedding_service=mock_embedding_service,
     )
+    svc.session_manager.build_session_context = AsyncMock(
+        return_value=SessionContext(learner_memory="", is_new_conversation=True)
+    )
+    return svc
 
 
 @pytest.fixture

--- a/backend/tests/test_tutor_service.py
+++ b/backend/tests/test_tutor_service.py
@@ -12,7 +12,7 @@ from app.ai.rag.retriever import SemanticRetriever
 from app.domain.models.conversation import TutorConversation
 from app.domain.models.user import User
 from app.domain.services.learner_memory_service import LearnerMemoryService
-from app.domain.services.tutor_service import TutorService
+from app.domain.services.tutor_service import SessionContext, TutorService
 
 
 @pytest.fixture
@@ -53,12 +53,16 @@ def tutor_service(
     mock_learner_memory_service,
 ):
     """TutorService with mocked dependencies."""
-    return TutorService(
+    svc = TutorService(
         anthropic_client=mock_anthropic_client,
         semantic_retriever=mock_semantic_retriever,
         embedding_service=mock_embedding_service,
         learner_memory_service=mock_learner_memory_service,
     )
+    svc.session_manager.build_session_context = AsyncMock(
+        return_value=SessionContext(learner_memory="", is_new_conversation=True)
+    )
+    return svc
 
 
 @pytest.fixture

--- a/backend/tests/test_tutor_tools.py
+++ b/backend/tests/test_tutor_tools.py
@@ -16,6 +16,7 @@ from app.domain.models.user import User
 from app.domain.services.learner_memory_service import LearnerMemoryService
 from app.domain.services.tutor_service import (
     MAX_TOOL_CALLS,
+    SessionContext,
     TutorService,
     _deduplicate_sources,
     _split_into_chunks,
@@ -101,12 +102,16 @@ def tutor_service(mock_retriever, mock_anthropic, mock_learner_memory_service):
     from app.ai.rag.embeddings import EmbeddingService
 
     embedding_service = AsyncMock(spec=EmbeddingService)
-    return TutorService(
+    svc = TutorService(
         anthropic_client=mock_anthropic,
         semantic_retriever=mock_retriever,
         embedding_service=embedding_service,
         learner_memory_service=mock_learner_memory_service,
     )
+    svc.session_manager.build_session_context = AsyncMock(
+        return_value=SessionContext(learner_memory="", is_new_conversation=True)
+    )
+    return svc
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements proper session management for the AI tutor so each new conversation starts with full context: compacted history from previous sessions, learner memory, and current progression data.

- **`SessionManager` class** in `tutor_service.py` — composes full session context with `build_session_context()`
- **New conversation**: loads `learner_memory` + last conversation's `compacted_context` as prior context
- **Continuing conversation**: loads `learner_memory` + current conversation's `compacted_context`
- **Token budget enforcement**: `SESSION_CONTEXT_TOKEN_BUDGET = 1500` — trims compact/memory when over budget via `_trim_to_budget()`
- **Progress snapshot**: level, country, streak injected via `_build_progress_snapshot(user)`
- **System prompt updated**: 3 new sections — `PROGRESSION ACTUELLE`, `MÉMOIRE DE L'APPRENANT`, `CONTEXTE DE LA SESSION PRÉCÉDENTE` (with natural reference hint)
- **`TutorContext` extended**: `previous_session_context` and `progress_snapshot` fields
- **`has_context` field** added to `ConversationSummary` schema (reflects if `compacted_context` is set)
- **`list_conversations` updated** to include `has_context: bool` per conversation

## Changes

- `backend/app/domain/services/tutor_service.py` — `SessionContext` dataclass, `SessionManager` class, `_build_progress_snapshot()`, `_trim_to_budget()`, updated `send_message()`, `list_conversations()`
- `backend/app/ai/prompts/tutor.py` — extended `TutorContext`, new `_format_previous_session_section()`, `_format_progress_section()` helpers, updated system prompt composition
- `backend/app/api/v1/schemas/tutor.py` — `has_context` field on `ConversationSummary`
- `backend/tests/test_session_manager.py` — 16 new tests covering all acceptance criteria
- `backend/tests/test_tutor_service.py`, `test_tutor_tools.py`, `test_tutor_compaction.py` — updated fixtures to mock `session_manager.build_session_context`

## Test plan

- [x] 205/205 backend pytest pass (`uv run pytest tests/`)
- [x] Ruff lint/format clean (`uv run ruff check . && uv run ruff format .`)
- [x] New conversation loads learner memory ✓
- [x] New conversation loads previous conversation's compact ✓
- [x] Continuing conversation uses current compact ✓
- [x] Total injected context ≤ 1500 tokens (enforced + tested) ✓
- [x] Session init latency < 200ms with mocked DB ✓
- [x] `has_context` field in list_conversations response ✓
- [x] Progress snapshot in system prompt ✓

Closes #331

Generated with [Claude Code](https://claude.ai/code)