### PR TITLE
fix(content): public module units endpoint + cascade fallback for unauthenticated users

### DIFF
--- a/backend/app/api/v1/content.py
+++ b/backend/app/api/v1/content.py
@@ -24,12 +24,15 @@ from app.api.v1.schemas.content import (
     FlashcardSetResponse,
     LessonGenerationRequest,
     LessonResponse,
+    ModuleUnitsResponse,
+    PublicUnitDetail,
     QuizGenerationRequest,
     QuizResponse,
     StreamingEvent,
 )
 from app.domain.models.content import GeneratedContent
 from app.domain.models.module import Module
+from app.domain.models.module_unit import ModuleUnit
 from app.domain.services.flashcard_service import FlashcardGenerationService
 from app.domain.services.lesson_service import CaseStudyGenerationService, LessonGenerationService
 from app.domain.services.progress_service import ProgressService
@@ -1145,3 +1148,98 @@ async def stream_case_study_by_module_and_unit(
             "Access-Control-Allow-Headers": "Cache-Control",
         },
     )
+
+
+@router.get(
+    "/modules/{module_id}/units",
+    response_model=ModuleUnitsResponse,
+    status_code=status.HTTP_200_OK,
+    responses={
+        404: {"model": ErrorResponse, "description": "Module not found"},
+        500: {"model": ErrorResponse, "description": "Internal error"},
+    },
+)
+async def get_module_units(
+    module_id: str,
+    session: AsyncSession = Depends(get_db),
+) -> ModuleUnitsResponse:
+    """
+    Return module info and its units without progress data (no auth required).
+
+    Intended as a public fallback for unauthenticated users viewing module detail
+    pages.  Progress data stays behind authentication — this endpoint only returns
+    the curriculum structure so the page is never empty.
+
+    **Parameters:**
+    - **module_id**: Module identifier (code like "M01" or UUID string)
+    """
+    try:
+        resolved_module_id = await _resolve_module_id(module_id, session)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "module_not_found", "message": str(e)},
+        )
+
+    try:
+        module_query = select(Module).where(Module.id == resolved_module_id)
+        module_result = await session.execute(module_query)
+        module = module_result.scalar_one_or_none()
+
+        if not module:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={
+                    "error": "module_not_found",
+                    "message": f"Module {module_id} not found",
+                },
+            )
+
+        units_query = (
+            select(ModuleUnit)
+            .where(ModuleUnit.module_id == resolved_module_id)
+            .order_by(ModuleUnit.order_index)
+        )
+        units_result = await session.execute(units_query)
+        units = units_result.scalars().all()
+
+        public_units = [
+            PublicUnitDetail(
+                id=str(u.id),
+                unit_number=u.unit_number,
+                title_fr=u.title_fr,
+                title_en=u.title_en,
+                description_fr=u.description_fr,
+                description_en=u.description_en,
+                estimated_minutes=u.estimated_minutes,
+                order_index=u.order_index,
+            )
+            for u in units
+        ]
+
+        logger.info(
+            "Public module units requested",
+            module_id=str(resolved_module_id),
+            units_count=len(public_units),
+        )
+
+        return ModuleUnitsResponse(
+            module_id=str(module.id),
+            module_number=module.module_number,
+            level=module.level,
+            title_fr=module.title_fr,
+            title_en=module.title_en,
+            description_fr=module.description_fr,
+            description_en=module.description_en,
+            estimated_hours=module.estimated_hours,
+            units=public_units,
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Failed to fetch module units", module_id=module_id, error=str(e))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"error": "internal_error", "message": "Failed to fetch module units"},
+        )

--- a/backend/app/api/v1/schemas/content.py
+++ b/backend/app/api/v1/schemas/content.py
@@ -353,6 +353,33 @@ class CaseStudyResponse(BaseModel):
     }
 
 
+class PublicUnitDetail(BaseModel):
+    """Public unit info without user-specific progress data."""
+
+    id: str = Field(description="Unit UUID")
+    unit_number: str = Field(description="Unit number e.g. M01-U01")
+    title_fr: str
+    title_en: str
+    description_fr: str | None = None
+    description_en: str | None = None
+    estimated_minutes: int
+    order_index: int
+
+
+class ModuleUnitsResponse(BaseModel):
+    """Public module info with units list (no auth required, no progress data)."""
+
+    module_id: str = Field(description="Module UUID")
+    module_number: int
+    level: int
+    title_fr: str
+    title_en: str
+    description_fr: str | None = None
+    description_en: str | None = None
+    estimated_hours: int
+    units: list[PublicUnitDetail] = Field(default_factory=list)
+
+
 class ErrorResponse(BaseModel):
     """Error response schema."""
 

