### PR TITLE
feat(backend): generated_images table + Alembic migration (#222)

### DIFF
--- a/backend/app/domain/models/__init__.py
+++ b/backend/app/domain/models/__init__.py
@@ -4,6 +4,7 @@ from app.domain.models.content import GeneratedContent
 from app.domain.models.conversation import TutorConversation
 from app.domain.models.document_chunk import DocumentChunk
 from app.domain.models.flashcard import FlashcardReview
+from app.domain.models.generated_image import GeneratedImage
 from app.domain.models.learner_memory import LearnerMemory
 from app.domain.models.module import Module
 from app.domain.models.module_unit import ModuleUnit
@@ -15,6 +16,7 @@ __all__ = [
     "Base",
     "DocumentChunk",
     "GeneratedContent",
+    "GeneratedImage",
     "LearnerMemory",
     "TutorConversation",
     "FlashcardReview",

--- a/backend/app/domain/models/generated_image.py
+++ b/backend/app/domain/models/generated_image.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from sqlalchemy import ForeignKey, Index, Integer, String, Text, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.domain.models.base import Base
+
+if TYPE_CHECKING:
+    from app.domain.models.content import GeneratedContent
+    from app.domain.models.module import Module
+
+
+class GeneratedImage(Base):
+    __tablename__ = "generated_images"
+    __table_args__ = (
+        Index("ix_generated_images_semantic_tags_gin", "semantic_tags", postgresql_using="gin"),
+        Index("ix_generated_images_status", "status"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    lesson_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("generated_content.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    module_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("modules.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    unit_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    concept: Mapped[str | None] = mapped_column(Text, nullable=True)
+    prompt: Mapped[str | None] = mapped_column(Text, nullable=True)
+    image_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    format: Mapped[str] = mapped_column(String(20), server_default="webp")
+    width: Mapped[int] = mapped_column(Integer, server_default="512")
+    alt_text_fr: Mapped[str | None] = mapped_column(Text, nullable=True)
+    alt_text_en: Mapped[str | None] = mapped_column(Text, nullable=True)
+    semantic_tags: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    reuse_count: Mapped[int] = mapped_column(Integer, server_default="0")
+    status: Mapped[str] = mapped_column(
+        sa.Enum("pending", "generating", "ready", "failed", name="image_status_enum"),
+        server_default="pending",
+    )
+    generated_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    file_size_bytes: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(server_default=func.now())
+
+    lesson: Mapped[GeneratedContent | None] = relationship(
+        "GeneratedContent",
+        foreign_keys=[lesson_id],
+    )
+    module: Mapped[Module | None] = relationship(
+        "Module",
+        foreign_keys=[module_id],
+    )

--- a/backend/migrations/versions/015_add_generated_images_table.py
+++ b/backend/migrations/versions/015_add_generated_images_table.py
@@ -1,0 +1,80 @@
+"""Add generated_images table for storing AI-generated lesson illustrations
+
+Revision ID: 015_add_generated_images_table
+Revises: 014_add_compacted_context_to_conversations
+Create Date: 2026-04-02
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "015_add_generated_images_table"
+down_revision: str | None = "014_add_compacted_context_to_conversations"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+image_status_enum = postgresql.ENUM(
+    "pending", "generating", "ready", "failed", name="image_status_enum"
+)
+
+
+def upgrade() -> None:
+    image_status_enum.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "generated_images",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("lesson_id", sa.UUID(), nullable=True),
+        sa.Column("module_id", sa.UUID(), nullable=True),
+        sa.Column("unit_id", sa.Text(), nullable=True),
+        sa.Column("concept", sa.Text(), nullable=True),
+        sa.Column("prompt", sa.Text(), nullable=True),
+        sa.Column("image_url", sa.Text(), nullable=True),
+        sa.Column("format", sa.String(20), server_default="webp", nullable=False),
+        sa.Column("width", sa.Integer(), server_default="512", nullable=False),
+        sa.Column("alt_text_fr", sa.Text(), nullable=True),
+        sa.Column("alt_text_en", sa.Text(), nullable=True),
+        sa.Column("semantic_tags", postgresql.JSONB(), nullable=True),
+        sa.Column("reuse_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column(
+            "status",
+            postgresql.ENUM(
+                "pending",
+                "generating",
+                "ready",
+                "failed",
+                name="image_status_enum",
+                create_type=False,
+            ),
+            server_default="pending",
+            nullable=False,
+        ),
+        sa.Column("generated_at", sa.DateTime(), nullable=True),
+        sa.Column("file_size_bytes", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["lesson_id"], ["generated_content.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["module_id"], ["modules.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_index(
+        "ix_generated_images_semantic_tags_gin",
+        "generated_images",
+        ["semantic_tags"],
+        postgresql_using="gin",
+    )
+    op.create_index(
+        "ix_generated_images_status",
+        "generated_images",
+        ["status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_generated_images_status", table_name="generated_images")
+    op.drop_index("ix_generated_images_semantic_tags_gin", table_name="generated_images")
+    op.drop_table("generated_images")
+    image_status_enum.drop(op.get_bind(), checkfirst=True)

--- a/backend/tests/test_generated_image_model.py
+++ b/backend/tests/test_generated_image_model.py
@@ -1,0 +1,139 @@
+"""Tests for GeneratedImage model — AI-generated lesson illustrations with semantic metadata."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import pytest
+
+from app.domain.models.generated_image import GeneratedImage
+
+
+def _make_image(**kwargs) -> GeneratedImage:
+    defaults = {
+        "id": uuid.uuid4(),
+        "lesson_id": None,
+        "module_id": None,
+        "unit_id": None,
+        "concept": None,
+        "prompt": None,
+        "image_url": None,
+        "format": "webp",
+        "width": 512,
+        "alt_text_fr": None,
+        "alt_text_en": None,
+        "semantic_tags": None,
+        "reuse_count": 0,
+        "status": "pending",
+        "generated_at": None,
+        "file_size_bytes": None,
+    }
+    defaults.update(kwargs)
+    return GeneratedImage(**defaults)
+
+
+class TestGeneratedImageInstantiation:
+    def test_create_with_minimal_fields(self):
+        image = _make_image()
+        assert isinstance(image.id, uuid.UUID)
+        assert image.format == "webp"
+        assert image.width == 512
+        assert image.reuse_count == 0
+        assert image.status == "pending"
+
+    def test_create_with_all_fields(self):
+        lesson_id = uuid.uuid4()
+        module_id = uuid.uuid4()
+        now = datetime.utcnow()
+        image = _make_image(
+            lesson_id=lesson_id,
+            module_id=module_id,
+            unit_id="u01",
+            concept="paludisme",
+            prompt="Illustration du cycle de vie du parasite du paludisme en Afrique de l'Ouest",
+            image_url="https://cdn.example.com/images/malaria-cycle.webp",
+            format="webp",
+            width=512,
+            alt_text_fr="Cycle de vie du parasite du paludisme",
+            alt_text_en="Malaria parasite life cycle",
+            semantic_tags=["épidémiologie", "paludisme", "AOF"],
+            reuse_count=3,
+            status="ready",
+            generated_at=now,
+            file_size_bytes=48200,
+        )
+        assert image.lesson_id == lesson_id
+        assert image.module_id == module_id
+        assert image.unit_id == "u01"
+        assert image.concept == "paludisme"
+        assert image.image_url == "https://cdn.example.com/images/malaria-cycle.webp"
+        assert image.alt_text_fr == "Cycle de vie du parasite du paludisme"
+        assert image.alt_text_en == "Malaria parasite life cycle"
+        assert image.reuse_count == 3
+        assert image.status == "ready"
+        assert image.generated_at == now
+        assert image.file_size_bytes == 48200
+
+    def test_default_format_is_webp(self):
+        image = _make_image()
+        assert image.format == "webp"
+
+    def test_default_width_is_512(self):
+        image = _make_image()
+        assert image.width == 512
+
+    def test_default_reuse_count_is_zero(self):
+        image = _make_image()
+        assert image.reuse_count == 0
+
+    def test_default_status_is_pending(self):
+        image = _make_image()
+        assert image.status == "pending"
+
+
+class TestSemanticTags:
+    def test_semantic_tags_accepts_list_of_strings(self):
+        tags = ["épidémiologie", "paludisme", "AOF", "Sénégal"]
+        image = _make_image(semantic_tags=tags)
+        assert image.semantic_tags == tags
+
+    def test_semantic_tags_can_be_none(self):
+        image = _make_image(semantic_tags=None)
+        assert image.semantic_tags is None
+
+    def test_semantic_tags_accepts_empty_list(self):
+        image = _make_image(semantic_tags=[])
+        assert image.semantic_tags == []
+
+    def test_semantic_tags_accepts_mixed_language_tags(self):
+        tags = ["épidémiologie", "epidemiology", "malaria", "paludisme"]
+        image = _make_image(semantic_tags=tags)
+        assert len(image.semantic_tags) == 4
+
+
+class TestStatusValues:
+    @pytest.mark.parametrize("status", ["pending", "generating", "ready", "failed"])
+    def test_all_valid_status_values(self, status: str):
+        image = _make_image(status=status)
+        assert image.status == status
+
+
+class TestForeignKeys:
+    def test_lesson_id_can_be_none(self):
+        image = _make_image(lesson_id=None)
+        assert image.lesson_id is None
+
+    def test_module_id_can_be_none(self):
+        image = _make_image(module_id=None)
+        assert image.module_id is None
+
+    def test_lesson_id_accepts_uuid(self):
+        lesson_id = uuid.uuid4()
+        image = _make_image(lesson_id=lesson_id)
+        assert image.lesson_id == lesson_id
+
+    def test_module_id_accepts_uuid(self):
+        module_id = uuid.uuid4()
+        image = _make_image(module_id=module_id)
+        assert image.module_id == module_id


### PR DESCRIPTION
## Summary

Implements the `generated_images` database table for storing AI-generated lesson illustrations with rich semantic metadata for reuse (SRS US-025, FR-03.2).

## Changes

- `backend/app/domain/models/generated_image.py` — new `GeneratedImage` SQLAlchemy 2.0 async model with all SRS Section 9 columns
- `backend/migrations/versions/015_add_generated_images_table.py` — Alembic migration creating the table with GIN index on `semantic_tags` (JSONB) and index on `status`
- `backend/app/domain/models/__init__.py` — exports `GeneratedImage`
- `backend/tests/test_generated_image_model.py` — 18 unit tests

## Acceptance criteria

- [x] Alembic migration in `backend/migrations/versions/` (`015_add_generated_images_table.py`)
- [x] Schema matches SRS Section 9 (all columns: id, lesson_id, module_id, unit_id, concept, prompt, image_url, format, width, alt_text_fr, alt_text_en, semantic_tags, reuse_count, status, generated_at, file_size_bytes)
- [x] SQLAlchemy 2.0 async model with `Mapped[]` syntax
- [x] GIN index on `semantic_tags` for fast similarity search
- [x] Index on `status` for querying pending/ready images
- [x] Migration is reversible (downgrade drops table + `image_status_enum` type)
- [x] 18 tests pass (instantiation, JSONB semantic_tags, status enum values, FK fields)

## Test plan

- [x] 18/18 unit tests pass (`tests/test_generated_image_model.py`)
- [x] `ruff check` clean on all new files

Closes #222

Generated with [Claude Code](https://claude.ai/code)