### PR TITLE
fix(layout): restore page scrolling — scope overflow-hidden to main area

### DIFF
--- a/frontend/app/[locale]/(app)/layout.tsx
+++ b/frontend/app/[locale]/(app)/layout.tsx
@@ -7,12 +7,12 @@ import { ChatLayout } from "@/components/chat/chat-layout";
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
     <ChatLayout>
-      <div className="flex h-dvh overflow-hidden flex-col md:flex-row">
+      <div className="flex h-dvh flex-col md:flex-row">
         <Sidebar />
         <div className="flex flex-1 flex-col min-h-0">
           <Header />
           <BreadcrumbNav />
-          <main className="flex flex-col flex-1 min-h-0 pb-16 pt-0 md:pb-0">{children}</main>
+          <main className="flex flex-col flex-1 overflow-y-auto pb-16 pt-0 md:pb-0">{children}</main>
         </div>
         <BottomNav />
       </div>

--- a/frontend/components/chat/chat-layout.tsx
+++ b/frontend/components/chat/chat-layout.tsx
@@ -34,7 +34,7 @@ interface ChatLayoutProps {
 export function ChatLayout({ children }: ChatLayoutProps) {
   return (
     <ChatProvider>
-      <div className="relative h-dvh overflow-hidden">
+      <div className="relative">
         {children}
         <ChatUIComponents />
       </div>


### PR DESCRIPTION
## Summary

All app pages were unscrollable due to two compounding `overflow-hidden` constraints:

1. `ChatLayout` wrapper (`chat-layout.tsx:37`) applied `h-dvh overflow-hidden` around the entire app, blocking scroll
2. `(app)/layout.tsx:10` had a second `h-dvh overflow-hidden` on the inner flex container
3. `main` had `flex-1 min-h-0` but no `overflow-y-auto`, so content overflowed and was clipped

## Changes

- `frontend/components/chat/chat-layout.tsx` — removed `h-dvh overflow-hidden` from the `ChatLayout` wrapper div (the floating `ChatPanel` uses `fixed` positioning so it doesn't need the parent constrained)
- `frontend/app/[locale]/(app)/layout.tsx` — removed `overflow-hidden` from outer flex div; added `overflow-y-auto` to `main` so pages scroll within the `h-dvh` shell

The tutor page (`tutor/page.tsx`) is unaffected — it uses `fixed inset-0` for its own full-viewport layout.

## Test plan

- [ ] Dashboard, modules list, module detail pages scroll correctly
- [ ] Lessons, quizzes, case studies, flashcards scroll correctly
- [ ] Tutor page still fills viewport with pinned input (fixed layout preserved)
- [ ] Floating chat button and chat panel still appear correctly on non-tutor pages
- [ ] Sidebar remains full height on desktop (h-dvh on outer flex container preserved)
- [ ] Mobile bottom nav remains fixed (not covered by scrolling content)

Closes #451

Generated with [Claude Code](https://claude.ai/code)