### PR TITLE
Merge dev → main: case study endpoints + parser fix

### DIFF
--- a/backend/app/api/v1/content.py
+++ b/backend/app/api/v1/content.py
@@ -17,6 +17,7 @@ from app.ai.rag.retriever import SemanticRetriever
 from app.api.deps import get_db
 from app.api.deps_local_auth import get_optional_user
 from app.api.v1.schemas.content import (
+    CaseStudyResponse,
     ErrorResponse,
     FlashcardGenerationRequest,
     FlashcardSetResponse,
@@ -28,7 +29,7 @@ from app.api.v1.schemas.content import (
 )
 from app.domain.models.module import Module
 from app.domain.services.flashcard_service import FlashcardGenerationService
-from app.domain.services.lesson_service import LessonGenerationService
+from app.domain.services.lesson_service import CaseStudyGenerationService, LessonGenerationService
 from app.domain.services.progress_service import ProgressService
 from app.domain.services.quiz_service import QuizService
 from app.infrastructure.config.settings import get_settings
@@ -109,6 +110,14 @@ def get_flashcard_service(
 ) -> FlashcardGenerationService:
     """Dependency to get flashcard generation service."""
     return FlashcardGenerationService(claude_service, semantic_retriever)
+
+
+def get_case_study_service(
+    claude_service: ClaudeService = Depends(get_claude_service),
+    semantic_retriever: SemanticRetriever = Depends(get_semantic_retriever),
+) -> CaseStudyGenerationService:
+    """Dependency to get case study generation service."""
+    return CaseStudyGenerationService(claude_service, semantic_retriever)
 
 
 def get_quiz_service(
@@ -825,3 +834,180 @@ async def get_quiz(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail={"error": "retrieval_failed", "message": "Failed to retrieve quiz"},
         )
+
+
+# ── Case Study Endpoints ────────────────────────────────────────────────────
+
+
+@router.get(
+    "/cases/{module_id}/{unit_id}",
+    response_model=CaseStudyResponse,
+    status_code=status.HTTP_200_OK,
+    responses={
+        400: {"model": ErrorResponse, "description": "Invalid request"},
+        404: {"model": ErrorResponse, "description": "Module or unit not found"},
+        500: {"model": ErrorResponse, "description": "Generation failed"},
+    },
+)
+async def get_or_generate_case_study(
+    module_id: str,
+    unit_id: str,
+    language: str = "fr",
+    level: int = 1,
+    country: str = "SN",
+    case_study_service: CaseStudyGenerationService = Depends(get_case_study_service),
+    session: AsyncSession = Depends(get_db),
+    current_user=Depends(get_optional_user),
+) -> CaseStudyResponse:
+    """
+    Get or generate case study content by module and unit ID.
+
+    **Parameters:**
+    - **module_id**: Module identifier (code like "M01" or UUID string)
+    - **unit_id**: Unit identifier (e.g., "M01-U05")
+    - **language**: Content language ("fr" or "en")
+    - **level**: User's level (1-4)
+    - **country**: Country context for examples (ISO 2-letter code)
+    """
+    try:
+        logger.info(
+            "Case study request",
+            module_id=module_id,
+            unit_id=unit_id,
+            language=language,
+            level=level,
+            country=country,
+        )
+
+        resolved_module_id = await _resolve_module_id(module_id, session)
+
+        case_study_response = await case_study_service.get_or_generate_case_study(
+            module_id=resolved_module_id,
+            unit_id=unit_id,
+            language=language,
+            country=country,
+            level=level,
+            session=session,
+        )
+
+        if current_user is not None:
+            try:
+                from uuid import UUID as _UUID
+
+                progress_service = ProgressService(session)
+                await progress_service.track_lesson_access(
+                    user_id=_UUID(str(current_user.id)),
+                    module_id=resolved_module_id,
+                    lesson_id=case_study_response.id,
+                )
+            except Exception as track_err:
+                logger.warning(
+                    "Failed to track case study access (non-fatal)",
+                    error=str(track_err),
+                )
+
+        logger.info(
+            "Case study request completed",
+            case_study_id=str(case_study_response.id),
+            cached=case_study_response.cached,
+        )
+
+        return case_study_response
+
+    except ValueError as e:
+        logger.warning("Invalid case study request", error=str(e))
+        if "not found" in str(e).lower():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"error": "module_or_unit_not_found", "message": str(e)},
+            )
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={"error": "invalid_request", "message": str(e)},
+            )
+
+    except Exception as e:
+        logger.error("Case study request failed", error=str(e), exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={
+                "error": "generation_failed",
+                "message": "Une erreur interne s'est produite lors de la génération",
+            },
+        )
+
+
+@router.get(
+    "/cases/{module_id}/{unit_id}/stream",
+    status_code=status.HTTP_200_OK,
+    responses={
+        400: {"description": "Invalid request"},
+        404: {"description": "Module or unit not found"},
+        500: {"description": "Generation failed"},
+    },
+)
+async def stream_case_study_by_module_and_unit(
+    module_id: str,
+    unit_id: str,
+    language: str = "fr",
+    level: int = 1,
+    country: str = "SN",
+    case_study_service: CaseStudyGenerationService = Depends(get_case_study_service),
+    session: AsyncSession = Depends(get_db),
+) -> StreamingResponse:
+    """
+    Stream case study generation by module and unit ID using Server-Sent Events (SSE).
+
+    **Event Types:**
+    - `chunk`: Incremental content as it's generated
+    - `complete`: Final case study object when generation finishes
+    - `error`: Error information if generation fails
+    """
+
+    async def generate_events() -> AsyncGenerator[str, None]:
+        try:
+            logger.info(
+                "Starting case study streaming",
+                module_id=module_id,
+                unit_id=unit_id,
+                language=language,
+                level=level,
+                country=country,
+            )
+
+            resolved_module_id = await _resolve_module_id(module_id, session)
+
+            async for event in case_study_service.stream_case_study_generation(
+                module_id=resolved_module_id,
+                unit_id=unit_id,
+                language=language,
+                country=country,
+                level=level,
+                session=session,
+            ):
+                yield event.to_sse_format()
+
+            logger.info("Case study streaming completed")
+
+        except Exception as e:
+            logger.error("Case study streaming failed", error=str(e), exc_info=True)
+            error_event = StreamingEvent(
+                event="error",
+                data={
+                    "error": "streaming_failed",
+                    "message": "Erreur lors de la génération en streaming",
+                },
+            )
+            yield error_event.to_sse_format()
+
+    return StreamingResponse(
+        generate_events(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Headers": "Cache-Control",
+        },
+    )

