### PR TITLE
fix: quiz regenerates every access — unit_id missing from cache

### DIFF
--- a/backend/app/domain/services/quiz_service.py
+++ b/backend/app/domain/services/quiz_service.py
@@ -108,7 +108,7 @@ class QuizService:
                 content_type="quiz",
                 language=language,
                 level=level,
-                content=quiz_content.model_dump(),
+                content={**quiz_content.model_dump(), "unit_id": unit_id},
                 sources_cited=self._extract_sources_from_quiz(quiz_content),
                 country_context=country,
                 validated=False,


### PR DESCRIPTION
Quiz cache lookup filtered by content->>'unit_id' but generated quizzes never stored unit_id in JSONB content. Now included at save time.