### PR TITLE
fix(content): fix unique constraint crash on async Celery generation

### DIFF
--- a/backend/app/domain/services/flashcard_service.py
+++ b/backend/app/domain/services/flashcard_service.py
@@ -5,6 +5,7 @@ import uuid
 
 import structlog
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.ai.claude_service import ClaudeService
@@ -232,9 +233,31 @@ class FlashcardGenerationService:
             validated=False,
         )
 
-        session.add(generated_content)
-        await session.commit()
-        await session.refresh(generated_content)
+        try:
+            session.add(generated_content)
+            await session.commit()
+            await session.refresh(generated_content)
+        except IntegrityError:
+            await session.rollback()
+            logger.warning(
+                "Flashcard set already cached by concurrent request, fetching existing",
+                module_id=str(module_id),
+                language=language,
+                country=country,
+            )
+            existing_query = select(GeneratedContent).where(
+                GeneratedContent.module_id == module_id,
+                GeneratedContent.content_type == "flashcard",
+                GeneratedContent.language == language,
+                GeneratedContent.country_context == country,
+                GeneratedContent.level == level,
+            )
+            existing_result = await session.execute(existing_query)
+            existing = existing_result.scalar_one_or_none()
+            if existing:
+                logger.info("Returning existing flashcard set", content_id=str(existing.id))
+                return existing
+            raise
 
         logger.info("Flashcard set saved to database", content_id=str(content_id))
         return generated_content

--- a/backend/app/domain/services/lesson_service.py
+++ b/backend/app/domain/services/lesson_service.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 import structlog
 from sqlalchemy import and_, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.ai.claude_service import ClaudeService
@@ -418,8 +419,29 @@ class LessonGenerationService:
             validated=False,
         )
 
-        session.add(cached_content)
-        await session.commit()
+        try:
+            session.add(cached_content)
+            await session.commit()
+        except IntegrityError:
+            await session.rollback()
+            logger.warning(
+                "Lesson already cached by concurrent request, skipping insert",
+                module_id=str(lesson_response.module_id),
+                unit_id=lesson_response.unit_id,
+                language=lesson_response.language,
+            )
+            existing = await self._get_cached_lesson(
+                lesson_response.module_id,
+                lesson_response.unit_id,
+                lesson_response.language,
+                lesson_response.country_context,
+                lesson_response.level,
+                session,
+            )
+            if existing:
+                lesson_response.id = existing.id
+                lesson_response.cached = True
+            return
 
         logger.info(
             "Cached lesson content",
@@ -881,8 +903,29 @@ class CaseStudyGenerationService:
             validated=False,
         )
 
-        session.add(cached_content)
-        await session.commit()
+        try:
+            session.add(cached_content)
+            await session.commit()
+        except IntegrityError:
+            await session.rollback()
+            logger.warning(
+                "Case study already cached by concurrent request, skipping insert",
+                module_id=str(case_study_response.module_id),
+                unit_id=case_study_response.unit_id,
+                language=case_study_response.language,
+            )
+            existing = await self._get_cached_case_study(
+                case_study_response.module_id,
+                case_study_response.unit_id,
+                case_study_response.language,
+                case_study_response.country_context,
+                case_study_response.level,
+                session,
+            )
+            if existing:
+                case_study_response.id = existing.id
+                case_study_response.cached = True
+            return
 
         logger.info(
             "Cached case study content",

--- a/backend/app/domain/services/quiz_service.py
+++ b/backend/app/domain/services/quiz_service.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 import structlog
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.ai.claude_service import ClaudeService
@@ -117,9 +118,41 @@ class QuizService:
                 validated=False,
             )
 
