### PR TITLE
feat(tutor): file upload in AI tutor chat — images, PDFs, documents

### DIFF
--- a/backend/app/api/v1/schemas/tutor.py
+++ b/backend/app/api/v1/schemas/tutor.py
@@ -7,6 +7,16 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 
 
+class FileUploadResponse(BaseModel):
+    """Response schema for file upload endpoint."""
+
+    file_id: str = Field(..., description="Unique identifier for the uploaded file")
+    original_name: str = Field(..., description="Original filename")
+    mime_type: str = Field(..., description="Detected MIME type")
+    size_bytes: int = Field(..., description="File size in bytes")
+    expires_at: datetime = Field(..., description="When the temp file will be deleted")
+
+
 class TutorMessage(BaseModel):
     """A message in a tutor conversation."""
 
@@ -29,6 +39,7 @@ class TutorChatRequest(BaseModel):
     )
     context_id: UUID | None = Field(None, description="Context-specific ID")
     conversation_id: UUID | None = Field(None, description="Existing conversation ID")
+    file_ids: list[str] = Field(default_factory=list, description="Uploaded file IDs to attach")
 
 
 class TutorChatResponse(BaseModel):

--- a/backend/app/api/v1/tutor.py
+++ b/backend/app/api/v1/tutor.py
@@ -2,11 +2,13 @@
 
 import json
 import uuid
+from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 import structlog
 from anthropic import AsyncAnthropic
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -15,17 +17,21 @@ from app.ai.rag.retriever import SemanticRetriever
 from app.api.deps import get_db_session
 from app.api.deps_local_auth import AuthenticatedUser, get_current_user
 from app.api.v1.schemas.tutor import (
+    FileUploadResponse,
     TutorChatRequest,
     TutorConversationListResponse,
     TutorConversationResponse,
     TutorStatsResponse,
 )
+from app.domain.services.file_processor import FileProcessor
 from app.domain.services.tutor_service import TutorService
 from app.infrastructure.config.settings import get_settings
 
 logger = structlog.get_logger()
 
 router = APIRouter(prefix="/tutor", tags=["tutor"])
+
+_file_upload_counts: dict[str, list[datetime]] = {}
 
 
 async def get_tutor_service() -> TutorService:
@@ -42,6 +48,79 @@ async def get_tutor_service() -> TutorService:
     )
 
 
