### PR TITLE
fix(image): use DALL-E 2 at 512x512 instead of DALL-E 3 at 1024x1024

### DIFF
--- a/backend/app/domain/services/image_service.py
+++ b/backend/app/domain/services/image_service.py
@@ -1,4 +1,4 @@
-"""Service for AI-generated lesson illustrations using DALL-E 3 with semantic reuse."""
+"""Service for AI-generated lesson illustrations using DALL-E 2 with semantic reuse."""
 
 from __future__ import annotations
 
@@ -30,7 +30,7 @@ def _jaccard_similarity(tags_a: list[str], tags_b: list[str]) -> float:
 
 
 class ImageGenerationService:
-    """Pipeline: concept extraction → semantic reuse → DALL-E 3 → WebP → bilingual alt-text."""
+    """Pipeline: concept extraction → semantic reuse → DALL-E 2 → WebP → bilingual alt-text."""
 
     async def generate_for_lesson(
         self,
@@ -165,17 +165,17 @@ class ImageGenerationService:
         return None
 
     async def _call_dalle(self, prompt: str) -> tuple[bytes, str]:
-        """Call OpenAI DALL-E 3 API and return (image_bytes, image_url)."""
+        """Call OpenAI DALL-E 2 API and return (image_bytes, image_url)."""
         import httpx
         from openai import AsyncOpenAI
 
         client = AsyncOpenAI(api_key=settings.openai_api_key)
 
         response = await client.images.generate(
-            model="dall-e-3",
+            model="dall-e-2",
             prompt=prompt,
             n=1,
-            size="1024x1024",
+            size="512x512",
             response_format="url",
         )
 
@@ -264,7 +264,7 @@ def _parse_alt_text(text: str, concept: str) -> tuple[str, str]:
 
 
 def _resize_to_webp(image_bytes: bytes, max_width: int = 512) -> tuple[bytes, int]:
-    """Convert image bytes to WebP format with max_width constraint."""
+    """Convert image bytes to WebP format, skipping resize if already at target width."""
     try:
         from PIL import Image
 

--- a/backend/tests/test_image_generation.py
+++ b/backend/tests/test_image_generation.py
@@ -1,4 +1,4 @@
-"""Tests for DALL-E 3 async image generation pipeline (issue #223, US-025)."""
+"""Tests for DALL-E 2 async image generation pipeline (issue #223, US-025)."""
 
 from __future__ import annotations
 
@@ -13,6 +13,7 @@ from app.domain.services.image_service import (
     _jaccard_similarity,
     _parse_alt_text,
     _parse_concept_response,
+    _resize_to_webp,
 )
 
 
@@ -70,6 +71,49 @@ class TestParseAltText:
         fr, en = _parse_alt_text("", "malaria")
         assert "malaria" in fr.lower()
         assert "malaria" in en.lower()
+
+
+class TestResizeToWebp:
+    def test_skips_resize_when_already_at_target_width(self):
+        """When input is already 512px wide, no resize should occur — only WebP conversion."""
+        import io
+
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("Pillow not installed")
+
+        img = Image.new("RGB", (512, 512), color=(100, 150, 200))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        png_bytes = buf.getvalue()
+
+        webp_bytes, width = _resize_to_webp(png_bytes, max_width=512)
+
+        assert width == 512
+        result_img = Image.open(io.BytesIO(webp_bytes))
+        assert result_img.format == "WEBP"
+        assert result_img.width == 512
+
+    def test_resizes_when_larger_than_target(self):
+        """When input is larger than max_width, it must be resized down."""
+        import io
+
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("Pillow not installed")
+
+        img = Image.new("RGB", (1024, 1024), color=(100, 150, 200))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        png_bytes = buf.getvalue()
+
+        webp_bytes, width = _resize_to_webp(png_bytes, max_width=512)
+
+        assert width == 512
+        result_img = Image.open(io.BytesIO(webp_bytes))
+        assert result_img.width == 512
 
 
 def _make_db_image(tags: list[str], status: str = "ready") -> GeneratedImage:
@@ -153,7 +197,7 @@ class TestImageGenerationService:
     async def test_new_generation_calls_dalle(
         self, service, mock_session, mock_claude_response, mock_alt_text_response
     ):
-        """When no matching image, DALL-E 3 must be called and image saved."""
+        """When no matching image, DALL-E 2 must be called and image saved."""
         mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = []
         mock_session.execute = AsyncMock(return_value=mock_result)
@@ -194,6 +238,9 @@ class TestImageGenerationService:
                     )
 
             mock_openai.images.generate.assert_called_once()
+            call_kwargs = mock_openai.images.generate.call_args.kwargs
+            assert call_kwargs.get("model") == "dall-e-2"
+            assert call_kwargs.get("size") == "512x512"
 
         assert result.status == "ready"
 


### PR DESCRIPTION
## Summary

- Switch from DALL-E 3 (1024×1024, ~\$0.04/image) to DALL-E 2 (512×512, ~\$0.018/image) — **55% cost reduction**
- Update `_resize_to_webp` docstring to clarify it skips resize when input is already at target width (512px)
- Still converts to WebP quality 85 in all cases

## Changes

- `backend/app/domain/services/image_service.py` — `model="dall-e-2"`, `size="512x512"`, updated docstrings
- `backend/tests/test_image_generation.py` — Added `TestResizeToWebp` (skip resize + resize-down cases), asserts DALL-E call uses correct model/size

## Test plan

- [x] Backend tests pass (20/20)
- [x] Ruff lint passes
- [x] `_resize_to_webp` verified: no resize when already 512px, resizes when 1024px input

Closes #435

Generated with [Claude Code](https://claude.ai/code)