--- a/frontend/components/learning/module-progress-overlay.tsx
+++ b/frontend/components/learning/module-progress-overlay.tsx
@@ -8,7 +8,7 @@ import { Link } from '@/i18n/routing';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
-import { getModuleDetailWithProgress, type ModuleDetailWithProgressResponse, type UnitProgressDetail } from '@/lib/api';
+import { getModuleDetailWithProgress, getModuleUnits, type ModuleDetailWithProgressResponse, type UnitProgressDetail } from '@/lib/api';
 import type { Unit } from '@/lib/modules';
 
 interface ModuleProgressOverlayProps {
@@ -77,12 +77,54 @@ export function ModuleProgressOverlay({
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    getModuleDetailWithProgress(moduleId)
-      .then(setData)
-      .catch(() => {
-        // Silently fall back to static data on error (offline support)
-      })
-      .finally(() => setLoading(false));
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const result = await getModuleDetailWithProgress(moduleId);
+        if (!cancelled) setData(result);
+      } catch {
+        try {
+          const publicResult = await getModuleUnits(moduleId);
+          if (!cancelled) {
+            setData({
+              id: publicResult.module_id,
+              module_number: publicResult.module_number,
+              level: publicResult.level,
+              title_fr: publicResult.title_fr,
+              title_en: publicResult.title_en,
+              description_fr: publicResult.description_fr,
+              description_en: publicResult.description_en,
+              estimated_hours: publicResult.estimated_hours,
+              prereq_modules: [],
+              status: 'locked',
+              completion_pct: 0,
+              quiz_score_avg: null,
+              time_spent_minutes: 0,
+              last_accessed: null,
+              units: publicResult.units.map((u) => ({
+                id: u.id,
+                unit_number: u.unit_number,
+                title_fr: u.title_fr,
+                title_en: u.title_en,
+                description_fr: u.description_fr,
+                description_en: u.description_en,
+                estimated_minutes: u.estimated_minutes,
+                order_index: u.order_index,
+                status: 'pending',
+              })),
+            });
+          }
+        } catch {
+          // Both endpoints failed — fall back to hardcoded static units
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    load();
+    return () => { cancelled = true; };
   }, [moduleId]);
 
   const staticUnitsFallback: UnitProgressDetail[] = (staticUnits ?? []).map((u, i) => ({

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -71,6 +71,33 @@ export async function getModuleDetailWithProgress(
   );
 }
 
+export interface PublicUnitDetail {
+  id: string;
+  unit_number: string;
+  title_fr: string;
+  title_en: string;
+  description_fr?: string;
+  description_en?: string;
+  estimated_minutes: number;
+  order_index: number;
+}
+
+export interface ModuleUnitsResponse {
+  module_id: string;
+  module_number: number;
+  level: number;
+  title_fr: string;
+  title_en: string;
+  description_fr?: string;
+  description_en?: string;
+  estimated_hours: number;
+  units: PublicUnitDetail[];
+}
+
+export async function getModuleUnits(moduleId: string): Promise<ModuleUnitsResponse> {
+  return apiFetch<ModuleUnitsResponse>(`/api/v1/content/modules/${moduleId}/units`);
+}
+
 export async function trackLessonAccess(
   request: LessonAccessRequest
 ): Promise<ModuleProgressResponse> {


### PR DESCRIPTION
## Summary

- Adds a **public** `GET /api/v1/content/modules/{module_id}/units` endpoint (no auth required) that returns module info + ordered units without any user-specific progress data.
- Updates `ModuleProgressOverlay` to use a **cascade fallback**: authenticated progress endpoint → public units endpoint → hardcoded static units (offline only).
- This fixes the empty page shown for M02-M15 when visiting `/modules/M04` (or any module page) while not logged in.

## Changes

- `backend/app/api/v1/schemas/content.py` — new `PublicUnitDetail` and `ModuleUnitsResponse` Pydantic schemas
- `backend/app/api/v1/content.py` — new `GET /content/modules/{module_id}/units` router endpoint
- `frontend/lib/api.ts` — new `getModuleUnits()` function + TypeScript interfaces
- `frontend/components/learning/module-progress-overlay.tsx` — cascade fallback in `useEffect`

## Test plan

- [ ] Backend lint passes (`ruff check`)
- [ ] Frontend lint passes (ESLint)
- [ ] TypeScript type check passes (no new errors)
- [ ] Unauthenticated visit to `/en/modules/M04` shows unit list instead of empty page
- [ ] Authenticated visit still shows full progress data
- [ ] Offline fallback (both endpoints fail) still uses hardcoded static units for M01

Closes #401

Generated with [Claude Code](https://claude.ai/code)