+def _check_upload_rate_limit(user_id: str, daily_limit: int) -> None:
+    """Check and enforce per-user daily upload rate limit (in-memory, resets at UTC midnight)."""
+    today_start = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    timestamps = _file_upload_counts.get(user_id, [])
+    timestamps = [ts for ts in timestamps if ts >= today_start]
+    _file_upload_counts[user_id] = timestamps
+
+    if len(timestamps) >= daily_limit:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Daily file upload limit reached. Try again tomorrow.",
+        )
+
+    _file_upload_counts[user_id] = timestamps + [datetime.utcnow()]
+
+
+@router.post("/upload", response_model=FileUploadResponse)
+async def upload_file(
+    file: UploadFile = File(...),
+    current_user: AuthenticatedUser = Depends(get_current_user),
+) -> FileUploadResponse:
+    """Upload a file for use in tutor chat (images, PDFs, documents).
+
+    Returns a file_id to include in subsequent chat requests.
+    Files are stored temporarily with a 24h TTL.
+    """
+    settings = get_settings()
+    _check_upload_rate_limit(str(current_user.id), settings.upload_daily_limit)
+
+    data = await file.read()
+    filename = file.filename or "upload"
+    mime_type = file.content_type or "application/octet-stream"
+
+    processor = FileProcessor()
+
+    try:
+        processed = await processor.process(
+            filename=filename,
+            mime_type=mime_type,
+            data=data,
+            user_id=current_user.id,
+        )
+    except ValueError as exc:
+        logger.warning(
+            "File upload rejected",
+            reason=str(exc),
+            filename=filename,
+            mime_type=mime_type,
+            user_id=str(current_user.id),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+
+    logger.info(
+        "File uploaded",
+        file_id=processed.file_id,
+        filename=filename,
+        mime_type=mime_type,
+        size_bytes=processed.size_bytes,
+        user_id=str(current_user.id),
+    )
+
+    return FileUploadResponse(
+        file_id=processed.file_id,
+        original_name=processed.original_name,
+        mime_type=processed.mime_type,
+        size_bytes=processed.size_bytes,
+        expires_at=processed.expires_at,
+    )
+
+
 @router.post("/chat", response_model=None)
 async def chat_with_tutor(
     request: TutorChatRequest,
@@ -53,6 +132,7 @@ async def chat_with_tutor(
     Chat with the AI tutor using Socratic pedagogical approach.
 
     Streams response using Server-Sent Events (SSE).
+    Optionally attach file_ids from previously uploaded files.
     """
     logger.info(
         "Tutor chat request",
@@ -60,7 +140,10 @@ async def chat_with_tutor(
         message_length=len(request.message),
         module_id=str(request.module_id) if request.module_id else None,
         context_type=request.context_type,
+        file_count=len(request.file_ids),
     )
+
+    file_content_blocks = _load_file_content_blocks(request.file_ids, str(current_user.id))
 
     async def stream_tutor_response():
         """Stream the tutor response."""
@@ -73,8 +156,8 @@ async def chat_with_tutor(
                 context_type=request.context_type,
                 context_id=request.context_id,
                 conversation_id=request.conversation_id,
+                file_content_blocks=file_content_blocks,
             ):
-                # Format as SSE
                 yield f"data: {json.dumps(chunk)}\n\n"
 
         except Exception as e:
@@ -93,9 +176,54 @@ async def chat_with_tutor(
         headers={
             "Cache-Control": "no-cache",
             "Connection": "keep-alive",
-            "X-Accel-Buffering": "no",  # Disable nginx buffering
+            "X-Accel-Buffering": "no",
         },
     )
+
+
+def _load_file_content_blocks(file_ids: list[str], user_id: str) -> list[dict[str, Any]]:
+    """Load content blocks for the given file_ids from temp storage."""
+    if not file_ids:
+        return []
+
+    settings = get_settings()
+    temp_dir = Path(settings.upload_temp_dir)
+    processor = FileProcessor()
+    blocks: list[dict[str, Any]] = []
+
+    for file_id in file_ids:
+        matching = list(temp_dir.glob(f"{user_id}_{file_id}.*")) if temp_dir.exists() else []
+        if not matching:
+            logger.warning("File not found for file_id", file_id=file_id, user_id=user_id)
+            continue
+
+        file_path = matching[0]
+        ext = file_path.suffix.lower()
+        mime_map = {
+            ".png": "image/png",
+            ".jpg": "image/jpeg",
+            ".jpeg": "image/jpeg",
+            ".webp": "image/webp",
+            ".gif": "image/gif",
+            ".pdf": "application/pdf",
+            ".csv": "text/csv",
+            ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            ".txt": "text/plain",
+            ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        }
+        mime_type = mime_map.get(ext, "application/octet-stream")
+
+        try:
+            file_blocks = processor.load_content_blocks_from_path(str(file_path), mime_type)
+            blocks.extend(file_blocks)
+        except Exception as e:
+            logger.warning(
+                "Failed to load file content blocks",
+                file_id=file_id,
+                error=str(e),
+            )
+
+    return blocks
 
 
 @router.get("/conversations", response_model=TutorConversationListResponse)

--- a/backend/app/domain/services/file_processor.py
+++ b/backend/app/domain/services/file_processor.py
@@ -1,0 +1,347 @@
+"""File processing service for tutor file uploads.
+
+Handles:
+- Image files: base64 encoding for Claude vision API
+- PDF files: text extraction via PyMuPDF (max 5000 tokens)
+- CSV/XLSX files: summary stats + first N rows via basic parsing
+- TXT/DOCX: plain text extraction
+"""
+
+import base64
+import csv
+import io
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pymupdf
+import structlog
+
+from app.infrastructure.config.settings import get_settings
+
+logger = structlog.get_logger()
+
+DANGEROUS_MAGIC_BYTES: list[tuple[bytes, str]] = [
+    (b"MZ", "pe_executable"),
+    (b"\x7fELF", "elf_executable"),
+    (b"#!/", "shell_script"),
+    (b"#!", "shell_script"),
+]
+
+IMAGE_MIME_TYPES = {"image/png", "image/jpeg", "image/jpg", "image/webp", "image/gif"}
+PDF_MIME_TYPE = "application/pdf"
+CSV_MIME_TYPE = "text/csv"
+XLSX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+TXT_MIME_TYPE = "text/plain"
+DOCX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+
+
+@dataclass
+class ProcessedFile:
+    """Result of processing an uploaded file."""
+
+    file_id: str
+    original_name: str
+    mime_type: str
+    size_bytes: int
+    file_path: str
+    processed_at: datetime
+    expires_at: datetime
+    content_for_claude: list[dict]
+
+
+def _check_magic_bytes(data: bytes) -> None:
+    """Raise ValueError if file starts with known dangerous magic bytes."""
+    for magic, label in DANGEROUS_MAGIC_BYTES:
+        if data.startswith(magic):
+            raise ValueError(f"Rejected file type: {label}")
+
+
+def _extract_pdf_text(data: bytes, max_tokens: int) -> str:
+    """Extract text from a PDF using PyMuPDF, respecting token budget."""
+    doc = pymupdf.open(stream=data, filetype="pdf")
+    texts: list[str] = []
+    char_budget = max_tokens * 4
+
+    try:
+        for page in doc:
+            page_text = page.get_text().strip()
+            if page_text:
+                texts.append(page_text)
+                if sum(len(t) for t in texts) >= char_budget:
+                    break
+    finally:
+        doc.close()
+
+    combined = "\n\n".join(texts)
+    return combined[:char_budget]
+
+
+def _parse_csv_text(data: bytes, max_rows: int) -> str:
+    """Parse CSV data and return a human-readable summary."""
+    text = data.decode("utf-8", errors="replace")
+    reader = csv.reader(io.StringIO(text))
+    rows: list[list[str]] = []
+    for i, row in enumerate(reader):
+        if i > max_rows + 1:
+            break
+        rows.append(row)
+
+    if not rows:
+        return "Empty CSV file."
+
+    header = rows[0] if rows else []
+    data_rows = rows[1 : max_rows + 1]
+    num_cols = len(header)
+    num_rows_total = len(rows) - 1
+
+    lines = [
+        f"CSV file — {num_rows_total} rows, {num_cols} columns",
+        f"Columns: {', '.join(header)}",
+        "",
+        "First rows (sample):",
+    ]
+    for row in data_rows:
+        lines.append("  | ".join(str(v) for v in row))
+
+    return "\n".join(lines)
+
+
+def _extract_docx_text(data: bytes) -> str:
+    """Extract plain text from a DOCX file (basic XML parsing)."""
+    import xml.etree.ElementTree as ET
+    import zipfile
+
+    try:
+        with zipfile.ZipFile(io.BytesIO(data)) as z:
+            if "word/document.xml" not in z.namelist():
+                return "Could not extract text from DOCX."
+            xml_content = z.read("word/document.xml")
+        root = ET.fromstring(xml_content)
+        ns = {"w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main"}
+        paragraphs = root.findall(".//w:p", ns)
+        texts = []
+        for para in paragraphs:
+            runs = para.findall(".//w:t", ns)
+            para_text = "".join(r.text or "" for r in runs).strip()
+            if para_text:
+                texts.append(para_text)
+        return "\n".join(texts)
+    except Exception as e:
+        logger.warning("DOCX extraction failed", error=str(e))
+        return "Could not extract text from DOCX."
+
+
+class FileProcessor:
+    """Processes uploaded files and prepares content blocks for Claude API."""
+
+    def __init__(self) -> None:
+        self.settings = get_settings()
+
+    def prepare_temp_dir(self) -> Path:
+        """Ensure temp upload directory exists."""
+        temp_dir = Path(self.settings.upload_temp_dir)
+        temp_dir.mkdir(parents=True, exist_ok=True)
+        return temp_dir
+
+    def validate_file(self, filename: str, mime_type: str, size_bytes: int, data: bytes) -> None:
+        """Validate file before processing. Raises ValueError on rejection."""
+        allowed = self.settings.upload_allowed_types_list
+        if mime_type not in allowed:
+            raise ValueError(f"File type '{mime_type}' is not allowed.")
+
+        if size_bytes > self.settings.upload_max_size_bytes:
+            max_mb = self.settings.upload_max_size_bytes // (1024 * 1024)
+            raise ValueError(f"File exceeds maximum size of {max_mb}MB.")
+
+        _check_magic_bytes(data)
+
+        ext = Path(filename).suffix.lower()
+        dangerous_extensions = {".exe", ".sh", ".bat", ".py", ".js", ".cmd", ".ps1", ".dll"}
+        if ext in dangerous_extensions:
+            raise ValueError(f"File extension '{ext}' is not allowed.")
+
+    async def process(
+        self, filename: str, mime_type: str, data: bytes, user_id: uuid.UUID
+    ) -> ProcessedFile:
+        """Process an uploaded file: validate, store, prepare Claude content blocks."""
+        size_bytes = len(data)
+        self.validate_file(filename, mime_type, size_bytes, data)
+
+        temp_dir = self.prepare_temp_dir()
+        file_id = str(uuid.uuid4())
+        safe_ext = Path(filename).suffix.lower() or ".bin"
+        file_path = temp_dir / f"{user_id}_{file_id}{safe_ext}"
+        file_path.write_bytes(data)
+
+        now = datetime.utcnow()
+        expires_at = now + timedelta(hours=self.settings.upload_ttl_hours)
+
+        content_blocks = self._build_content_blocks(mime_type, data)
+
+        logger.info(
+            "File processed",
+            file_id=file_id,
+            filename=filename,
+            mime_type=mime_type,
+            size_bytes=size_bytes,
+            user_id=str(user_id),
+        )
+
+        return ProcessedFile(
+            file_id=file_id,
+            original_name=filename,
+            mime_type=mime_type,
+            size_bytes=size_bytes,
+            file_path=str(file_path),
+            processed_at=now,
+            expires_at=expires_at,
+            content_for_claude=content_blocks,
+        )
+
+    def _build_content_blocks(self, mime_type: str, data: bytes) -> list[dict]:
+        """Build Claude API content blocks from raw file data."""
+        if mime_type in IMAGE_MIME_TYPES:
+            return self._image_blocks(mime_type, data)
+        elif mime_type == PDF_MIME_TYPE:
+            return self._pdf_blocks(data)
+        elif mime_type in {CSV_MIME_TYPE, XLSX_MIME_TYPE}:
+            return self._csv_blocks(mime_type, data)
+        elif mime_type == DOCX_MIME_TYPE:
+            return self._docx_blocks(data)
+        else:
+            return self._text_blocks(data)
+
+    def _image_blocks(self, mime_type: str, data: bytes) -> list[dict]:
+        b64 = base64.standard_b64encode(data).decode("ascii")
+        media_map = {
+            "image/jpg": "image/jpeg",
+            "image/jpeg": "image/jpeg",
+            "image/png": "image/png",
+            "image/webp": "image/webp",
+            "image/gif": "image/gif",
+        }
+        media_type = media_map.get(mime_type, "image/jpeg")
+        return [
+            {
+                "type": "image",
+                "source": {"type": "base64", "media_type": media_type, "data": b64},
+            }
+        ]
+
+    def _pdf_blocks(self, data: bytes) -> list[dict]:
+        text = _extract_pdf_text(data, self.settings.upload_max_pdf_tokens)
+        if not text.strip():
+            text = "(PDF contained no extractable text)"
+        return [{"type": "text", "text": f"[PDF content]\n{text}"}]
+
+    def _csv_blocks(self, mime_type: str, data: bytes) -> list[dict]:
+        if mime_type == XLSX_MIME_TYPE:
+            summary = self._parse_xlsx(data)
+        else:
+            summary = _parse_csv_text(data, self.settings.upload_max_csv_rows)
+        return [{"type": "text", "text": f"[Spreadsheet content]\n{summary}"}]
+
+    def _parse_xlsx(self, data: bytes) -> str:
+        """Parse XLSX using zipfile + basic XML (no pandas dependency required)."""
+        import xml.etree.ElementTree as ET
+        import zipfile
+
+        try:
+            with zipfile.ZipFile(io.BytesIO(data)) as z:
+                names = z.namelist()
+                sheet_path = next(
+                    (
+                        n
+                        for n in names
+                        if n.startswith("xl/worksheets/sheet") and n.endswith(".xml")
+                    ),
+                    None,
+                )
+                if not sheet_path:
+                    return "Could not read XLSX sheet."
+
+                shared_strings: list[str] = []
+                if "xl/sharedStrings.xml" in names:
+                    ss_xml = z.read("xl/sharedStrings.xml")
+                    ss_root = ET.fromstring(ss_xml)
+                    ns = {"ns": "http://schemas.openxmlformats.org/spreadsheetml/2006/main"}
+                    for si in ss_root.findall("ns:si", ns):
+                        t_elements = si.findall(".//ns:t", ns)
+                        shared_strings.append("".join(t.text or "" for t in t_elements))
+
+                sheet_xml = z.read(sheet_path)
+                sheet_root = ET.fromstring(sheet_xml)
+                ns2 = {"ns": "http://schemas.openxmlformats.org/spreadsheetml/2006/main"}
+                rows = sheet_root.findall(".//ns:row", ns2)
+                result_rows: list[list[str]] = []
+                for row in rows[: self.settings.upload_max_csv_rows + 1]:
+                    cells = row.findall("ns:c", ns2)
+                    row_vals: list[str] = []
+                    for cell in cells:
+                        t_attr = cell.get("t", "")
+                        v_el = cell.find("ns:v", ns2)
+                        val = v_el.text if v_el is not None else ""
+                        if t_attr == "s" and val is not None:
+                            idx = int(val)
+                            val = shared_strings[idx] if idx < len(shared_strings) else val
+                        row_vals.append(val or "")
+                    result_rows.append(row_vals)
+
+            if not result_rows:
+                return "Empty spreadsheet."
+
+            header = result_rows[0]
+            data_rows = result_rows[1:]
+            lines = [
+                f"XLSX file — {len(data_rows)} rows, {len(header)} columns",
+                f"Columns: {', '.join(header)}",
+                "",
+                "First rows (sample):",
+            ]
+            for row in data_rows[: self.settings.upload_max_csv_rows]:
+                lines.append("  | ".join(row))
+            return "\n".join(lines)
+        except Exception as e:
+            logger.warning("XLSX parse failed", error=str(e))
+            return "Could not parse XLSX file."
+
+    def _docx_blocks(self, data: bytes) -> list[dict]:
+        text = _extract_docx_text(data)
+        max_chars = self.settings.upload_max_pdf_tokens * 4
+        return [{"type": "text", "text": f"[Document content]\n{text[:max_chars]}"}]
+
+    def _text_blocks(self, data: bytes) -> list[dict]:
+        text = data.decode("utf-8", errors="replace")
+        max_chars = self.settings.upload_max_pdf_tokens * 4
+        return [{"type": "text", "text": f"[Text file content]\n{text[:max_chars]}"}]
+
+    def load_content_blocks_from_path(self, file_path: str, mime_type: str) -> list[dict]:
+        """Reload content blocks from a stored temp file."""
+        path = Path(file_path)
+        if not path.exists():
+            raise FileNotFoundError(f"Temp file not found: {file_path}")
+        data = path.read_bytes()
+        return self._build_content_blocks(mime_type, data)
+
+    def cleanup_expired_files(self) -> int:
+        """Delete temp files older than the TTL. Returns count deleted."""
+        temp_dir = Path(self.settings.upload_temp_dir)
+        if not temp_dir.exists():
+            return 0
+
+        cutoff = datetime.utcnow() - timedelta(hours=self.settings.upload_ttl_hours)
+        deleted = 0
+        for f in temp_dir.iterdir():
+            if f.is_file():
+                mtime = datetime.utcfromtimestamp(f.stat().st_mtime)
+                if mtime < cutoff:
+                    try:
+                        f.unlink()
+                        deleted += 1
+                    except Exception as e:
+                        logger.warning("Failed to delete expired upload", path=str(f), error=str(e))
+
+        logger.info("Cleaned up expired uploads", deleted=deleted)
+        return deleted

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -210,6 +210,7 @@ class TutorService:
         context_type: str | None = None,
         context_id: uuid.UUID | None = None,
         conversation_id: uuid.UUID | None = None,
+        file_content_blocks: list[dict[str, Any]] | None = None,
     ) -> AsyncGenerator[dict[str, Any], None]:
         """
         Send a message to the AI tutor and stream the response using agentic tool_use.
@@ -225,6 +226,7 @@ class TutorService:
             context_type: Optional context type ("module", "lesson", "quiz")
             context_id: Optional context-specific ID
             conversation_id: Optional existing conversation ID
+            file_content_blocks: Optional list of Claude API content blocks (images/text) from uploads
 
         Yields:
             Stream chunks with tutor response data
@@ -296,8 +298,14 @@ class TutorService:
                 "role": "user",
                 "content": message,
                 "timestamp": datetime.utcnow().isoformat(),
+                "has_files": bool(file_content_blocks),
             }
-            conversation_history.append({"role": "user", "content": message})
+
+            if file_content_blocks:
+                user_content: list[Any] = [*file_content_blocks, {"type": "text", "text": message}]
+                conversation_history.append({"role": "user", "content": user_content})
+            else:
+                conversation_history.append({"role": "user", "content": message})
 
             tool_executor = TutorToolExecutor(
                 retriever=self.retriever,

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -43,9 +43,28 @@ class Settings(BaseSettings):
     cors_origins: str = "http://localhost:3000"
     api_v1_prefix: str = "/api/v1"
 
+    # File upload settings
+    upload_temp_dir: str = "/tmp/santepublique_uploads"
+    upload_max_size_bytes: int = 10 * 1024 * 1024  # 10MB
+    upload_ttl_hours: int = 24
+    upload_daily_limit: int = 10
+    upload_allowed_types: str = (
+        "image/png,image/jpeg,image/jpg,image/webp,image/gif,"
+        "application/pdf,text/csv,"
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,"
+        "text/plain,"
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    )
+    upload_max_pdf_tokens: int = 5000
+    upload_max_csv_rows: int = 20
+
     @property
     def cors_origins_list(self) -> list[str]:
         return [o.strip() for o in self.cors_origins.split(",") if o.strip()]
+
+    @property
+    def upload_allowed_types_list(self) -> list[str]:
+        return [t.strip() for t in self.upload_allowed_types.split(",") if t.strip()]
 
 
 settings = Settings()

--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -15,6 +15,7 @@ celery_app = Celery(
     include=[
         "app.tasks.content_generation",
         "app.tasks.data_etl",
+        "app.tasks.file_cleanup",
     ],
 )
 
@@ -51,6 +52,10 @@ celery_app.conf.beat_schedule = {
     "cleanup-expired-cache": {
         "task": "app.tasks.data_etl.cleanup_expired_cache",
         "schedule": 3600 * 6,  # Every 6 hours
+    },
+    "cleanup-expired-uploads": {
+        "task": "app.tasks.file_cleanup.cleanup_expired_uploads",
+        "schedule": 3600,  # Every hour
     },
 }
 

--- a/backend/app/tasks/file_cleanup.py
+++ b/backend/app/tasks/file_cleanup.py
@@ -1,0 +1,21 @@
+"""Celery task for cleaning up expired tutor file uploads."""
+
+import structlog
+
+from app.domain.services.file_processor import FileProcessor
+from app.tasks.celery_app import celery_app
+
+logger = structlog.get_logger(__name__)
+
+
+@celery_app.task(name="app.tasks.file_cleanup.cleanup_expired_uploads", bind=True, max_retries=3)
+def cleanup_expired_uploads(self) -> dict[str, int]:
+    """Delete temp upload files older than the configured TTL (default 24h)."""
+    try:
+        processor = FileProcessor()
+        deleted = processor.cleanup_expired_files()
+        logger.info("File cleanup task completed", deleted=deleted)
+        return {"deleted": deleted}
+    except Exception as exc:
+        logger.error("File cleanup task failed", error=str(exc))
+        raise self.retry(exc=exc, countdown=300) from exc

--- a/backend/tests/test_file_upload.py
+++ b/backend/tests/test_file_upload.py
@@ -1,0 +1,218 @@
+"""Tests for file upload endpoint and file processor service."""
+
+import io
+import os
+import struct
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.domain.services.file_processor import FileProcessor, _extract_pdf_text, _parse_csv_text
+from app.infrastructure.config.settings import get_settings
+
+
+class TestFileProcessor:
+    """Unit tests for FileProcessor."""
+
+    def setup_method(self):
+        self.processor = FileProcessor()
+
+    def _make_tiny_png(self) -> bytes:
+        """Return a minimal valid 1x1 PNG."""
+        return (
+            b"\x89PNG\r\n\x1a\n"
+            b"\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde"
+            b"\x00\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00\x05\x18\xd8N"
+            b"\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
+
+    def test_validate_accepts_valid_png(self):
+        data = self._make_tiny_png()
+        self.processor.validate_file("test.png", "image/png", len(data), data)
+
+    def test_validate_rejects_oversized_file(self):
+        large_data = b"x" * (11 * 1024 * 1024)
+        with pytest.raises(ValueError, match="exceeds maximum size"):
+            self.processor.validate_file("big.png", "image/png", len(large_data), large_data)
+
+    def test_validate_rejects_disallowed_mime_type(self):
+        data = b"fake"
+        with pytest.raises(ValueError, match="not allowed"):
+            self.processor.validate_file("script.py", "text/x-python", len(data), data)
+
+    def test_validate_rejects_executable_extension(self):
+        data = b"fake binary"
+        with pytest.raises(ValueError, match="not allowed"):
+            self.processor.validate_file("malware.exe", "image/png", len(data), data)
+
+    def test_validate_rejects_pe_magic_bytes(self):
+        data = b"MZ\x90\x00" + b"\x00" * 100
+        with pytest.raises(ValueError, match="pe_executable"):
+            self.processor.validate_file("bad.png", "image/png", len(data), data)
+
+    def test_validate_rejects_elf_magic_bytes(self):
+        data = b"\x7fELF" + b"\x00" * 100
+        with pytest.raises(ValueError, match="elf_executable"):
+            self.processor.validate_file("bad.png", "image/png", len(data), data)
+
+    def test_validate_rejects_shell_script(self):
+        data = b"#!/bin/bash\necho hi"
+        with pytest.raises(ValueError, match="shell_script"):
+            self.processor.validate_file("script.png", "image/png", len(data), data)
+
+    def test_parse_csv_returns_summary(self):
+        csv_data = b"country,cases,deaths\nSenegal,100,5\nGhana,200,8\n"
+        result = _parse_csv_text(csv_data, 20)
+        assert "country" in result
+        assert "cases" in result
+        assert "Senegal" in result
+
+    def test_image_blocks_contain_base64(self):
+        data = self._make_tiny_png()
+        blocks = self.processor._image_blocks("image/png", data)
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "image"
+        assert blocks[0]["source"]["type"] == "base64"
+        assert blocks[0]["source"]["media_type"] == "image/png"
+        assert len(blocks[0]["source"]["data"]) > 0
+
+    def test_text_blocks_contain_content(self):
+        data = b"Hello world text content"
+        blocks = self.processor._text_blocks(data)
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "text"
+        assert "Hello world" in blocks[0]["text"]
+
+    def test_csv_blocks_contain_content(self):
+        csv_data = b"col1,col2\nval1,val2\n"
+        blocks = self.processor._csv_blocks("text/csv", csv_data)
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "text"
+        assert "col1" in blocks[0]["text"]
+
+    async def test_process_stores_file_and_returns_metadata(self, tmp_path):
+        with patch.object(self.processor, "prepare_temp_dir", return_value=tmp_path):
+            data = self._make_tiny_png()
+            user_id = uuid.uuid4()
+            result = await self.processor.process("photo.png", "image/png", data, user_id)
+
+        assert result.file_id
+        assert result.original_name == "photo.png"
+        assert result.mime_type == "image/png"
+        assert result.size_bytes == len(data)
+        assert result.content_for_claude
+        assert Path(result.file_path).exists()
+
+    def test_cleanup_expired_files_deletes_old_files(self, tmp_path):
+        with patch.object(self.processor.settings, "upload_temp_dir", str(tmp_path)):
+            old_file = tmp_path / "old_upload.png"
+            old_file.write_bytes(b"old")
+            import time
+            old_time = time.time() - (25 * 3600)
+            os.utime(old_file, (old_time, old_time))
+
+            new_file = tmp_path / "new_upload.png"
+            new_file.write_bytes(b"new")
+
+            deleted = self.processor.cleanup_expired_files()
+
+        assert deleted == 1
+        assert not old_file.exists()
+        assert new_file.exists()
+
+
+class TestFileUploadEndpoint:
+    """Integration-style tests for the upload endpoint."""
+
+    async def test_upload_accepts_valid_png(self, client, auth_headers):
+        png_data = (
+            b"\x89PNG\r\n\x1a\n"
+            b"\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde"
+            b"\x00\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00\x05\x18\xd8N"
+            b"\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
+        response = await client.post(
+            "/api/v1/tutor/upload",
+            headers=auth_headers,
+            files={"file": ("test.png", io.BytesIO(png_data), "image/png")},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "file_id" in data
+        assert data["mime_type"] == "image/png"
+        assert data["original_name"] == "test.png"
+
+    async def test_upload_rejects_oversized_file(self, client, auth_headers):
+        large_data = b"x" * (11 * 1024 * 1024)
+        response = await client.post(
+            "/api/v1/tutor/upload",
+            headers=auth_headers,
+            files={"file": ("big.png", io.BytesIO(large_data), "image/png")},
+        )
+        assert response.status_code == 422
+
+    async def test_upload_rejects_executable_file(self, client, auth_headers):
+        exe_data = b"MZ\x90\x00" + b"\x00" * 100
+        response = await client.post(
+            "/api/v1/tutor/upload",
+            headers=auth_headers,
+            files={"file": ("malware.exe", io.BytesIO(exe_data), "application/octet-stream")},
+        )
+        assert response.status_code in (422, 400)
+
+    async def test_upload_requires_auth(self, client):
+        response = await client.post(
+            "/api/v1/tutor/upload",
+            files={"file": ("test.png", io.BytesIO(b"data"), "image/png")},
+        )
+        assert response.status_code == 401
+
+    async def test_pdf_text_extraction_returns_content(self, tmp_path):
+        settings = get_settings()
+        pdf_bytes = _create_minimal_pdf()
+        result = _extract_pdf_text(pdf_bytes, settings.upload_max_pdf_tokens)
+        assert isinstance(result, str)
+
+    async def test_file_ids_included_in_chat(self, client, auth_headers):
+        request_body = {
+            "message": "Analyse this file",
+            "file_ids": ["non-existent-id"],
+        }
+        with patch("app.domain.services.tutor_service.TutorService.send_message") as mock_send:
+            async def _fake_stream(*args, **kwargs):
+                yield {"type": "content", "data": {"text": "ok"}}
+                yield {"type": "finished", "data": {"remaining_messages": 49}, "finished": True}
+
+            mock_send.return_value = _fake_stream()
+            response = await client.post(
+                "/api/v1/tutor/chat",
+                headers=auth_headers,
+                json=request_body,
+            )
+        assert response.status_code == 200
+
+
+def _create_minimal_pdf() -> bytes:
+    """Create a minimal valid PDF with some text for testing extraction."""
+    return b"""%PDF-1.4
+1 0 obj<</Type /Catalog /Pages 2 0 R>>endobj
+2 0 obj<</Type /Pages /Kids [3 0 R] /Count 1>>endobj
+3 0 obj<</Type /Page /MediaBox [0 0 612 792] /Parent 2 0 R /Contents 4 0 R /Resources<</Font<</F1<</Type /Font /Subtype /Type1 /BaseFont /Helvetica>>>>>>>>endobj
+4 0 obj<</Length 44>>
+stream
+BT /F1 12 Tf 100 700 Td (Test PDF content) Tj ET
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f
+0000000009 00000 n
+0000000058 00000 n
+0000000115 00000 n
+0000000317 00000 n
+trailer<</Size 5 /Root 1 0 R>>
+startxref
+413
+%%EOF"""

--- a/frontend/components/chat/chat-input.tsx
+++ b/frontend/components/chat/chat-input.tsx
@@ -1,31 +1,70 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
-import { Send } from 'lucide-react';
+import { Send, Paperclip } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { uploadTutorFile } from '@/lib/tutor-api';
+import { FilePreview, type PendingFile } from '@/components/chat/file-preview';
+
+const ACCEPTED_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/jpg',
+  'image/webp',
+  'image/gif',
+  'application/pdf',
+  'text/csv',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'text/plain',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+].join(',');
+
+const MAX_SIZE_BYTES = 10 * 1024 * 1024;
+
+export interface AttachedFileInfo {
+  fileId: string;
+  name: string;
+  mimeType: string;
+  sizeBytes: number;
+}
 
 interface ChatInputProps {
-  onSendMessage: (message: string) => void;
+  onSendMessage: (message: string, attachedFiles: AttachedFileInfo[]) => void;
   disabled?: boolean;
   placeholder?: string;
+}
+
+function generateLocalId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
 export function ChatInput({ onSendMessage, disabled = false, placeholder }: ChatInputProps) {
   const t = useTranslations('ChatTutor');
   const [message, setMessage] = useState('');
+  const [pendingFiles, setPendingFiles] = useState<PendingFile[]>([]);
+  const [isDragging, setIsDragging] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const actualPlaceholder = placeholder || t('placeholder');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const trimmedMessage = message.trim();
-    if (trimmedMessage && !disabled) {
-      onSendMessage(trimmedMessage);
+    const readyFiles = pendingFiles.filter((f) => f.fileId && !f.error);
+
+    if ((trimmedMessage || readyFiles.length > 0) && !disabled) {
+      const attachedFiles: AttachedFileInfo[] = readyFiles.map((f) => ({
+        fileId: f.fileId!,
+        name: f.file.name,
+        mimeType: f.file.type,
+        sizeBytes: f.file.size,
+      }));
+      onSendMessage(trimmedMessage || ' ', attachedFiles);
       setMessage('');
-      // Reset textarea height
+      setPendingFiles([]);
       if (textareaRef.current) {
         textareaRef.current.style.height = 'auto';
       }
@@ -39,49 +78,192 @@ export function ChatInput({ onSendMessage, disabled = false, placeholder }: Chat
     }
   };
 
-  // Auto-resize textarea
   useEffect(() => {
     const textarea = textareaRef.current;
     if (textarea) {
       textarea.style.height = 'auto';
-      const newHeight = Math.min(textarea.scrollHeight, 120); // Max 5 lines
+      const newHeight = Math.min(textarea.scrollHeight, 120);
       textarea.style.height = `${newHeight}px`;
     }
   }, [message]);
 
+  const processFile = useCallback(
+    async (file: File) => {
+      const localId = generateLocalId();
+      let previewUrl: string | undefined;
+
+      if (file.type.startsWith('image/')) {
+        previewUrl = URL.createObjectURL(file);
+      }
+
+      let errorMsg: string | undefined;
+      if (file.size > MAX_SIZE_BYTES) {
+        errorMsg = t('fileUpload.tooLarge');
+      } else if (!ACCEPTED_TYPES.includes(file.type)) {
+        errorMsg = t('fileUpload.unsupportedType');
+      }
+
+      const newFile: PendingFile = {
+        localId,
+        file,
+        previewUrl,
+        uploading: !errorMsg,
+        progress: 0,
+        error: errorMsg,
+      };
+
+      setPendingFiles((prev) => [...prev, newFile]);
+
+      if (errorMsg) return;
+
+      try {
+        const result = await uploadTutorFile(file, (percent) => {
+          setPendingFiles((prev) =>
+            prev.map((f) => (f.localId === localId ? { ...f, progress: percent } : f))
+          );
+        });
+
+        setPendingFiles((prev) =>
+          prev.map((f) =>
+            f.localId === localId ? { ...f, uploading: false, progress: 100, fileId: result.file_id } : f
+          )
+        );
+      } catch (err) {
+        const isDailyLimit = err instanceof Error && err.message === 'DAILY_LIMIT_REACHED';
+        setPendingFiles((prev) =>
+          prev.map((f) =>
+            f.localId === localId
+              ? {
+                  ...f,
+                  uploading: false,
+                  error: isDailyLimit ? t('fileUpload.dailyLimitReached') : t('fileUpload.uploadFailed'),
+                }
+              : f
+          )
+        );
+      }
+    },
+    [t]
+  );
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files) return;
+    Array.from(files).forEach(processFile);
+    e.target.value = '';
+  };
+
+  const handleRemoveFile = (localId: string) => {
+    setPendingFiles((prev) => {
+      const removed = prev.find((f) => f.localId === localId);
+      if (removed?.previewUrl) URL.revokeObjectURL(removed.previewUrl);
+      return prev.filter((f) => f.localId !== localId);
+    });
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+    const files = e.dataTransfer.files;
+    if (!files) return;
+    Array.from(files).forEach(processFile);
+  };
+
+  const hasReadyFiles = pendingFiles.some((f) => f.fileId && !f.error);
+  const isUploading = pendingFiles.some((f) => f.uploading);
+  const canSend = (message.trim() || hasReadyFiles) && !disabled && !isUploading;
+
   return (
-    <form onSubmit={handleSubmit} className="flex items-end gap-2 p-4 border-t bg-background">
-      <div className="flex-1 relative">
-        <textarea
-          ref={textareaRef}
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder={actualPlaceholder}
-          disabled={disabled}
-          rows={1}
-          className={cn(
-            'w-full resize-none rounded-md border border-input px-3 py-2',
-            'text-sm bg-background placeholder:text-muted-foreground',
-            'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
-            'min-h-[44px] max-h-[120px]', // Ensure minimum touch target
-            disabled && 'opacity-50 cursor-not-allowed'
-          )}
-          style={{
-            lineHeight: '1.4',
-            fontSize: '16px' // Prevent iOS zoom
-          }}
+    <div
+      className={cn(
+        'border-t bg-background transition-colors',
+        isDragging && 'bg-primary/5 border-primary'
+      )}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      {isDragging && (
+        <div className="flex items-center justify-center py-3 text-sm text-primary font-medium">
+          {t('fileUpload.dragDrop')}
+        </div>
+      )}
+
+      {pendingFiles.length > 0 && (
+        <div className="flex flex-col gap-1.5 px-4 pt-3">
+          {pendingFiles.map((pf) => (
+            <FilePreview key={pf.localId} pendingFile={pf} onRemove={handleRemoveFile} />
+          ))}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="flex items-end gap-2 p-4">
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={ACCEPTED_TYPES}
+          multiple
+          onChange={handleFileChange}
+          className="sr-only"
+          aria-hidden="true"
+          capture="environment"
         />
-      </div>
-      <Button
-        type="submit"
-        size="icon"
-        disabled={disabled || !message.trim()}
-        className="min-h-[44px] min-w-[44px] shrink-0"
-        aria-label={t('send')}
-      >
-        <Send className="h-4 w-4" />
-      </Button>
-    </form>
+
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="min-h-[44px] min-w-[44px] shrink-0"
+          aria-label={t('fileUpload.attachAriaLabel')}
+          disabled={disabled}
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <Paperclip className="h-4 w-4" />
+        </Button>
+
+        <div className="flex-1 relative">
+          <textarea
+            ref={textareaRef}
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={actualPlaceholder}
+            disabled={disabled}
+            rows={1}
+            className={cn(
+              'w-full resize-none rounded-md border border-input px-3 py-2',
+              'text-sm bg-background placeholder:text-muted-foreground',
+              'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+              'min-h-[44px] max-h-[120px]',
+              disabled && 'opacity-50 cursor-not-allowed'
+            )}
+            style={{
+              lineHeight: '1.4',
+              fontSize: '16px',
+            }}
+          />
+        </div>
+
+        <Button
+          type="submit"
+          size="icon"
+          disabled={!canSend}
+          className="min-h-[44px] min-w-[44px] shrink-0"
+          aria-label={t('send')}
+        >
+          <Send className="h-4 w-4" />
+        </Button>
+      </form>
+    </div>
   );
 }

--- a/frontend/components/chat/chat-message.tsx
+++ b/frontend/components/chat/chat-message.tsx
@@ -4,11 +4,19 @@ import { useTranslations } from 'next-intl';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { cn } from '@/lib/utils';
+import { AttachedFileCard } from '@/components/chat/file-preview';
 
 export interface ChatSource {
   title: string;
   chapter?: number;
   page?: number;
+}
+
+export interface AttachedFileInfo {
+  fileId: string;
+  name: string;
+  mimeType: string;
+  sizeBytes: number;
 }
 
 export interface ChatMessage {
@@ -18,6 +26,7 @@ export interface ChatMessage {
   timestamp: Date;
   sources?: ChatSource[];
   isStreaming?: boolean;
+  attachedFiles?: AttachedFileInfo[];
 }
 
 interface ChatMessageProps {
@@ -26,6 +35,7 @@ interface ChatMessageProps {
 
 export function ChatMessage({ message }: ChatMessageProps) {
   const t = useTranslations('ChatTutor');
+  const hasFiles = message.attachedFiles && message.attachedFiles.length > 0;
 
   return (
     <div
@@ -42,11 +52,37 @@ export function ChatMessage({ message }: ChatMessageProps) {
             : 'bg-muted mr-4'
         )}
       >
-        {/* Message content */}
+        {hasFiles && (
+          <div className="flex flex-wrap gap-1.5 mb-2">
+            {message.attachedFiles!.map((f) => (
+              <AttachedFileCard
+                key={f.fileId}
+                name={f.name}
+                mimeType={f.mimeType}
+                sizeBytes={f.sizeBytes}
+              />
+            ))}
+          </div>
+        )}
+
+        {hasFiles && message.isUser && message.attachedFiles!.some((f) => f.mimeType.startsWith('image/')) && (
+          <div className="flex flex-wrap gap-1.5 mb-2">
+            {message.attachedFiles!
+              .filter((f) => f.mimeType.startsWith('image/'))
+              .map((f) => (
+                <div key={f.fileId} className="text-xs text-primary-foreground/70 italic">
+                  🖼 {f.name}
+                </div>
+              ))}
+          </div>
+        )}
+
         <div className="text-sm leading-relaxed">
           {message.isUser ? (
             <>
-              {message.content}
+              {message.content.trim() && message.content.trim() !== ' ' && (
+                <span>{message.content}</span>
+              )}
               {message.isStreaming && (
                 <span className="inline-block w-2 h-4 ml-1 bg-current animate-pulse" />
               )}
@@ -63,7 +99,6 @@ export function ChatMessage({ message }: ChatMessageProps) {
           )}
         </div>
 
-        {/* Sources */}
         {message.sources && message.sources.length > 0 && (
           <div className="mt-2 pt-2 border-t border-current/20">
             <div className="text-xs font-medium opacity-75 mb-1">
@@ -75,7 +110,6 @@ export function ChatMessage({ message }: ChatMessageProps) {
                   key={index}
                   className="text-xs px-2 py-1 rounded-md bg-current/10 hover:bg-current/20 transition-colors"
                   onClick={() => {
-                    // TODO: Navigate to source material
                     console.log('Navigate to source:', source);
                   }}
                 >
@@ -88,7 +122,6 @@ export function ChatMessage({ message }: ChatMessageProps) {
           </div>
         )}
 
-        {/* Timestamp */}
         <div
           className={cn(
             'text-xs opacity-60 mt-1',

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -140,7 +140,7 @@ export function ChatPanel({
     }
   }, [messages, isTyping]);
 
-  const handleSendMessage = async (messageContent: string) => {
+  const handleSendMessage = async (messageContent: string, attachedFiles: import('./chat-input').AttachedFileInfo[] = []) => {
     if (isLimitReached || isLoading) return;
 
     const userMessage: ChatMessage = {
@@ -148,6 +148,7 @@ export function ChatPanel({
       content: messageContent,
       isUser: true,
       timestamp: new Date(),
+      attachedFiles: attachedFiles.length > 0 ? attachedFiles : undefined,
     };
 
     setMessages((prev) => [...prev, userMessage]);
@@ -177,6 +178,7 @@ export function ChatPanel({
           message: messageContent,
           conversation_id: activeConversationId ?? null,
           module_id: moduleId ?? null,
+          file_ids: attachedFiles.map((f) => f.fileId),
         }),
       });
 
@@ -285,7 +287,7 @@ export function ChatPanel({
 
   const handleSuggestionClick = (suggestion: string) => {
     if (!isLimitReached && !isLoading) {
-      handleSendMessage(suggestion);
+      handleSendMessage(suggestion, []);
     }
   };
 

--- a/frontend/components/chat/file-preview.tsx
+++ b/frontend/components/chat/file-preview.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { X, FileText, FileSpreadsheet, File } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export interface PendingFile {
+  localId: string;
+  file: File;
+  previewUrl?: string;
+  uploading: boolean;
+  progress: number;
+  error?: string;
+  fileId?: string;
+}
+
+interface FilePreviewProps {
+  pendingFile: PendingFile;
+  onRemove: (localId: string) => void;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function FileIcon({ mimeType, className }: { mimeType: string; className?: string }) {
+  if (mimeType.startsWith('image/')) return null;
+  if (mimeType === 'application/pdf') return <FileText className={className} />;
+  if (
+    mimeType === 'text/csv' ||
+    mimeType === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  ) {
+    return <FileSpreadsheet className={className} />;
+  }
+  return <File className={className} />;
+}
+
+export function FilePreview({ pendingFile, onRemove }: FilePreviewProps) {
+  const t = useTranslations('ChatTutor');
+  const isImage = pendingFile.file.type.startsWith('image/');
+  const sizeLabel = formatBytes(pendingFile.file.size);
+
+  return (
+    <div
+      className={cn(
+        'relative flex items-center gap-2 rounded-lg border bg-muted/50 p-2',
+        'min-h-[56px]',
+        pendingFile.error && 'border-destructive/50 bg-destructive/5'
+      )}
+    >
+      {isImage && pendingFile.previewUrl ? (
+        <img
+          src={pendingFile.previewUrl}
+          alt={pendingFile.file.name}
+          className="h-12 w-12 rounded object-cover shrink-0"
+        />
+      ) : (
+        <div className="flex h-12 w-12 items-center justify-center rounded bg-muted shrink-0">
+          <FileIcon mimeType={pendingFile.file.type} className="h-6 w-6 text-muted-foreground" />
+        </div>
+      )}
+
+      <div className="flex-1 min-w-0">
+        <p className="truncate text-sm font-medium leading-tight">{pendingFile.file.name}</p>
+        <p className="text-xs text-muted-foreground">{sizeLabel}</p>
+
+        {pendingFile.uploading && (
+          <div className="mt-1 h-1 w-full overflow-hidden rounded-full bg-muted">
+            <div
+              className="h-full bg-primary transition-all duration-200"
+              style={{ width: `${pendingFile.progress}%` }}
+            />
+          </div>
+        )}
+
+        {pendingFile.error && (
+          <p className="text-xs text-destructive mt-0.5">{pendingFile.error}</p>
+        )}
+
+        {pendingFile.uploading && (
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {t('fileUpload.uploadProgress', { percent: pendingFile.progress })}
+          </p>
+        )}
+      </div>
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 shrink-0 rounded-full"
+        onClick={() => onRemove(pendingFile.localId)}
+        aria-label={t('fileUpload.remove')}
+        disabled={pendingFile.uploading}
+      >
+        <X className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}
+
+interface AttachedFileCardProps {
+  name: string;
+  mimeType: string;
+  sizeBytes: number;
+}
+
+export function AttachedFileCard({ name, mimeType, sizeBytes }: AttachedFileCardProps) {
+  const isImage = mimeType.startsWith('image/');
+  const sizeLabel = formatBytes(sizeBytes);
+
+  return (
+    <div className="flex items-center gap-2 rounded-md border bg-muted/30 px-2 py-1.5 text-xs">
+      {isImage ? (
+        <span className="text-base">🖼</span>
+      ) : (
+        <FileIcon mimeType={mimeType} className="h-3.5 w-3.5 text-muted-foreground" />
+      )}
+      <span className="truncate font-medium max-w-[120px]">{name}</span>
+      <span className="text-muted-foreground shrink-0">{sizeLabel}</span>
+    </div>
+  );
+}

--- a/frontend/lib/tutor-api.ts
+++ b/frontend/lib/tutor-api.ts
@@ -4,6 +4,57 @@ import { authClient } from '@/lib/auth';
 
 export const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
+export interface UploadedFile {
+  file_id: string;
+  original_name: string;
+  mime_type: string;
+  size_bytes: number;
+  expires_at: string;
+}
+
+export async function uploadTutorFile(
+  file: File,
+  onProgress?: (percent: number) => void
+): Promise<UploadedFile> {
+  const token = await authClient.getValidToken();
+  const formData = new FormData();
+  formData.append('file', file);
+
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', `${API_BASE}/api/v1/tutor/upload`);
+    xhr.setRequestHeader('Authorization', `Bearer ${token}`);
+
+    xhr.upload.onprogress = (event) => {
+      if (event.lengthComputable && onProgress) {
+        onProgress(Math.round((event.loaded / event.total) * 100));
+      }
+    };
+
+    xhr.onload = () => {
+      if (xhr.status === 200) {
+        try {
+          resolve(JSON.parse(xhr.responseText) as UploadedFile);
+        } catch {
+          reject(new Error('Invalid response from server'));
+        }
+      } else if (xhr.status === 429) {
+        reject(new Error('DAILY_LIMIT_REACHED'));
+      } else {
+        try {
+          const err = JSON.parse(xhr.responseText);
+          reject(new Error(err.detail || 'Upload failed'));
+        } catch {
+          reject(new Error(`Upload failed: ${xhr.status}`));
+        }
+      }
+    };
+
+    xhr.onerror = () => reject(new Error('Network error during upload'));
+    xhr.send(formData);
+  });
+}
+
 const CACHE_KEY_CONVERSATIONS = 'tutor_conversations_cache';
 const CACHE_KEY_PREFIX_CONVERSATION = 'tutor_conversation_';
 const CACHE_TTL_MS = 5 * 60 * 1000;

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -326,7 +326,22 @@
     "selectConversationDescription": "Choose a conversation from the sidebar or start a new one",
     "messageCount": "{count} {count, plural, one {message} other {messages}}",
     "cancel": "Cancel",
-    "newConversationTitle": "New Conversation"
+    "newConversationTitle": "New Conversation",
+    "fileUpload": {
+      "attach": "Attach a file",
+      "attachAriaLabel": "Attach a file",
+      "remove": "Remove file",
+      "uploading": "Uploading...",
+      "uploadProgress": "{percent}%",
+      "tooLarge": "File too large (max 10 MB)",
+      "unsupportedType": "Unsupported file type",
+      "uploadFailed": "File upload failed",
+      "dailyLimitReached": "Daily upload limit reached (10 files/day)",
+      "dragDrop": "Drag and drop a file here",
+      "fileCard": "{name} ({size})",
+      "captureCamera": "Take a photo",
+      "acceptedTypes": "Images, PDF, CSV, XLSX, TXT, DOCX (max 10 MB)"
+    }
   },
   "Flashcards": {
     "title": "Flashcards",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -326,7 +326,22 @@
     "selectConversationDescription": "Choisissez une conversation dans la barre latérale ou commencez-en une nouvelle",
     "messageCount": "{count} {count, plural, one {message} other {messages}}",
     "cancel": "Annuler",
-    "newConversationTitle": "Nouvelle Conversation"
+    "newConversationTitle": "Nouvelle Conversation",
+    "fileUpload": {
+      "attach": "Joindre un fichier",
+      "attachAriaLabel": "Joindre un fichier",
+      "remove": "Supprimer le fichier",
+      "uploading": "Envoi en cours...",
+      "uploadProgress": "{percent}%",
+      "tooLarge": "Fichier trop volumineux (max 10 Mo)",
+      "unsupportedType": "Type de fichier non pris en charge",
+      "uploadFailed": "Échec de l'envoi du fichier",
+      "dailyLimitReached": "Limite de téléchargement quotidienne atteinte (10 fichiers/jour)",
+      "dragDrop": "Glissez-déposez un fichier ici",
+      "fileCard": "{name} ({size})",
+      "captureCamera": "Prendre une photo",
+      "acceptedTypes": "Images, PDF, CSV, XLSX, TXT, DOCX (max 10 Mo)"
+    }
   },
   "Flashcards": {
     "title": "Flashcards",


### PR DESCRIPTION
## Summary

Implements file upload support for the tutor AI chat (issue #370), allowing learners to attach images, PDFs, and spreadsheets directly in the chat interface. Files are processed server-side and passed as Claude API content blocks.

## Changes

**Backend:**
- `backend/app/domain/services/file_processor.py` — new service: validates uploads, extracts PDF text (PyMuPDF), parses CSV/XLSX, base64-encodes images for Claude vision API, 24h TTL cleanup
- `backend/app/api/v1/tutor.py` — `POST /api/v1/tutor/upload` endpoint (multipart/form-data), rate limit 10/day/user; chat endpoint updated to accept `file_ids` and attach content blocks to Claude API call
- `backend/app/api/v1/schemas/tutor.py` — `FileUploadResponse` schema; `TutorChatRequest.file_ids` field added
- `backend/app/domain/services/tutor_service.py` — `send_message()` accepts `file_content_blocks` and passes them as Claude multimodal content
- `backend/app/infrastructure/config/settings.py` — upload limits (10MB, 24h TTL, 10/day), allowed MIME types, temp dir
- `backend/app/tasks/celery_app.py` + `backend/app/tasks/file_cleanup.py` — hourly Celery beat task deletes expired uploads
- `backend/tests/test_file_upload.py` — 13 unit/integration tests covering valid PNG, oversized file, executable rejection, magic byte check, CSV parsing, image base64 blocks, 24h cleanup

**Frontend:**
- `frontend/components/chat/file-preview.tsx` — new: `FilePreview` (upload progress, error states, remove button) and `AttachedFileCard` (inline chip in sent messages)
- `frontend/components/chat/chat-input.tsx` — paperclip button, native file picker (images capture), drag-and-drop, per-file upload with XHR progress, client-side validation
- `frontend/components/chat/chat-message.tsx` — renders attached file cards on sent messages
- `frontend/components/chat/chat-panel.tsx` — `handleSendMessage` updated to pass `attachedFiles` and `file_ids` to API
- `frontend/lib/tutor-api.ts` — `uploadTutorFile()` with XHR progress callback
- `frontend/messages/fr.json` + `en.json` — file upload i18n strings

## Test plan

- [x] Backend pytest: 13 tests pass (`test_file_upload.py::TestFileProcessor`)
- [x] Frontend lint: `npm run lint` → 0 errors
- [x] Test upload accepts valid PNG
- [x] Test upload rejects oversized file (>10MB)
- [x] Test upload rejects executable files (PE magic bytes, ELF, shell scripts, .exe extension)
- [x] Test CSV parsing returns summary + rows
- [x] Test image blocks contain base64
- [x] Test 24h cleanup deletes expired files
- [x] i18n: all strings in FR and EN
- [ ] Manually verify attachment button accessible on mobile viewport (requires running instance)

Closes #370

Generated with [Claude Code](https://claude.ai/code)