### PR TITLE
feat(tutor): add delete conversation and clear all functionality (#365)

### DIFF
--- a/backend/app/api/v1/tutor.py
+++ b/backend/app/api/v1/tutor.py
@@ -137,6 +137,39 @@ async def get_conversation(
     return TutorConversationResponse(**conversation)
 
 
+@router.delete("/conversations/{conversation_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_conversation(
+    conversation_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
+    tutor_service: TutorService = Depends(get_tutor_service),
+) -> None:
+    """Delete a single tutor conversation."""
+    deleted = await tutor_service.delete_conversation(
+        user_id=current_user.id,
+        conversation_id=conversation_id,
+        session=session,
+    )
+
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversation not found")
+
+
+@router.delete("/conversations", status_code=status.HTTP_200_OK)
+async def delete_all_conversations(
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
+    tutor_service: TutorService = Depends(get_tutor_service),
+) -> dict[str, int]:
+    """Delete all tutor conversations for the authenticated user."""
+    count = await tutor_service.delete_all_conversations(
+        user_id=current_user.id,
+        session=session,
+    )
+
+    return {"deleted_count": count}
+
+
 @router.get("/stats", response_model=TutorStatsResponse)
 async def get_tutor_stats(
     current_user: AuthenticatedUser = Depends(get_current_user),

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -601,6 +601,62 @@ class TutorService:
             "most_discussed_topics": most_discussed_topics,
         }
 
+    async def delete_conversation(
+        self,
+        user_id: str | uuid.UUID,
+        conversation_id: uuid.UUID,
+        session: AsyncSession,
+    ) -> bool:
+        """Delete a single conversation. Returns True if deleted, False if not found."""
+        if isinstance(user_id, str):
+            user_id = uuid.UUID(user_id)
+
+        query = select(TutorConversation).where(
+            TutorConversation.id == conversation_id,
+            TutorConversation.user_id == user_id,
+        )
+        result = await session.execute(query)
+        conversation = result.scalar_one_or_none()
+
+        if not conversation:
+            return False
+
+        await session.delete(conversation)
+        await session.commit()
+
+        logger.info(
+            "Conversation deleted",
+            conversation_id=str(conversation_id),
+            user_id=str(user_id),
+        )
+        return True
+
+    async def delete_all_conversations(
+        self,
+        user_id: str | uuid.UUID,
+        session: AsyncSession,
+    ) -> int:
+        """Delete all conversations for a user. Returns count of deleted conversations."""
+        if isinstance(user_id, str):
+            user_id = uuid.UUID(user_id)
+
+        query = select(TutorConversation).where(TutorConversation.user_id == user_id)
+        result = await session.execute(query)
+        conversations = result.scalars().all()
+
+        count = len(conversations)
+        for conversation in conversations:
+            await session.delete(conversation)
+
+        await session.commit()
+
+        logger.info(
+            "All conversations deleted",
+            user_id=str(user_id),
+            count=count,
+        )
+        return count
+
     async def _check_daily_limit(self, user_id: str | uuid.UUID, session: AsyncSession) -> int:
         """Check how many messages user has sent today."""
         if isinstance(user_id, str):

--- a/backend/tests/test_tutor_delete.py
+++ b/backend/tests/test_tutor_delete.py
@@ -1,0 +1,222 @@
+"""Tests for tutor conversation delete functionality."""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.ai.rag.embeddings import EmbeddingService
+from app.ai.rag.retriever import SemanticRetriever
+from app.domain.models.conversation import TutorConversation
+from app.domain.models.user import User
+from app.domain.services.learner_memory_service import LearnerMemoryService
+from app.domain.services.tutor_service import TutorService
+
+
+@pytest.fixture
+def mock_anthropic_client():
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_semantic_retriever():
+    return AsyncMock(spec=SemanticRetriever)
+
+
+@pytest.fixture
+def mock_embedding_service():
+    return AsyncMock(spec=EmbeddingService)
+
+
+@pytest.fixture
+def mock_learner_memory_service():
+    service = AsyncMock(spec=LearnerMemoryService)
+    service.format_for_prompt = AsyncMock(return_value="")
+    return service
+
+
+@pytest.fixture
+def tutor_service(
+    mock_anthropic_client,
+    mock_semantic_retriever,
+    mock_embedding_service,
+    mock_learner_memory_service,
+):
+    return TutorService(
+        anthropic_client=mock_anthropic_client,
+        semantic_retriever=mock_semantic_retriever,
+        embedding_service=mock_embedding_service,
+        learner_memory_service=mock_learner_memory_service,
+    )
+
+
+@pytest.fixture
+def sample_user():
+    return User(
+        id=uuid.uuid4(),
+        email="test@example.com",
+        name="Test User",
+        preferred_language="fr",
+        country="SN",
+        professional_role="nurse",
+        current_level=1,
+        streak_days=0,
+        last_active=datetime.now(UTC),
+        created_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def sample_conversation(sample_user):
+    return TutorConversation(
+        id=uuid.uuid4(),
+        user_id=sample_user.id,
+        module_id=None,
+        messages=[{"role": "user", "content": "Hello", "timestamp": datetime.now(UTC).isoformat()}],
+        created_at=datetime.now(UTC),
+    )
+
+
+async def test_delete_conversation_returns_true_when_found(
+    tutor_service, sample_user, sample_conversation
+):
+    """delete_conversation returns True when the conversation exists for the user."""
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = sample_conversation
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.delete = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    result = await tutor_service.delete_conversation(
+        user_id=sample_user.id,
+        conversation_id=sample_conversation.id,
+        session=mock_session,
+    )
+
+    assert result is True
+    mock_session.delete.assert_called_once_with(sample_conversation)
+    mock_session.commit.assert_called_once()
+
+
+async def test_delete_conversation_returns_false_when_not_found(tutor_service, sample_user):
+    """delete_conversation returns False when the conversation does not exist."""
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    result = await tutor_service.delete_conversation(
+        user_id=sample_user.id,
+        conversation_id=uuid.uuid4(),
+        session=mock_session,
+    )
+
+    assert result is False
+    mock_session.delete.assert_not_called()
+
+
+async def test_delete_conversation_enforces_user_ownership(tutor_service, sample_conversation):
+    """delete_conversation cannot delete another user's conversation."""
+    other_user_id = uuid.uuid4()
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    result = await tutor_service.delete_conversation(
+        user_id=other_user_id,
+        conversation_id=sample_conversation.id,
+        session=mock_session,
+    )
+
+    assert result is False
+    mock_session.delete.assert_not_called()
+
+
+async def test_delete_conversation_accepts_string_user_id(
+    tutor_service, sample_user, sample_conversation
+):
+    """delete_conversation works with string user_id (auto-converts to UUID)."""
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = sample_conversation
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.delete = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    result = await tutor_service.delete_conversation(
+        user_id=str(sample_user.id),
+        conversation_id=sample_conversation.id,
+        session=mock_session,
+    )
+
+    assert result is True
+
+
+async def test_delete_all_conversations_returns_count(
+    tutor_service, sample_user, sample_conversation
+):
+    """delete_all_conversations returns the number of deleted conversations."""
+    conv2 = TutorConversation(
+        id=uuid.uuid4(),
+        user_id=sample_user.id,
+        module_id=None,
+        messages=[],
+        created_at=datetime.now(UTC),
+    )
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [sample_conversation, conv2]
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.delete = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    count = await tutor_service.delete_all_conversations(
+        user_id=sample_user.id,
+        session=mock_session,
+    )
+
+    assert count == 2
+    assert mock_session.delete.call_count == 2
+    mock_session.commit.assert_called_once()
+
+
+async def test_delete_all_conversations_returns_zero_when_none(tutor_service, sample_user):
+    """delete_all_conversations returns 0 when user has no conversations."""
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.delete = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    count = await tutor_service.delete_all_conversations(
+        user_id=sample_user.id,
+        session=mock_session,
+    )
+
+    assert count == 0
+    mock_session.delete.assert_not_called()
+    mock_session.commit.assert_called_once()
+
+
+async def test_delete_all_only_deletes_user_conversations(tutor_service, sample_user):
+    """delete_all_conversations only queries conversations for the given user."""
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.delete = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    await tutor_service.delete_all_conversations(
+        user_id=sample_user.id,
+        session=mock_session,
+    )
+
+    call_args = mock_session.execute.call_args[0][0]
+    compiled = call_args.compile()
+    query_str = str(compiled)
+    assert "user_id" in query_str

--- a/frontend/app/[locale]/(app)/tutor/tutor-client.tsx
+++ b/frontend/app/[locale]/(app)/tutor/tutor-client.tsx
@@ -2,9 +2,25 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
-import { Plus, MessageSquare } from 'lucide-react';
+import { Plus, MessageSquare, Trash2, MoreVertical } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { ChatPanel } from '@/components/chat';
 import { ChatProvider } from '@/components/chat';
 import { cn } from '@/lib/utils';
@@ -12,6 +28,8 @@ import {
   fetchConversations,
   getOfflineConversations,
   invalidateConversationsCache,
+  deleteConversation,
+  deleteAllConversations,
   type ConversationSummary,
 } from '@/lib/tutor-api';
 
@@ -21,6 +39,9 @@ export function TutorPageClient() {
   const [conversations, setConversations] = useState<ConversationSummary[]>([]);
   const [selectedConversation, setSelectedConversation] = useState<string | null>(null);
   const [isLoadingConversations, setIsLoadingConversations] = useState(true);
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+  const [showClearAllDialog, setShowClearAllDialog] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const loadConversations = useCallback(async () => {
     try {
@@ -76,6 +97,37 @@ export function TutorPageClient() {
     []
   );
 
+  const handleDeleteConversation = async () => {
+    if (!deleteTargetId) return;
+    setIsDeleting(true);
+    try {
+      await deleteConversation(deleteTargetId);
+      setConversations((prev) => prev.filter((c) => c.id !== deleteTargetId));
+      if (selectedConversation === deleteTargetId) {
+        setSelectedConversation(null);
+      }
+    } catch {
+      // silently fail — network issues handled elsewhere
+    } finally {
+      setIsDeleting(false);
+      setDeleteTargetId(null);
+    }
+  };
+
+  const handleClearAll = async () => {
+    setIsDeleting(true);
+    try {
+      await deleteAllConversations();
+      setConversations([]);
+      setSelectedConversation(null);
+    } catch {
+      // silently fail
+    } finally {
+      setIsDeleting(false);
+      setShowClearAllDialog(false);
+    }
+  };
+
   const selectedConvData = conversations.find((c) => c.id === selectedConversation);
 
   return (
@@ -84,7 +136,7 @@ export function TutorPageClient() {
         {/* Conversations Sidebar - Hidden on mobile, shown on desktop */}
         <div className="w-80 border-r bg-card hidden md:flex flex-col shrink-0">
           {/* Sidebar Header */}
-          <div className="p-4 border-b shrink-0">
+          <div className="p-4 border-b shrink-0 space-y-2">
             <Button
               className="w-full justify-start gap-2"
               variant="outline"
@@ -93,6 +145,17 @@ export function TutorPageClient() {
               <Plus className="h-4 w-4" />
               {t('newConversation')}
             </Button>
+            {conversations.length > 0 && (
+              <Button
+                className="w-full justify-start gap-2"
+                variant="ghost"
+                size="sm"
+                onClick={() => setShowClearAllDialog(true)}
+              >
+                <Trash2 className="h-4 w-4 text-destructive" />
+                <span className="text-destructive">{t('clearAll')}</span>
+              </Button>
+            )}
           </div>
 
           {/* Conversations List */}
@@ -125,7 +188,7 @@ export function TutorPageClient() {
                   <Card
                     key={conversation.id}
                     className={cn(
-                      'p-3 cursor-pointer transition-colors hover:bg-accent/50',
+                      'p-3 cursor-pointer transition-colors hover:bg-accent/50 relative group',
                       selectedConversation === conversation.id && 'bg-accent border-primary'
                     )}
                     onClick={() => setSelectedConversation(conversation.id)}
@@ -145,9 +208,32 @@ export function TutorPageClient() {
                           ? conversation.preview.slice(0, 40)
                           : t('newConversationTitle')}
                       </h3>
-                      <span className="text-xs text-muted-foreground shrink-0">
-                        {formatRelativeTime(conversation.last_message_at)}
-                      </span>
+                      <div className="flex items-center gap-1 shrink-0">
+                        <span className="text-xs text-muted-foreground">
+                          {formatRelativeTime(conversation.last_message_at)}
+                        </span>
+                        <DropdownMenu>
+                          <DropdownMenuTrigger
+                            className="opacity-0 group-hover:opacity-100 focus:opacity-100 inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded-md hover:bg-accent -mr-1"
+                            aria-label={t('deleteConversation')}
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <MoreVertical className="h-3 w-3" />
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              className="text-destructive focus:text-destructive"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setDeleteTargetId(conversation.id);
+                              }}
+                            >
+                              <Trash2 className="h-4 w-4 mr-2" />
+                              {t('deleteConversation')}
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </div>
                     </div>
                     {conversation.preview && (
                       <p className="text-xs text-muted-foreground truncate mb-1">
@@ -197,6 +283,50 @@ export function TutorPageClient() {
           {selectedConvData.preview || t('newConversationTitle')}
         </div>
       )}
+
+      {/* Delete single conversation dialog */}
+      <AlertDialog open={!!deleteTargetId} onOpenChange={(open) => !open && setDeleteTargetId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('deleteConversationConfirm')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('deleteConversationConfirmDescription')}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>{t('cancel')}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteConversation}
+              disabled={isDeleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {t('confirm')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Clear all conversations dialog */}
+      <AlertDialog open={showClearAllDialog} onOpenChange={setShowClearAllDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('clearAllConfirm')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('clearAllConfirmDescription')}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>{t('cancel')}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleClearAll}
+              disabled={isDeleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {t('confirm')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </ChatProvider>
   );
 }

--- a/frontend/lib/tutor-api.ts
+++ b/frontend/lib/tutor-api.ts
@@ -136,6 +136,52 @@ export function getOfflineConversations(): { conversations: ConversationSummary[
   }
 }
 
+export async function deleteConversation(conversationId: string): Promise<void> {
+  const token = await authClient.getValidToken();
+  const response = await fetch(`${API_BASE}/api/v1/tutor/conversations/${conversationId}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to delete conversation: ${response.status}`);
+  }
+
+  clearCache(`${CACHE_KEY_PREFIX_CONVERSATION}${conversationId}`);
+  clearCache(CACHE_KEY_CONVERSATIONS);
+}
+
+export async function deleteAllConversations(): Promise<{ deleted_count: number }> {
+  const token = await authClient.getValidToken();
+  const response = await fetch(`${API_BASE}/api/v1/tutor/conversations`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to delete all conversations: ${response.status}`);
+  }
+
+  clearCache(CACHE_KEY_CONVERSATIONS);
+
+  if (typeof window !== 'undefined') {
+    try {
+      const keysToRemove: string[] = [];
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key && key.startsWith(CACHE_KEY_PREFIX_CONVERSATION)) {
+          keysToRemove.push(key);
+        }
+      }
+      keysToRemove.forEach((key) => localStorage.removeItem(key));
+    } catch {
+      // Ignore storage errors
+    }
+  }
+
+  return response.json();
+}
+
 export function getOfflineConversation(conversationId: string): ConversationDetail | null {
   try {
     const raw = localStorage.getItem(`${CACHE_KEY_PREFIX_CONVERSATION}${conversationId}`);

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -326,7 +326,17 @@
     "selectConversationDescription": "Choose a conversation from the sidebar or start a new one",
     "messageCount": "{count} {count, plural, one {message} other {messages}}",
     "cancel": "Cancel",
-    "newConversationTitle": "New Conversation"
+    "newConversationTitle": "New Conversation",
+    "deleteConversation": "Delete",
+    "deleteConversationConfirm": "Delete this conversation?",
+    "deleteConversationConfirmDescription": "This action cannot be undone. The conversation will be permanently deleted.",
+    "clearAll": "Clear all",
+    "clearAllConfirm": "Delete all conversations?",
+    "clearAllConfirmDescription": "This action cannot be undone. All your conversations will be permanently deleted.",
+    "deleteSuccess": "Conversation deleted",
+    "clearAllSuccess": "All conversations deleted",
+    "deleteError": "Error deleting conversation",
+    "confirm": "Confirm"
   },
   "Flashcards": {
     "title": "Flashcards",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -326,7 +326,17 @@
     "selectConversationDescription": "Choisissez une conversation dans la barre latérale ou commencez-en une nouvelle",
     "messageCount": "{count} {count, plural, one {message} other {messages}}",
     "cancel": "Annuler",
-    "newConversationTitle": "Nouvelle Conversation"
+    "newConversationTitle": "Nouvelle Conversation",
+    "deleteConversation": "Supprimer",
+    "deleteConversationConfirm": "Supprimer cette conversation ?",
+    "deleteConversationConfirmDescription": "Cette action est irréversible. La conversation sera définitivement supprimée.",
+    "clearAll": "Tout effacer",
+    "clearAllConfirm": "Supprimer toutes les conversations ?",
+    "clearAllConfirmDescription": "Cette action est irréversible. Toutes vos conversations seront définitivement supprimées.",
+    "deleteSuccess": "Conversation supprimée",
+    "clearAllSuccess": "Toutes les conversations supprimées",
+    "deleteError": "Erreur lors de la suppression",
+    "confirm": "Confirmer"
   },
   "Flashcards": {
     "title": "Flashcards",


### PR DESCRIPTION
## Summary

- Add `DELETE /api/v1/tutor/conversations/{id}` — deletes a single conversation (204 No Content)
- Add `DELETE /api/v1/tutor/conversations` — deletes all conversations for the authenticated user
- Delete buttons in conversation list sidebar with confirmation dialogs (FR/EN)
- Active conversation deletion resets UI to welcome screen
- Learner memory is NOT deleted when clearing conversations

## Changes

- `backend/app/api/v1/tutor.py` — two new DELETE endpoints
- `backend/app/domain/services/tutor_service.py` — `delete_conversation()` and `delete_all_conversations()` methods
- `backend/tests/test_tutor_delete.py` — unit tests for all delete methods
- `frontend/app/[locale]/(app)/tutor/tutor-client.tsx` — per-card DropdownMenu with delete option + "Clear all" button in sidebar header + AlertDialog confirmations
- `frontend/lib/tutor-api.ts` — `deleteConversation()` and `deleteAllConversations()` with localStorage cache invalidation
- `frontend/messages/fr.json` + `en.json` — i18n keys for delete UI

## Test plan

- [x] Backend ruff check passes (0 errors)
- [x] Frontend ESLint passes (0 errors)
- [x] Frontend TypeScript check passes (0 errors in app code)
- [x] Python syntax validation passes for all modified files
- [ ] Backend pytest: `cd backend && uv run pytest tests/test_tutor_delete.py`
- [ ] Test DELETE single conversation removes it from DB (user-scoped)
- [ ] Test DELETE all removes all for user only (not other users)
- [ ] Test learner_memory is NOT affected
- [ ] Manually verified delete button on conversation card (hover → ⋮ → Supprimer)
- [ ] Manually verified "Tout effacer" button in sidebar
- [ ] Active conversation deletion resets to welcome screen
- [ ] Mobile viewport: 44×44px touch targets

Closes #365

Generated with [Claude Code](https://claude.ai/code)