### PR TITLE
fix(case-study): fix SSE event handling and i18n for M01-U05 (#317)

### DIFF
--- a/frontend/components/learning/case-study-viewer.tsx
+++ b/frontend/components/learning/case-study-viewer.tsx
@@ -82,18 +82,30 @@ export function CaseStudyViewer({
         const streamUrl = `${API_BASE}/api/v1/content/cases/${moduleId}/${unitId}/stream?language=${language}&level=${level}&country=${countryContext}`;
         eventSource = new EventSource(streamUrl);
 
-        eventSource.onmessage = (event) => {
+        eventSource.addEventListener('complete', (event) => {
           try {
             const data = JSON.parse(event.data);
-            if (data.event === 'complete') {
-              setCaseStudyData(data.data);
-              setIsStreaming(false);
-              eventSource?.close();
-            }
+            setCaseStudyData(data);
+            setIsStreaming(false);
+            eventSource?.close();
           } catch (e) {
-            console.error('Error parsing SSE data:', e);
+            console.error('Error parsing SSE complete event:', e);
+            setError(t('streamError'));
+            setIsStreaming(false);
+            eventSource?.close();
           }
-        };
+        });
+
+        eventSource.addEventListener('error', (event) => {
+          try {
+            const data = JSON.parse((event as MessageEvent).data);
+            console.error('SSE error event:', data);
+          } catch {
+          }
+          setError(t('streamError'));
+          setIsStreaming(false);
+          eventSource?.close();
+        });
 
         eventSource.onerror = () => {
           setError(t('streamError'));
@@ -259,7 +271,7 @@ export function CaseStudyViewer({
                 onClick={() => setCorrectionVisible(true)}
                 className="min-h-11 border-green-300 text-green-700 hover:bg-green-50"
               >
-                {language === 'fr' ? 'Voir la correction' : 'Show correction'}
+                {t('showCorrection')}
               </Button>
             )}
           </div>

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -599,6 +599,7 @@
     "guidedQuestions": "Guided Questions",
     "question": "Question {number}",
     "annotatedCorrection": "Annotated Correction",
+    "showCorrection": "Show correction",
     "sourceCitations": "Source Citations",
     "markComplete": "Mark as Complete",
     "completed": "Completed"

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -599,6 +599,7 @@
     "guidedQuestions": "Questions guidées",
     "question": "Question {number}",
     "annotatedCorrection": "Correction annotée",
+    "showCorrection": "Voir la correction",
     "sourceCitations": "Sources citées",
     "markComplete": "Marquer comme Terminé",
     "completed": "Terminé"


### PR DESCRIPTION
## Summary

Fixes production bug where case study at `/fr/modules/M01/lessons/M01-U05` returns \"Une erreur est survenue\".

## Root cause

The `CaseStudyViewer` component used `EventSource.onmessage` to listen for streaming events, but the backend emits **named** SSE events (`event: complete\ndata: {...}`). The `onmessage` handler only fires for **unnamed** events — so the complete event was silently dropped, leaving the viewer in a loading state that eventually timed out with an error.

## Changes

- `frontend/components/learning/case-study-viewer.tsx`
  - Replace `onmessage` with `addEventListener('complete', ...)` to correctly receive the backend's named `complete` event
  - Add `addEventListener('error', ...)` to properly handle backend-sent error events
  - Replace hardcoded `'Voir la correction'`/`'Show correction'` string with `t('showCorrection')` i18n key

- `frontend/messages/fr.json` — add `showCorrection: "Voir la correction"` key
- `frontend/messages/en.json` — add `showCorrection: "Show correction"` key

The backend (endpoints, service, prompts, content parsing) was already correct — this was a pure frontend bug.

## Test plan

- [x] Backend tests: 11/11 passed
- [x] Frontend lint: 0 errors (9 pre-existing warnings)
- [ ] Manual test: `/fr/modules/M01/lessons/M01-U05` should generate Épidémie Ebola Guinée 2014 case study
- [ ] Solutions panel hidden by default, reveals on click

Closes #317

Generated with [Claude Code](https://claude.ai/code)