### PR TITLE
fix(tasks): increase DALL-E image task timeout to 120s/150s

### DIFF
--- a/backend/app/tasks/content_generation.py
+++ b/backend/app/tasks/content_generation.py
@@ -198,8 +198,8 @@ def generate_flashcards(self, module_id: str, language: str = "fr", count: int =
 @celery_app.task(
     bind=True,
     base=CallbackTask,
-    soft_time_limit=15,
-    time_limit=20,
+    soft_time_limit=120,
+    time_limit=150,
     rate_limit="5/m",
 )
 def generate_lesson_image(


### PR DESCRIPTION
## Summary

Increased Celery task timeouts for `generate_lesson_image` to accommodate DALL-E 3's actual generation time (30-60s). The previous 15s soft limit caused `SoftTimeLimitExceeded` on every image generation request.

## Changes

- `backend/app/tasks/content_generation.py`: `soft_time_limit` 15→120, `time_limit` 20→150

## Test plan
- [ ] Backend tests pass
- [ ] Image generation completes without timeout errors
- [ ] Manually verified on mobile viewport

Closes #448

Generated with [Claude Code](https://claude.ai/code)