### PR TITLE
fix(images): always override stored URL with own data endpoint (#471)

### DIFF
--- a/backend/app/api/v1/images.py
+++ b/backend/app/api/v1/images.py
@@ -69,13 +69,11 @@ def _get_alt_text(image: GeneratedImage, lang: str) -> str:
 def _resolve_image_url(img: GeneratedImage) -> str | None:
     """Return a public URL for a ready image.
 
-    Prefers `image_url` when already set (e.g. CDN URL).
-    Falls back to the data endpoint so binary BYTEA images are always servable.
+    Always returns our own data endpoint to avoid exposing expired third-party
+    URLs (e.g. Azure blob storage) stored in the DB.
     """
     if img.status != "ready":
         return None
-    if img.image_url:
-        return img.image_url
     return f"/api/v1/images/{img.id}/data"
 
 

--- a/backend/tests/test_images.py
+++ b/backend/tests/test_images.py
@@ -152,6 +152,35 @@ class TestGetLessonImages:
         finally:
             app.dependency_overrides.pop(get_db_session, None)
 
+    async def test_azure_url_overridden_with_own_endpoint(
+        self, client: AsyncClient, allow_rate_limit
+    ) -> None:
+        azure_image = _make_image(
+            IMAGE_READY_ID,
+            LESSON_ID,
+            "ready",
+            image_url="https://oaidalleapiprodscus.blob.core.windows.net/expired-url",
+            alt_text_fr="Illustration de la leçon",
+        )
+        db_mock = AsyncMock()
+        db_mock.execute.return_value = _make_db_scalars([azure_image])
+        from app.api.deps import get_db_session
+        from app.main import app
+
+        async def override():
+            yield db_mock
+
+        app.dependency_overrides[get_db_session] = override
+        try:
+            response = await client.get(f"/api/v1/images/lesson/{LESSON_ID}")
+            assert response.status_code == 200
+            images = response.json()["images"]
+            assert len(images) == 1
+            assert images[0]["image_url"] == f"/api/v1/images/{IMAGE_READY_ID}/data"
+            assert "blob.core.windows.net" not in (images[0]["image_url"] or "")
+        finally:
+            app.dependency_overrides.pop(get_db_session, None)
+
     async def test_pending_image_has_null_url(self, client: AsyncClient, allow_rate_limit) -> None:
         db_mock = AsyncMock()
         db_mock.execute.return_value = _make_db_scalars(_ALL_LESSON_IMAGES)


### PR DESCRIPTION
## Summary

- `_resolve_image_url()` was preferring `image.image_url` from the DB (expired Azure blob URL) over our own endpoint
- Changed to always return `/api/v1/images/{id}/data` for ready images, completely ignoring stored third-party URLs
- Added regression test `test_azure_url_overridden_with_own_endpoint` to prevent this from regressing

## Changes

- `backend/app/api/v1/images.py` — simplified `_resolve_image_url()` to always return our own data endpoint
- `backend/tests/test_images.py` — added regression test with an Azure blob URL stored in the DB

## Test plan

- [x] Backend tests pass (19/19 tests pass)
- [x] Backend lint passes (ruff check + format)
- [x] New regression test specifically verifies Azure blob URL is never returned

Closes #471

Generated with [Claude Code](https://claude.ai/code)