### PR TITLE
feat: add explanatory mode to tutor AI

### DIFF
--- a/backend/app/ai/prompts/tutor.py
+++ b/backend/app/ai/prompts/tutor.py
@@ -17,6 +17,7 @@ class TutorContext:
     learner_memory: str | None = None  # Pre-formatted memory text for system prompt
     previous_session_context: str | None = None  # Compacted context from prior session
     progress_snapshot: str | None = None  # Short learner progress summary
+    tutor_mode: str = "socratic"  # "socratic" (guided questions) or "explanatory" (direct answers)
 
 
 def get_socratic_system_prompt(context: TutorContext, rag_chunks: list[dict[str, Any]]) -> str:
@@ -47,70 +48,20 @@ def get_socratic_system_prompt(context: TutorContext, rag_chunks: list[dict[str,
     country_context = _get_country_context(context.user_country)
     sources_context = _format_sources_context(rag_chunks)
 
-    prompt = f"""Tu es un tuteur IA spécialisé en santé publique pour l'Afrique de l'Ouest,
-adoptant une approche pédagogique socratique. Ta mission est de guider les apprenants
-vers la compréhension plutôt que de donner des réponses directes.
+    pedagogical_section = _get_pedagogical_rules(context.tutor_mode)
+
+    prompt = f"""Tu es un tuteur IA spécialisé en santé publique pour l'Afrique de l'Ouest.
+{_get_mode_intro(context.tutor_mode)}
 
 ## CONTEXTE DE L'APPRENANT
 - Niveau: {level_instruction}
 - Langue: {language_instruction}
 - Pays: {country_context}
 - Module actuel: {context.module_id or "Non spécifié"}
+- Mode: {"Socratique (guidage par questions)" if context.tutor_mode == "socratic" else "Explicatif (réponses directes)"}
 {_format_progress_section(context.progress_snapshot)}{_format_memory_section(context.learner_memory)}{_format_previous_session_section(context.previous_session_context)}
 
-## LES 10 RÈGLES PÉDAGOGIQUES OBLIGATOIRES
-
-### 1. GUIDAGE PAR QUESTIONS
-- Ne donne JAMAIS de réponses directes
-- Pose des questions qui orientent l'apprenant vers la découverte
-- Utilise des questions ouvertes qui stimulent la réflexion
-- Exemple: Au lieu de "La surveillance épidémiologique consiste à...",
-  dis "Que penses-tu qu'il faut observer pour détecter une épidémie ?"
-
-### 2. DÉCOMPOSITION PROGRESSIVE
-- Découpe les concepts complexes en étapes logiques
-- Assure-toi que chaque étape est comprise avant de passer à la suivante
-- Utilise une progression "du simple au complexe"
-
-### 3. ANALOGIES ET EXEMPLES AOF
-- Utilise des analogies tirées de la vie quotidienne en Afrique de l'Ouest
-- Donne des exemples concrets de santé publique dans la région
-- Contextualise avec des données réelles (paludisme, méningite, fièvre jaune, etc.)
-
-### 4. ENCOURAGEMENT CONSTANT
-- Encourage chaque effort de l'apprenant
-- Valorise les tentatives même incorrectes
-- Utilise des phrases comme "Excellente réflexion !" ou "Tu es sur la bonne voie !"
-
-### 5. INDICES AVANT CORRECTION
-- Donne d'abord des indices subtils
-- Si l'apprenant ne trouve pas, donne des indices plus directs
-- La correction directe n'arrive qu'en dernier recours
-
-### 6. REFORMULATION APRÈS 2 ÉCHECS
-- Après 2 tentatives incorrectes, reformule différemment
-- Si l'apprenant échoue encore, explique alors clairement
-- Utilise une approche différente (visuelle, analogie, exemple)
-
-### 7. CITATIONS OBLIGATOIRES
-- Cite TOUJOURS tes sources: (Livre, Chapitre, Page)
-- Utilise le format: "Selon [Source] (Ch. X, p. Y), ..."
-- Chaque concept doit être rattaché aux références
-
-### 8. ADAPTATION VOCABULAIRE
-- Niveau 1-2: Vocabulaire simple, définitions claires, évite le jargon
-- Niveau 3-4: Terminologie rigoureuse, concepts avancés acceptés
-- Toujours vérifier la compréhension du vocabulaire technique
-
-### 9. MINI-QUIZ DE VÉRIFICATION
-- Après les concepts difficiles, propose un mini-quiz (2-3 questions)
-- Format: "Veux-tu vérifier ta compréhension avec un petit quiz ?"
-- Questions courtes et ciblées sur le concept discuté
-
-### 10. SUGGESTIONS D'ACTIVITÉS
-- Propose des activités complémentaires pertinentes
-- Suggestions: flashcards pour la mémorisation, quiz pour l'évaluation, exercices pratiques
-- Format: "Pour approfondir, je te suggère..."
+{pedagogical_section}
 
 ## SOURCES DISPONIBLES
 {sources_context}
@@ -223,6 +174,109 @@ def _format_progress_section(progress_snapshot: str | None) -> str:
     if not progress_snapshot:
         return ""
     return f"\n## PROGRESSION ACTUELLE\n{progress_snapshot}"
+
+
+def _get_mode_intro(tutor_mode: str) -> str:
+    """Return the mission statement based on tutor mode."""
+    if tutor_mode == "explanatory":
+        return (
+            "Tu adoptes une approche explicative directe. Ta mission est de fournir "
+            "des réponses claires, structurées et complètes aux questions de l'apprenant."
+        )
+    return (
+        "Tu adoptes une approche pédagogique socratique. Ta mission est de guider "
+        "les apprenants vers la compréhension plutôt que de donner des réponses directes."
+    )
+
+
+def _get_pedagogical_rules(tutor_mode: str) -> str:
+    """Return the pedagogical rules section based on tutor mode."""
+    if tutor_mode == "explanatory":
+        return """## APPROCHE EXPLICATIVE — RÈGLES
+
+### 1. RÉPONSES DIRECTES ET STRUCTURÉES
+- Donne des réponses claires et complètes dès la première réponse
+- Structure: Définition → Explication → Exemple concret → Source
+- Va droit au but, pas de questions rhétoriques inutiles
+
+### 2. STRUCTURE CLAIRE
+- Utilise des titres, listes et paragraphes bien organisés
+- Pour les concepts complexes, décompose en sections numérotées
+- Résume les points clés à la fin si nécessaire
+
+### 3. ANALOGIES ET EXEMPLES AOF
+- Utilise des analogies tirées de la vie quotidienne en Afrique de l'Ouest
+- Donne des exemples concrets de santé publique dans la région
+- Contextualise avec des données réelles (paludisme, méningite, fièvre jaune, etc.)
+
+### 4. CITATIONS OBLIGATOIRES
+- Cite TOUJOURS tes sources: (Livre, Chapitre, Page)
+- Utilise le format: "Selon [Source] (Ch. X, p. Y), ..."
+- Chaque concept doit être rattaché aux références
+
+### 5. ADAPTATION VOCABULAIRE
+- Niveau 1-2: Vocabulaire simple, définitions claires, évite le jargon
+- Niveau 3-4: Terminologie rigoureuse, concepts avancés acceptés
+
+### 6. PAS DE QUESTIONS DE SUIVI
+- Ne pose PAS de questions de suivi après ta réponse
+- Ne propose PAS de mini-quiz sauf si l'apprenant le demande
+- L'apprenant pose les questions, tu réponds directement
+- Termine par les sources, pas par une question"""
+
+    return """## LES 10 RÈGLES PÉDAGOGIQUES OBLIGATOIRES
+
+### 1. GUIDAGE PAR QUESTIONS
+- Ne donne JAMAIS de réponses directes
+- Pose des questions qui orientent l'apprenant vers la découverte
+- Utilise des questions ouvertes qui stimulent la réflexion
+- Exemple: Au lieu de "La surveillance épidémiologique consiste à...",
+  dis "Que penses-tu qu'il faut observer pour détecter une épidémie ?"
+
+### 2. DÉCOMPOSITION PROGRESSIVE
+- Découpe les concepts complexes en étapes logiques
+- Assure-toi que chaque étape est comprise avant de passer à la suivante
+- Utilise une progression "du simple au complexe"
+
+### 3. ANALOGIES ET EXEMPLES AOF
+- Utilise des analogies tirées de la vie quotidienne en Afrique de l'Ouest
+- Donne des exemples concrets de santé publique dans la région
+- Contextualise avec des données réelles (paludisme, méningite, fièvre jaune, etc.)
+
+### 4. ENCOURAGEMENT CONSTANT
+- Encourage chaque effort de l'apprenant
+- Valorise les tentatives même incorrectes
+- Utilise des phrases comme "Excellente réflexion !" ou "Tu es sur la bonne voie !"
+
+### 5. INDICES AVANT CORRECTION
+- Donne d'abord des indices subtils
+- Si l'apprenant ne trouve pas, donne des indices plus directs
+- La correction directe n'arrive qu'en dernier recours
+
+### 6. REFORMULATION APRÈS 2 ÉCHECS
+- Après 2 tentatives incorrectes, reformule différemment
+- Si l'apprenant échoue encore, explique alors clairement
+- Utilise une approche différente (visuelle, analogie, exemple)
+
+### 7. CITATIONS OBLIGATOIRES
+- Cite TOUJOURS tes sources: (Livre, Chapitre, Page)
+- Utilise le format: "Selon [Source] (Ch. X, p. Y), ..."
+- Chaque concept doit être rattaché aux références
+
+### 8. ADAPTATION VOCABULAIRE
+- Niveau 1-2: Vocabulaire simple, définitions claires, évite le jargon
+- Niveau 3-4: Terminologie rigoureuse, concepts avancés acceptés
+- Toujours vérifier la compréhension du vocabulaire technique
+
+### 9. MINI-QUIZ DE VÉRIFICATION
+- Après les concepts difficiles, propose un mini-quiz (2-3 questions)
+- Format: "Veux-tu vérifier ta compréhension avec un petit quiz ?"
+- Questions courtes et ciblées sur le concept discuté
+
+### 10. SUGGESTIONS D'ACTIVITÉS
+- Propose des activités complémentaires pertinentes
+- Suggestions: flashcards pour la mémorisation, quiz pour l'évaluation, exercices pratiques
+- Format: "Pour approfondir, je te suggère..." """
 
 
 def _get_language_instruction(language: str) -> str:

--- a/backend/app/api/v1/schemas/tutor.py
+++ b/backend/app/api/v1/schemas/tutor.py
@@ -1,7 +1,7 @@
 """Pydantic schemas for tutor API endpoints."""
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -29,6 +29,10 @@ class TutorChatRequest(BaseModel):
     )
     context_id: UUID | None = Field(None, description="Context-specific ID")
     conversation_id: UUID | None = Field(None, description="Existing conversation ID")
+    tutor_mode: Literal["socratic", "explanatory"] = Field(
+        default="socratic",
+        description="Tutor mode: socratic (guided questions) or explanatory (direct answers)",
+    )
 
 
 class TutorChatResponse(BaseModel):

--- a/backend/app/api/v1/tutor.py
+++ b/backend/app/api/v1/tutor.py
@@ -73,6 +73,7 @@ async def chat_with_tutor(
                 context_type=request.context_type,
                 context_id=request.context_id,
                 conversation_id=request.conversation_id,
+                tutor_mode=request.tutor_mode,
             ):
                 # Format as SSE
                 yield f"data: {json.dumps(chunk)}\n\n"

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -210,6 +210,7 @@ class TutorService:
         context_type: str | None = None,
         context_id: uuid.UUID | None = None,
         conversation_id: uuid.UUID | None = None,
+        tutor_mode: str = "socratic",
     ) -> AsyncGenerator[dict[str, Any], None]:
         """
         Send a message to the AI tutor and stream the response using agentic tool_use.
@@ -282,6 +283,7 @@ class TutorService:
                 user_country=user.country or "SN",
                 module_id=str(module_id) if module_id else None,
                 context_type=context_type,
+                tutor_mode=tutor_mode,
                 context_id=str(context_id) if context_id else None,
                 learner_memory=session_ctx.learner_memory,
                 previous_session_context=session_ctx.previous_compact,

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { useTranslations } from 'next-intl';
-import { X, MoreVertical, Trash2, Menu } from 'lucide-react';
+import { X, MoreVertical, Trash2, Menu, HelpCircle, BookOpen } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -70,6 +70,7 @@ export function ChatPanel({
   const [activeConversationId, setActiveConversationId] = useState<string | null>(
     conversationId ?? null
   );
+  const [tutorMode, setTutorMode] = useState<'socratic' | 'explanatory'>('socratic');
   const scrollAreaRef = useRef<HTMLDivElement>(null);
 
   const isLimitReached = currentUsage >= maxDailyUsage;
@@ -183,6 +184,7 @@ export function ChatPanel({
           message: messageContent,
           conversation_id: activeConversationId ?? null,
           module_id: moduleId ?? null,
+          tutor_mode: tutorMode,
         }),
       });
 
@@ -338,6 +340,19 @@ export function ChatPanel({
             <h2 className="text-base font-semibold">{t('title')}</h2>
           </div>
           <div className="flex items-center gap-1">
+            <Button
+              variant={tutorMode === 'socratic' ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => setTutorMode(tutorMode === 'socratic' ? 'explanatory' : 'socratic')}
+              className="h-9 gap-1.5 text-xs"
+              title={tutorMode === 'socratic' ? t('modeSocraticTooltip') : t('modeExplanatoryTooltip')}
+            >
+              {tutorMode === 'socratic' ? (
+                <><HelpCircle className="h-3.5 w-3.5" />{t('modeSocratic')}</>
+              ) : (
+                <><BookOpen className="h-3.5 w-3.5" />{t('modeExplanatory')}</>
+              )}
+            </Button>
             <DropdownMenu>
               <DropdownMenuTrigger>
                 <Button variant="ghost" size="icon" className="h-11 w-11">

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -330,7 +330,11 @@
     "conversations": "Conversations",
     "openConversations": "Open conversations",
     "closeDrawer": "Close",
-    "toggleSuggestions": "Quick actions"
+    "toggleSuggestions": "Quick actions",
+    "modeSocratic": "Socratic Mode",
+    "modeExplanatory": "Explanatory Mode",
+    "modeSocraticTooltip": "Guided questions",
+    "modeExplanatoryTooltip": "Direct answers"
   },
   "Flashcards": {
     "title": "Flashcards",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -330,7 +330,11 @@
     "conversations": "Conversations",
     "openConversations": "Ouvrir les conversations",
     "closeDrawer": "Fermer",
-    "toggleSuggestions": "Actions rapides"
+    "toggleSuggestions": "Actions rapides",
+    "modeSocratic": "Mode Socratique",
+    "modeExplanatory": "Mode Explicatif",
+    "modeSocraticTooltip": "Guidage par questions",
+    "modeExplanatoryTooltip": "Réponses directes"
   },
   "Flashcards": {
     "title": "Flashcards",


### PR DESCRIPTION
## Summary

Fixes #418 — Adds an "Explanatory Mode" to the AI tutor alongside the default Socratic mode.

- **Socratic (default)**: Guides through questions, never gives direct answers, uses hints and progressive decomposition
- **Explanatory (new)**: Gives clear, structured, direct answers — definition → explanation → example → source. No follow-up questions unless asked.

Both modes still use RAG search, cite sources, adapt vocabulary to level, and use AOF examples.

### Changes
- `tutor_mode` field added to `TutorChatRequest` (`"socratic"` | `"explanatory"`, default `"socratic"`)
- Conditional system prompt in `tutor.py` — swaps pedagogical rules section based on mode
- Toggle button in chat header (Socratic = HelpCircle icon, Explanatory = BookOpen icon)
- i18n keys for FR/EN

## Test plan

- [ ] Default behavior unchanged — messages without mode toggle use Socratic approach
- [ ] Toggle to Explanatory → direct answers, no follow-up questions, sources still cited
- [ ] Toggle persists across messages in same session
- [ ] All 47 tutor tests pass (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)