### PR TITLE
feat(progress): enforce quiz score ≥80% for lesson completion

### DIFF
--- a/backend/app/api/v1/progress.py
+++ b/backend/app/api/v1/progress.py
@@ -11,6 +11,8 @@ from app.api.deps import get_db
 from app.api.deps_local_auth import get_current_user
 from app.api.v1.content import _resolve_module_id
 from app.api.v1.schemas.progress import (
+    CompleteLessonRequest,
+    CompleteLessonResponse,
     ErrorResponse,
     LessonAccessRequest,
     ModuleDetailWithProgressResponse,
@@ -18,7 +20,7 @@ from app.api.v1.schemas.progress import (
     UnitProgressDetail,
 )
 from app.domain.models.user import User
-from app.domain.services.progress_service import ProgressService
+from app.domain.services.progress_service import _UNLOCK_THRESHOLD_SCORE, ProgressService
 
 logger = structlog.get_logger()
 router = APIRouter(prefix="/progress", tags=["progress"])
@@ -202,4 +204,78 @@ async def get_module_detail_with_progress(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail={"error": "fetch_failed", "message": "Failed to retrieve module detail"},
+        )
+
+
+@router.post(
+    "/complete-lesson",
+    response_model=CompleteLessonResponse,
+    status_code=status.HTTP_200_OK,
+    responses={
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        403: {"model": ErrorResponse, "description": "Quiz not passed"},
+        404: {"model": ErrorResponse, "description": "Module not found"},
+        500: {"model": ErrorResponse, "description": "Internal error"},
+    },
+)
+async def complete_lesson(
+    request: CompleteLessonRequest,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> CompleteLessonResponse:
+    """
+    Mark a unit/lesson as completed.
+
+    Requires a passing quiz attempt (score ≥ 80%) for the given module + unit.
+    Returns 403 with error code 'quiz_required' if no passing attempt exists.
+    """
+    try:
+        user_id = UUID(str(current_user.id))
+        service = ProgressService(db)
+
+        quiz_passed = await service.check_quiz_passed_for_unit(
+            user_id=user_id,
+            module_id=request.module_id,
+            unit_id=request.unit_id,
+        )
+
+        if not quiz_passed:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "error": "quiz_required",
+                    "message": "Pass the unit quiz with ≥80% to complete this lesson",
+                },
+            )
+
+        progress = await service.update_progress_after_quiz(
+            user_id=user_id,
+            module_id=request.module_id,
+            unit_id=request.unit_id,
+            score=_UNLOCK_THRESHOLD_SCORE,
+            passed=True,
+        )
+
+        logger.info(
+            "Lesson completed via complete-lesson endpoint",
+            user_id=str(user_id),
+            module_id=str(request.module_id),
+            unit_id=request.unit_id,
+            completion_pct=progress.completion_pct,
+        )
+
+        return CompleteLessonResponse(
+            completed=True,
+            module_progress=_make_module_progress_response(user_id, request.module_id, progress),
+        )
+
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except Exception as e:
+        logger.error("Failed to complete lesson", error=str(e), exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"error": "completion_failed", "message": "Failed to complete lesson"},
         )

--- a/backend/app/api/v1/schemas/progress.py
+++ b/backend/app/api/v1/schemas/progress.py
@@ -68,6 +68,20 @@ class ModuleDetailWithProgressResponse(BaseModel):
     units: list[UnitProgressDetail] = Field(default_factory=list)
 
 
+class CompleteLessonRequest(BaseModel):
+    """Request to mark a lesson/unit as completed (requires passing quiz)."""
+
+    module_id: UUID = Field(description="Module UUID")
+    unit_id: str = Field(description="Unit ID, e.g. 'M01-U02'")
+
+
+class CompleteLessonResponse(BaseModel):
+    """Response after attempting to complete a lesson."""
+
+    completed: bool = Field(description="Whether the lesson was marked as completed")
+    module_progress: ModuleProgressResponse
+
+
 class ErrorResponse(BaseModel):
     """Standard error response."""
 

--- a/backend/app/domain/services/progress_service.py
+++ b/backend/app/domain/services/progress_service.py
@@ -153,6 +153,42 @@ class ProgressService:
         )
         return progress
 
+    async def check_quiz_passed_for_unit(
+        self,
+        user_id: UUID,
+        module_id: UUID,
+        unit_id: str,
+    ) -> bool:
+        """
+        Return True if the user has at least one quiz attempt with score ≥ 80
+        for the given module + unit combination.
+
+        Per FR-02.2: lesson completion requires passing the validation quiz (≥80%).
+        """
+        from app.domain.models.content import GeneratedContent
+        from app.domain.models.quiz import QuizAttempt
+
+        content_result = await self.db.execute(
+            select(GeneratedContent.id).where(
+                GeneratedContent.module_id == module_id,
+                GeneratedContent.content_type == "quiz",
+                GeneratedContent.content["unit_id"].astext == unit_id,
+            )
+        )
+        quiz_ids = [row[0] for row in content_result.all()]
+
+        if not quiz_ids:
+            return False
+
+        attempt_result = await self.db.execute(
+            select(func.max(QuizAttempt.score)).where(
+                QuizAttempt.user_id == user_id,
+                QuizAttempt.quiz_id.in_(quiz_ids),
+            )
+        )
+        max_score = attempt_result.scalar()
+        return max_score is not None and max_score >= _UNLOCK_THRESHOLD_SCORE
+
     async def get_module_progress(
         self, user_id: UUID, module_id: UUID
     ) -> UserModuleProgress | None:

