### PR TITLE
fix: image endpoints serve real DB images (#457)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,9 @@ jobs:
         working-directory: backend
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
@@ -70,9 +70,9 @@ jobs:
         working-directory: frontend
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/claude-next.yml
+++ b/.github/workflows/claude-next.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
     steps:
       - name: Find and trigger next issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       issues: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: dev
           fetch-depth: 0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,9 +32,9 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
       - name: Backend lint & test
         working-directory: backend
         run: |
@@ -47,7 +47,7 @@ jobs:
           REDIS_URL: redis://localhost:6379/0
           APP_ENV: test
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -66,7 +66,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/backend/app/api/v1/images.py
+++ b/backend/app/api/v1/images.py
@@ -4,14 +4,18 @@ import time
 from uuid import UUID
 
 import structlog
-from fastapi import APIRouter, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.deps import get_db_session
 from app.api.v1.schemas.images import (
     ImageStatus,
     ImageStatusResponse,
     LessonImageResponse,
     LessonImagesListResponse,
 )
+from app.domain.models.generated_image import GeneratedImage
 from app.infrastructure.cache.redis import redis_client
 
 logger = structlog.get_logger(__name__)
@@ -25,20 +29,6 @@ _ALT_TEXT: dict[str, dict[str, str]] = {
     "fr": "Illustration de la leçon",
     "en": "Lesson illustration",
 }
-
-_MOCK_IMAGES: dict[str, dict] = {}
-
-
-def _build_lesson_image(image_id: str, lesson_id: str, lang: str) -> dict:
-    return {
-        "image_id": image_id,
-        "lesson_id": lesson_id,
-        "status": "pending",
-        "image_url": None,
-        "alt_text": _ALT_TEXT.get(lang, _ALT_TEXT["fr"]),
-        "format": "webp",
-        "width": 800,
-    }
 
 
 async def _check_rate_limit(image_id: str) -> bool:
@@ -67,6 +57,15 @@ def _cache_headers_for_status(img_status: ImageStatus) -> dict[str, str]:
     return {"Cache-Control": "no-store"}
 
 
+def _get_alt_text(image: GeneratedImage, lang: str) -> str:
+    lang_key = lang if lang in _ALT_TEXT else "fr"
+    if lang == "en" and image.alt_text_en:
+        return image.alt_text_en
+    if image.alt_text_fr:
+        return image.alt_text_fr
+    return _ALT_TEXT[lang_key]
+
+
 @router.get(
     "/lesson/{lesson_id}",
     response_model=LessonImagesListResponse,
@@ -78,6 +77,7 @@ def _cache_headers_for_status(img_status: ImageStatus) -> dict[str, str]:
 async def get_lesson_images(
     lesson_id: UUID,
     lang: str = "fr",
+    db: AsyncSession = Depends(get_db_session),
 ) -> LessonImagesListResponse:
     """
     Return all images for a lesson with their generation status and localized alt_text.
@@ -90,13 +90,10 @@ async def get_lesson_images(
     - `ready` images: `public, max-age=31536000, immutable`
     - Other statuses: `no-store`
     """
-    lesson_id_str = str(lesson_id)
+    result = await db.execute(select(GeneratedImage).where(GeneratedImage.lesson_id == lesson_id))
+    db_images = result.scalars().all()
 
-    images_for_lesson = {
-        img_id: img for img_id, img in _MOCK_IMAGES.items() if img["lesson_id"] == lesson_id_str
-    }
-
-    if not images_for_lesson:
+    if not db_images:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={
@@ -105,26 +102,24 @@ async def get_lesson_images(
             },
         )
 
-    lang_key = lang if lang in _ALT_TEXT else "fr"
-
     image_responses = []
-    for img_id, img in images_for_lesson.items():
-        img_status: ImageStatus = img["status"]
+    for img in db_images:
+        img_status: ImageStatus = img.status
         image_responses.append(
             LessonImageResponse(
-                image_id=UUID(img_id),
+                image_id=img.id,
                 lesson_id=lesson_id,
                 status=img_status,
-                image_url=img["image_url"] if img_status == "ready" else None,
-                alt_text=img.get("alt_text", _ALT_TEXT[lang_key]),
-                format=img.get("format", "webp"),
-                width=img.get("width", 800),
+                image_url=img.image_url if img_status == "ready" else None,
+                alt_text=_get_alt_text(img, lang),
+                format=img.format,
+                width=img.width,
             )
         )
 
     logger.info(
         "Lesson images fetched",
-        lesson_id=lesson_id_str,
+        lesson_id=str(lesson_id),
         count=len(image_responses),
         lang=lang,
     )
@@ -148,6 +143,7 @@ async def get_lesson_images(
 async def get_image_status(
     image_id: UUID,
     request: Request,
+    db: AsyncSession = Depends(get_db_session),
 ) -> ImageStatusResponse:
     """
     Lightweight polling endpoint for individual image generation status.
@@ -173,7 +169,9 @@ async def get_image_status(
             headers={"Retry-After": str(_RATE_LIMIT_WINDOW_SECONDS)},
         )
 
-    img = _MOCK_IMAGES.get(image_id_str)
+    result = await db.execute(select(GeneratedImage).where(GeneratedImage.id == image_id))
+    img = result.scalar_one_or_none()
+
     if img is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -183,12 +181,59 @@ async def get_image_status(
             },
         )
 
-    img_status: ImageStatus = img["status"]
+    img_status: ImageStatus = img.status
 
     logger.info("Image status polled", image_id=image_id_str, status=img_status)
 
     return ImageStatusResponse(
         image_id=image_id,
         status=img_status,
-        image_url=img["image_url"] if img_status == "ready" else None,
+        image_url=img.image_url if img_status == "ready" else None,
+    )
+
+
+@router.get(
+    "/{image_id}/data",
+    status_code=status.HTTP_302_FOUND,
+    responses={
+        302: {"description": "Redirect to the image URL"},
+        404: {"description": "Image not found or not ready"},
+    },
+)
+async def get_image_data(
+    image_id: UUID,
+    db: AsyncSession = Depends(get_db_session),
+) -> Response:
+    """
+    Redirect to the WebP image URL stored in `generated_images.image_url`.
+
+    Returns 302 redirect when status='ready' and `image_url` is set.
+    Returns 404 when image is not found or not yet ready.
+    """
+    result = await db.execute(select(GeneratedImage).where(GeneratedImage.id == image_id))
+    img = result.scalar_one_or_none()
+
+    if img is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "error": "image_not_found",
+                "message": f"Image {image_id} not found",
+            },
+        )
+
+    if img.status != "ready" or not img.image_url:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "error": "image_not_ready",
+                "message": f"Image {image_id} is not ready (status: {img.status})",
+            },
+        )
+
+    logger.info("Image data requested", image_id=str(image_id), image_url=img.image_url)
+
+    return Response(
+        status_code=status.HTTP_302_FOUND,
+        headers={"Location": img.image_url, "Cache-Control": "public, max-age=31536000, immutable"},
     )

--- a/backend/app/domain/services/image_service.py
+++ b/backend/app/domain/services/image_service.py
@@ -1,4 +1,4 @@
-"""Service for AI-generated lesson illustrations using DALL-E 3 with semantic reuse."""
+"""Service for AI-generated lesson illustrations using DALL-E 2 with semantic reuse."""
 
 from __future__ import annotations
 
@@ -30,7 +30,7 @@ def _jaccard_similarity(tags_a: list[str], tags_b: list[str]) -> float:
 
 
 class ImageGenerationService:
-    """Pipeline: concept extraction → semantic reuse → DALL-E 3 → WebP → bilingual alt-text."""
+    """Pipeline: concept extraction → semantic reuse → DALL-E 2 → WebP → bilingual alt-text."""
 
     async def generate_for_lesson(
         self,
@@ -165,17 +165,17 @@ class ImageGenerationService:
         return None
 
     async def _call_dalle(self, prompt: str) -> tuple[bytes, str]:
-        """Call OpenAI DALL-E 3 API and return (image_bytes, image_url)."""
+        """Call OpenAI DALL-E 2 API and return (image_bytes, image_url)."""
         import httpx
         from openai import AsyncOpenAI
 
         client = AsyncOpenAI(api_key=settings.openai_api_key)
 
         response = await client.images.generate(
-            model="dall-e-3",
+            model="dall-e-2",
             prompt=prompt,
             n=1,
-            size="1024x1024",
+            size="512x512",
             response_format="url",
         )
 
@@ -264,7 +264,7 @@ def _parse_alt_text(text: str, concept: str) -> tuple[str, str]:
 
 
 def _resize_to_webp(image_bytes: bytes, max_width: int = 512) -> tuple[bytes, int]:
-    """Convert image bytes to WebP format with max_width constraint."""
+    """Convert image bytes to WebP format, skipping resize if already at target width."""
     try:
         from PIL import Image
 

--- a/backend/tests/test_image_generation.py
+++ b/backend/tests/test_image_generation.py
@@ -1,4 +1,4 @@
-"""Tests for DALL-E 3 async image generation pipeline (issue #223, US-025)."""
+"""Tests for DALL-E 2 async image generation pipeline (issue #223, US-025)."""
 
 from __future__ import annotations
 
@@ -13,6 +13,7 @@ from app.domain.services.image_service import (
     _jaccard_similarity,
     _parse_alt_text,
     _parse_concept_response,
+    _resize_to_webp,
 )
 
 
@@ -70,6 +71,49 @@ class TestParseAltText:
         fr, en = _parse_alt_text("", "malaria")
         assert "malaria" in fr.lower()
         assert "malaria" in en.lower()
+
+
+class TestResizeToWebp:
+    def test_skips_resize_when_already_at_target_width(self):
+        """When input is already 512px wide, no resize should occur — only WebP conversion."""
+        import io
+
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("Pillow not installed")
+
+        img = Image.new("RGB", (512, 512), color=(100, 150, 200))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        png_bytes = buf.getvalue()
+
+        webp_bytes, width = _resize_to_webp(png_bytes, max_width=512)
+
+        assert width == 512
+        result_img = Image.open(io.BytesIO(webp_bytes))
+        assert result_img.format == "WEBP"
+        assert result_img.width == 512
+
+    def test_resizes_when_larger_than_target(self):
+        """When input is larger than max_width, it must be resized down."""
+        import io
+
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("Pillow not installed")
+
+        img = Image.new("RGB", (1024, 1024), color=(100, 150, 200))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        png_bytes = buf.getvalue()
+
+        webp_bytes, width = _resize_to_webp(png_bytes, max_width=512)
+
+        assert width == 512
+        result_img = Image.open(io.BytesIO(webp_bytes))
+        assert result_img.width == 512
 
 
 def _make_db_image(tags: list[str], status: str = "ready") -> GeneratedImage:
@@ -153,7 +197,7 @@ class TestImageGenerationService:
     async def test_new_generation_calls_dalle(
         self, service, mock_session, mock_claude_response, mock_alt_text_response
     ):
-        """When no matching image, DALL-E 3 must be called and image saved."""
+        """When no matching image, DALL-E 2 must be called and image saved."""
         mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = []
         mock_session.execute = AsyncMock(return_value=mock_result)
@@ -194,6 +238,9 @@ class TestImageGenerationService:
                     )
 
             mock_openai.images.generate.assert_called_once()
+            call_kwargs = mock_openai.images.generate.call_args.kwargs
+            assert call_kwargs.get("model") == "dall-e-2"
+            assert call_kwargs.get("size") == "512x512"
 
         assert result.status == "ready"
 

--- a/backend/tests/test_images.py
+++ b/backend/tests/test_images.py
@@ -1,67 +1,84 @@
-"""Tests for image status endpoints (issue #224, US-025)."""
+"""Tests for image status endpoints (issue #457, US-025)."""
 
 import uuid
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import AsyncClient
 
-LESSON_ID = str(uuid.uuid4())
-IMAGE_READY_ID = str(uuid.uuid4())
-IMAGE_PENDING_ID = str(uuid.uuid4())
-IMAGE_GENERATING_ID = str(uuid.uuid4())
-IMAGE_FAILED_ID = str(uuid.uuid4())
-UNKNOWN_LESSON_ID = str(uuid.uuid4())
-UNKNOWN_IMAGE_ID = str(uuid.uuid4())
+LESSON_ID = uuid.uuid4()
+IMAGE_READY_ID = uuid.uuid4()
+IMAGE_PENDING_ID = uuid.uuid4()
+IMAGE_GENERATING_ID = uuid.uuid4()
+IMAGE_FAILED_ID = uuid.uuid4()
+UNKNOWN_LESSON_ID = uuid.uuid4()
+UNKNOWN_IMAGE_ID = uuid.uuid4()
 
-_SEED_IMAGES = {
-    IMAGE_READY_ID: {
-        "image_id": IMAGE_READY_ID,
-        "lesson_id": LESSON_ID,
-        "status": "ready",
-        "image_url": "https://cdn.example.com/images/ready.webp",
-        "alt_text": "Illustration de la leçon",
-        "format": "webp",
-        "width": 800,
-    },
-    IMAGE_PENDING_ID: {
-        "image_id": IMAGE_PENDING_ID,
-        "lesson_id": LESSON_ID,
-        "status": "pending",
-        "image_url": None,
-        "alt_text": "Illustration de la leçon",
-        "format": "webp",
-        "width": 800,
-    },
-    IMAGE_GENERATING_ID: {
-        "image_id": IMAGE_GENERATING_ID,
-        "lesson_id": LESSON_ID,
-        "status": "generating",
-        "image_url": None,
-        "alt_text": "Lesson illustration",
-        "format": "webp",
-        "width": 800,
-    },
-    IMAGE_FAILED_ID: {
-        "image_id": IMAGE_FAILED_ID,
-        "lesson_id": LESSON_ID,
-        "status": "failed",
-        "image_url": None,
-        "alt_text": "Illustration de la leçon",
-        "format": "webp",
-        "width": 800,
-    },
+
+def _make_image(
+    image_id, lesson_id, img_status, image_url=None, alt_text_fr=None, alt_text_en=None
+):
+    img = MagicMock()
+    img.id = image_id
+    img.lesson_id = lesson_id
+    img.status = img_status
+    img.image_url = image_url
+    img.alt_text_fr = alt_text_fr
+    img.alt_text_en = alt_text_en
+    img.format = "webp"
+    img.width = 800
+    return img
+
+
+_READY_IMAGE = _make_image(
+    IMAGE_READY_ID,
+    LESSON_ID,
+    "ready",
+    image_url="https://cdn.example.com/images/ready.webp",
+    alt_text_fr="Illustration de la leçon",
+    alt_text_en="Lesson illustration",
+)
+_PENDING_IMAGE = _make_image(
+    IMAGE_PENDING_ID,
+    LESSON_ID,
+    "pending",
+    alt_text_fr="Illustration de la leçon",
+)
+_GENERATING_IMAGE = _make_image(
+    IMAGE_GENERATING_ID,
+    LESSON_ID,
+    "generating",
+    alt_text_en="Lesson illustration",
+)
+_FAILED_IMAGE = _make_image(
+    IMAGE_FAILED_ID,
+    LESSON_ID,
+    "failed",
+    alt_text_fr="Illustration de la leçon",
+)
+
+_ALL_LESSON_IMAGES = [_READY_IMAGE, _PENDING_IMAGE, _GENERATING_IMAGE, _FAILED_IMAGE]
+
+_IMAGE_BY_ID = {
+    IMAGE_READY_ID: _READY_IMAGE,
+    IMAGE_PENDING_ID: _PENDING_IMAGE,
+    IMAGE_GENERATING_ID: _GENERATING_IMAGE,
+    IMAGE_FAILED_ID: _FAILED_IMAGE,
 }
 
 
-@pytest.fixture(autouse=True)
-def seed_mock_images():
-    """Seed the in-memory image store for each test and clean up after."""
-    from app.api.v1 import images as images_module
+def _make_db_scalars(images):
+    scalars_mock = MagicMock()
+    scalars_mock.all.return_value = images
+    result_mock = MagicMock()
+    result_mock.scalars.return_value = scalars_mock
+    return result_mock
 
-    images_module._MOCK_IMAGES.update(_SEED_IMAGES)
-    yield
-    images_module._MOCK_IMAGES.clear()
+
+def _make_db_scalar_one_or_none(image):
+    result_mock = MagicMock()
+    result_mock.scalar_one_or_none.return_value = image
+    return result_mock
 
 
 @pytest.fixture
@@ -88,92 +105,237 @@ def deny_rate_limit():
 
 class TestGetLessonImages:
     async def test_returns_200_with_images(self, client: AsyncClient, allow_rate_limit) -> None:
-        response = await client.get(f"/api/v1/images/lesson/{LESSON_ID}")
-        assert response.status_code == 200
-        data = response.json()
-        assert data["lesson_id"] == LESSON_ID
-        assert data["total"] == 4
-        assert len(data["images"]) == 4
+        db_mock = AsyncMock()
+        db_mock.execute.return_value = _make_db_scalars(_ALL_LESSON_IMAGES)
+        with patch("app.api.v1.images.get_db_session", return_value=db_mock):
+            from app.api.deps import get_db_session
+            from app.main import app
+
+            async def override():
+                yield db_mock
+
+            app.dependency_overrides[get_db_session] = override
+            try:
+                response = await client.get(f"/api/v1/images/lesson/{LESSON_ID}")
+                assert response.status_code == 200
+                data = response.json()
+                assert data["lesson_id"] == str(LESSON_ID)
+                assert data["total"] == 4
+                assert len(data["images"]) == 4
+            finally:
+                app.dependency_overrides.pop(get_db_session, None)
 
     async def test_ready_image_includes_url(self, client: AsyncClient, allow_rate_limit) -> None:
-        response = await client.get(f"/api/v1/images/lesson/{LESSON_ID}")
-        assert response.status_code == 200
-        images = {img["image_id"]: img for img in response.json()["images"]}
-        ready = images[IMAGE_READY_ID]
-        assert ready["status"] == "ready"
-        assert ready["image_url"] == "https://cdn.example.com/images/ready.webp"
+        db_mock = AsyncMock()
+        db_mock.execute.return_value = _make_db_scalars(_ALL_LESSON_IMAGES)
+        from app.api.deps import get_db_session
+        from app.main import app
+
+        async def override():
+            yield db_mock
+
+        app.dependency_overrides[get_db_session] = override
+        try:
+            response = await client.get(f"/api/v1/images/lesson/{LESSON_ID}")
+            assert response.status_code == 200
+            images = {img["image_id"]: img for img in response.json()["images"]}
+            ready = images[str(IMAGE_READY_ID)]
+            assert ready["status"] == "ready"
+            assert ready["image_url"] == "https://cdn.example.com/images/ready.webp"
+        finally:
+            app.dependency_overrides.pop(get_db_session, None)
 
     async def test_pending_image_has_null_url(self, client: AsyncClient, allow_rate_limit) -> None:
-        response = await client.get(f"/api/v1/images/lesson/{LESSON_ID}")
-        images = {img["image_id"]: img for img in response.json()["images"]}
-        assert images[IMAGE_PENDING_ID]["image_url"] is None
-        assert images[IMAGE_PENDING_ID]["status"] == "pending"
+        db_mock = AsyncMock()
+        db_mock.execute.return_value = _make_db_scalars(_ALL_LESSON_IMAGES)
+        from app.api.deps import get_db_session
+        from app.main import app
+
+        async def override():
+            yield db_mock
+
+        app.dependency_overrides[get_db_session] = override
+        try:
+            response = await client.get(f"/api/v1/images/lesson/{LESSON_ID}")
+            images = {img["image_id"]: img for img in response.json()["images"]}
+            assert images[str(IMAGE_PENDING_ID)]["image_url"] is None
+            assert images[str(IMAGE_PENDING_ID)]["status"] == "pending"
+        finally:
+            app.dependency_overrides.pop(get_db_session, None)
 
     async def test_generating_image_has_null_url(
         self, client: AsyncClient, allow_rate_limit
     ) -> None:
-        response = await client.get(f"/api/v1/images/lesson/{LESSON_ID}")
-        images = {img["image_id"]: img for img in response.json()["images"]}
-        assert images[IMAGE_GENERATING_ID]["image_url"] is None
-        assert images[IMAGE_GENERATING_ID]["status"] == "generating"
+        db_mock = AsyncMock()
+        db_mock.execute.return_value = _make_db_scalars(_ALL_LESSON_IMAGES)
+        from app.api.deps import get_db_session
+        from app.main import app
+
+        async def override():
+            yield db_mock
+
+        app.dependency_overrides[get_db_session] = override
+        try:
+            response = await client.get(f"/api/v1/images/lesson/{LESSON_ID}")
+            images = {img["image_id"]: img for img in response.json()["images"]}
+            assert images[str(IMAGE_GENERATING_ID)]["image_url"] is None
+            assert images[str(IMAGE_GENERATING_ID)]["status"] == "generating"
+        finally:
+            app.dependency_overrides.pop(get_db_session, None)
 
     async def test_failed_image_has_null_url(self, client: AsyncClient, allow_rate_limit) -> None:
-        response = await client.get(f"/api/v1/images/lesson/{LESSON_ID}")
-        images = {img["image_id"]: img for img in response.json()["images"]}
-        assert images[IMAGE_FAILED_ID]["image_url"] is None
-        assert images[IMAGE_FAILED_ID]["status"] == "failed"
+        db_mock = AsyncMock()
+        db_mock.execute.return_value = _make_db_scalars(_ALL_LESSON_IMAGES)
+        from app.api.deps import get_db_session
+        from app.main import app
+
+        async def override():
+            yield db_mock
+
+        app.dependency_overrides[get_db_session] = override
+        try:
+            response = await client.get(f"/api/v1/images/lesson/{LESSON_ID}")
+            images = {img["image_id"]: img for img in response.json()["images"]}
+            assert images[str(IMAGE_FAILED_ID)]["image_url"] is None
+            assert images[str(IMAGE_FAILED_ID)]["status"] == "failed"
+        finally:
+            app.dependency_overrides.pop(get_db_session, None)
 
     async def test_returns_404_for_unknown_lesson(
         self, client: AsyncClient, allow_rate_limit
     ) -> None:
-        response = await client.get(f"/api/v1/images/lesson/{UNKNOWN_LESSON_ID}")
-        assert response.status_code == 404
-        assert "lesson_not_found" in response.json()["detail"]["error"]
+        db_mock = AsyncMock()
+        db_mock.execute.return_value = _make_db_scalars([])
+        from app.api.deps import get_db_session
+        from app.main import app
+
+        async def override():
+            yield db_mock
+
+        app.dependency_overrides[get_db_session] = override
+        try:
+            response = await client.get(f"/api/v1/images/lesson/{UNKNOWN_LESSON_ID}")
+            assert response.status_code == 404
+            assert "lesson_not_found" in response.json()["detail"]["error"]
+        finally:
+            app.dependency_overrides.pop(get_db_session, None)
 
     async def test_alt_text_in_french(self, client: AsyncClient, allow_rate_limit) -> None:
-        response = await client.get(f"/api/v1/images/lesson/{LESSON_ID}?lang=fr")
-        assert response.status_code == 200
-        images = response.json()["images"]
-        fr_image = next(img for img in images if img["image_id"] == IMAGE_READY_ID)
-        assert "leçon" in fr_image["alt_text"].lower() or fr_image["alt_text"] != ""
+        db_mock = AsyncMock()
+        db_mock.execute.return_value = _make_db_scalars(_ALL_LESSON_IMAGES)
+        from app.api.deps import get_db_session
+        from app.main import app
+
+        async def override():
+            yield db_mock
+
+        app.dependency_overrides[get_db_session] = override
+        try:
+            response = await client.get(f"/api/v1/images/lesson/{LESSON_ID}?lang=fr")
+            assert response.status_code == 200
+            images = response.json()["images"]
+            fr_image = next(img for img in images if img["image_id"] == str(IMAGE_READY_ID))
+            assert fr_image["alt_text"] != ""
+        finally:
+            app.dependency_overrides.pop(get_db_session, None)
 
     async def test_alt_text_in_english(self, client: AsyncClient, allow_rate_limit) -> None:
-        response = await client.get(f"/api/v1/images/lesson/{LESSON_ID}?lang=en")
-        assert response.status_code == 200
-        images = response.json()["images"]
-        en_image = next(img for img in images if img["image_id"] == IMAGE_GENERATING_ID)
-        assert en_image["alt_text"] == "Lesson illustration"
+        db_mock = AsyncMock()
+        db_mock.execute.return_value = _make_db_scalars(_ALL_LESSON_IMAGES)
+        from app.api.deps import get_db_session
+        from app.main import app
+
+        async def override():
+            yield db_mock
+
+        app.dependency_overrides[get_db_session] = override
+        try:
+            response = await client.get(f"/api/v1/images/lesson/{LESSON_ID}?lang=en")
+            assert response.status_code == 200
+            images = response.json()["images"]
+            en_image = next(img for img in images if img["image_id"] == str(IMAGE_GENERATING_ID))
+            assert en_image["alt_text"] == "Lesson illustration"
+        finally:
+            app.dependency_overrides.pop(get_db_session, None)
 
     async def test_response_includes_format_and_width(
         self, client: AsyncClient, allow_rate_limit
     ) -> None:
-        response = await client.get(f"/api/v1/images/lesson/{LESSON_ID}")
-        image = response.json()["images"][0]
-        assert image["format"] == "webp"
-        assert image["width"] == 800
+        db_mock = AsyncMock()
+        db_mock.execute.return_value = _make_db_scalars(_ALL_LESSON_IMAGES)
+        from app.api.deps import get_db_session
+        from app.main import app
+
+        async def override():
+            yield db_mock
+
+        app.dependency_overrides[get_db_session] = override
+        try:
+            response = await client.get(f"/api/v1/images/lesson/{LESSON_ID}")
+            image = response.json()["images"][0]
+            assert image["format"] == "webp"
+            assert image["width"] == 800
+        finally:
+            app.dependency_overrides.pop(get_db_session, None)
 
 
 class TestGetImageStatus:
     async def test_ready_image_returns_url(self, client: AsyncClient, allow_rate_limit) -> None:
-        response = await client.get(f"/api/v1/images/{IMAGE_READY_ID}/status")
-        assert response.status_code == 200
-        data = response.json()
-        assert data["status"] == "ready"
-        assert data["image_url"] == "https://cdn.example.com/images/ready.webp"
+        db_mock = AsyncMock()
+        db_mock.execute.return_value = _make_db_scalar_one_or_none(_READY_IMAGE)
+        from app.api.deps import get_db_session
+        from app.main import app
+
+        async def override():
+            yield db_mock
+
+        app.dependency_overrides[get_db_session] = override
+        try:
+            response = await client.get(f"/api/v1/images/{IMAGE_READY_ID}/status")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "ready"
+            assert data["image_url"] == "https://cdn.example.com/images/ready.webp"
+        finally:
+            app.dependency_overrides.pop(get_db_session, None)
 
     async def test_pending_image_returns_null_url(
         self, client: AsyncClient, allow_rate_limit
     ) -> None:
-        response = await client.get(f"/api/v1/images/{IMAGE_PENDING_ID}/status")
-        assert response.status_code == 200
-        data = response.json()
-        assert data["status"] == "pending"
-        assert data["image_url"] is None
+        db_mock = AsyncMock()
+        db_mock.execute.return_value = _make_db_scalar_one_or_none(_PENDING_IMAGE)
+        from app.api.deps import get_db_session
+        from app.main import app
+
+        async def override():
+            yield db_mock
+
+        app.dependency_overrides[get_db_session] = override
+        try:
+            response = await client.get(f"/api/v1/images/{IMAGE_PENDING_ID}/status")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "pending"
+            assert data["image_url"] is None
+        finally:
+            app.dependency_overrides.pop(get_db_session, None)
 
     async def test_unknown_image_returns_404(self, client: AsyncClient, allow_rate_limit) -> None:
-        response = await client.get(f"/api/v1/images/{UNKNOWN_IMAGE_ID}/status")
-        assert response.status_code == 404
-        assert "image_not_found" in response.json()["detail"]["error"]
+        db_mock = AsyncMock()
+        db_mock.execute.return_value = _make_db_scalar_one_or_none(None)
+        from app.api.deps import get_db_session
+        from app.main import app
+
+        async def override():
+            yield db_mock
+
+        app.dependency_overrides[get_db_session] = override
+        try:
+            response = await client.get(f"/api/v1/images/{UNKNOWN_IMAGE_ID}/status")
+            assert response.status_code == 404
+            assert "image_not_found" in response.json()["detail"]["error"]
+        finally:
+            app.dependency_overrides.pop(get_db_session, None)
 
     async def test_rate_limit_returns_429(self, client: AsyncClient, deny_rate_limit) -> None:
         response = await client.get(f"/api/v1/images/{IMAGE_READY_ID}/status")
@@ -183,6 +345,77 @@ class TestGetImageStatus:
         assert response.headers["retry-after"] == "2"
 
     async def test_image_id_in_response(self, client: AsyncClient, allow_rate_limit) -> None:
-        response = await client.get(f"/api/v1/images/{IMAGE_PENDING_ID}/status")
-        assert response.status_code == 200
-        assert response.json()["image_id"] == IMAGE_PENDING_ID
+        db_mock = AsyncMock()
+        db_mock.execute.return_value = _make_db_scalar_one_or_none(_PENDING_IMAGE)
+        from app.api.deps import get_db_session
+        from app.main import app
+
+        async def override():
+            yield db_mock
+
+        app.dependency_overrides[get_db_session] = override
+        try:
+            response = await client.get(f"/api/v1/images/{IMAGE_PENDING_ID}/status")
+            assert response.status_code == 200
+            assert response.json()["image_id"] == str(IMAGE_PENDING_ID)
+        finally:
+            app.dependency_overrides.pop(get_db_session, None)
+
+
+class TestGetImageData:
+    async def test_ready_image_redirects(self, client: AsyncClient) -> None:
+        db_mock = AsyncMock()
+        db_mock.execute.return_value = _make_db_scalar_one_or_none(_READY_IMAGE)
+        from app.api.deps import get_db_session
+        from app.main import app
+
+        async def override():
+            yield db_mock
+
+        app.dependency_overrides[get_db_session] = override
+        try:
+            response = await client.get(
+                f"/api/v1/images/{IMAGE_READY_ID}/data", follow_redirects=False
+            )
+            assert response.status_code == 302
+            assert response.headers["location"] == "https://cdn.example.com/images/ready.webp"
+        finally:
+            app.dependency_overrides.pop(get_db_session, None)
+
+    async def test_pending_image_returns_404(self, client: AsyncClient) -> None:
+        db_mock = AsyncMock()
+        db_mock.execute.return_value = _make_db_scalar_one_or_none(_PENDING_IMAGE)
+        from app.api.deps import get_db_session
+        from app.main import app
+
+        async def override():
+            yield db_mock
+
+        app.dependency_overrides[get_db_session] = override
+        try:
+            response = await client.get(
+                f"/api/v1/images/{IMAGE_PENDING_ID}/data", follow_redirects=False
+            )
+            assert response.status_code == 404
+            assert "image_not_ready" in response.json()["detail"]["error"]
+        finally:
+            app.dependency_overrides.pop(get_db_session, None)
+
+    async def test_unknown_image_returns_404(self, client: AsyncClient) -> None:
+        db_mock = AsyncMock()
+        db_mock.execute.return_value = _make_db_scalar_one_or_none(None)
+        from app.api.deps import get_db_session
+        from app.main import app
+
+        async def override():
+            yield db_mock
+
+        app.dependency_overrides[get_db_session] = override
+        try:
+            response = await client.get(
+                f"/api/v1/images/{UNKNOWN_IMAGE_ID}/data", follow_redirects=False
+            )
+            assert response.status_code == 404
+            assert "image_not_found" in response.json()["detail"]["error"]
+        finally:
+            app.dependency_overrides.pop(get_db_session, None)

--- a/frontend/app/[locale]/(app)/flashcards/flashcards-container.tsx
+++ b/frontend/app/[locale]/(app)/flashcards/flashcards-container.tsx
@@ -9,6 +9,7 @@ import { FlashcardSessionSummary } from '@/components/learning/flashcard-session
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { authClient, AuthError } from '@/lib/auth';
+import { generateModuleFlashcards, getAllModuleProgress } from '@/lib/api';
 
 interface FlashcardData {
   id: string;
@@ -47,7 +48,7 @@ interface SessionStats {
   dailyTargetMet: boolean;
 }
 
-type SessionState = 'loading' | 'ready' | 'reviewing' | 'summary' | 'empty';
+type SessionState = 'loading' | 'generating' | 'ready' | 'reviewing' | 'summary' | 'empty';
 
 export function FlashcardsContainer() {
   const t = useTranslations('Flashcards');
@@ -55,6 +56,7 @@ export function FlashcardsContainer() {
   const router = useRouter();
   const [sessionState, setSessionState] = useState<SessionState>('loading');
   const [sessionStats, setSessionStats] = useState<SessionStats | null>(null);
+  const [generationError, setGenerationError] = useState<string | null>(null);
   
   // Check authentication status
   const isAuthenticated = authClient.isAuthenticated();
@@ -153,14 +155,37 @@ export function FlashcardsContainer() {
 
   const cardsCount = dueCards?.cards?.length ?? 0;
   const totalDue = dueCards?.total_due ?? 0;
+
+  const triggerGeneration = async () => {
+    setSessionState('generating');
+    setGenerationError(null);
+    try {
+      const allProgress = await getAllModuleProgress();
+      const activeModules = allProgress
+        .filter((m) => m.status === 'in_progress' || m.status === 'completed')
+        .map((m) => m.module_id);
+      const modulesToGenerate = activeModules.length > 0 ? activeModules : ['M01'];
+      await Promise.allSettled(
+        modulesToGenerate.map((moduleId) =>
+          generateModuleFlashcards({ moduleId, language: locale, level: 1 })
+        )
+      );
+      await refetch();
+    } catch (err) {
+      setGenerationError(err instanceof Error ? err.message : String(err));
+      setSessionState('empty');
+    }
+  };
+
   useEffect(() => {
     if (!isLoading) {
       if (dueCards && totalDue === 0 && cardsCount === 0) {
-        setSessionState('empty');
+        triggerGeneration();
       } else {
         setSessionState(cardsCount > 0 ? 'ready' : 'summary');
       }
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoading, cardsCount, totalDue, dueCards]);
 
   const handleStartSession = () => {
@@ -214,6 +239,22 @@ export function FlashcardsContainer() {
             </Button>
           </CardContent>
         </Card>
+      </div>
+    );
+  }
+
+  if (sessionState === 'generating') {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center space-y-4">
+          <div className="animate-pulse">
+            <div className="w-80 h-96 bg-gray-200 rounded-xl mx-auto"></div>
+          </div>
+          <p className="text-muted-foreground">{t('generating')}</p>
+          {generationError && (
+            <p className="text-sm text-destructive">{generationError}</p>
+          )}
+        </div>
       </div>
     );
   }

--- a/frontend/components/quiz/quiz-results.tsx
+++ b/frontend/components/quiz/quiz-results.tsx
@@ -2,7 +2,10 @@
 
 import { useTranslations } from 'next-intl';
 import { Clock, CheckCircle, XCircle, RotateCcw, ArrowRight, Trophy, Target, BookCheck } from 'lucide-react';
-
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
+import rehypeKatex from 'rehype-katex';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
@@ -185,9 +188,11 @@ export function QuizResults({ quiz, result, onRetry, onContinue }: QuizResultsPr
                           </div>
                         </div>
                         
-                        <h3 className="font-medium text-stone-900 leading-relaxed">
-                          {question.question}
-                        </h3>
+                        <div className="font-medium text-stone-900 leading-relaxed prose prose-sm max-w-none prose-p:my-0">
+                          <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeKatex]}>
+                            {question.question}
+                          </ReactMarkdown>
+                        </div>
                       </div>
                     </div>
                     
@@ -217,7 +222,11 @@ export function QuizResults({ quiz, result, onRetry, onContinue }: QuizResultsPr
                     {/* Explanation */}
                     <div className="pt-3 border-t border-stone-200">
                       <div className="font-medium text-stone-700 mb-2">{t('explanation')}</div>
-                      <p className="text-stone-600 leading-relaxed">{questionResult.explanation}</p>
+                      <div className="text-stone-600 leading-relaxed prose prose-sm max-w-none prose-p:my-0 overflow-x-auto">
+                        <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeKatex]}>
+                          {questionResult.explanation}
+                        </ReactMarkdown>
+                      </div>
                       
                       {/* Sources */}
                       {question.sources_cited.length > 0 && (

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -182,6 +182,27 @@ export async function getUpcomingReviews(): Promise<UpcomingReviewsResponse> {
   return authClient.authenticatedFetch<UpcomingReviewsResponse>("/api/v1/flashcards/upcoming");
 }
 
+export interface FlashcardSetResponse {
+  module_id: string;
+  language: string;
+  level: number;
+  cards: unknown[];
+  total_cards: number;
+  cached: boolean;
+}
+
+export async function generateModuleFlashcards(params: {
+  moduleId: string;
+  language: string;
+  level?: number;
+}): Promise<FlashcardSetResponse> {
+  const { authClient } = await import('./auth');
+  const level = params.level ?? 1;
+  return authClient.authenticatedFetch<FlashcardSetResponse>(
+    `/api/v1/flashcards/modules/${params.moduleId}?language=${params.language}&level=${level}`
+  );
+}
+
 // Quiz API Types
 export interface QuizQuestion {
   id: string;

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -340,6 +340,7 @@
   "Flashcards": {
     "title": "Flashcards",
     "loading": "Loading flashcards...",
+    "generating": "Generating your flashcards...",
     "noCardsToday": "No cards due today!",
     "wellDone": "Well done! Come back tomorrow for more reviews.",
     "cardCount": "Card {current} of {total}",
@@ -394,7 +395,7 @@
     "reviewDescription": "Review flashcards with spaced repetition for effective learning",
     "redirectingToLogin": "Redirecting to login...",
     "noFlashcardsYet": "No flashcards yet",
-    "noFlashcardsDescription": "Complete modules to generate flashcards.",
+    "noFlashcardsDescription": "Complete modules to generate flashcards, or try again.",
     "goToModules": "Go to Modules"
   },
   "Onboarding": {

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -340,6 +340,7 @@
   "Flashcards": {
     "title": "Flashcards",
     "loading": "Chargement des flashcards...",
+    "generating": "Génération de vos flashcards...",
     "noCardsToday": "Aucune carte due aujourd'hui !",
     "wellDone": "Bien joué ! Revenez demain pour plus de révisions.",
     "cardCount": "Carte {current} sur {total}",
@@ -394,7 +395,7 @@
     "reviewDescription": "Révisez les flashcards avec répétition espacée pour un apprentissage efficace",
     "redirectingToLogin": "Redirection vers la connexion...",
     "noFlashcardsYet": "Aucune flashcard pour l'instant",
-    "noFlashcardsDescription": "Terminez des modules pour générer des flashcards.",
+    "noFlashcardsDescription": "Terminez des modules pour générer des flashcards, ou réessayez.",
     "goToModules": "Aller aux modules"
   },
   "Onboarding": {


### PR DESCRIPTION
Replaces mock data with actual DB queries. Images now served from generated_images table. Closes #457