### PR TITLE
feat(quiz): add KaTeX math rendering to quiz results (#436)

### DIFF
--- a/frontend/components/quiz/quiz-results.tsx
+++ b/frontend/components/quiz/quiz-results.tsx
@@ -2,7 +2,10 @@
 
 import { useTranslations } from 'next-intl';
 import { Clock, CheckCircle, XCircle, RotateCcw, ArrowRight, Trophy, Target, BookCheck } from 'lucide-react';
-
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
+import rehypeKatex from 'rehype-katex';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
@@ -185,9 +188,11 @@ export function QuizResults({ quiz, result, onRetry, onContinue }: QuizResultsPr
                           </div>
                         </div>
                         
-                        <h3 className="font-medium text-stone-900 leading-relaxed">
-                          {question.question}
-                        </h3>
+                        <div className="font-medium text-stone-900 leading-relaxed prose prose-sm max-w-none prose-p:my-0">
+                          <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeKatex]}>
+                            {question.question}
+                          </ReactMarkdown>
+                        </div>
                       </div>
                     </div>
                     
@@ -217,7 +222,11 @@ export function QuizResults({ quiz, result, onRetry, onContinue }: QuizResultsPr
                     {/* Explanation */}
                     <div className="pt-3 border-t border-stone-200">
                       <div className="font-medium text-stone-700 mb-2">{t('explanation')}</div>
-                      <p className="text-stone-600 leading-relaxed">{questionResult.explanation}</p>
+                      <div className="text-stone-600 leading-relaxed prose prose-sm max-w-none prose-p:my-0 overflow-x-auto">
+                        <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeKatex]}>
+                          {questionResult.explanation}
+                        </ReactMarkdown>
+                      </div>
                       
                       {/* Sources */}
                       {question.sources_cited.length > 0 && (


### PR DESCRIPTION
## Summary

- Adds `ReactMarkdown` with `remarkMath` + `rehypeKatex` plugins to `quiz-results.tsx` for question text and explanations in the results breakdown view
- The other 4 files (`lesson-viewer.tsx`, `case-study-viewer.tsx`, `quiz-interface.tsx`, `chat-message.tsx`) were already updated with KaTeX support, as were the package dependencies (`remark-math`, `rehype-katex`, `katex`) and the CSS import in `layout.tsx`

## Changes

- `frontend/components/quiz/quiz-results.tsx` — replaced plain `<h3>` and `<p>` text rendering with `ReactMarkdown` using `remarkGfm`, `remarkMath`, and `rehypeKatex` plugins for question text (line 188) and explanation text (line 220)

## Test plan

- [ ] Backend tests pass
- [ ] Frontend lint passes (0 errors confirmed)
- [ ] Manually verify quiz results page renders LaTeX formulas (e.g. `$\frac{a}{b}$`, `$$\text{Taux} = \frac{n}{N} \times k$$`)
- [ ] Verified on mobile viewport (320px min)

Closes #436

Generated with [Claude Code](https://claude.ai/code)