### PR TITLE
feat(frontend): lesson image placeholder with fade-in and lazy loading

### DIFF
--- a/frontend/components/learning/lesson-image.tsx
+++ b/frontend/components/learning/lesson-image.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useTranslations } from 'next-intl';
+import { X } from 'lucide-react';
+import { getLessonImageStatus } from '@/lib/api';
+import type { LessonImageStatus } from '@/lib/api';
+
+const POLL_INTERVAL_MS = 3000;
+const MAX_POLL_ATTEMPTS = 40;
+
+interface LessonImageProps {
+  lessonId: string;
+  language: 'fr' | 'en';
+}
+
+export function LessonImage({ lessonId, language }: LessonImageProps) {
+  const t = useTranslations('LessonImage');
+  const [status, setStatus] = useState<LessonImageStatus>('pending');
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [altText, setAltText] = useState<string>('');
+  const [isVisible, setIsVisible] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  const poll = useCallback(async () => {
+    let attempts = 0;
+
+    const tick = async () => {
+      if (attempts >= MAX_POLL_ATTEMPTS) {
+        setStatus('failed');
+        return;
+      }
+      attempts++;
+
+      try {
+        const data = await getLessonImageStatus(lessonId);
+        setStatus(data.status);
+
+        if (data.status === 'ready' && data.url) {
+          const alt =
+            language === 'fr'
+              ? (data.alt_text_fr ?? data.alt_text ?? '')
+              : (data.alt_text_en ?? data.alt_text ?? '');
+          setAltText(alt);
+          setImageUrl(data.url);
+          setTimeout(() => setIsVisible(true), 50);
+          return;
+        }
+
+        if (data.status === 'failed') {
+          return;
+        }
+
+        setTimeout(tick, POLL_INTERVAL_MS);
+      } catch {
+        setTimeout(tick, POLL_INTERVAL_MS);
+      }
+    };
+
+    tick();
+  }, [lessonId, language]);
+
+  useEffect(() => {
+    poll();
+  }, [poll]);
+
+  if (status === 'failed') {
+    return null;
+  }
+
+  if (status !== 'ready' || !imageUrl) {
+    return (
+      <div
+        className="w-full max-w-[512px] mx-auto my-6 rounded-lg overflow-hidden animate-pulse"
+        aria-busy="true"
+        aria-label={t('imagePending')}
+      >
+        <div className="bg-gray-200 h-48 flex items-center justify-center rounded-lg">
+          <p className="text-gray-500 text-sm text-center px-4">{t('imagePending')}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="w-full max-w-[512px] mx-auto my-6">
+        <button
+          type="button"
+          className="w-full rounded-lg overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 min-h-11"
+          aria-label={t('imageViewFullscreen')}
+          onClick={() => setIsFullscreen(true)}
+        >
+          <img
+            src={imageUrl}
+            alt={altText}
+            width={512}
+            loading="lazy"
+            className={`w-full h-auto object-cover rounded-lg transition-opacity duration-300 ${
+              isVisible ? 'opacity-100' : 'opacity-0'
+            }`}
+          />
+        </button>
+      </div>
+
+      {isFullscreen && (
+        <div
+          className="fixed inset-0 z-50 bg-black/90 flex items-center justify-center p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label={altText}
+          onClick={() => setIsFullscreen(false)}
+        >
+          <button
+            type="button"
+            className="absolute top-4 right-4 min-h-11 min-w-11 flex items-center justify-center rounded-full bg-white/10 text-white hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+            aria-label={t('imageCloseFullscreen')}
+            onClick={(e) => {
+              e.stopPropagation();
+              setIsFullscreen(false);
+            }}
+          >
+            <X className="w-5 h-5" aria-hidden="true" />
+          </button>
+          <img
+            src={imageUrl}
+            alt={altText}
+            width={512}
+            className="max-w-full max-h-full object-contain rounded-lg"
+            onClick={(e) => e.stopPropagation()}
+          />
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/components/learning/lesson-viewer.tsx
+++ b/frontend/components/learning/lesson-viewer.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { LessonSkeleton } from './lesson-skeleton';
+import { LessonImage } from './lesson-image';
 import { SourceCitations } from './source-citations';
 import { apiFetch } from '@/lib/api';
 
@@ -210,6 +211,9 @@ export function LessonViewer({
               <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>{content.introduction}</ReactMarkdown>
             </div>
           </div>
+
+          {/* Lesson Illustration */}
+          <LessonImage lessonId={lessonData.id} language={lessonData.language} />
 
           {/* Key Concepts */}
           <div className="mb-8">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -121,6 +121,22 @@ export async function apiFetch<T>(
 // Alias for backward compatibility and common usage
 export const fetchApi = apiFetch;
 
+// Lesson Image API Types
+export type LessonImageStatus = 'pending' | 'generating' | 'ready' | 'failed';
+
+export interface LessonImageResponse {
+  lesson_id: string;
+  status: LessonImageStatus;
+  url?: string;
+  alt_text?: string;
+  alt_text_fr?: string;
+  alt_text_en?: string;
+}
+
+export async function getLessonImageStatus(lessonId: string): Promise<LessonImageResponse> {
+  return apiFetch<LessonImageResponse>(`/api/v1/images/lesson/${lessonId}`);
+}
+
 export interface DashboardStats {
   streak_days: number;
   average_quiz_score: number;

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -585,6 +585,11 @@
     "markComplete": "Mark as Complete",
     "completed": "Completed"
   },
+  "LessonImage": {
+    "imagePending": "Generating illustration...",
+    "imageViewFullscreen": "View fullscreen",
+    "imageCloseFullscreen": "Close fullscreen"
+  },
   "CaseStudyViewer": {
     "error": "An error occurred",
     "streamError": "Streaming error occurred",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -585,6 +585,11 @@
     "markComplete": "Marquer comme Terminé",
     "completed": "Terminé"
   },
+  "LessonImage": {
+    "imagePending": "Illustration en cours de génération...",
+    "imageViewFullscreen": "Voir en plein écran",
+    "imageCloseFullscreen": "Fermer le plein écran"
+  },
   "CaseStudyViewer": {
     "error": "Une erreur est survenue",
     "streamError": "Erreur lors de la diffusion en continu",


### PR DESCRIPTION
## Summary

Implements all acceptance criteria from issue #225: lesson image placeholder, polling, fade-in transition, lazy loading, fullscreen view, and graceful failure handling.

## Changes

- **`frontend/lib/api.ts`** — adds `LessonImageStatus` type, `LessonImageResponse` interface, and `getLessonImageStatus(lessonId)` function polling `GET /api/v1/images/lesson/{lesson_id}`
- **`frontend/messages/fr.json`** — adds `LessonImage.imagePending`, `imageViewFullscreen`, `imageCloseFullscreen`
- **`frontend/messages/en.json`** — same keys in English
- **`frontend/components/learning/lesson-image.tsx`** (new) — polls every 3s (max 40 attempts), `animate-pulse` skeleton with i18n text while pending, 300ms opacity fade-in on `ready`, returns `null` on `failed`, `<img loading="lazy" width="512">`, fullscreen tap-to-view modal with 44×44px close button, language-aware alt-text
- **`frontend/components/learning/lesson-viewer.tsx`** — integrates `<LessonImage lessonId={lessonData.id} language={lessonData.language} />` after the introduction section

## Test plan

- [ ] Frontend lint passes (0 errors)
- [ ] Placeholder skeleton renders while image status is pending/generating
- [ ] Image fades in (300ms) when status is ready
- [ ] Alt text is present and matches current language (FR/EN)
- [ ] Tapping image opens fullscreen modal (44×44px touch target)
- [ ] If generation fails, component returns null — no broken image
- [ ] Works on 360×640 mobile viewport (image scales to container)
- [ ] i18n: placeholder text present in both FR and EN

Closes #225

Generated with [Claude Code](https://claude.ai/code)