-            session.add(generated_content)
-            await session.commit()
-            await session.refresh(generated_content)
+            try:
+                session.add(generated_content)
+                await session.commit()
+                await session.refresh(generated_content)
+            except IntegrityError:
+                await session.rollback()
+                logger.warning(
+                    "Quiz already cached by concurrent request, fetching existing",
+                    module_id=str(module_id),
+                    unit_id=unit_id,
+                    language=language,
+                )
+                existing_query = select(GeneratedContent).where(
+                    GeneratedContent.module_id == module_id,
+                    GeneratedContent.content_type == "quiz",
+                    GeneratedContent.language == language,
+                    GeneratedContent.level == level,
+                    GeneratedContent.country_context == country,
+                    GeneratedContent.content["unit_id"].astext == unit_id,
+                )
+                existing_result = await session.execute(existing_query)
+                existing = existing_result.scalar_one_or_none()
+                if existing:
+                    return QuizResponse(
+                        id=existing.id,
+                        module_id=existing.module_id,
+                        unit_id=existing.content.get("unit_id", unit_id),
+                        language=existing.language,
+                        level=existing.level,
+                        country_context=existing.country_context or country,
+                        content=QuizContent(**existing.content),
+                        generated_at=existing.generated_at.isoformat(),
+                        cached=True,
+                    )
+                raise
 
             logger.info(
                 "Quiz generated and cached",

--- a/backend/migrations/versions/017_fix_unique_lesson_per_unit_index.py
+++ b/backend/migrations/versions/017_fix_unique_lesson_per_unit_index.py
@@ -1,0 +1,46 @@
+"""Fix unique constraint on generated_content to include country_context and level.
+
+The previous index (if deployed) only covered (module_id, content_type, language,
+content->>'unit_id'), which caused UniqueViolationError when generating content for
+the same module+unit+language but different country or level.
+
+The corrected index adds country_context and level so that content for different
+country/level combinations can coexist, matching the 6-field cache key used by the
+service layer: (module_id, content_type, language, level, country_context, unit_id).
+
+Revision ID: 017_fix_unique_lesson_per_unit_index
+Revises: 016_add_image_data_bytea
+Create Date: 2026-04-03
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "017_fix_unique_lesson_per_unit_index"
+down_revision: str | None = "016_add_image_data_bytea"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_unique_lesson_per_unit")
+
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_lesson_per_unit
+        ON generated_content (
+            module_id,
+            content_type,
+            language,
+            level,
+            country_context,
+            (content ->> 'unit_id')
+        )
+        WHERE content ->> 'unit_id' IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_unique_lesson_per_unit")


### PR DESCRIPTION
## Summary

Fixes critical bug where all first-time content generation fails with `UniqueViolationError` after async Celery deployment (#474).

## Root Causes Fixed

**Option A — Index fix:** The `idx_unique_lesson_per_unit` partial unique index was too restrictive (only 4 fields), missing `country_context` and `level`. Content for same module+unit+language but different country or level would violate the constraint.

**Option B — Race condition resilience:** Even with the correct index, concurrent Celery tasks could race to INSERT the same row. All service cache methods now catch `IntegrityError`, rollback, and return the existing row.

## Changes

- `backend/migrations/versions/017_fix_unique_lesson_per_unit_index.py` — Alembic migration: drops old index (if exists), recreates with 6-field unique constraint `(module_id, content_type, language, level, country_context, content->>'unit_id')`
- `backend/app/domain/services/lesson_service.py` — `IntegrityError` handling in `_cache_lesson_content` and `_cache_case_study_content`
- `backend/app/domain/services/quiz_service.py` — `IntegrityError` handling in `get_or_generate_quiz`
- `backend/app/domain/services/flashcard_service.py` — `IntegrityError` handling in `_generate_flashcard_set`

## Test plan

- [ ] Backend tests pass
- [ ] `ruff check` passes (verified locally — all clean)
- [ ] Run migration on staging DB and verify index is recreated correctly
- [ ] Verify concurrent generation for same module+unit, different countries does not crash
- [ ] Verify existing cached content still loads correctly

Closes #480

Generated with [Claude Code](https://claude.ai/code)