### PR TITLE
fix(content): stale content after profile change — cache invalidation + force regenerate (#421)

### DIFF
--- a/backend/app/api/v1/content.py
+++ b/backend/app/api/v1/content.py
@@ -323,6 +323,7 @@ async def get_or_generate_lesson_by_module_and_unit(
     language: str = "fr",
     level: int = 1,
     country: str = "SN",
+    force_regenerate: bool = False,
     lesson_service: LessonGenerationService = Depends(get_lesson_service),
     session: AsyncSession = Depends(get_db),
     current_user=Depends(get_optional_user),
@@ -369,6 +370,7 @@ async def get_or_generate_lesson_by_module_and_unit(
             country=country,
             level=level,
             session=session,
+            force_regenerate=force_regenerate,
         )
 
         # Track lesson access for authenticated users
@@ -855,6 +857,7 @@ async def get_or_generate_case_study(
     language: str = "fr",
     level: int = 1,
     country: str = "SN",
+    force_regenerate: bool = False,
     case_study_service: CaseStudyGenerationService = Depends(get_case_study_service),
     session: AsyncSession = Depends(get_db),
     current_user=Depends(get_optional_user),
@@ -888,6 +891,7 @@ async def get_or_generate_case_study(
             country=country,
             level=level,
             session=session,
+            force_regenerate=force_regenerate,
         )
 
         if current_user is not None:

--- a/backend/app/api/v1/quiz.py
+++ b/backend/app/api/v1/quiz.py
@@ -144,6 +144,7 @@ async def generate_quiz(
             level=request.level,
             num_questions=request.num_questions,
             session=session,
+            force_regenerate=request.force_regenerate,
         )
 
         logger.info(

--- a/backend/app/api/v1/schemas/quiz.py
+++ b/backend/app/api/v1/schemas/quiz.py
@@ -98,6 +98,9 @@ class QuizGenerationRequest(BaseModel):
     num_questions: int = Field(
         description="Number of questions to generate", ge=5, le=20, default=10
     )
+    force_regenerate: bool = Field(
+        description="Skip cache and force fresh content generation", default=False
+    )
 
 
 class SummativeAssessmentRequest(BaseModel):

--- a/backend/app/domain/services/quiz_service.py
+++ b/backend/app/domain/services/quiz_service.py
@@ -31,6 +31,7 @@ class QuizService:
         level: int,
         num_questions: int,
         session: AsyncSession,
+        force_regenerate: bool = False,
     ) -> QuizResponse:
         """
         Get existing quiz from cache or generate new one using RAG + Claude API.
@@ -52,17 +53,19 @@ class QuizService:
             Exception: If quiz generation fails
         """
         try:
-            # Cache lookup: match module, unit, language, and level
-            query = select(GeneratedContent).where(
-                GeneratedContent.module_id == module_id,
-                GeneratedContent.content_type == "quiz",
-                GeneratedContent.language == language,
-                GeneratedContent.level == level,
-                GeneratedContent.content["unit_id"].astext == unit_id,
-            )
+            cached_quiz = None
+            if not force_regenerate:
+                # Cache lookup: match module, unit, language, and level
+                query = select(GeneratedContent).where(
+                    GeneratedContent.module_id == module_id,
+                    GeneratedContent.content_type == "quiz",
+                    GeneratedContent.language == language,
+                    GeneratedContent.level == level,
+                    GeneratedContent.content["unit_id"].astext == unit_id,
+                )
 
-            result = await session.execute(query)
-            cached_quiz = result.scalar_one_or_none()
+                result = await session.execute(query)
+                cached_quiz = result.scalar_one_or_none()
 
             if cached_quiz:
                 logger.info(

--- a/frontend/app/[locale]/(app)/modules/[moduleId]/lessons/[unitId]/page.tsx
+++ b/frontend/app/[locale]/(app)/modules/[moduleId]/lessons/[unitId]/page.tsx
@@ -65,7 +65,6 @@ export default async function LessonPage({ params }: LessonPageProps) {
           unitId={unitId}
           language={language}
           level={moduleLevel}
-          countryContext="SN"
         />
       ) : (
         <LessonViewer
@@ -73,7 +72,6 @@ export default async function LessonPage({ params }: LessonPageProps) {
           unitId={unitId}
           language={language}
           level={moduleLevel}
-          countryContext="SN"
         />
       )}
     </div>

--- a/frontend/app/[locale]/(app)/modules/[moduleId]/quiz/page.tsx
+++ b/frontend/app/[locale]/(app)/modules/[moduleId]/quiz/page.tsx
@@ -36,7 +36,6 @@ export default async function QuizPage({ params, searchParams }: QuizPageProps) 
         moduleId={moduleId}
         unitId={unitId}
         language={language}
-        country="senegal"
         level={moduleData?.level || 1}
       />
     </div>

--- a/frontend/app/[locale]/(app)/modules/[moduleId]/quiz/quiz-page-client.tsx
+++ b/frontend/app/[locale]/(app)/modules/[moduleId]/quiz/quiz-page-client.tsx
@@ -7,7 +7,6 @@ interface QuizPageClientProps {
   moduleId: string;
   unitId: string;
   language: string;
-  country: string;
   level: number;
 }
 
@@ -15,7 +14,6 @@ export function QuizPageClient({
   moduleId,
   unitId,
   language,
-  country,
   level,
 }: QuizPageClientProps) {
   const router = useRouter();
@@ -29,7 +27,6 @@ export function QuizPageClient({
       moduleId={moduleId}
       unitId={unitId}
       language={language}
-      country={country}
       level={level}
       onComplete={handleQuizComplete}
     />

--- a/frontend/components/learning/case-study-viewer.tsx
+++ b/frontend/components/learning/case-study-viewer.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
-import { CheckCircle, Clock, FileText } from 'lucide-react';
+import { CheckCircle, Clock, FileText, RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -13,6 +13,7 @@ import rehypeKatex from 'rehype-katex';
 import { LessonSkeleton } from './lesson-skeleton';
 import { SourceCitations } from './source-citations';
 import { apiFetch } from '@/lib/api';
+import { useCurrentUser } from '@/lib/hooks/use-current-user';
 
 interface CaseStudyContent {
   aof_context: string;
@@ -39,7 +40,7 @@ interface CaseStudyViewerProps {
   unitId: string;
   language: 'fr' | 'en';
   level: number;
-  countryContext: string;
+  countryContext?: string;
   onComplete?: () => void;
 }
 
@@ -56,6 +57,11 @@ export function CaseStudyViewer({
   const [error, setError] = useState<string | null>(null);
   const [isCompleted, setIsCompleted] = useState(false);
   const [correctionVisible, setCorrectionVisible] = useState(false);
+  const [forceRegenerate, setForceRegenerate] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const currentUser = useCurrentUser();
+  const country = countryContext || currentUser?.country || 'SN';
 
   const t = useTranslations('CaseStudyViewer');
 
@@ -67,21 +73,25 @@ export function CaseStudyViewer({
         setIsStreaming(true);
         setError(null);
 
-        try {
-          const cachedData = await apiFetch<CaseStudyData>(
-            `/api/v1/content/cases/${moduleId}/${unitId}?language=${language}&level=${level}&country=${countryContext}`
-          );
+        if (!forceRegenerate) {
+          try {
+            const cachedData = await apiFetch<CaseStudyData>(
+              `/api/v1/content/cases/${moduleId}/${unitId}?language=${language}&level=${level}&country=${country}`
+            );
 
-          if (cachedData.cached) {
-            setCaseStudyData(cachedData);
-            setIsStreaming(false);
-            return;
+            if (cachedData.cached) {
+              setCaseStudyData(cachedData);
+              setIsStreaming(false);
+              setIsRefreshing(false);
+              return;
+            }
+          } catch {
           }
-        } catch {
         }
 
         const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
-        const streamUrl = `${API_BASE}/api/v1/content/cases/${moduleId}/${unitId}/stream?language=${language}&level=${level}&country=${countryContext}`;
+        const forceParam = forceRegenerate ? '&force_regenerate=true' : '';
+        const streamUrl = `${API_BASE}/api/v1/content/cases/${moduleId}/${unitId}/stream?language=${language}&level=${level}&country=${country}${forceParam}`;
         eventSource = new EventSource(streamUrl);
 
         eventSource.addEventListener('complete', (event) => {
@@ -89,11 +99,14 @@ export function CaseStudyViewer({
             const data = JSON.parse(event.data);
             setCaseStudyData(data);
             setIsStreaming(false);
+            setIsRefreshing(false);
+            setForceRegenerate(false);
             eventSource?.close();
           } catch (e) {
             console.error('Error parsing SSE complete event:', e);
             setError(t('streamError'));
             setIsStreaming(false);
+            setIsRefreshing(false);
             eventSource?.close();
           }
         });
@@ -106,17 +119,20 @@ export function CaseStudyViewer({
           }
           setError(t('streamError'));
           setIsStreaming(false);
+          setIsRefreshing(false);
           eventSource?.close();
         });
 
         eventSource.onerror = () => {
           setError(t('streamError'));
           setIsStreaming(false);
+          setIsRefreshing(false);
           eventSource?.close();
         };
       } catch {
         setError(t('loadError'));
         setIsStreaming(false);
+        setIsRefreshing(false);
       }
     };
 
@@ -125,7 +141,13 @@ export function CaseStudyViewer({
     return () => {
       eventSource?.close();
     };
-  }, [moduleId, unitId, language, level, countryContext, t]);
+  }, [moduleId, unitId, language, level, country, forceRegenerate, t]);
+
+  const handleRefresh = () => {
+    setCaseStudyData(null);
+    setIsRefreshing(true);
+    setForceRegenerate(true);
+  };
 
   const handleMarkComplete = async () => {
     try {
@@ -196,17 +218,30 @@ export function CaseStudyViewer({
     <div className="container mx-auto max-w-4xl px-4 py-6">
       {/* Header */}
       <div className="mb-8">
-        <div className="flex items-center gap-3 mb-3">
-          <Badge variant="outline" className="flex items-center gap-1">
-            <FileText className="w-3 h-3" />
-            {t('badge')}
-          </Badge>
-          <Badge variant="outline">{t('level', { level })}</Badge>
-          <div className="flex items-center text-gray-600">
-            <Clock className="w-4 h-4 mr-1" />
-            {t('estimatedTime')}
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-3">
+            <Badge variant="outline" className="flex items-center gap-1">
+              <FileText className="w-3 h-3" />
+              {t('badge')}
+            </Badge>
+            <Badge variant="outline">{t('level', { level })}</Badge>
+            <div className="flex items-center text-gray-600">
+              <Clock className="w-4 h-4 mr-1" />
+              {t('estimatedTime')}
+            </div>
+            {caseStudyData.cached && <Badge variant="secondary">{t('cached')}</Badge>}
           </div>
-          {caseStudyData.cached && <Badge variant="secondary">{t('cached')}</Badge>}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleRefresh}
+            disabled={isRefreshing || isStreaming}
+            className="min-h-11 gap-1.5 text-gray-500 hover:text-gray-900"
+            title={t('refreshContent')}
+          >
+            <RefreshCw className={`w-4 h-4 ${isRefreshing ? 'animate-spin' : ''}`} />
+            <span className="hidden sm:inline">{t('refreshContent')}</span>
+          </Button>
         </div>
         <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-3">
           {t('unitTitle', { unit: unitId })}

--- a/frontend/components/learning/lesson-viewer.tsx
+++ b/frontend/components/learning/lesson-viewer.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
-import { CheckCircle, Clock } from 'lucide-react';
+import { CheckCircle, Clock, RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -14,6 +14,7 @@ import { LessonSkeleton } from './lesson-skeleton';
 import { LessonImage } from './lesson-image';
 import { SourceCitations } from './source-citations';
 import { apiFetch } from '@/lib/api';
+import { useCurrentUser } from '@/lib/hooks/use-current-user';
 
 interface LessonContent {
   introduction: string;
@@ -40,7 +41,7 @@ interface LessonViewerProps {
   unitId: string;
   language: 'fr' | 'en';
   level: number;
-  countryContext: string;
+  countryContext?: string;
   onComplete?: () => void;
 }
 
@@ -56,6 +57,11 @@ export function LessonViewer({
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isCompleted, setIsCompleted] = useState(false);
+  const [forceRegenerate, setForceRegenerate] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const currentUser = useCurrentUser();
+  const country = countryContext || currentUser?.country || 'SN';
   
   const t = useTranslations('LessonViewer');
 
@@ -67,25 +73,29 @@ export function LessonViewer({
         setIsStreaming(true);
         setError(null);
         
-        // First check if cached content exists
-        try {
-          const cachedData = await apiFetch<LessonData>(
-            `/api/v1/content/lessons/${moduleId}/${unitId}?language=${language}&level=${level}&country=${countryContext}`
-          );
-          
-          if (cachedData.cached) {
-            setLessonData(cachedData);
-            setIsStreaming(false);
-            return;
+        if (!forceRegenerate) {
+          // First check if cached content exists
+          try {
+            const cachedData = await apiFetch<LessonData>(
+              `/api/v1/content/lessons/${moduleId}/${unitId}?language=${language}&level=${level}&country=${country}`
+            );
+            
+            if (cachedData.cached) {
+              setLessonData(cachedData);
+              setIsStreaming(false);
+              setIsRefreshing(false);
+              return;
+            }
+          } catch (cacheErr) {
+            // If cache check fails, continue to streaming
+            console.log('Cache check failed, falling back to streaming:', cacheErr);
           }
-        } catch (cacheErr) {
-          // If cache check fails, continue to streaming
-          console.log('Cache check failed, falling back to streaming:', cacheErr);
         }
 
-        // If no cached content, start streaming
+        // If no cached content or force_regenerate, start streaming
         const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
-        const streamUrl = `${API_BASE}/api/v1/content/lessons/${moduleId}/${unitId}/stream?language=${language}&level=${level}&country=${countryContext}`;
+        const forceParam = forceRegenerate ? '&force_regenerate=true' : '';
+        const streamUrl = `${API_BASE}/api/v1/content/lessons/${moduleId}/${unitId}/stream?language=${language}&level=${level}&country=${country}${forceParam}`;
         eventSource = new EventSource(streamUrl);
         
         eventSource.onmessage = (event) => {
@@ -97,6 +107,8 @@ export function LessonViewer({
             } else if (data.event === 'complete') {
               setLessonData(data.data);
               setIsStreaming(false);
+              setIsRefreshing(false);
+              setForceRegenerate(false);
               eventSource?.close();
             }
           } catch (e) {
@@ -108,6 +120,7 @@ export function LessonViewer({
           console.error('SSE error:', event);
           setError(t('streamError'));
           setIsStreaming(false);
+          setIsRefreshing(false);
           eventSource?.close();
         };
         
@@ -115,6 +128,7 @@ export function LessonViewer({
         console.error('Error starting lesson stream:', err);
         setError(t('loadError'));
         setIsStreaming(false);
+        setIsRefreshing(false);
       }
     };
 
@@ -123,7 +137,13 @@ export function LessonViewer({
     return () => {
       eventSource?.close();
     };
-  }, [moduleId, unitId, language, level, countryContext, t]);
+  }, [moduleId, unitId, language, level, country, forceRegenerate, t]);
+
+  const handleRefresh = () => {
+    setLessonData(null);
+    setIsRefreshing(true);
+    setForceRegenerate(true);
+  };
 
   const handleMarkComplete = async () => {
     try {
@@ -189,15 +209,28 @@ export function LessonViewer({
     <div className="container mx-auto max-w-4xl px-4 py-6">
       {/* Header */}
       <div className="mb-8">
-        <div className="flex items-center gap-3 mb-3">
-          <Badge variant="outline">{t('level', { level })}</Badge>
-          <div className="flex items-center text-gray-600">
-            <Clock className="w-4 h-4 mr-1" />
-            {t('readingTime')}
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-3">
+            <Badge variant="outline">{t('level', { level })}</Badge>
+            <div className="flex items-center text-gray-600">
+              <Clock className="w-4 h-4 mr-1" />
+              {t('readingTime')}
+            </div>
+            {lessonData.cached && (
+              <Badge variant="secondary">{t('cached')}</Badge>
+            )}
           </div>
-          {lessonData.cached && (
-            <Badge variant="secondary">{t('cached')}</Badge>
-          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleRefresh}
+            disabled={isRefreshing || isStreaming}
+            className="min-h-11 gap-1.5 text-gray-500 hover:text-gray-900"
+            title={t('refreshContent')}
+          >
+            <RefreshCw className={`w-4 h-4 ${isRefreshing ? 'animate-spin' : ''}`} />
+            <span className="hidden sm:inline">{t('refreshContent')}</span>
+          </Button>
         </div>
         <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-3">
           {t('unitTitle', { unit: unitId })}

--- a/frontend/components/quiz/quiz-container.tsx
+++ b/frontend/components/quiz/quiz-container.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
-import { Loader2, AlertTriangle, Play } from 'lucide-react';
+import { Loader2, AlertTriangle, Play, RefreshCw } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -11,12 +11,13 @@ import { QuizInterface } from './quiz-interface';
 import { QuizResults } from './quiz-results';
 import type { Quiz, QuizAttemptResponse } from '@/lib/api';
 import { generateQuiz } from '@/lib/api';
+import { useCurrentUser } from '@/lib/hooks/use-current-user';
 
 interface QuizContainerProps {
   moduleId: string;
   unitId: string;
   language: string;
-  country: string;
+  country?: string;
   level: number;
   onComplete?: () => void;
   onError?: (error: string) => void;
@@ -34,12 +35,15 @@ export function QuizContainer({
   onError
 }: QuizContainerProps) {
   const t = useTranslations('Quiz');
+  const currentUser = useCurrentUser();
+  const resolvedCountry = country || currentUser?.country || 'SN';
   
   const [state, setState] = useState<QuizState>('loading');
   const [quiz, setQuiz] = useState<Quiz | null>(null);
   const [result, setResult] = useState<QuizAttemptResponse | null>(null);
   const [error, setError] = useState<string>('');
   const [retryCount, setRetryCount] = useState(0);
+  const [forceRegenerate, setForceRegenerate] = useState(false);
   
   useEffect(() => {
     const fetchQuiz = async () => {
@@ -51,12 +55,14 @@ export function QuizContainer({
           module_id: moduleId,
           unit_id: unitId,
           language,
-          country,
+          country: resolvedCountry,
           level,
           num_questions: 10,
+          force_regenerate: forceRegenerate,
         });
         
         setQuiz(quizData);
+        setForceRegenerate(false);
         setState('ready');
       } catch (err) {
         console.error('Failed to load quiz:', err);
@@ -69,7 +75,7 @@ export function QuizContainer({
     
     fetchQuiz();
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [moduleId, unitId, language, country, level, retryCount]);
+  }, [moduleId, unitId, language, resolvedCountry, level, retryCount, forceRegenerate]);
   
   const handleStartQuiz = () => {
     setState('in-progress');
@@ -90,6 +96,12 @@ export function QuizContainer({
     setResult(null);
     setQuiz(null);
     setRetryCount(prev => prev + 1);
+  };
+
+  const handleRefreshContent = () => {
+    setResult(null);
+    setQuiz(null);
+    setForceRegenerate(true);
   };
   
   const handleContinue = () => {
@@ -204,7 +216,7 @@ export function QuizContainer({
             </div>
             
             {/* Additional Info */}
-            <div className="flex flex-wrap gap-2 justify-center">
+            <div className="flex flex-wrap gap-2 justify-center items-center">
               <Badge variant="outline">
                 {t('level')} {level}
               </Badge>
@@ -216,6 +228,15 @@ export function QuizContainer({
               <Badge variant="outline">
                 {language.toUpperCase()}
               </Badge>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleRefreshContent}
+                className="min-h-11 gap-1.5 text-stone-500 hover:text-stone-900"
+              >
+                <RefreshCw className="w-4 h-4" />
+                <span className="hidden sm:inline">{t('refreshContent')}</span>
+              </Button>
             </div>
           </CardContent>
         </Card>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -255,6 +255,7 @@ export async function generateQuiz(params: {
   country: string;
   level: number;
   num_questions?: number;
+  force_regenerate?: boolean;
 }): Promise<Quiz> {
   return apiFetch<Quiz>("/api/v1/quiz/generate", {
     method: "POST",
@@ -265,6 +266,7 @@ export async function generateQuiz(params: {
       country: params.country,
       level: params.level,
       num_questions: params.num_questions || 10,
+      force_regenerate: params.force_regenerate || false,
     }),
   });
 }

--- a/frontend/lib/hooks/use-current-user.ts
+++ b/frontend/lib/hooks/use-current-user.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import type { User } from '@/lib/auth';
+
+export function useCurrentUser(): User | null {
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const load = () => {
+      try {
+        const raw = localStorage.getItem('user');
+        setUser(raw ? (JSON.parse(raw) as User) : null);
+      } catch {
+        setUser(null);
+      }
+    };
+
+    load();
+
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === 'user') load();
+    };
+
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
+
+  return user;
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -276,7 +276,8 @@
     "lessonCompleted": "Lesson validated!",
     "lessonCompletedDesc": "You scored ≥80%. This lesson is now marked as complete in your progress.",
     "lessonNotValidated": "Lesson not validated",
-    "lessonNotValidatedDesc": "You need at least {score}% to validate this lesson. Try again!"
+    "lessonNotValidatedDesc": "You need at least {score}% to validate this lesson. Try again!",
+    "refreshContent": "Refresh content"
   },
   "ChatTutor": {
     "title": "AI Tutor",
@@ -583,7 +584,8 @@
     "synthesis": "Synthesis",
     "keyPoints": "Key Points",
     "markComplete": "Mark as Complete",
-    "completed": "Completed"
+    "completed": "Completed",
+    "refreshContent": "Refresh content"
   },
   "LessonImage": {
     "imagePending": "Generating illustration...",
@@ -607,7 +609,8 @@
     "showCorrection": "Show correction",
     "sourceCitations": "Source Citations",
     "markComplete": "Mark as Complete",
-    "completed": "Completed"
+    "completed": "Completed",
+    "refreshContent": "Refresh content"
   },
   "QuizPage": {
     "backToModule": "Back to {module}"

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -276,7 +276,8 @@
     "lessonCompleted": "Leçon validée !",
     "lessonCompletedDesc": "Vous avez obtenu un score ≥ 80%. Cette leçon est maintenant marquée comme terminée dans votre progression.",
     "lessonNotValidated": "Leçon non validée",
-    "lessonNotValidatedDesc": "Vous devez obtenir au moins {score}% pour valider cette leçon. Réessayez !"
+    "lessonNotValidatedDesc": "Vous devez obtenir au moins {score}% pour valider cette leçon. Réessayez !",
+    "refreshContent": "Actualiser le contenu"
   },
   "ChatTutor": {
     "title": "Tuteur IA",
@@ -583,7 +584,8 @@
     "synthesis": "Synthèse",
     "keyPoints": "Points Clés",
     "markComplete": "Marquer comme Terminé",
-    "completed": "Terminé"
+    "completed": "Terminé",
+    "refreshContent": "Actualiser le contenu"
   },
   "LessonImage": {
     "imagePending": "Illustration en cours de génération...",
@@ -607,7 +609,8 @@
     "showCorrection": "Voir la correction",
     "sourceCitations": "Sources citées",
     "markComplete": "Marquer comme Terminé",
-    "completed": "Terminé"
+    "completed": "Terminé",
+    "refreshContent": "Actualiser le contenu"
   },
   "QuizPage": {
     "backToModule": "Retour à {module}"


### PR DESCRIPTION
## Summary

Fixes stale content displayed after a user changes their country in profile settings.

- **Root cause 1 fixed**: Frontend was hardcoding `countryContext="SN"` / `country="senegal"` in lesson, case study, and quiz pages, ignoring the user's actual country.
- **Root cause 2 fixed**: No mechanism to bypass cache when content is stale.

## Changes

### Backend
- `backend/app/api/v1/content.py` — wire `force_regenerate: bool = False` query param through to `get_or_generate_lesson` and `get_or_generate_case_study` (service already supported it)
- `backend/app/api/v1/schemas/quiz.py` — add `force_regenerate: bool` field to `QuizGenerationRequest`
- `backend/app/api/v1/quiz.py` — pass `force_regenerate` from request body to quiz service
- `backend/app/domain/services/quiz_service.py` — add `force_regenerate` param; skip cache lookup when true

### Frontend
- `frontend/lib/hooks/use-current-user.ts` — new hook reading `User` from localStorage, reactive to storage events
- `frontend/app/.../lessons/[unitId]/page.tsx` — remove hardcoded `countryContext="SN"`
- `frontend/app/.../quiz/page.tsx` — remove hardcoded `country="senegal"`
- `frontend/app/.../quiz/quiz-page-client.tsx` — remove `country` prop (now optional)
- `frontend/components/learning/lesson-viewer.tsx` — use `useCurrentUser` to resolve country; add Refresh Content button
- `frontend/components/learning/case-study-viewer.tsx` — same as above
- `frontend/components/quiz/quiz-container.tsx` — use `useCurrentUser` to resolve country; add Refresh Content button
- `frontend/lib/api.ts` — add `force_regenerate` to `generateQuiz` params
- `frontend/messages/en.json` + `fr.json` — add `refreshContent` key to LessonViewer, CaseStudyViewer, Quiz

## Test plan
- [ ] Backend tests pass (`uv run pytest`)
- [ ] Frontend lint passes (`npm run lint`)
- [ ] Change country in profile → navigate to a lesson → content is generated for new country
- [ ] Click "Refresh content" button → spinner shows → new content generated from scratch
- [ ] Mobile viewport (320px) verified — touch targets ≥ 44px

Closes #421

Generated with [Claude Code](https://claude.ai/code)