### PR TITLE
fix: quiz submission crash — use real user ID

### DIFF
--- a/backend/app/api/v1/quiz.py
+++ b/backend/app/api/v1/quiz.py
@@ -13,6 +13,7 @@ from app.ai.claude_service import ClaudeService
 from app.ai.rag.embeddings import EmbeddingService
 from app.ai.rag.retriever import SemanticRetriever
 from app.api.deps import get_db
+from app.api.deps_local_auth import get_current_user
 from app.api.v1.schemas.quiz import (
     ErrorResponse,
     QuizAttemptRequest,
@@ -28,6 +29,7 @@ from app.domain.models.content import GeneratedContent
 from app.domain.models.module import Module
 from app.domain.models.progress import UserModuleProgress
 from app.domain.models.quiz import QuizAttempt, SummativeAssessmentAttempt
+from app.domain.models.user import User
 from app.domain.services.progress_service import ProgressService
 from app.domain.services.quiz_service import QuizService
 from app.infrastructure.config.settings import get_settings
@@ -247,7 +249,7 @@ async def get_quiz(
 async def submit_quiz_attempt(
     request: QuizAttemptRequest,
     session: AsyncSession = Depends(get_db),
-    # user_id: UUID = Depends(get_current_user_id),  # TODO: Add auth dependency
+    current_user: User = Depends(get_current_user),
 ) -> QuizAttemptResponse:
     """
     Submit a completed quiz attempt and get immediate feedback.
@@ -266,8 +268,7 @@ async def submit_quiz_attempt(
     **Rate Limiting:** Users can retake quizzes unlimited times.
     """
     try:
-        # For now, use a dummy user_id until auth is implemented
-        user_id = uuid.uuid4()  # TODO: Replace with actual user from auth
+        user_id = uuid.UUID(str(current_user.id))
 
         logger.info(
             "Quiz attempt submitted",
@@ -527,7 +528,7 @@ async def generate_summative_assessment(
 async def can_attempt_summative_assessment(
     module_id: UUID,
     session: AsyncSession = Depends(get_db),
-    # user_id: UUID = Depends(get_current_user_id),  # TODO: Add auth dependency
+    current_user: User = Depends(get_current_user),
 ) -> SummativeAssessmentAttemptCheck:
     """
     Check if user can attempt summative assessment for a module.
@@ -539,7 +540,7 @@ async def can_attempt_summative_assessment(
     """
     try:
         # For now, use a dummy user_id until auth is implemented
-        user_id = uuid.uuid4()  # TODO: Replace with actual user from auth
+        user_id = uuid.UUID(str(current_user.id))
 
         # Check if module exists
         query = select(Module).where(Module.id == module_id)
@@ -632,7 +633,7 @@ async def can_attempt_summative_assessment(
 async def submit_summative_assessment_attempt(
     request: QuizAttemptRequest,
     session: AsyncSession = Depends(get_db),
-    # user_id: UUID = Depends(get_current_user_id),  # TODO: Add auth dependency
+    current_user: User = Depends(get_current_user),
 ) -> SummativeAssessmentResponse:
     """
     Submit a completed summative assessment attempt.
@@ -648,7 +649,7 @@ async def submit_summative_assessment_attempt(
     """
     try:
         # For now, use a dummy user_id until auth is implemented
-        user_id = uuid.uuid4()  # TODO: Replace with actual user from auth
+        user_id = uuid.UUID(str(current_user.id))
 
         logger.info(
             "Summative assessment attempt submitted",


### PR DESCRIPTION
Fixes FK violation. All quiz endpoints use authenticated user.