### PR TITLE
fix(tasks): register LessonReading model in Celery worker context

### DIFF
--- a/backend/app/domain/models/__init__.py
+++ b/backend/app/domain/models/__init__.py
@@ -6,6 +6,7 @@ from app.domain.models.document_chunk import DocumentChunk
 from app.domain.models.flashcard import FlashcardReview
 from app.domain.models.generated_image import GeneratedImage
 from app.domain.models.learner_memory import LearnerMemory
+from app.domain.models.lesson_reading import LessonReading
 from app.domain.models.module import Module
 from app.domain.models.module_unit import ModuleUnit
 from app.domain.models.progress import UserModuleProgress
@@ -18,6 +19,7 @@ __all__ = [
     "GeneratedContent",
     "GeneratedImage",
     "LearnerMemory",
+    "LessonReading",
     "TutorConversation",
     "FlashcardReview",
     "MagicLink",

--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -3,6 +3,7 @@
 import structlog
 from celery import Celery
 
+import app.domain.models  # noqa: F401 — register all SQLAlchemy models with the mapper
 from app.infrastructure.config.settings import settings
 
 logger = structlog.get_logger(__name__)


### PR DESCRIPTION
## Summary

- Added `LessonReading` import to `app/domain/models/__init__.py` so the model is registered with the SQLAlchemy mapper alongside all other models
- Added `import app.domain.models` in `celery_app.py` to eagerly load all models when the Celery worker starts

## Root cause

`LessonReading` existed in `lesson_reading.py` and was referenced by the `User.lesson_readings` relationship, but was not imported in `domain/models/__init__.py`. When the Celery worker initialized, SQLAlchemy couldn't resolve the `LessonReading` name, causing `expression 'LessonReading' failed to locate a name` errors on all tasks that touched `User` objects.

## Changes

- `backend/app/domain/models/__init__.py` — added `LessonReading` import and export
- `backend/app/tasks/celery_app.py` — added `import app.domain.models` to eagerly register all models

## Test plan

- [x] Backend tests pass (269 passed)
- [x] Ruff lint/format passes
- [x] `LessonReading` mapper now registered before any Celery task runs

Closes #439

Generated with [Claude Code](https://claude.ai/code)