--- a/backend/tests/test_progress_service.py
+++ b/backend/tests/test_progress_service.py
@@ -365,6 +365,125 @@ class TestGetModuleProgress:
         assert "in_progress" in statuses
 
 
+class TestCheckQuizPassedForUnit:
+    async def test_returns_false_when_no_quiz_content_found(
+        self, progress_service, mock_db, user_id, module_id
+    ):
+        mock_db.execute = AsyncMock(return_value=MagicMock(all=MagicMock(return_value=[])))
+
+        result = await progress_service.check_quiz_passed_for_unit(
+            user_id=user_id,
+            module_id=module_id,
+            unit_id="M01-U01",
+        )
+
+        assert result is False
+
+    async def test_returns_false_when_no_passing_attempt(
+        self, progress_service, mock_db, user_id, module_id
+    ):
+        quiz_id = uuid.uuid4()
+        call_count = 0
+
+        async def mock_execute(query):
+            nonlocal call_count
+            call_count += 1
+            mock_result = MagicMock()
+            if call_count == 1:
+                mock_result.all = MagicMock(return_value=[(quiz_id,)])
+            else:
+                mock_result.scalar = MagicMock(return_value=70.0)
+            return mock_result
+
+        mock_db.execute = mock_execute
+
+        result = await progress_service.check_quiz_passed_for_unit(
+            user_id=user_id,
+            module_id=module_id,
+            unit_id="M01-U01",
+        )
+
+        assert result is False
+
+    async def test_returns_true_when_passing_attempt_exists(
+        self, progress_service, mock_db, user_id, module_id
+    ):
+        quiz_id = uuid.uuid4()
+        call_count = 0
+
+        async def mock_execute(query):
+            nonlocal call_count
+            call_count += 1
+            mock_result = MagicMock()
+            if call_count == 1:
+                mock_result.all = MagicMock(return_value=[(quiz_id,)])
+            else:
+                mock_result.scalar = MagicMock(return_value=85.0)
+            return mock_result
+
+        mock_db.execute = mock_execute
+
+        result = await progress_service.check_quiz_passed_for_unit(
+            user_id=user_id,
+            module_id=module_id,
+            unit_id="M01-U01",
+        )
+
+        assert result is True
+
+    async def test_returns_true_exactly_at_80_threshold(
+        self, progress_service, mock_db, user_id, module_id
+    ):
+        quiz_id = uuid.uuid4()
+        call_count = 0
+
+        async def mock_execute(query):
+            nonlocal call_count
+            call_count += 1
+            mock_result = MagicMock()
+            if call_count == 1:
+                mock_result.all = MagicMock(return_value=[(quiz_id,)])
+            else:
+                mock_result.scalar = MagicMock(return_value=80.0)
+            return mock_result
+
+        mock_db.execute = mock_execute
+
+        result = await progress_service.check_quiz_passed_for_unit(
+            user_id=user_id,
+            module_id=module_id,
+            unit_id="M01-U01",
+        )
+
+        assert result is True
+
+    async def test_returns_false_when_no_attempt_at_all(
+        self, progress_service, mock_db, user_id, module_id
+    ):
+        quiz_id = uuid.uuid4()
+        call_count = 0
+
+        async def mock_execute(query):
+            nonlocal call_count
+            call_count += 1
+            mock_result = MagicMock()
+            if call_count == 1:
+                mock_result.all = MagicMock(return_value=[(quiz_id,)])
+            else:
+                mock_result.scalar = MagicMock(return_value=None)
+            return mock_result
+
+        mock_db.execute = mock_execute
+
+        result = await progress_service.check_quiz_passed_for_unit(
+            user_id=user_id,
+            module_id=module_id,
+            unit_id="M01-U01",
+        )
+
+        assert result is False
+
+
 class TestUnitNumberToUnitId:
     def test_converts_basic_format(self):
         assert ProgressService._unit_number_to_unit_id("1.1", 1) == "M01-U01"


### PR DESCRIPTION
## Summary

Implements the backend fix for issue #220. Adds `POST /api/v1/progress/complete-lesson` endpoint that gates lesson completion on a passing quiz attempt (score ≥ 80%), removing the ability to bypass the quiz path.

## Changes

- **`backend/app/api/v1/schemas/progress.py`** — Added `CompleteLessonRequest` and `CompleteLessonResponse` Pydantic schemas
- **`backend/app/domain/services/progress_service.py`** — Added `check_quiz_passed_for_unit()` method that queries `quiz_attempts` for a passing score (≥80%) matching the given module + unit
- **`backend/app/api/v1/progress.py`** — Added `POST /progress/complete-lesson` endpoint: returns 403 with `{"error": "quiz_required"}` if no passing attempt exists; otherwise delegates to existing `update_progress_after_quiz()` to mark the unit complete and trigger module unlock logic
- **`backend/tests/test_progress_service.py`** — Added 5 unit tests for `check_quiz_passed_for_unit()` covering: no quiz content found, score below threshold, score at exactly 80, score above 80, and no attempts at all

## Test plan

- [x] `ruff check` passes with no errors
- [x] `ruff format` applied
- [ ] Backend unit tests pass (`uv run pytest`)
- [ ] Manually test: POST /complete-lesson without a quiz attempt → 403
- [ ] Manually test: POST /complete-lesson after passing quiz → 200 with updated progress

## Notes

The quiz completion path via `POST /quiz/attempt` **already** calls `update_progress_after_quiz()` when score ≥ 80. This new endpoint ensures that no client can bypass the quiz by directly calling a "complete" action. Frontend counterpart tracked in #221.

Closes #220

Generated with [Claude Code](https://claude.ai/code)