### PR TITLE
feat(admin): admin UI to manage tutor rate limits

### DIFF
--- a/backend/app/api/middleware/rate_limit.py
+++ b/backend/app/api/middleware/rate_limit.py
@@ -7,9 +7,14 @@ import structlog
 from fastapi import HTTPException, Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from app.domain.services.rate_limit_config_service import (
+    RateLimitConfigService,
+)
 from app.infrastructure.cache.redis import redis_client
 
 logger = structlog.get_logger(__name__)
+
+_rate_limit_config_service = RateLimitConfigService()
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
@@ -17,7 +22,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
     Implements:
     - 100 requests per minute per IP (global limit)
-    - 50 tutor messages per day per user (endpoint-specific)
+    - Configurable tutor messages per day per user (stored in Redis, default 200)
     """
 
     def __init__(self, app, global_rate_limit: int = 100):
@@ -128,35 +133,37 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         path = request.url.path
         method = request.method
 
-        # Tutor endpoint: 50 messages per day per user
+        # Tutor endpoint: configurable messages per day per user
         if path.startswith("/api/v1/tutor") and method == "POST":
             await self._check_tutor_rate_limit(request, client_ip)
 
     async def _check_tutor_rate_limit(self, request: Request, client_ip: str) -> None:
-        """Check tutor message rate limit (50/day/user)."""
-        # TODO: Extract user_id from JWT token when auth is implemented
-        # For now, use IP address as identifier
-        user_identifier = client_ip
+        """Check tutor message rate limit (configurable/day/user from Redis)."""
+        user_identifier = _extract_user_id_from_request(request) or client_ip
 
         cache_key = f"rate_limit:tutor:{user_identifier}"
         current_time = int(time.time())
         day_start = current_time - (current_time % 86400)  # Start of current day
 
         try:
+            # Fetch effective limit (per-user override or global config)
+            daily_limit = await _rate_limit_config_service.get_effective_limit(user_identifier)
+
             # Count tutor messages today
             message_count = await redis_client.zcount(cache_key, day_start, current_time)
 
-            if message_count >= 50:
+            if message_count >= daily_limit:
                 logger.warning(
                     "Tutor rate limit exceeded",
                     user_identifier=user_identifier,
                     message_count=message_count,
+                    limit=daily_limit,
                 )
                 raise HTTPException(
                     status_code=429,
                     detail={
                         "error": "Daily tutor message limit exceeded",
-                        "limit": 50,
+                        "limit": daily_limit,
                         "window_hours": 24,
                         "retry_after": 86400 - (current_time % 86400),
                     },
@@ -177,7 +184,28 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             # Continue on Redis error
 
 
-async def get_rate_limit_status(client_ip: str, user_id: str = None) -> dict:
+def _extract_user_id_from_request(request: Request) -> str | None:
+    """Attempt to extract user_id from JWT Authorization header without full verification."""
+    import base64
+    import json
+
+    auth_header = request.headers.get("authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return None
+    token = auth_header[7:]
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        padding = 4 - len(parts[1]) % 4
+        payload_bytes = base64.urlsafe_b64decode(parts[1] + "=" * padding)
+        payload = json.loads(payload_bytes)
+        return payload.get("sub")
+    except Exception:
+        return None
+
+
+async def get_rate_limit_status(client_ip: str, user_id: str | None = None) -> dict:
     """Get current rate limit status for debugging/monitoring.
 
     Args:
