### PR TITLE
fix: download and store image binary data from DALL-E (#477)

### DIFF
--- a/backend/app/tasks/content_generation.py
+++ b/backend/app/tasks/content_generation.py
@@ -269,3 +269,111 @@ def generate_lesson_image(
             task_id=self.request.id,
         )
         return {"image_id": None, "status": "failed", "error": str(exc)}
+
+
+@celery_app.task(
+    bind=True,
+    base=CallbackTask,
+    soft_time_limit=600,
+    time_limit=660,
+    rate_limit="1/m",
+)
+def backfill_missing_image_data(self) -> dict:
+    """Re-generate image data for ready images that have NULL binary data (expired Azure URLs).
+
+    Finds all GeneratedImage rows with status='ready' and image_data=NULL,
+    then re-downloads and stores binary WebP for each one via the image service.
+
+    Returns:
+        dict with counts of processed, succeeded, and failed images
+    """
+    import asyncio
+
+    from sqlalchemy import select
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+    from app.domain.models.generated_image import GeneratedImage
+    from app.domain.services.image_service import ImageGenerationService, _resize_to_webp
+    from app.infrastructure.config.settings import settings
+
+    logger.info("Starting backfill of missing image binary data", task_id=self.request.id)
+
+    async def _run() -> dict:
+        engine = create_async_engine(settings.database_url, echo=False)
+        session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        processed = 0
+        succeeded = 0
+        failed = 0
+
+        try:
+            async with session_factory() as session:
+                result = await session.execute(
+                    select(GeneratedImage).where(
+                        GeneratedImage.status == "ready",
+                        GeneratedImage.image_data.is_(None),
+                    )
+                )
+                images = result.scalars().all()
+                logger.info("Found images missing binary data", count=len(images))
+
+                service = ImageGenerationService()
+                for img in images:
+                    processed += 1
+                    try:
+                        if not img.concept:
+                            logger.warning(
+                                "Skipping image with no concept — cannot re-generate",
+                                image_id=str(img.id),
+                            )
+                            failed += 1
+                            continue
+
+                        prompt = img.prompt or (
+                            f"Educational illustration of {img.concept} "
+                            "for West African public health"
+                        )
+                        image_bytes, _ = await service._call_dalle(prompt)
+                        webp_bytes, width = _resize_to_webp(image_bytes, max_width=512)
+
+                        img.image_data = webp_bytes
+                        img.image_url = f"/api/v1/images/{img.id}/data"
+                        img.width = width
+                        img.format = "webp"
+                        img.file_size_bytes = len(webp_bytes)
+                        await session.flush()
+                        succeeded += 1
+                        logger.info(
+                            "Backfilled image binary data",
+                            image_id=str(img.id),
+                            size_bytes=len(webp_bytes),
+                        )
+                    except Exception as exc:
+                        failed += 1
+                        logger.error(
+                            "Failed to backfill image",
+                            image_id=str(img.id),
+                            error=str(exc),
+                        )
+
+                await session.commit()
+
+        finally:
+            await engine.dispose()
+
+        return {"processed": processed, "succeeded": succeeded, "failed": failed}
+
+    try:
+        result = asyncio.run(_run())
+        logger.info(
+            "Backfill completed",
+            result=result,
+            task_id=self.request.id,
+        )
+        return result
+    except Exception as exc:
+        logger.error(
+            "Backfill task failed",
+            exception=str(exc),
+            task_id=self.request.id,
+        )
+        return {"processed": 0, "succeeded": 0, "failed": 0, "error": str(exc)}

--- a/backend/tests/test_image_generation.py
+++ b/backend/tests/test_image_generation.py
@@ -249,6 +249,8 @@ class TestImageGenerationService:
         assert result.status == "ready"
         assert result.image_url == f"/api/v1/images/{result.id}/data"
         assert "oaidalleapiprodscus" not in (result.image_url or "")
+        assert result.image_data is not None
+        assert len(result.image_data) > 0
 
     async def test_failure_handling_sets_failed_status(self, service, mock_session):
         """When DALL-E raises an exception, status must be 'failed' and lesson unaffected."""
@@ -354,3 +356,57 @@ class TestImageGenerationService:
         assert callable(generate_lesson_image)
         assert hasattr(generate_lesson_image, "delay")
         assert hasattr(generate_lesson_image, "apply_async")
+
+    def test_backfill_task_is_registered(self):
+        """Verify backfill_missing_image_data task is importable and has expected signature."""
+        from app.tasks.content_generation import backfill_missing_image_data
+
+        assert callable(backfill_missing_image_data)
+        assert hasattr(backfill_missing_image_data, "delay")
+        assert hasattr(backfill_missing_image_data, "apply_async")
+
+    async def test_new_generation_image_data_not_null(
+        self, service, mock_session, mock_claude_response, mock_alt_text_response
+    ):
+        """image_data must be stored (not NULL) after successful DALL-E generation."""
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        dalle_response = MagicMock()
+        dalle_response.data = [MagicMock(url="https://example.com/img.png")]
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
+            mock_client = AsyncMock()
+            mock_anthropic_cls.return_value = mock_client
+            mock_client.messages.create = AsyncMock(
+                side_effect=[mock_claude_response, mock_alt_text_response]
+            )
+
+            with patch("openai.AsyncOpenAI") as mock_openai_cls:
+                mock_openai = AsyncMock()
+                mock_openai_cls.return_value = mock_openai
+                mock_openai.images.generate = AsyncMock(return_value=dalle_response)
+
+                with patch("httpx.AsyncClient") as mock_http_cls:
+                    mock_http = AsyncMock()
+                    mock_http_cls.return_value.__aenter__ = AsyncMock(return_value=mock_http)
+                    mock_http_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+                    mock_http.get = AsyncMock(
+                        return_value=MagicMock(
+                            content=b"FAKE_PNG_BINARY_DATA", raise_for_status=MagicMock()
+                        )
+                    )
+
+                    result = await service.generate_for_lesson(
+                        lesson_id=uuid.uuid4(),
+                        module_id=uuid.uuid4(),
+                        unit_id="u01",
+                        lesson_content="Lesson about tuberculosis surveillance in Senegal.",
+                        session=mock_session,
+                    )
+
+        assert result.image_data is not None, "image_data must not be NULL after generation"
+        assert len(result.image_data) > 0
+        assert result.image_url == f"/api/v1/images/{result.id}/data"
+        assert "blob.core.windows.net" not in (result.image_url or "")


### PR DESCRIPTION
Downloads image bytes, converts to WebP, stores in image_data column. Closes #477