### PR TITLE
fix(quiz): replace non-existent generate_content() with generate_structured_content()

### DIFF
--- a/backend/app/domain/services/quiz_service.py
+++ b/backend/app/domain/services/quiz_service.py
@@ -1,6 +1,5 @@
 """Quiz generation service using Claude API and RAG."""
 
-import json
 import uuid
 from uuid import UUID
 
@@ -189,7 +188,7 @@ class QuizService:
             )
 
             # Generate quiz using Claude API with structured prompt
-            quiz_prompt = self._build_quiz_prompt(
+            system_prompt, user_message = self._build_quiz_prompt(
                 context=context_text,
                 unit_id=unit_id,
                 language=language,
@@ -198,10 +197,12 @@ class QuizService:
                 num_questions=num_questions,
             )
 
-            response = await self.claude_service.generate_content(quiz_prompt)
+            response = await self.claude_service.generate_structured_content(
+                system_prompt, user_message, "quiz"
+            )
 
-            # Parse Claude's response into structured quiz content
-            quiz_data = self._parse_quiz_response(response, unit_id, num_questions)
+            # Validate and normalize the parsed dict from Claude
+            quiz_data = self._validate_and_normalize_quiz(response, unit_id, num_questions)
 
             return QuizContent(**quiz_data)
 
@@ -217,8 +218,8 @@ class QuizService:
         country: str,
         level: int,
         num_questions: int,
-    ) -> str:
-        """Build the prompt for Claude API to generate quiz questions."""
+    ) -> tuple[str, str]:
+        """Build the system and user prompts for Claude API to generate quiz questions."""
 
         lang_instruction = "in French" if language == "fr" else "in English"
         level_desc = {
@@ -228,7 +229,9 @@ class QuizService:
             4: "expert (research, policy implications)",
         }
 
-        return f"""You are creating a multiple-choice quiz for public health professionals in West Africa.
+        system_prompt = """You are an expert public health educator creating adaptive quiz content for West African health professionals. Always respond with valid JSON matching the requested format exactly."""
+
+        user_message = f"""Create a multiple-choice quiz for public health professionals in West Africa.
 
 CONTEXT MATERIAL:
 {context}
@@ -278,45 +281,31 @@ RESPONSE FORMAT (JSON):
 
 Generate the quiz now, ensuring all questions are relevant to public health practice in West Africa."""
 
-    def _parse_quiz_response(self, response: str, unit_id: str, expected_questions: int) -> dict:
+        return system_prompt, user_message
+
+    def _validate_and_normalize_quiz(
+        self, quiz_data: dict, unit_id: str, expected_questions: int
+    ) -> dict:
         """
-        Parse Claude's response into structured quiz data.
+        Validate and normalize parsed quiz data from Claude API.
 
         Args:
-            response: Raw response from Claude API
+            quiz_data: Parsed dict returned by generate_structured_content
             unit_id: Unit identifier to include in response
             expected_questions: Expected number of questions for validation
 
         Returns:
-            Dictionary with parsed quiz content
+            Normalized dictionary with quiz content
 
         Raises:
