### PR TITLE
fix: lesson images rendered — binary WebP endpoint + frontend URL (#462)

### DIFF
--- a/backend/app/api/v1/images.py
+++ b/backend/app/api/v1/images.py
@@ -66,6 +66,19 @@ def _get_alt_text(image: GeneratedImage, lang: str) -> str:
     return _ALT_TEXT[lang_key]
 
 
+def _resolve_image_url(img: GeneratedImage) -> str | None:
+    """Return a public URL for a ready image.
+
+    Prefers `image_url` when already set (e.g. CDN URL).
+    Falls back to the data endpoint so binary BYTEA images are always servable.
+    """
+    if img.status != "ready":
+        return None
+    if img.image_url:
+        return img.image_url
+    return f"/api/v1/images/{img.id}/data"
+
+
 @router.get(
     "/lesson/{lesson_id}",
     response_model=LessonImagesListResponse,
@@ -110,7 +123,7 @@ async def get_lesson_images(
                 image_id=img.id,
                 lesson_id=lesson_id,
                 status=img_status,
-                image_url=img.image_url if img_status == "ready" else None,
+                image_url=_resolve_image_url(img),
                 alt_text=_get_alt_text(img, lang),
                 format=img.format,
                 width=img.width,
@@ -188,15 +201,16 @@ async def get_image_status(
     return ImageStatusResponse(
         image_id=image_id,
         status=img_status,
-        image_url=img.image_url if img_status == "ready" else None,
+        image_url=_resolve_image_url(img),
     )
 
 
 @router.get(
     "/{image_id}/data",
-    status_code=status.HTTP_302_FOUND,
+    status_code=status.HTTP_200_OK,
     responses={
-        302: {"description": "Redirect to the image URL"},
+        200: {"content": {"image/webp": {}}, "description": "Binary WebP image data"},
+        302: {"description": "Redirect to the CDN image URL when binary data is unavailable"},
         404: {"description": "Image not found or not ready"},
     },
 )
@@ -205,10 +219,11 @@ async def get_image_data(
     db: AsyncSession = Depends(get_db_session),
 ) -> Response:
     """
-    Redirect to the WebP image URL stored in `generated_images.image_url`.
+    Serve the WebP image for a lesson illustration.
 
-    Returns 302 redirect when status='ready' and `image_url` is set.
-    Returns 404 when image is not found or not yet ready.
+    - Returns binary WebP (`Content-Type: image/webp`) when `image_data` is stored.
+    - Falls back to a 302 redirect to `image_url` when only a CDN URL is available.
+    - Returns 404 when the image is not found or not yet ready.
     """
     result = await db.execute(select(GeneratedImage).where(GeneratedImage.id == image_id))
     img = result.scalar_one_or_none()
@@ -222,7 +237,7 @@ async def get_image_data(
             },
         )
 
-    if img.status != "ready" or not img.image_url:
+    if img.status != "ready":
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={
@@ -231,9 +246,28 @@ async def get_image_data(
             },
         )
 
-    logger.info("Image data requested", image_id=str(image_id), image_url=img.image_url)
+    if img.image_data:
+        logger.info("Serving binary image data", image_id=str(image_id))
+        return Response(
+            content=img.image_data,
+            media_type="image/webp",
+            headers={"Cache-Control": "public, max-age=31536000, immutable"},
+        )
 
-    return Response(
-        status_code=status.HTTP_302_FOUND,
-        headers={"Location": img.image_url, "Cache-Control": "public, max-age=31536000, immutable"},
+    if img.image_url:
+        logger.info("Redirecting to CDN image URL", image_id=str(image_id), image_url=img.image_url)
+        return Response(
+            status_code=status.HTTP_302_FOUND,
+            headers={
+                "Location": img.image_url,
+                "Cache-Control": "public, max-age=3600",
+            },
+        )
+
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail={
+            "error": "image_data_unavailable",
+            "message": f"Image {image_id} has no stored data or URL",
+        },
     )

--- a/backend/app/domain/models/generated_image.py
+++ b/backend/app/domain/models/generated_image.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
-from sqlalchemy import ForeignKey, Index, Integer, String, Text, func
+from sqlalchemy import ForeignKey, Index, Integer, LargeBinary, String, Text, func
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -36,6 +36,7 @@ class GeneratedImage(Base):
     concept: Mapped[str | None] = mapped_column(Text, nullable=True)
     prompt: Mapped[str | None] = mapped_column(Text, nullable=True)
     image_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    image_data: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
     format: Mapped[str] = mapped_column(String(20), server_default="webp")
     width: Mapped[int] = mapped_column(Integer, server_default="512")
     alt_text_fr: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/domain/services/image_service.py
+++ b/backend/app/domain/services/image_service.py
@@ -88,6 +88,7 @@ class ImageGenerationService:
 
             image_record.status = "ready"
             image_record.image_url = image_url
+            image_record.image_data = webp_bytes
             image_record.alt_text_fr = alt_fr
             image_record.alt_text_en = alt_en
             image_record.width = width

--- a/backend/migrations/versions/016_add_image_data_bytea.py
+++ b/backend/migrations/versions/016_add_image_data_bytea.py
@@ -1,0 +1,27 @@
+"""Add image_data BYTEA column to generated_images for persistent binary storage
+
+Revision ID: 016_add_image_data_bytea
+Revises: 015_add_generated_images_table
+Create Date: 2026-04-03
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "016_add_image_data_bytea"
+down_revision: str | None = "015_add_generated_images_table"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "generated_images",
+        sa.Column("image_data", sa.LargeBinary(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("generated_images", "image_data")

--- a/backend/tests/test_images.py
+++ b/backend/tests/test_images.py
@@ -16,13 +16,20 @@ UNKNOWN_IMAGE_ID = uuid.uuid4()
 
 
 def _make_image(
-    image_id, lesson_id, img_status, image_url=None, alt_text_fr=None, alt_text_en=None
+    image_id,
+    lesson_id,
+    img_status,
+    image_url=None,
+    alt_text_fr=None,
+    alt_text_en=None,
+    image_data=None,
 ):
     img = MagicMock()
     img.id = image_id
     img.lesson_id = lesson_id
     img.status = img_status
     img.image_url = image_url
+    img.image_data = image_data
     img.alt_text_fr = alt_text_fr
     img.alt_text_en = alt_text_en
     img.format = "webp"
@@ -363,7 +370,33 @@ class TestGetImageStatus:
 
 
 class TestGetImageData:
-    async def test_ready_image_redirects(self, client: AsyncClient) -> None:
+    async def test_ready_image_serves_binary_data(self, client: AsyncClient) -> None:
+        ready_with_data = _make_image(
+            IMAGE_READY_ID,
+            LESSON_ID,
+            "ready",
+            image_data=b"fake-webp-bytes",
+        )
+        db_mock = AsyncMock()
+        db_mock.execute.return_value = _make_db_scalar_one_or_none(ready_with_data)
+        from app.api.deps import get_db_session
+        from app.main import app
+
+        async def override():
+            yield db_mock
+
+        app.dependency_overrides[get_db_session] = override
+        try:
+            response = await client.get(
+                f"/api/v1/images/{IMAGE_READY_ID}/data", follow_redirects=False
+            )
+            assert response.status_code == 200
+            assert response.headers["content-type"] == "image/webp"
+            assert response.content == b"fake-webp-bytes"
+        finally:
+            app.dependency_overrides.pop(get_db_session, None)
+
+    async def test_ready_image_redirects_when_no_binary_data(self, client: AsyncClient) -> None:
         db_mock = AsyncMock()
         db_mock.execute.return_value = _make_db_scalar_one_or_none(_READY_IMAGE)
         from app.api.deps import get_db_session

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -133,8 +133,36 @@ export interface LessonImageResponse {
   alt_text_en?: string;
 }
 
+interface _ApiLessonImage {
+  image_id: string;
+  lesson_id: string;
+  status: LessonImageStatus;
+  image_url: string | null;
+  alt_text: string;
+  format: string;
+  width: number;
+}
+
+interface _ApiLessonImagesListResponse {
+  lesson_id: string;
+  images: _ApiLessonImage[];
+  total: number;
+}
+
 export async function getLessonImageStatus(lessonId: string): Promise<LessonImageResponse> {
-  return apiFetch<LessonImageResponse>(`/api/v1/images/lesson/${lessonId}`);
+  const data = await apiFetch<_ApiLessonImagesListResponse>(`/api/v1/images/lesson/${lessonId}`);
+  const first = data.images[0];
+  if (!first) {
+    return { lesson_id: lessonId, status: 'pending' };
+  }
+  return {
+    lesson_id: first.lesson_id,
+    status: first.status,
+    url: first.image_url ?? undefined,
+    alt_text: first.alt_text,
+    alt_text_fr: first.alt_text,
+    alt_text_en: first.alt_text,
+  };
 }
 
 export interface DashboardStats {


### PR DESCRIPTION
Serves images as binary WebP, frontend renders img tag. Closes #462