### PR TITLE
fix(tasks): register LessonReading model in Celery worker context (#439)

### DIFF
--- a/backend/app/domain/models/__init__.py
+++ b/backend/app/domain/models/__init__.py
@@ -6,6 +6,7 @@ from app.domain.models.document_chunk import DocumentChunk
 from app.domain.models.flashcard import FlashcardReview
 from app.domain.models.generated_image import GeneratedImage
 from app.domain.models.learner_memory import LearnerMemory
+from app.domain.models.lesson_reading import LessonReading
 from app.domain.models.module import Module
 from app.domain.models.module_unit import ModuleUnit
 from app.domain.models.progress import UserModuleProgress
@@ -18,6 +19,7 @@ __all__ = [
     "GeneratedContent",
     "GeneratedImage",
     "LearnerMemory",
+    "LessonReading",
     "TutorConversation",
     "FlashcardReview",
     "MagicLink",

--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -3,6 +3,7 @@
 import structlog
 from celery import Celery
 
+import app.domain.models  # noqa: F401 — ensure all SQLAlchemy models are registered
 from app.infrastructure.config.settings import settings
 
 logger = structlog.get_logger(__name__)


### PR DESCRIPTION
## Summary

- Add `LessonReading` to `backend/app/domain/models/__init__.py` imports and `__all__`
- Add `import app.domain.models` at top of `backend/app/tasks/celery_app.py` to eagerly register all SQLAlchemy models when the Celery worker process starts

## Root cause

`LessonReading` exists in `lesson_reading.py` and is referenced by the `User.lesson_readings` relationship, but was never imported in `domain/models/__init__.py`. When the Celery worker starts and SQLAlchemy configures mappers, it cannot resolve the `LessonReading` name → `expression 'LessonReading' failed to locate a name`.

## Changes

- `backend/app/domain/models/__init__.py` — added `LessonReading` import and entry in `__all__`
- `backend/app/tasks/celery_app.py` — added `import app.domain.models` to eagerly load all models before any task runs

## Test plan

- [ ] Backend tests pass
- [ ] Image generation tasks execute without mapper errors
- [ ] `generated_images` table gets populated

Closes #439

Generated with [Claude Code](https://claude.ai/code)