### PR TITLE
fix(infra): use uv run celery to fix celery not found in PATH

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -95,7 +95,7 @@ services:
   celery-worker:
     image: etutor-backend:latest
     container_name: etutor-celery-worker
-    command: celery -A app.tasks.celery_app worker --loglevel=info
+    command: uv run celery -A app.tasks.celery_app worker --loglevel=info
     environment:
       DATABASE_URL: postgresql+asyncpg://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:5432/santepublique_aof
       REDIS_URL: redis://redis:6379/0


### PR DESCRIPTION
## Summary
Fixes critical deploy failure where celery-worker container fails with `exec: "celery": executable file not found in $PATH`.

The backend Docker image uses `uv` for Python environment management, so the celery binary lives inside the uv-managed virtual environment and is not directly on `$PATH`. Using `uv run celery` ensures the binary is resolved correctly through uv's environment.

## Changes
- `docker-compose.prod.yml`: Changed celery-worker command from `celery -A app.tasks.celery_app worker --loglevel=info` to `uv run celery -A app.tasks.celery_app worker --loglevel=info`

## Test plan
- [ ] Deploy passes without celery PATH error
- [ ] `docker compose ps` shows celery-worker as healthy

Closes #426

Generated with [Claude Code](https://claude.ai/code)