--- a/backend/app/domain/services/lesson_service.py
+++ b/backend/app/domain/services/lesson_service.py
@@ -1,5 +1,6 @@
 """Service for lesson and case study content generation and management."""
 
+import re
 import uuid
 from collections.abc import AsyncGenerator
 from datetime import datetime
@@ -737,7 +738,17 @@ class CaseStudyGenerationService:
     async def _parse_case_study_content(
         self, content_text: str, rag_chunks: list
     ) -> CaseStudyContent:
-        """Parse generated content into structured case study format."""
+        """Parse generated content into structured case study format.
+
+        Claude produces 4 numbered sections with bold headers like:
+          1. **Contexte AOF** / 1. **AOF Context**
+          2. **Données réelles** / 2. **Real Data**
+          3. **Questions guidées** / 3. **Guided Questions**
+          4. **Correction annotée** / 4. **Annotated Correction**
+
+        This method splits on those headers and maps each section.
+        """
+        # Extract source citations from RAG chunks
         sources_cited = []
         for chunk in rag_chunks:
             if hasattr(chunk, "chunk"):
@@ -758,19 +769,67 @@ class CaseStudyGenerationService:
             if source_citation not in sources_cited:
                 sources_cited.append(source_citation)
 
-        half = len(content_text) // 2
+        # Split on numbered section headers: "1. **...**", "## 1. **...**", etc.
+        section_pattern = r"(?:^|\n)(?:#{1,3}\s*)?(\d+)\.\s*\*\*[^*]+\*\*"
+        splits = list(re.finditer(section_pattern, content_text))
+
+        sections: dict[int, str] = {}
+        for i, match in enumerate(splits):
+            section_num = int(match.group(1))
+            start = match.end()
+            end = splits[i + 1].start() if i + 1 < len(splits) else len(content_text)
+            sections[section_num] = content_text[start:end].strip()
+
+        # Fallback: if regex found no sections, split by paragraphs proportionally
+        if not sections:
+            logger.warning("Case study section headers not found, using paragraph fallback")
+            paragraphs = [p.strip() for p in content_text.split("\n\n") if p.strip()]
+            if len(paragraphs) >= 4:
+                quarter = max(1, len(paragraphs) // 4)
+                sections = {
+                    1: "\n\n".join(paragraphs[:quarter]),
+                    2: "\n\n".join(paragraphs[quarter : 2 * quarter]),
+                    3: "\n\n".join(paragraphs[2 * quarter : 3 * quarter]),
+                    4: "\n\n".join(paragraphs[3 * quarter :]),
+                }
+            else:
+                # Too few paragraphs — split by character position
+                chunk_size = max(1, len(content_text) // 4)
+                sections = {
+                    1: content_text[:chunk_size].strip(),
+                    2: content_text[chunk_size : 2 * chunk_size].strip(),
+                    3: content_text[2 * chunk_size : 3 * chunk_size].strip(),
+                    4: content_text[3 * chunk_size :].strip(),
+                }
+
+        # Parse guided questions from section 3 (numbered or bulleted lines)
+        questions_text = sections.get(3, "")
+        question_lines = re.findall(
+            r"(?:^|\n)\s*(?:\d+[\.\)]\s*|-\s*|\*\s*)(.+?)(?=\n\s*(?:\d+[\.\)]|-|\*)|\Z)",
+            questions_text,
+            re.DOTALL,
+        )
+        guided_questions = [q.strip() for q in question_lines if q.strip()]
+
+        # If individual question extraction failed, use the whole section text
+        if not guided_questions and questions_text.strip():
+            guided_questions = [
+                line.strip()
+                for line in questions_text.strip().split("\n")
+                if line.strip() and not re.match(r"^#{1,3}\s", line)
+            ]
+
+        # Ensure minimum 2 questions (schema constraint: min_length=2)
+        if len(guided_questions) < 2:
+            guided_questions = [questions_text.strip() or sections.get(3, "")]
+            if len(guided_questions) < 2:
+                guided_questions.append("")
+
         return CaseStudyContent(
-            aof_context=content_text[:300] + "..." if len(content_text) > 300 else content_text,
-            real_data=content_text[300:600] + "..."
-            if len(content_text) > 600
-            else content_text[300:],
-            guided_questions=[
-                "Question guidée 1 — sera extraite du contenu généré",
-                "Question guidée 2 — sera extraite du contenu généré",
-            ],
-            annotated_correction=content_text[half:]
-            if len(content_text) > half
-            else "Correction annotée sera extraite du contenu généré.",
+            aof_context=sections.get(1, content_text[:500]),
+            real_data=sections.get(2, ""),
+            guided_questions=guided_questions,
+            annotated_correction=sections.get(4, ""),
             sources_cited=sources_cited,
         )
 

--- a/frontend/components/learning/case-study-viewer.tsx
+++ b/frontend/components/learning/case-study-viewer.tsx
@@ -66,7 +66,7 @@ export function CaseStudyViewer({
 
         try {
           const cachedData = await apiFetch<CaseStudyData>(
-            `/api/v1/content/lessons/${moduleId}/${unitId}?language=${language}&level=${level}&country=${countryContext}&content_type=case`
+            `/api/v1/content/cases/${moduleId}/${unitId}?language=${language}&level=${level}&country=${countryContext}`
           );
 
           if (cachedData.cached) {
@@ -78,7 +78,7 @@ export function CaseStudyViewer({
         }
 
         const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
-        const streamUrl = `${API_BASE}/api/v1/content/lessons/${moduleId}/${unitId}/stream?language=${language}&level=${level}&country=${countryContext}&content_type=case`;
+        const streamUrl = `${API_BASE}/api/v1/content/cases/${moduleId}/${unitId}/stream?language=${language}&level=${level}&country=${countryContext}`;
         eventSource = new EventSource(streamUrl);
 
         eventSource.onmessage = (event) => {


### PR DESCRIPTION
## Summary

- Fixes #383 — wire case study API endpoints and rewrite content parser
- Includes quiz cache fix from #382

## Changes

- `GET /content/cases/{module_id}/{unit_id}` + SSE stream endpoint
- Rewrote `_parse_case_study_content()` with regex section splitting
- Frontend URLs fixed from `/lessons/?content_type=case` → `/cases/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)