### PR TITLE
fix: remove flag from language switcher

### DIFF
--- a/frontend/components/shared/locale-switcher.tsx
+++ b/frontend/components/shared/locale-switcher.tsx
@@ -55,9 +55,6 @@ export function LocaleSwitcher() {
       title={t("switchTo")}
       aria-label={t("switchTo")}
     >
-      <span className="text-base" role="img" aria-hidden="true">
-        {getFlagIcon(locale)}
-      </span>
       <span className="text-sm font-medium">
         {getLanguageAbbrev(locale)}
       </span>


### PR DESCRIPTION
Removes flag emoji, shows only FR/EN text.