### PR TITLE
fix(flashcards): auto-trigger generation when no flashcards exist

### DIFF
--- a/frontend/app/[locale]/(app)/flashcards/flashcards-container.tsx
+++ b/frontend/app/[locale]/(app)/flashcards/flashcards-container.tsx
@@ -9,6 +9,7 @@ import { FlashcardSessionSummary } from '@/components/learning/flashcard-session
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { authClient, AuthError } from '@/lib/auth';
+import { generateModuleFlashcards, getAllModuleProgress } from '@/lib/api';
 
 interface FlashcardData {
   id: string;
@@ -47,7 +48,7 @@ interface SessionStats {
   dailyTargetMet: boolean;
 }
 
-type SessionState = 'loading' | 'ready' | 'reviewing' | 'summary' | 'empty';
+type SessionState = 'loading' | 'generating' | 'ready' | 'reviewing' | 'summary' | 'empty';
 
 export function FlashcardsContainer() {
   const t = useTranslations('Flashcards');
@@ -55,6 +56,7 @@ export function FlashcardsContainer() {
   const router = useRouter();
   const [sessionState, setSessionState] = useState<SessionState>('loading');
   const [sessionStats, setSessionStats] = useState<SessionStats | null>(null);
+  const [generationError, setGenerationError] = useState<string | null>(null);
   
   // Check authentication status
   const isAuthenticated = authClient.isAuthenticated();
@@ -153,14 +155,37 @@ export function FlashcardsContainer() {
 
   const cardsCount = dueCards?.cards?.length ?? 0;
   const totalDue = dueCards?.total_due ?? 0;
+
+  const triggerGeneration = async () => {
+    setSessionState('generating');
+    setGenerationError(null);
+    try {
+      const allProgress = await getAllModuleProgress();
+      const activeModules = allProgress
+        .filter((m) => m.status === 'in_progress' || m.status === 'completed')
+        .map((m) => m.module_id);
+      const modulesToGenerate = activeModules.length > 0 ? activeModules : ['M01'];
+      await Promise.allSettled(
+        modulesToGenerate.map((moduleId) =>
+          generateModuleFlashcards({ moduleId, language: locale, level: 1 })
+        )
+      );
+      await refetch();
+    } catch (err) {
+      setGenerationError(err instanceof Error ? err.message : String(err));
+      setSessionState('empty');
+    }
+  };
+
   useEffect(() => {
     if (!isLoading) {
       if (dueCards && totalDue === 0 && cardsCount === 0) {
-        setSessionState('empty');
+        triggerGeneration();
       } else {
         setSessionState(cardsCount > 0 ? 'ready' : 'summary');
       }
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoading, cardsCount, totalDue, dueCards]);
 
   const handleStartSession = () => {
@@ -214,6 +239,22 @@ export function FlashcardsContainer() {
             </Button>
           </CardContent>
         </Card>
+      </div>
+    );
+  }
+
+  if (sessionState === 'generating') {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center space-y-4">
+          <div className="animate-pulse">
+            <div className="w-80 h-96 bg-gray-200 rounded-xl mx-auto"></div>
+          </div>
+          <p className="text-muted-foreground">{t('generating')}</p>
+          {generationError && (
+            <p className="text-sm text-destructive">{generationError}</p>
+          )}
+        </div>
       </div>
     );
   }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -182,6 +182,27 @@ export async function getUpcomingReviews(): Promise<UpcomingReviewsResponse> {
   return authClient.authenticatedFetch<UpcomingReviewsResponse>("/api/v1/flashcards/upcoming");
 }
 
+export interface FlashcardSetResponse {
+  module_id: string;
+  language: string;
+  level: number;
+  cards: unknown[];
+  total_cards: number;
+  cached: boolean;
+}
+
+export async function generateModuleFlashcards(params: {
+  moduleId: string;
+  language: string;
+  level?: number;
+}): Promise<FlashcardSetResponse> {
+  const { authClient } = await import('./auth');
+  const level = params.level ?? 1;
+  return authClient.authenticatedFetch<FlashcardSetResponse>(
+    `/api/v1/flashcards/modules/${params.moduleId}?language=${params.language}&level=${level}`
+  );
+}
+
 // Quiz API Types
 export interface QuizQuestion {
   id: string;

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -340,6 +340,7 @@
   "Flashcards": {
     "title": "Flashcards",
     "loading": "Loading flashcards...",
+    "generating": "Generating your flashcards...",
     "noCardsToday": "No cards due today!",
     "wellDone": "Well done! Come back tomorrow for more reviews.",
     "cardCount": "Card {current} of {total}",
@@ -394,7 +395,7 @@
     "reviewDescription": "Review flashcards with spaced repetition for effective learning",
     "redirectingToLogin": "Redirecting to login...",
     "noFlashcardsYet": "No flashcards yet",
-    "noFlashcardsDescription": "Complete modules to generate flashcards.",
+    "noFlashcardsDescription": "Complete modules to generate flashcards, or try again.",
     "goToModules": "Go to Modules"
   },
   "Onboarding": {

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -340,6 +340,7 @@
   "Flashcards": {
     "title": "Flashcards",
     "loading": "Chargement des flashcards...",
+    "generating": "Génération de vos flashcards...",
     "noCardsToday": "Aucune carte due aujourd'hui !",
     "wellDone": "Bien joué ! Revenez demain pour plus de révisions.",
     "cardCount": "Carte {current} sur {total}",
@@ -394,7 +395,7 @@
     "reviewDescription": "Révisez les flashcards avec répétition espacée pour un apprentissage efficace",
     "redirectingToLogin": "Redirection vers la connexion...",
     "noFlashcardsYet": "Aucune flashcard pour l'instant",
-    "noFlashcardsDescription": "Terminez des modules pour générer des flashcards.",
+    "noFlashcardsDescription": "Terminez des modules pour générer des flashcards, ou réessayez.",
     "goToModules": "Aller aux modules"
   },
   "Onboarding": {


### PR DESCRIPTION
## Summary

Fixes the critical bug where flashcards are never shown because the generation endpoint is never called.

- When \`GET /flashcards/due\` returns 0 cards, the frontend now automatically triggers flashcard generation
- Fetches user's active/completed modules via the progress API, falls back to M01 if none
- Calls \`GET /flashcards/modules/{module_id}\` (which invokes RAG + Claude) for each module
- Re-fetches due cards after generation completes
- Shows a "Generating your flashcards..." loading state with bilingual i18n support

## Changes

- \`frontend/app/[locale]/(app)/flashcards/flashcards-container.tsx\` — added \`generating\` session state, \`triggerGeneration()\` function, updated empty state detection
- \`frontend/lib/api.ts\` — added \`generateModuleFlashcards()\` and \`FlashcardSetResponse\` type
- \`frontend/messages/en.json\` — added \`generating\` translation key
- \`frontend/messages/fr.json\` — added \`generating\` translation key (FR)

## Test plan

- [ ] Backend tests pass
- [ ] Frontend lint passes (0 errors)
- [ ] Visit /flashcards as a new user — "Generating your flashcards..." appears, then cards load
- [ ] Manually verified on mobile viewport (320px)

Closes #454

Generated with [Claude Code](https://claude.ai/code)