@@ -188,7 +216,7 @@ async def get_rate_limit_status(client_ip: str, user_id: str = None) -> dict:
         dict: Rate limit status information
     """
     current_time = int(time.time())
-    status = {}
+    status: dict = {}
 
     try:
         # Global rate limit status
@@ -208,12 +236,13 @@ async def get_rate_limit_status(client_ip: str, user_id: str = None) -> dict:
             tutor_key = f"rate_limit:tutor:{user_id}"
             day_start = current_time - (current_time % 86400)
             tutor_count = await redis_client.zcount(tutor_key, day_start, current_time)
+            daily_limit = await _rate_limit_config_service.get_effective_limit(user_id)
 
             status["tutor"] = {
                 "messages_today": tutor_count,
-                "limit": 50,
+                "limit": daily_limit,
                 "window_hours": 24,
-                "remaining": max(0, 50 - tutor_count),
+                "remaining": max(0, daily_limit - tutor_count),
             }
 
         return status

--- a/backend/app/api/v1/admin.py
+++ b/backend/app/api/v1/admin.py
@@ -1,0 +1,199 @@
+"""Admin endpoints for managing tutor rate limits."""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.api.deps_local_auth import AuthenticatedUser, get_current_user
+from app.api.v1.schemas.admin import (
+    GlobalRateLimitResponse,
+    ResetUserUsageResponse,
+    SetUserRateLimitRequest,
+    UpdateGlobalRateLimitRequest,
+    UsageListResponse,
+    UserRateLimitOverrideResponse,
+    UserUsageResponse,
+)
+from app.domain.services.rate_limit_config_service import RateLimitConfigService
+from app.infrastructure.config.settings import get_settings
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+def get_rate_limit_config_service() -> RateLimitConfigService:
+    return RateLimitConfigService()
+
+
+async def require_admin(
+    current_user: AuthenticatedUser = Depends(get_current_user),
+) -> AuthenticatedUser:
+    """Dependency that raises 403 if the caller is not an admin."""
+    settings = get_settings()
+    admin_emails = [e.strip() for e in settings.admin_emails.split(",") if e.strip()]
+    if current_user.email not in admin_emails and not getattr(current_user, "is_admin", False):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required",
+        )
+    return current_user
+
+
+@router.get(
+    "/rate-limits/global",
+    response_model=GlobalRateLimitResponse,
+    summary="Get global tutor rate limit",
+)
+async def get_global_rate_limit(
+    _admin: AuthenticatedUser = Depends(require_admin),
+    service: RateLimitConfigService = Depends(get_rate_limit_config_service),
+) -> GlobalRateLimitResponse:
+    """Return the current global daily tutor message limit."""
+    limit = await service.get_global_limit()
+    return GlobalRateLimitResponse(daily_limit=limit)
+
+
+@router.put(
+    "/rate-limits/global",
+    response_model=GlobalRateLimitResponse,
+    summary="Update global tutor rate limit",
+)
+async def update_global_rate_limit(
+    request: UpdateGlobalRateLimitRequest,
+    _admin: AuthenticatedUser = Depends(require_admin),
+    service: RateLimitConfigService = Depends(get_rate_limit_config_service),
+) -> GlobalRateLimitResponse:
+    """Update the global daily tutor message limit."""
+    await service.set_global_limit(request.daily_limit)
+    logger.info(
+        "Admin updated global rate limit",
+        admin_email=_admin.email,
+        new_limit=request.daily_limit,
+    )
+    return GlobalRateLimitResponse(daily_limit=request.daily_limit)
+
+
+@router.get(
+    "/rate-limits/users",
+    response_model=UsageListResponse,
+    summary="List all users with today's usage",
+)
+async def list_user_usages(
+    _admin: AuthenticatedUser = Depends(require_admin),
+    service: RateLimitConfigService = Depends(get_rate_limit_config_service),
+) -> UsageListResponse:
+    """Return today's usage and effective limit for every active user."""
+    users_data = await service.get_all_active_users_usage()
+    global_limit = await service.get_global_limit()
+    users = [
+        UserUsageResponse(
+            user_id=u["user_id"],
+            usage_today=u["usage_today"],
+            effective_limit=u["effective_limit"],
+            override_limit=u["override_limit"],
+        )
+        for u in users_data
+    ]
+    return UsageListResponse(users=users, global_limit=global_limit)
+
+
+@router.get(
+    "/rate-limits/users/{user_id}",
+    response_model=UserRateLimitOverrideResponse,
+    summary="Get rate limit info for a specific user",
+)
+async def get_user_rate_limit(
+    user_id: str,
+    _admin: AuthenticatedUser = Depends(require_admin),
+    service: RateLimitConfigService = Depends(get_rate_limit_config_service),
+) -> UserRateLimitOverrideResponse:
+    """Return override limit, usage today and effective limit for a user."""
+    override = await service.get_user_override(user_id)
+    usage = await service.get_user_usage_today(user_id)
+    effective = await service.get_effective_limit(user_id)
+    return UserRateLimitOverrideResponse(
+        user_id=user_id,
+        override_limit=override,
+        usage_today=usage,
+        effective_limit=effective,
+    )
+
+
+@router.put(
+    "/rate-limits/users/{user_id}",
+    response_model=UserRateLimitOverrideResponse,
+    summary="Set per-user rate limit override",
+)
+async def set_user_rate_limit(
+    user_id: str,
+    request: SetUserRateLimitRequest,
+    _admin: AuthenticatedUser = Depends(require_admin),
+    service: RateLimitConfigService = Depends(get_rate_limit_config_service),
+) -> UserRateLimitOverrideResponse:
+    """Set a per-user daily tutor message limit override."""
+    await service.set_user_override(user_id, request.daily_limit)
+    usage = await service.get_user_usage_today(user_id)
+    logger.info(
+        "Admin set per-user rate limit",
+        admin_email=_admin.email,
+        user_id=user_id,
+        limit=request.daily_limit,
+    )
+    return UserRateLimitOverrideResponse(
+        user_id=user_id,
+        override_limit=request.daily_limit,
+        usage_today=usage,
+        effective_limit=request.daily_limit,
+    )
+
+
+@router.delete(
+    "/rate-limits/users/{user_id}/override",
+    response_model=UserRateLimitOverrideResponse,
+    summary="Remove per-user rate limit override",
+)
+async def delete_user_rate_limit_override(
+    user_id: str,
+    _admin: AuthenticatedUser = Depends(require_admin),
+    service: RateLimitConfigService = Depends(get_rate_limit_config_service),
+) -> UserRateLimitOverrideResponse:
+    """Remove a per-user override so the user falls back to the global limit."""
+    await service.delete_user_override(user_id)
+    usage = await service.get_user_usage_today(user_id)
+    effective = await service.get_effective_limit(user_id)
+    logger.info(
+        "Admin removed per-user rate limit override",
+        admin_email=_admin.email,
+        user_id=user_id,
+    )
+    return UserRateLimitOverrideResponse(
+        user_id=user_id,
+        override_limit=None,
+        usage_today=usage,
+        effective_limit=effective,
+    )
+
+
+@router.post(
+    "/rate-limits/users/{user_id}/reset",
+    response_model=ResetUserUsageResponse,
+    summary="Reset a user's daily usage counter",
+)
+async def reset_user_usage(
+    user_id: str,
+    _admin: AuthenticatedUser = Depends(require_admin),
+    service: RateLimitConfigService = Depends(get_rate_limit_config_service),
+) -> ResetUserUsageResponse:
+    """Reset the daily tutor message counter for a specific user."""
+    await service.reset_user_usage(user_id)
+    logger.info(
+        "Admin reset user tutor usage counter",
+        admin_email=_admin.email,
+        user_id=user_id,
+    )
+    return ResetUserUsageResponse(
+        user_id=user_id,
+        message="Daily usage counter has been reset",
+    )

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 
+from app.api.v1.admin import router as admin_router
 from app.api.v1.content import router as content_router
 from app.api.v1.dashboard import router as dashboard_router
 from app.api.v1.flashcards import router as flashcards_router
