### PR TITLE
feat(auth): add logout button to profile page and sidebar

### DIFF
--- a/frontend/app/[locale]/(app)/profile/profile-client.tsx
+++ b/frontend/app/[locale]/(app)/profile/profile-client.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 import { useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+import { useLocale } from "next-intl";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -20,7 +22,8 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Link } from "@/i18n/routing";
 import { PlacementResultsHistory } from "@/components/placement/placement-results-history";
-import { Upload, User as UserIcon, AlertTriangle, CheckCircle, ClipboardList } from "lucide-react";
+import { Upload, User as UserIcon, AlertTriangle, CheckCircle, ClipboardList, LogOut } from "lucide-react";
+import { authClient } from "@/lib/auth";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -108,7 +111,10 @@ export function ProfileClient() {
   const [isEditing, setIsEditing] = useState(false);
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
   const [showRecontextAlert, setShowRecontextAlert] = useState(false);
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
   const queryClient = useQueryClient();
+  const router = useRouter();
+  const locale = useLocale();
 
   const { data: profile, isLoading } = useQuery({
     queryKey: ["profile"],
@@ -144,6 +150,17 @@ export function ProfileClient() {
       setAvatarFile(null);
     },
   });
+
+  const handleLogout = async () => {
+    setIsLoggingOut(true);
+    try {
+      await authClient.logout();
+      queryClient.clear();
+      router.push(`/${locale}/login`);
+    } catch {
+      setIsLoggingOut(false);
+    }
+  };
 
   const onSubmit = (data: ProfileFormData) => {
     updateMutation.mutate(data);
@@ -461,6 +478,21 @@ export function ProfileClient() {
 
       {/* Placement Results History */}
       <PlacementResultsHistory compact />
+
+      {/* Logout */}
+      <Card className="border-destructive/50">
+        <CardContent className="pt-6">
+          <Button
+            variant="destructive"
+            className="w-full"
+            onClick={handleLogout}
+            disabled={isLoggingOut}
+          >
+            <LogOut className="mr-2 h-4 w-4" />
+            {isLoggingOut ? t("loggingOut") : t("logout")}
+          </Button>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useTranslations, useLocale } from "next-intl";
 import {
   Home,
@@ -14,17 +14,34 @@ import {
   ChevronLeft,
   ChevronRight,
   Menu,
+  LogOut,
 } from "lucide-react";
 import { LocaleSwitcher } from "@/components/shared/locale-switcher";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { authClient } from "@/lib/auth";
+import { useQueryClient } from "@tanstack/react-query";
 
 export function Sidebar() {
   const t = useTranslations("Navigation");
   const tCommon = useTranslations("Common");
   const pathname = usePathname();
   const locale = useLocale();
+  const router = useRouter();
+  const queryClient = useQueryClient();
   const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  const handleLogout = async () => {
+    setIsLoggingOut(true);
+    try {
+      await authClient.logout();
+      queryClient.clear();
+      router.push(`/${locale}/login`);
+    } catch {
+      setIsLoggingOut(false);
+    }
+  };
 
   const navItems = [
     {
@@ -132,11 +149,22 @@ export function Sidebar() {
       
       <div className="border-t p-2">
         {!isCollapsed ? (
-          <div className="p-2">
+          <div className="space-y-1 p-2">
             <LocaleSwitcher />
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full justify-start text-destructive hover:bg-destructive/10 hover:text-destructive min-h-11"
+              onClick={handleLogout}
+              disabled={isLoggingOut}
+              aria-label={t("logoutDescription")}
+            >
+              <LogOut className="mr-2 h-4 w-4" aria-hidden="true" />
+              {t("logout")}
+            </Button>
           </div>
         ) : (
-          <div className="flex justify-center">
+          <div className="flex flex-col items-center gap-1">
             <Button
               variant="ghost"
               size="sm"
@@ -144,6 +172,16 @@ export function Sidebar() {
               aria-label={t("languageSettings")}
             >
               <Menu className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="min-h-11 min-w-11 p-2 text-destructive hover:bg-destructive/10 hover:text-destructive"
+              onClick={handleLogout}
+              disabled={isLoggingOut}
+              aria-label={t("logoutDescription")}
+            >
+              <LogOut className="h-4 w-4" aria-hidden="true" />
             </Button>
           </div>
         )}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -33,7 +33,9 @@
     "navigateTo": "Navigate to",
     "lessons": "Lessons",
     "quiz": "Quiz",
-    "caseStudy": "Case Study"
+    "caseStudy": "Case Study",
+    "logout": "Log out",
+    "logoutDescription": "Sign out of your account"
   },
   "Auth": {
     "login": "Sign in",
@@ -705,6 +707,9 @@
     "edit": "Edit",
     "cancel": "Cancel",
     "save": "Save Changes",
+    "logout": "Log out",
+    "logoutDescription": "Sign out of your account",
+    "loggingOut": "Logging out...",
     "languages": {
       "french": "Français",
       "english": "English"

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -33,7 +33,9 @@
     "navigateTo": "Naviguer vers",
     "lessons": "Leçons",
     "quiz": "Quiz",
-    "caseStudy": "Étude de cas"
+    "caseStudy": "Étude de cas",
+    "logout": "Déconnexion",
+    "logoutDescription": "Se déconnecter de votre compte"
   },
   "Auth": {
     "login": "Se connecter",
@@ -705,6 +707,9 @@
     "edit": "Modifier",
     "cancel": "Annuler",
     "save": "Sauvegarder",
+    "logout": "Déconnexion",
+    "logoutDescription": "Se déconnecter de votre compte",
+    "loggingOut": "Déconnexion en cours...",
     "languages": {
       "french": "Français",
       "english": "English"


### PR DESCRIPTION
## Summary
- Add full-width destructive logout button at the bottom of the profile page
- Add logout button to desktop sidebar footer (expanded label + collapsed icon-only)
- Both call `authClient.logout()`, clear TanStack Query cache, and redirect to `/{locale}/login`
- FR/EN i18n strings added to `Navigation` and `Profile` namespaces

## Changes
- `frontend/app/[locale]/(app)/profile/profile-client.tsx` — logout card with destructive button
- `frontend/components/layout/sidebar.tsx` — logout button in sidebar footer
- `frontend/messages/fr.json` — `logout`, `logoutDescription`, `loggingOut` strings
- `frontend/messages/en.json` — `logout`, `logoutDescription`, `loggingOut` strings

## Test plan
- [ ] Click logout on profile page → redirects to login
- [ ] Click logout in sidebar (expanded) → redirects to login
- [ ] Click logout in sidebar (collapsed, icon-only) → redirects to login
- [ ] Tokens cleared from localStorage after logout
- [ ] FR and EN labels display correctly
- [ ] Frontend lint passes (0 errors)

Closes #228

Generated with [Claude Code](https://claude.ai/code)