-            ValueError: If response cannot be parsed or is invalid
+            ValueError: If quiz_data is invalid or missing required fields
         """
         try:
-            # Try to extract JSON from Claude's response
-            # Claude sometimes wraps JSON in markdown code blocks
-            response_text = response.strip()
-
-            if "```json" in response_text:
-                start = response_text.find("```json") + 7
-                end = response_text.find("```", start)
-                response_text = response_text[start:end].strip()
-            elif "```" in response_text:
-                start = response_text.find("```") + 3
-                end = response_text.rfind("```")
-                response_text = response_text[start:end].strip()
-
-            # Parse JSON
-            quiz_data = json.loads(response_text)
-
-            # Validate structure
             required_fields = ["title", "questions"]
             for field in required_fields:
                 if field not in quiz_data:
                     raise ValueError(f"Missing required field: {field}")
 
-            # Ensure description has a default value
             quiz_data.setdefault("description", "")
 
             questions = quiz_data["questions"]
@@ -332,24 +321,18 @@ Generate the quiz now, ensuring all questions are relevant to public health prac
                     got=len(questions),
                 )
 
-            # Validate each question
             for i, question in enumerate(questions):
                 self._validate_question(question, f"question {i + 1}")
 
-            # Set defaults for optional fields
             quiz_data.setdefault("time_limit_minutes", max(10, len(questions) * 2))
             quiz_data.setdefault("passing_score", 80.0)
             if quiz_data.get("passing_score", 80.0) < 80.0:
                 quiz_data["passing_score"] = 80.0
 
-            # Add unit_id to content
             quiz_data["unit_id"] = unit_id
 
             return quiz_data
 
-        except json.JSONDecodeError as e:
-            logger.error("Failed to parse quiz JSON", response_preview=response[:200], error=str(e))
-            raise ValueError(f"Invalid JSON response from Claude API: {e}")
         except Exception as e:
             logger.error("Quiz response validation failed", error=str(e))
             raise ValueError(f"Invalid quiz format: {e}")

--- a/backend/tests/test_quiz_service.py
+++ b/backend/tests/test_quiz_service.py
@@ -1,6 +1,5 @@
 """Tests for the quiz generation service."""
 
-import json
 import uuid
 from unittest.mock import AsyncMock, MagicMock
 
@@ -8,32 +7,30 @@ import pytest
 
 from app.domain.services.quiz_service import QuizService
 
-SAMPLE_QUIZ_JSON = json.dumps(
-    {
-        "title": "Public Health Foundations Quiz",
-        "description": "Test your knowledge of public health fundamentals.",
-        "questions": [
-            {
-                "id": f"q{i}",
-                "question": f"Sample question {i}?",
-                "options": ["Option A", "Option B", "Option C", "Option D"],
-                "correct_answer": 0,
-                "explanation": f"Explanation {i}.",
-                "sources_cited": ["Donaldson Ch.1, p.10"],
-                "difficulty": "medium",
-            }
-            for i in range(1, 11)
-        ],
-        "time_limit_minutes": 15,
-        "passing_score": 80.0,
-    }
-)
+SAMPLE_QUIZ_DICT = {
+    "title": "Public Health Foundations Quiz",
+    "description": "Test your knowledge of public health fundamentals.",
+    "questions": [
+        {
+            "id": f"q{i}",
+            "question": f"Sample question {i}?",
+            "options": ["Option A", "Option B", "Option C", "Option D"],
+            "correct_answer": 0,
+            "explanation": f"Explanation {i}.",
+            "sources_cited": ["Donaldson Ch.1, p.10"],
+            "difficulty": "medium",
+        }
+        for i in range(1, 11)
+    ],
+    "time_limit_minutes": 15,
+    "passing_score": 80.0,
+}
 
 
 @pytest.fixture
 def mock_claude_service():
     service = AsyncMock()
-    service.generate_content = AsyncMock(return_value=SAMPLE_QUIZ_JSON)
+    service.generate_structured_content = AsyncMock(return_value=SAMPLE_QUIZ_DICT)
     return service
 
 
@@ -55,59 +52,61 @@ def quiz_service(mock_claude_service, mock_retriever):
     return QuizService(mock_claude_service, mock_retriever)
 
 
-class TestParseQuizResponse:
-    def test_parses_valid_json_response(self, quiz_service):
-        result = quiz_service._parse_quiz_response(SAMPLE_QUIZ_JSON, "M01-U04", 10)
+class TestValidateAndNormalizeQuiz:
+    def test_parses_valid_dict(self, quiz_service):
+        import copy
+
+        data = copy.deepcopy(SAMPLE_QUIZ_DICT)
+        result = quiz_service._validate_and_normalize_quiz(data, "M01-U04", 10)
         assert result["title"] == "Public Health Foundations Quiz"
         assert len(result["questions"]) == 10
         assert result["unit_id"] == "M01-U04"
 
-    def test_parses_json_wrapped_in_markdown_code_block(self, quiz_service):
-        wrapped = f"```json\n{SAMPLE_QUIZ_JSON}\n```"
-        result = quiz_service._parse_quiz_response(wrapped, "M01-U04", 10)
-        assert len(result["questions"]) == 10
-
-    def test_parses_json_wrapped_in_generic_code_block(self, quiz_service):
-        wrapped = f"```\n{SAMPLE_QUIZ_JSON}\n```"
-        result = quiz_service._parse_quiz_response(wrapped, "M01-U04", 10)
-        assert len(result["questions"]) == 10
-
-    def test_raises_on_invalid_json(self, quiz_service):
-        with pytest.raises(ValueError, match="Invalid JSON"):
-            quiz_service._parse_quiz_response("not valid json", "M01-U04", 10)
-
     def test_raises_on_missing_title_field(self, quiz_service):
-        data = json.loads(SAMPLE_QUIZ_JSON)
+        import copy
+
+        data = copy.deepcopy(SAMPLE_QUIZ_DICT)
         del data["title"]
         with pytest.raises(ValueError, match="Missing required field"):
-            quiz_service._parse_quiz_response(json.dumps(data), "M01-U04", 10)
+            quiz_service._validate_and_normalize_quiz(data, "M01-U04", 10)
 
     def test_raises_on_empty_questions_list(self, quiz_service):
-        data = json.loads(SAMPLE_QUIZ_JSON)
+        import copy
+
+        data = copy.deepcopy(SAMPLE_QUIZ_DICT)
         data["questions"] = []
         with pytest.raises(ValueError, match="at least one question"):
-            quiz_service._parse_quiz_response(json.dumps(data), "M01-U04", 10)
+            quiz_service._validate_and_normalize_quiz(data, "M01-U04", 10)
 
     def test_sets_default_passing_score_to_80(self, quiz_service):
-        data = json.loads(SAMPLE_QUIZ_JSON)
+        import copy
+
+        data = copy.deepcopy(SAMPLE_QUIZ_DICT)
         del data["passing_score"]
-        result = quiz_service._parse_quiz_response(json.dumps(data), "M01-U04", 10)
+        result = quiz_service._validate_and_normalize_quiz(data, "M01-U04", 10)
         assert result["passing_score"] == 80.0
 
     def test_enforces_minimum_passing_score_of_80(self, quiz_service):
-        data = json.loads(SAMPLE_QUIZ_JSON)
+        import copy
+
+        data = copy.deepcopy(SAMPLE_QUIZ_DICT)
         data["passing_score"] = 60.0
-        result = quiz_service._parse_quiz_response(json.dumps(data), "M01-U04", 10)
+        result = quiz_service._validate_and_normalize_quiz(data, "M01-U04", 10)
         assert result["passing_score"] == 80.0
 
     def test_accepts_slightly_fewer_questions_than_requested(self, quiz_service):
-        data = json.loads(SAMPLE_QUIZ_JSON)
+        import copy
+
+        data = copy.deepcopy(SAMPLE_QUIZ_DICT)
         data["questions"] = data["questions"][:8]
-        result = quiz_service._parse_quiz_response(json.dumps(data), "M01-U04", 10)
+        result = quiz_service._validate_and_normalize_quiz(data, "M01-U04", 10)
         assert len(result["questions"]) == 8
 
     def test_unit_id_added_to_result(self, quiz_service):
-        result = quiz_service._parse_quiz_response(SAMPLE_QUIZ_JSON, "M01-U04", 10)
+        import copy
+
+        data = copy.deepcopy(SAMPLE_QUIZ_DICT)
+        result = quiz_service._validate_and_normalize_quiz(data, "M01-U04", 10)
         assert result["unit_id"] == "M01-U04"
 
 
@@ -233,7 +232,7 @@ class TestGenerateQuizContent:
             num_questions=10,
         )
         mock_retriever.search_for_module.assert_called_once()
-        mock_claude_service.generate_content.assert_called_once()
+        mock_claude_service.generate_structured_content.assert_called_once()
         assert len(result.questions) == 10
 
     async def test_generated_content_has_passing_score_80(self, quiz_service, mock_claude_service):
@@ -249,7 +248,7 @@ class TestGenerateQuizContent:
         assert result.passing_score == 80.0
 
     async def test_raises_on_claude_error(self, quiz_service, mock_claude_service):
-        mock_claude_service.generate_content.side_effect = Exception("API error")
+        mock_claude_service.generate_structured_content.side_effect = Exception("API error")
         module_id = uuid.uuid4()
         with pytest.raises(Exception, match="API error"):
             await quiz_service._generate_quiz_content(
@@ -263,8 +262,8 @@ class TestGenerateQuizContent:
 
 
 class TestBuildQuizPrompt:
-    def test_prompt_contains_unit_id(self, quiz_service):
-        prompt = quiz_service._build_quiz_prompt(
+    def test_returns_tuple_of_system_and_user(self, quiz_service):
+        result = quiz_service._build_quiz_prompt(
             context="Some context",
             unit_id="M01-U04",
             language="fr",
@@ -272,10 +271,22 @@ class TestBuildQuizPrompt:
             level=1,
             num_questions=10,
         )
-        assert "M01-U04" in prompt
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+    def test_prompt_contains_unit_id(self, quiz_service):
+        _system_prompt, user_message = quiz_service._build_quiz_prompt(
+            context="Some context",
+            unit_id="M01-U04",
+            language="fr",
+            country="senegal",
+            level=1,
+            num_questions=10,
+        )
+        assert "M01-U04" in user_message
 
     def test_prompt_uses_french_instruction(self, quiz_service):
-        prompt = quiz_service._build_quiz_prompt(
+        _system_prompt, user_message = quiz_service._build_quiz_prompt(
             context="context",
             unit_id="M01-U04",
             language="fr",
@@ -283,10 +294,10 @@ class TestBuildQuizPrompt:
             level=1,
             num_questions=5,
         )
-        assert "in French" in prompt
+        assert "in French" in user_message
 
     def test_prompt_uses_english_instruction(self, quiz_service):
-        prompt = quiz_service._build_quiz_prompt(
+        _system_prompt, user_message = quiz_service._build_quiz_prompt(
             context="context",
             unit_id="M01-U04",
             language="en",
@@ -294,10 +305,10 @@ class TestBuildQuizPrompt:
             level=2,
             num_questions=5,
         )
-        assert "in English" in prompt
+        assert "in English" in user_message
 
     def test_prompt_includes_passing_score_80(self, quiz_service):
-        prompt = quiz_service._build_quiz_prompt(
+        _system_prompt, user_message = quiz_service._build_quiz_prompt(
             context="context",
             unit_id="M01-U04",
             language="fr",
@@ -305,4 +316,4 @@ class TestBuildQuizPrompt:
             level=1,
             num_questions=10,
         )
-        assert "80.0" in prompt
+        assert "80.0" in user_message


### PR DESCRIPTION
## Summary
- Replace `ClaudeService.generate_content(prompt)` (method doesn't exist) with `generate_structured_content(system_prompt, user_message, "quiz")` which returns a parsed `dict`
- Refactor `_build_quiz_prompt` to return `(system_prompt, user_message)` tuple instead of a single string
- Replace `_parse_quiz_response(str)` with `_validate_and_normalize_quiz(dict)` — no redundant JSON parsing needed since `generate_structured_content` already handles that

## Changes
- `backend/app/domain/services/quiz_service.py` — fixed method call and refactored prompt/parse helpers
- `backend/tests/test_quiz_service.py` — updated mocks, fixtures, and test classes to match new API

## Test plan
- [x] `ruff check` passes — no lint errors
- [x] 22/22 unit tests pass (`pytest tests/test_quiz_service.py`)
- [ ] Manually verify quiz generation succeeds end-to-end

Closes #375

Generated with [Claude Code](https://claude.ai/code)