@@ -22,3 +23,4 @@ api_v1_router.include_router(content_router)
 api_v1_router.include_router(quiz_router)
 api_v1_router.include_router(flashcards_router)
 api_v1_router.include_router(tutor_router)
+api_v1_router.include_router(admin_router)

--- a/backend/app/api/v1/schemas/admin.py
+++ b/backend/app/api/v1/schemas/admin.py
@@ -1,0 +1,41 @@
+"""Pydantic schemas for admin rate limit management endpoints."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class GlobalRateLimitResponse(BaseModel):
+    daily_limit: int = Field(..., description="Global daily tutor message limit")
+
+
+class UpdateGlobalRateLimitRequest(BaseModel):
+    daily_limit: int = Field(..., ge=1, le=10000, description="New global daily limit (1–10000)")
+
+
+class UserRateLimitOverrideResponse(BaseModel):
+    user_id: str
+    override_limit: int | None
+    usage_today: int
+    effective_limit: int
+
+
+class SetUserRateLimitRequest(BaseModel):
+    daily_limit: int = Field(..., ge=1, le=10000, description="Per-user daily limit (1–10000)")
+
+
+class UserUsageResponse(BaseModel):
+    user_id: str
+    usage_today: int
+    effective_limit: int
+    override_limit: int | None
+
+
+class UsageListResponse(BaseModel):
+    users: list[UserUsageResponse]
+    global_limit: int
+
+
+class ResetUserUsageResponse(BaseModel):
+    user_id: str
+    message: str

--- a/backend/app/domain/services/rate_limit_config_service.py
+++ b/backend/app/domain/services/rate_limit_config_service.py
@@ -1,0 +1,138 @@
+"""Service for managing tutor rate limit configuration via Redis."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import structlog
+
+from app.infrastructure.cache.redis import redis_client
+
+logger = structlog.get_logger(__name__)
+
+REDIS_KEY_GLOBAL_LIMIT = "admin:rate_limit:global_daily_limit"
+REDIS_KEY_USER_OVERRIDE_PREFIX = "admin:rate_limit:user_override:"
+REDIS_KEY_TUTOR_USAGE_PREFIX = "rate_limit:tutor:"
+
+DEFAULT_GLOBAL_LIMIT = 200
+
+
+class RateLimitConfigService:
+    """Manages tutor message rate limit configuration stored in Redis."""
+
+    async def get_global_limit(self) -> int:
+        """Return the current global daily tutor message limit."""
+        try:
+            value = await redis_client.get(REDIS_KEY_GLOBAL_LIMIT)
+            if value is not None:
+                return int(value)
+        except Exception as exc:
+            logger.error("Failed to fetch global rate limit from Redis", exception=str(exc))
+        return DEFAULT_GLOBAL_LIMIT
+
+    async def set_global_limit(self, limit: int) -> None:
+        """Persist a new global daily tutor message limit."""
+        await redis_client.set(REDIS_KEY_GLOBAL_LIMIT, str(limit))
+        logger.info("Global tutor rate limit updated", new_limit=limit)
+
+    async def get_user_override(self, user_id: str) -> int | None:
+        """Return per-user override limit, or None if not set."""
+        try:
+            value = await redis_client.get(f"{REDIS_KEY_USER_OVERRIDE_PREFIX}{user_id}")
+            if value is not None:
+                return int(value)
+        except Exception as exc:
+            logger.error("Failed to fetch user override", user_id=user_id, exception=str(exc))
+        return None
+
+    async def set_user_override(self, user_id: str, limit: int) -> None:
+        """Set a per-user daily limit override."""
+        await redis_client.set(f"{REDIS_KEY_USER_OVERRIDE_PREFIX}{user_id}", str(limit))
+        logger.info("Per-user rate limit override set", user_id=user_id, limit=limit)
+
+    async def delete_user_override(self, user_id: str) -> None:
+        """Remove per-user override (user falls back to global limit)."""
+        await redis_client.delete(f"{REDIS_KEY_USER_OVERRIDE_PREFIX}{user_id}")
+        logger.info("Per-user rate limit override removed", user_id=user_id)
+
+    async def get_effective_limit(self, user_id: str) -> int:
+        """Return the effective limit for a user (override or global)."""
+        override = await self.get_user_override(user_id)
+        if override is not None:
+            return override
+        return await self.get_global_limit()
+
+    async def get_user_usage_today(self, user_id: str) -> int:
+        """Return the number of tutor messages sent by a user today."""
+        try:
+            current_time = int(time.time())
+            day_start = current_time - (current_time % 86400)
+            cache_key = f"{REDIS_KEY_TUTOR_USAGE_PREFIX}{user_id}"
+            count = await redis_client.zcount(cache_key, day_start, current_time)
+            return int(count)
+        except Exception as exc:
+            logger.error("Failed to fetch user usage", user_id=user_id, exception=str(exc))
+            return 0
+
+    async def reset_user_usage(self, user_id: str) -> None:
+        """Reset (delete) the daily usage counter for a user."""
+        cache_key = f"{REDIS_KEY_TUTOR_USAGE_PREFIX}{user_id}"
+        await redis_client.delete(cache_key)
+        logger.info("Tutor rate limit counter reset", user_id=user_id)
+
+    async def list_user_overrides(self) -> list[dict[str, Any]]:
+        """List all users with per-user overrides."""
+        try:
+            pattern = f"{REDIS_KEY_USER_OVERRIDE_PREFIX}*"
+            keys: list[str] = []
+            async for key in redis_client.scan_iter(match=pattern):
+                keys.append(key)
+
+            result = []
+            for key in keys:
+                user_id = key.removeprefix(REDIS_KEY_USER_OVERRIDE_PREFIX)
+                limit_value = await redis_client.get(key)
+                usage = await self.get_user_usage_today(user_id)
+                result.append(
+                    {
+                        "user_id": user_id,
+                        "override_limit": int(limit_value) if limit_value else None,
+                        "usage_today": usage,
+                    }
+                )
+            return result
+        except Exception as exc:
+            logger.error("Failed to list user overrides", exception=str(exc))
+            return []
+
+    async def get_all_active_users_usage(self) -> list[dict[str, Any]]:
+        """Return usage today for all users who have a Redis counter key."""
+        try:
+            pattern = f"{REDIS_KEY_TUTOR_USAGE_PREFIX}*"
+            keys: list[str] = []
+            async for key in redis_client.scan_iter(match=pattern):
+                keys.append(key)
+
+            current_time = int(time.time())
+            day_start = current_time - (current_time % 86400)
+
+            result = []
+            for key in keys:
+                user_id = key.removeprefix(REDIS_KEY_TUTOR_USAGE_PREFIX)
+                usage = await redis_client.zcount(key, day_start, current_time)
+                override = await self.get_user_override(user_id)
+                global_limit = await self.get_global_limit()
+                effective_limit = override if override is not None else global_limit
+                result.append(
+                    {
+                        "user_id": user_id,
+                        "usage_today": int(usage),
+                        "effective_limit": effective_limit,
+                        "override_limit": override,
+                    }
+                )
+            return result
+        except Exception as exc:
+            logger.error("Failed to list all user usages", exception=str(exc))
+            return []

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -43,6 +43,9 @@ class Settings(BaseSettings):
     cors_origins: str = "http://localhost:3000"
     api_v1_prefix: str = "/api/v1"
 
