### PR TITLE
fix(lesson-viewer): replace mark-complete button with quiz validation flow

### DIFF
--- a/frontend/components/learning/lesson-viewer.tsx
+++ b/frontend/components/learning/lesson-viewer.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
-import { CheckCircle, Clock, RefreshCw } from 'lucide-react';
+import { CheckCircle, Clock, RefreshCw, PlayCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -13,8 +13,10 @@ import rehypeKatex from 'rehype-katex';
 import { LessonSkeleton } from './lesson-skeleton';
 import { LessonImage } from './lesson-image';
 import { SourceCitations } from './source-citations';
-import { apiFetch } from '@/lib/api';
+import { apiFetch, checkUnitQuizPassed } from '@/lib/api';
 import { useCurrentUser } from '@/lib/hooks/use-current-user';
+import { useRouter } from 'next/navigation';
+import { useLocale } from 'next-intl';
 
 interface LessonContent {
   introduction: string;
@@ -51,19 +53,36 @@ export function LessonViewer({
   language,
   level,
   countryContext,
-  onComplete
 }: LessonViewerProps) {
   const [lessonData, setLessonData] = useState<LessonData | null>(null);
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [isCompleted, setIsCompleted] = useState(false);
+  const [isQuizPassed, setIsQuizPassed] = useState(false);
+  const [isCheckingQuiz, setIsCheckingQuiz] = useState(false);
   const [forceRegenerate, setForceRegenerate] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   const currentUser = useCurrentUser();
   const country = countryContext || currentUser?.country || 'SN';
-  
+  const router = useRouter();
+  const locale = useLocale();
+
   const t = useTranslations('LessonViewer');
+
+  useEffect(() => {
+    const checkQuizStatus = async () => {
+      setIsCheckingQuiz(true);
+      try {
+        const status = await checkUnitQuizPassed(moduleId, unitId);
+        setIsQuizPassed(status.passed);
+      } catch {
+        // If check fails, default to not passed (show quiz button)
+      } finally {
+        setIsCheckingQuiz(false);
+      }
+    };
+    checkQuizStatus();
+  }, [moduleId, unitId]);
 
   useEffect(() => {
     let eventSource: EventSource | null = null;
@@ -145,21 +164,8 @@ export function LessonViewer({
     setForceRegenerate(true);
   };
 
-  const handleMarkComplete = async () => {
-    try {
-      await apiFetch(`/api/v1/progress/complete-lesson`, {
-        method: 'POST',
-        body: JSON.stringify({
-          module_id: moduleId,
-          unit_id: unitId
-        })
-      });
-      
-      setIsCompleted(true);
-      onComplete?.();
-    } catch (err) {
-      console.error('Error marking lesson complete:', err);
-    }
+  const handleValidateWithQuiz = () => {
+    router.push(`/${locale}/modules/${moduleId}/quiz?unit=${unitId}`);
   };
 
   const mdClass = "prose prose-gray max-w-none prose-headings:text-gray-900 prose-p:text-gray-700 prose-li:text-gray-700 prose-strong:text-gray-900 prose-table:text-sm";
@@ -297,23 +303,32 @@ export function LessonViewer({
       {/* Source Citations */}
       <SourceCitations sources={content.sources_cited} />
 
-      {/* Mark as Complete Button */}
+      {/* Quiz Validation */}
       <div className="mt-8 text-center">
-        <Button
-          onClick={handleMarkComplete}
-          disabled={isCompleted || isStreaming}
-          className="min-h-11 px-8"
-          size="lg"
-        >
-          {isCompleted ? (
-            <>
-              <CheckCircle className="w-4 h-4 mr-2" />
-              {t('completed')}
-            </>
-          ) : (
-            t('markComplete')
-          )}
-        </Button>
+        {isCheckingQuiz ? (
+          <div className="inline-flex items-center gap-2 text-gray-500 text-sm">
+            <RefreshCw className="w-4 h-4 animate-spin" />
+            {t('checkingStatus')}
+          </div>
+        ) : isQuizPassed ? (
+          <div
+            role="status"
+            className="inline-flex items-center gap-2 bg-green-50 border border-green-200 text-green-700 font-medium px-6 py-3 rounded-lg"
+          >
+            <CheckCircle className="w-5 h-5" />
+            {t('completed')}
+          </div>
+        ) : (
+          <Button
+            onClick={handleValidateWithQuiz}
+            disabled={isStreaming}
+            className="min-h-11 px-8 bg-teal-600 hover:bg-teal-700"
+            size="lg"
+          >
+            <PlayCircle className="w-4 h-4 mr-2" />
+            {t('validateWithQuiz')}
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -310,6 +310,22 @@ export interface SummativeAssessmentResponse {
   attempted_at: string;
 }
 
+// Unit Quiz Validation
+export interface UnitQuizValidationStatus {
+  passed: boolean;
+  best_score: number | null;
+  attempt_count: number;
+}
+
+export async function checkUnitQuizPassed(
+  moduleId: string,
+  unitId: string
+): Promise<UnitQuizValidationStatus> {
+  return apiFetch<UnitQuizValidationStatus>(
+    `/api/v1/quiz/attempts/status?module_id=${encodeURIComponent(moduleId)}&unit_id=${encodeURIComponent(unitId)}`
+  );
+}
+
 // Summative Assessment API Functions
 export async function generateSummativeAssessment(params: {
   module_id: string;

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -212,7 +212,7 @@
     "lockedDescription": "Complete the prerequisites to unlock this module",
     "unitStatus": {
       "pending": "Not started",
-      "in-progress": "In progress", 
+      "in-progress": "In progress",
       "completed": "Completed"
     },
     "unitNumber": "Unit {number}",
@@ -471,7 +471,7 @@
     "assessmentDomains": "Assessment Domains",
     "domains": {
       "foundations": "Public Health Foundations",
-      "epidemiology": "Epidemiology", 
+      "epidemiology": "Epidemiology",
       "biostatistics": "Biostatistics",
       "healthSystems": "Health Systems"
     },
@@ -482,7 +482,7 @@
     "timeRemaining": "Time remaining: {time}",
     "selectAnswer": "Select an answer to continue",
     "previous": "Previous",
-    "next": "Next", 
+    "next": "Next",
     "answered": "{count}/{total} answered",
     "submit": "Submit Assessment",
     "submitting": "Evaluating your responses...",
@@ -491,7 +491,7 @@
       "assignedLevel": "Your assigned level: Level {level}",
       "levelDescriptions": {
         "1": "Beginner - Build foundational knowledge",
-        "2": "Intermediate - Develop core competencies", 
+        "2": "Intermediate - Develop core competencies",
         "3": "Advanced - Strengthen specialized skills",
         "4": "Expert - Master advanced concepts"
       },
@@ -589,7 +589,9 @@
     "keyPoints": "Key Points",
     "markComplete": "Mark as Complete",
     "completed": "Completed",
-    "refreshContent": "Refresh content"
+    "refreshContent": "Refresh content",
+    "validateWithQuiz": "Validate with Quiz",
+    "checkingStatus": "Checking..."
   },
   "LessonImage": {
     "imagePending": "Generating illustration...",
@@ -703,7 +705,7 @@
     "cancel": "Cancel",
     "save": "Save Changes",
     "languages": {
-      "french": "Fran\u00e7ais",
+      "french": "Français",
       "english": "English"
     },
     "levels": {

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -471,7 +471,7 @@
     "assessmentDomains": "Domaines d'évaluation",
     "domains": {
       "foundations": "Fondements de Santé Publique",
-      "epidemiology": "Épidémiologie", 
+      "epidemiology": "Épidémiologie",
       "biostatistics": "Biostatistiques",
       "healthSystems": "Systèmes de Santé"
     },
@@ -482,7 +482,7 @@
     "timeRemaining": "Temps restant : {time}",
     "selectAnswer": "Sélectionnez une réponse pour continuer",
     "previous": "Précédent",
-    "next": "Suivant", 
+    "next": "Suivant",
     "answered": "{count}/{total} répondues",
     "submit": "Soumettre l'Évaluation",
     "submitting": "Évaluation de vos réponses...",
@@ -491,7 +491,7 @@
       "assignedLevel": "Votre niveau assigné : Niveau {level}",
       "levelDescriptions": {
         "1": "Débutant - Construire les connaissances de base",
-        "2": "Intermédiaire - Développer les compétences clés", 
+        "2": "Intermédiaire - Développer les compétences clés",
         "3": "Avancé - Renforcer les compétences spécialisées",
         "4": "Expert - Maîtriser les concepts avancés"
       },
@@ -589,7 +589,9 @@
     "keyPoints": "Points Clés",
     "markComplete": "Marquer comme Terminé",
     "completed": "Terminé",
-    "refreshContent": "Actualiser le contenu"
+    "refreshContent": "Actualiser le contenu",
+    "validateWithQuiz": "Valider avec le Quiz",
+    "checkingStatus": "Vérification..."
   },
   "LessonImage": {
     "imagePending": "Illustration en cours de génération...",


### PR DESCRIPTION
## Summary

Replaces the one-click \"Marquer comme Terminé\" button in `LessonViewer` with a quiz-gated validation flow, closing the learning progression bypass.

## Changes

- **`frontend/components/learning/lesson-viewer.tsx`** — Removed `handleMarkComplete()` and \"Mark as Complete\" button. Added:
  - On mount: calls `checkUnitQuizPassed()` to check if the unit quiz was already passed
  - **Quiz not yet passed**: shows teal \"Validate with Quiz\" button (`PlayCircle` icon) → navigates to `/[locale]/modules/{moduleId}/quiz?unit={unitId}`
  - **Quiz passed**: shows green \"Completed ✓\" badge (no button)
  - **Checking**: shows spinner while fetching status
- **`frontend/lib/api.ts`** — Added `UnitQuizValidationStatus` interface and `checkUnitQuizPassed(moduleId, unitId)` function (calls `GET /api/v1/quiz/attempts/status?module_id=X&unit_id=Y`)
- **`frontend/messages/fr.json`** + **`frontend/messages/en.json`** — Added `validateWithQuiz` and `checkingStatus` keys to `LessonViewer` namespace
- **`frontend/components/learning/case-study-viewer.tsx`** — Unchanged (case studies keep existing \"Mark Complete\" button per spec)

## Test plan

- [ ] Navigate to a lesson — see \"Validate with Quiz\" button
- [ ] Click button — redirects to quiz page for that module/unit
- [ ] Pass quiz (≥80%) — return to lesson, see green \"Completed ✓\" badge
- [ ] Case study page still shows \"Mark as Complete\" button
- [ ] Frontend lint passes (0 errors)
- [ ] TypeScript check: no errors in changed files

Closes #221

Generated with [Claude Code](https://claude.ai/code)