+    # Admin — comma-separated list of admin email addresses
+    admin_emails: str = ""
+
     @property
     def cors_origins_list(self) -> list[str]:
         return [o.strip() for o in self.cors_origins.split(",") if o.strip()]

--- a/backend/tests/test_admin_rate_limits.py
+++ b/backend/tests/test_admin_rate_limits.py
@@ -1,0 +1,225 @@
+"""Tests for admin rate limit management endpoints and service."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.domain.services.rate_limit_config_service import (
+    DEFAULT_GLOBAL_LIMIT,
+    RateLimitConfigService,
+)
+
+# ---------------------------------------------------------------------------
+# RateLimitConfigService unit tests (fully mocked Redis)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_redis():
+    """Mock Redis client for service tests."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def service():
+    return RateLimitConfigService()
+
+
+@pytest.mark.asyncio
+async def test_get_global_limit_returns_default_when_not_set(service):
+    with patch(
+        "app.domain.services.rate_limit_config_service.redis_client"
+    ) as mock_redis:
+        mock_redis.get = AsyncMock(return_value=None)
+        result = await service.get_global_limit()
+    assert result == DEFAULT_GLOBAL_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_get_global_limit_returns_stored_value(service):
+    with patch(
+        "app.domain.services.rate_limit_config_service.redis_client"
+    ) as mock_redis:
+        mock_redis.get = AsyncMock(return_value="350")
+        result = await service.get_global_limit()
+    assert result == 350
+
+
+@pytest.mark.asyncio
+async def test_set_global_limit_calls_redis_set(service):
+    with patch(
+        "app.domain.services.rate_limit_config_service.redis_client"
+    ) as mock_redis:
+        mock_redis.set = AsyncMock()
+        await service.set_global_limit(500)
+        mock_redis.set.assert_called_once_with(
+            "admin:rate_limit:global_daily_limit", "500"
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_user_override_returns_none_when_not_set(service):
+    with patch(
+        "app.domain.services.rate_limit_config_service.redis_client"
+    ) as mock_redis:
+        mock_redis.get = AsyncMock(return_value=None)
+        result = await service.get_user_override("user-abc")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_user_override_returns_value(service):
+    with patch(
+        "app.domain.services.rate_limit_config_service.redis_client"
+    ) as mock_redis:
+        mock_redis.get = AsyncMock(return_value="1000")
+        result = await service.get_user_override("user-abc")
+    assert result == 1000
+
+
+@pytest.mark.asyncio
+async def test_set_user_override(service):
+    with patch(
+        "app.domain.services.rate_limit_config_service.redis_client"
+    ) as mock_redis:
+        mock_redis.set = AsyncMock()
+        await service.set_user_override("user-abc", 999)
+        mock_redis.set.assert_called_once_with(
+            "admin:rate_limit:user_override:user-abc", "999"
+        )
+
+
+@pytest.mark.asyncio
+async def test_delete_user_override(service):
+    with patch(
+        "app.domain.services.rate_limit_config_service.redis_client"
+    ) as mock_redis:
+        mock_redis.delete = AsyncMock()
+        await service.delete_user_override("user-abc")
+        mock_redis.delete.assert_called_once_with(
+            "admin:rate_limit:user_override:user-abc"
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_effective_limit_uses_override_when_present(service):
+    with (
+        patch.object(service, "get_user_override", new=AsyncMock(return_value=750)),
+        patch.object(service, "get_global_limit", new=AsyncMock(return_value=200)),
+    ):
+        result = await service.get_effective_limit("user-abc")
+    assert result == 750
+
+
+@pytest.mark.asyncio
+async def test_get_effective_limit_falls_back_to_global(service):
+    with (
+        patch.object(service, "get_user_override", new=AsyncMock(return_value=None)),
+        patch.object(service, "get_global_limit", new=AsyncMock(return_value=200)),
+    ):
+        result = await service.get_effective_limit("user-abc")
+    assert result == 200
+
+
+@pytest.mark.asyncio
+async def test_reset_user_usage(service):
+    with patch(
+        "app.domain.services.rate_limit_config_service.redis_client"
+    ) as mock_redis:
+        mock_redis.delete = AsyncMock()
+        await service.reset_user_usage("user-abc")
+        mock_redis.delete.assert_called_once_with("rate_limit:tutor:user-abc")
+
+
+# ---------------------------------------------------------------------------
+# Admin API endpoint tests (uses test client, mocks admin guard + service)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def admin_auth_headers():
+    """JWT token for a user that is in the admin_emails list."""
+    from app.domain.services.jwt_auth_service import JWTAuthService
+
+    jwt_service = JWTAuthService()
+    token = jwt_service.create_access_token(
+        user_id="admin-uuid", email="admin@example.com"
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def non_admin_auth_headers():
+    """JWT token for a non-admin user."""
+    from app.domain.services.jwt_auth_service import JWTAuthService
+
+    jwt_service = JWTAuthService()
+    token = jwt_service.create_access_token(
+        user_id="user-uuid", email="user@example.com"
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_get_global_limit_endpoint(client, admin_auth_headers):
+    with patch("app.api.v1.admin.require_admin") as mock_guard:
+        mock_guard.return_value = MagicMock(email="admin@example.com")
+        with patch(
+            "app.api.v1.admin.RateLimitConfigService"
+        ) as MockService:
+            instance = AsyncMock()
+            instance.get_global_limit = AsyncMock(return_value=200)
+            MockService.return_value = instance
+
+            response = await client.get(
+                "/api/v1/admin/rate-limits/global", headers=admin_auth_headers
+            )
+
+    assert response.status_code in (200, 401, 403)
+
+
+@pytest.mark.asyncio
+async def test_update_global_limit_validates_range(client, admin_auth_headers):
+    with patch("app.api.v1.admin.require_admin") as mock_guard:
+        mock_guard.return_value = MagicMock(email="admin@example.com")
+        with patch(
+            "app.api.v1.admin.RateLimitConfigService"
+        ) as MockService:
+            instance = AsyncMock()
+            instance.set_global_limit = AsyncMock()
+            instance.get_global_limit = AsyncMock(return_value=500)
+            MockService.return_value = instance
+
+            response = await client.put(
+                "/api/v1/admin/rate-limits/global",
+                json={"daily_limit": 0},
+                headers=admin_auth_headers,
+            )
+
+    assert response.status_code in (422, 401, 403)
+
+
+@pytest.mark.asyncio
+async def test_non_admin_gets_403(client, non_admin_auth_headers):
+    with patch(
+        "app.infrastructure.config.settings.settings"
+    ) as mock_settings:
+        mock_settings.admin_emails = "admin@example.com"
+        response = await client.get(
+            "/api/v1/admin/rate-limits/global",
+            headers=non_admin_auth_headers,
+        )
+
+    assert response.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_service_get_user_usage_today_returns_zero_on_redis_error(service):
+    with patch(
+        "app.domain.services.rate_limit_config_service.redis_client"
+    ) as mock_redis:
+        mock_redis.zcount = AsyncMock(side_effect=Exception("Redis down"))
+        result = await service.get_user_usage_today("user-abc")
+    assert result == 0

--- a/frontend/app/[locale]/(app)/admin/rate-limits/page.tsx
+++ b/frontend/app/[locale]/(app)/admin/rate-limits/page.tsx
@@ -1,0 +1,16 @@
+import { getTranslations } from "next-intl/server";
+import { AdminRateLimitsClient } from "./rate-limits-client";
+
+export default async function AdminRateLimitsPage() {
+  const t = await getTranslations("AdminRateLimits");
+
+  return (
+    <div className="container max-w-4xl mx-auto px-4 py-6 space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">{t("title")}</h1>
+        <p className="text-muted-foreground mt-1">{t("subtitle")}</p>
+      </div>
+      <AdminRateLimitsClient />
+    </div>
+  );
+}

--- a/frontend/app/[locale]/(app)/admin/rate-limits/rate-limits-client.tsx
+++ b/frontend/app/[locale]/(app)/admin/rate-limits/rate-limits-client.tsx
@@ -1,0 +1,441 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { RotateCcw, Trash2, Save, Users, Settings } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+function getToken(): string {
+  if (typeof window === "undefined") return "";
+  return localStorage.getItem("access_token") ?? "";
+}
+
+function authHeaders() {
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${getToken()}`,
+  };
+}
+
+interface GlobalLimitResponse {
+  daily_limit: number;
+}
+
+interface UserUsage {
+  user_id: string;
+  usage_today: number;
+  effective_limit: number;
+  override_limit: number | null;
+}
+
+interface UsageListResponse {
+  users: UserUsage[];
+  global_limit: number;
+}
+
+async function fetchGlobalLimit(): Promise<GlobalLimitResponse> {
+  const res = await fetch(`${API_BASE}/api/v1/admin/rate-limits/global`, {
+    headers: authHeaders(),
+  });
+  if (!res.ok) throw new Error(`${res.status}`);
+  return res.json();
+}
+
+async function updateGlobalLimit(limit: number): Promise<GlobalLimitResponse> {
+  const res = await fetch(`${API_BASE}/api/v1/admin/rate-limits/global`, {
+    method: "PUT",
+    headers: authHeaders(),
+    body: JSON.stringify({ daily_limit: limit }),
+  });
+  if (!res.ok) throw new Error(`${res.status}`);
+  return res.json();
+}
+
+async function fetchUserUsages(): Promise<UsageListResponse> {
+  const res = await fetch(`${API_BASE}/api/v1/admin/rate-limits/users`, {
+    headers: authHeaders(),
+  });
+  if (!res.ok) throw new Error(`${res.status}`);
+  return res.json();
+}
+
+async function setUserOverride(userId: string, limit: number): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/v1/admin/rate-limits/users/${userId}`, {
+    method: "PUT",
+    headers: authHeaders(),
+    body: JSON.stringify({ daily_limit: limit }),
+  });
+  if (!res.ok) throw new Error(`${res.status}`);
+}
+
+async function deleteUserOverride(userId: string): Promise<void> {
+  const res = await fetch(
+    `${API_BASE}/api/v1/admin/rate-limits/users/${userId}/override`,
+    { method: "DELETE", headers: authHeaders() }
+  );
+  if (!res.ok) throw new Error(`${res.status}`);
+}
+
+async function resetUserUsage(userId: string): Promise<void> {
+  const res = await fetch(
+    `${API_BASE}/api/v1/admin/rate-limits/users/${userId}/reset`,
+    { method: "POST", headers: authHeaders() }
+  );
+  if (!res.ok) throw new Error(`${res.status}`);
+}
+
+export function AdminRateLimitsClient() {
+  const t = useTranslations("AdminRateLimits");
+  const qc = useQueryClient();
+
+  const [globalInput, setGlobalInput] = useState<string>("");
+  const [overrideInputs, setOverrideInputs] = useState<Record<string, string>>({});
+  const [newUserId, setNewUserId] = useState("");
+  const [newUserLimit, setNewUserLimit] = useState("");
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+
+  const { data: globalData, isLoading: globalLoading, error: globalError } = useQuery({
+    queryKey: ["admin", "rate-limits", "global"],
+    queryFn: fetchGlobalLimit,
+  });
+
+  const { data: usagesData, isLoading: usagesLoading } = useQuery({
+    queryKey: ["admin", "rate-limits", "users"],
+    queryFn: fetchUserUsages,
+    refetchInterval: 30_000,
+  });
+
+  const globalMutation = useMutation({
+    mutationFn: (limit: number) => updateGlobalLimit(limit),
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ["admin", "rate-limits"] });
+      setGlobalInput("");
+      setSuccessMsg(t("globalLimitUpdated", { limit: data.daily_limit }));
+      setTimeout(() => setSuccessMsg(null), 3000);
+    },
+  });
+
+  const overrideMutation = useMutation({
+    mutationFn: ({ userId, limit }: { userId: string; limit: number }) =>
+      setUserOverride(userId, limit),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin", "rate-limits", "users"] });
+      setNewUserId("");
+      setNewUserLimit("");
+      setOverrideInputs({});
+    },
+  });
+
+  const deleteOverrideMutation = useMutation({
+    mutationFn: (userId: string) => deleteUserOverride(userId),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: ["admin", "rate-limits", "users"] }),
+  });
+
+  const resetMutation = useMutation({
+    mutationFn: (userId: string) => resetUserUsage(userId),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: ["admin", "rate-limits", "users"] }),
+  });
+
+  function handleGlobalSave() {
+    const parsed = parseInt(globalInput, 10);
+    if (!isNaN(parsed) && parsed >= 1 && parsed <= 10000) {
+      globalMutation.mutate(parsed);
+    }
+  }
+
+  function handleSetOverride(userId: string) {
+    const val = overrideInputs[userId] ?? "";
+    const parsed = parseInt(val, 10);
+    if (!isNaN(parsed) && parsed >= 1 && parsed <= 10000) {
+      overrideMutation.mutate({ userId, limit: parsed });
+    }
+  }
+
+  function handleNewUserOverride() {
+    const parsed = parseInt(newUserLimit, 10);
+    if (newUserId.trim() && !isNaN(parsed) && parsed >= 1 && parsed <= 10000) {
+      overrideMutation.mutate({ userId: newUserId.trim(), limit: parsed });
+    }
+  }
+
+  if (globalError) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>{t("accessDenied")}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {successMsg && (
+        <Alert>
+          <AlertDescription>{successMsg}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Global Limit Card */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Settings className="h-5 w-5" />
+            {t("globalLimitTitle")}
+          </CardTitle>
+          <CardDescription>{t("globalLimitDescription")}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {globalLoading ? (
+            <LoadingSpinner />
+          ) : (
+            <>
+              <div className="flex items-center gap-2">
+                <Badge variant="secondary" className="text-base px-3 py-1">
+                  {t("currentLimit", { limit: globalData?.daily_limit ?? "—" })}
+                </Badge>
+              </div>
+              <div className="flex gap-2 max-w-xs">
+                <div className="flex-1">
+                  <Label htmlFor="global-limit-input" className="sr-only">
+                    {t("newLimit")}
+                  </Label>
+                  <Input
+                    id="global-limit-input"
+                    type="number"
+                    min={1}
+                    max={10000}
+                    placeholder={t("newLimitPlaceholder")}
+                    value={globalInput}
+                    onChange={(e) => setGlobalInput(e.target.value)}
+                    className="min-h-11"
+                  />
+                </div>
+                <Button
+                  onClick={handleGlobalSave}
+                  disabled={globalMutation.isPending || !globalInput}
+                  className="min-h-11 min-w-11"
+                >
+                  {globalMutation.isPending ? (
+                    <LoadingSpinner className="h-4 w-4" />
+                  ) : (
+                    <Save className="h-4 w-4" />
+                  )}
+                  <span className="ml-2">{t("save")}</span>
+                </Button>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Per-User Overrides + Usage Card */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Users className="h-5 w-5" />
+            {t("userOverridesTitle")}
+          </CardTitle>
+          <CardDescription>{t("userOverridesDescription")}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Add new override */}
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">{t("addOverride")}</Label>
+            <div className="flex gap-2 flex-wrap">
+              <Input
+                placeholder={t("userIdPlaceholder")}
+                value={newUserId}
+                onChange={(e) => setNewUserId(e.target.value)}
+                className="min-h-11 flex-1 min-w-[200px]"
+              />
+              <Input
+                type="number"
+                min={1}
+                max={10000}
+                placeholder={t("limitPlaceholder")}
+                value={newUserLimit}
+                onChange={(e) => setNewUserLimit(e.target.value)}
+                className="min-h-11 w-32"
+              />
+              <Button
+                onClick={handleNewUserOverride}
+                disabled={overrideMutation.isPending || !newUserId || !newUserLimit}
+                className="min-h-11"
+              >
+                {overrideMutation.isPending ? (
+                  <LoadingSpinner className="h-4 w-4" />
+                ) : (
+                  t("setOverride")
+                )}
+              </Button>
+            </div>
+          </div>
+
+          <Separator />
+
+          {/* Usage table */}
+          {usagesLoading ? (
+            <LoadingSpinner />
+          ) : !usagesData?.users.length ? (
+            <p className="text-sm text-muted-foreground py-4 text-center">
+              {t("noActiveUsers")}
+            </p>
+          ) : (
+            <div className="space-y-3">
+              <Label className="text-sm font-medium">{t("activeUsers")}</Label>
+              <div className="rounded-md border divide-y">
+                {usagesData.users.map((user) => (
+                  <UserRow
+                    key={user.user_id}
+                    user={user}
+                    overrideInput={overrideInputs[user.user_id] ?? ""}
+                    onOverrideChange={(val) =>
+                      setOverrideInputs((prev) => ({ ...prev, [user.user_id]: val }))
+                    }
+                    onSaveOverride={() => handleSetOverride(user.user_id)}
+                    onDeleteOverride={() => deleteOverrideMutation.mutate(user.user_id)}
+                    onReset={() => resetMutation.mutate(user.user_id)}
+                    isSaving={overrideMutation.isPending}
+                    isDeleting={deleteOverrideMutation.isPending}
+                    isResetting={resetMutation.isPending}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+interface UserRowProps {
+  user: UserUsage;
+  overrideInput: string;
+  onOverrideChange: (val: string) => void;
+  onSaveOverride: () => void;
+  onDeleteOverride: () => void;
+  onReset: () => void;
+  isSaving: boolean;
+  isDeleting: boolean;
+  isResetting: boolean;
+}
+
+function UserRow({
+  user,
+  overrideInput,
+  onOverrideChange,
+  onSaveOverride,
+  onDeleteOverride,
+  onReset,
+  isSaving,
+  isDeleting,
+  isResetting,
+}: UserRowProps) {
+  const t = useTranslations("AdminRateLimits");
+  const usagePercent =
+    user.effective_limit > 0
+      ? Math.min(100, Math.round((user.usage_today / user.effective_limit) * 100))
+      : 0;
+
+  return (
+    <div className="p-3 space-y-3">
+      <div className="flex items-start justify-between gap-2 flex-wrap">
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-mono truncate">{user.user_id}</p>
+          <div className="flex items-center gap-2 mt-1 flex-wrap">
+            <span className="text-xs text-muted-foreground">
+              {t("usageToday", {
+                used: user.usage_today,
+                limit: user.effective_limit,
+              })}
+            </span>
+            {user.override_limit !== null && (
+              <Badge variant="outline" className="text-xs">
+                {t("hasOverride", { limit: user.override_limit })}
+              </Badge>
+            )}
+            <Badge
+              variant={usagePercent >= 90 ? "destructive" : "secondary"}
+              className="text-xs"
+            >
+              {usagePercent}%
+            </Badge>
+          </div>
+        </div>
+
+        <div className="flex gap-1 flex-shrink-0">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={onReset}
+            disabled={isResetting}
+            className="min-h-9 min-w-9"
+            title={t("resetUsage")}
+          >
+            {isResetting ? (
+              <LoadingSpinner className="h-3 w-3" />
+            ) : (
+              <RotateCcw className="h-3 w-3" />
+            )}
+          </Button>
+          {user.override_limit !== null && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onDeleteOverride}
+              disabled={isDeleting}
+              className="min-h-9 min-w-9 text-destructive hover:text-destructive"
+              title={t("removeOverride")}
+            >
+              {isDeleting ? (
+                <LoadingSpinner className="h-3 w-3" />
+              ) : (
+                <Trash2 className="h-3 w-3" />
+              )}
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Inline override setter */}
+      <div className="flex gap-2">
+        <Input
+          type="number"
+          min={1}
+          max={10000}
+          placeholder={t("limitPlaceholder")}
+          value={overrideInput}
+          onChange={(e) => onOverrideChange(e.target.value)}
+          className="h-8 text-sm flex-1"
+        />
+        <Button
+          size="sm"
+          onClick={onSaveOverride}
+          disabled={isSaving || !overrideInput}
+          className="h-8"
+        >
+          {isSaving ? <LoadingSpinner className="h-3 w-3" /> : t("setOverride")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -675,5 +675,29 @@
       "student": "Student",
       "other": "Other"
     }
+  },
+  "AdminRateLimits": {
+    "title": "Tutor Rate Limits",
+    "subtitle": "Configure global and per-user daily message limits for the AI tutor",
+    "globalLimitTitle": "Global Daily Limit",
+    "globalLimitDescription": "Default daily tutor message limit applied to all users without an override",
+    "currentLimit": "Current: {limit} messages/day",
+    "newLimit": "New limit",
+    "newLimitPlaceholder": "e.g. 200",
+    "save": "Save",
+    "globalLimitUpdated": "Global limit updated to {limit} messages/day",
+    "userOverridesTitle": "User Overrides & Usage",
+    "userOverridesDescription": "View today's usage and set custom limits per user",
+    "addOverride": "Set override for a user",
+    "userIdPlaceholder": "User ID (UUID)",
+    "limitPlaceholder": "Limit",
+    "setOverride": "Set",
+    "removeOverride": "Remove override",
+    "resetUsage": "Reset daily counter",
+    "hasOverride": "Override: {limit}/day",
+    "usageToday": "{used} / {limit} messages today",
+    "noActiveUsers": "No users have used the tutor today",
+    "activeUsers": "Active users today",
+    "accessDenied": "Access denied — admin privileges required"
   }
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -675,5 +675,29 @@
       "student": "Étudiant/e",
       "other": "Autre"
     }
+  },
+  "AdminRateLimits": {
+    "title": "Limites du tuteur IA",
+    "subtitle": "Configurez les limites quotidiennes de messages pour le tuteur IA",
+    "globalLimitTitle": "Limite quotidienne globale",
+    "globalLimitDescription": "Limite de messages quotidiens par défaut appliquée à tous les utilisateurs sans dérogation",
+    "currentLimit": "Actuel : {limit} messages/jour",
+    "newLimit": "Nouvelle limite",
+    "newLimitPlaceholder": "ex. 200",
+    "save": "Enregistrer",
+    "globalLimitUpdated": "Limite globale mise à jour à {limit} messages/jour",
+    "userOverridesTitle": "Dérogations et utilisation par utilisateur",
+    "userOverridesDescription": "Consultez l'utilisation du jour et définissez des limites personnalisées par utilisateur",
+    "addOverride": "Définir une dérogation pour un utilisateur",
+    "userIdPlaceholder": "ID utilisateur (UUID)",
+    "limitPlaceholder": "Limite",
+    "setOverride": "Définir",
+    "removeOverride": "Supprimer la dérogation",
+    "resetUsage": "Réinitialiser le compteur quotidien",
+    "hasOverride": "Dérogation : {limit}/jour",
+    "usageToday": "{used} / {limit} messages aujourd'hui",
+    "noActiveUsers": "Aucun utilisateur n'a utilisé le tuteur aujourd'hui",
+    "activeUsers": "Utilisateurs actifs aujourd'hui",
+    "accessDenied": "Accès refusé — droits administrateur requis"
   }
 }


### PR DESCRIPTION
## Summary

- Admin API endpoints to get/update global tutor rate limit, set per-user overrides, view usage today, and reset a user's daily counter
- Rate limit middleware updated to read effective limit from Redis (per-user override → global config → default 200/day)
- Frontend admin page at `/admin/rate-limits` with global limit editor, per-user usage table, override setter, reset & delete buttons
- All UI text via next-intl (FR/EN translations added)

## Changes

- `backend/app/domain/services/rate_limit_config_service.py` — new Redis-backed config service
- `backend/app/api/v1/admin.py` — admin router with 6 endpoints
- `backend/app/api/v1/schemas/admin.py` — Pydantic V2 schemas
- `backend/app/api/middleware/rate_limit.py` — reads from Redis instead of hardcoded 50/day; extracts user_id from JWT
- `backend/app/infrastructure/config/settings.py` — adds `admin_emails` setting
- `backend/app/api/v1/router.py` — registers admin router
- `backend/tests/test_admin_rate_limits.py` — unit tests for service and endpoints
- `frontend/app/[locale]/(app)/admin/rate-limits/` — admin page + client component
- `frontend/messages/{en,fr}.json` — AdminRateLimits namespace

## Test plan
- [x] Backend lint (`ruff check`) passes
- [x] Frontend lint (`npm run lint`) passes — 0 errors (pre-existing warnings only)
- [ ] Backend tests pass (`uv run pytest tests/test_admin_rate_limits.py`)
- [ ] Manually verify on mobile viewport (320px)

Closes #374