### PR TITLE
fix(image): improve DALL-E prompts — no text/labels, better visual quality

### DIFF
--- a/backend/app/domain/services/image_service.py
+++ b/backend/app/domain/services/image_service.py
@@ -127,7 +127,14 @@ class ImageGenerationService:
             "You are an expert in public health education for West Africa. "
             "Given lesson content, extract: "
             "1) A short key concept (5 words max), "
-            "2) A vivid DALL-E 3 illustration prompt (max 120 chars, educational style, no text), "
+            "2) A vivid DALL-E 3 illustration prompt that follows these STRICT rules:\n"
+            "   - NEVER include any text, words, labels, numbers, letters, captions, or titles in the image\n"
+            "   - Focus on visual metaphors, diagrams without text, people, scenes, objects\n"
+            "   - Style: clean flat illustration, infographic style, vibrant colors, educational\n"
+            "   - Context: West African setting, diverse people, health facilities\n"
+            "   - Max 120 chars\n"
+            "   - Examples of GOOD prompts: 'African health worker examining patient in rural clinic, stethoscope, colorful flat illustration'\n"
+            "   - Examples of BAD prompts: 'Chart showing mortality rates with labels and percentages'\n"
             "3) A JSON array of 5-8 lowercase semantic tags. "
             "Reply ONLY in this exact format:\n"
             "CONCEPT: <concept>\n"
@@ -174,9 +181,12 @@ class ImageGenerationService:
 
         client = AsyncOpenAI(api_key=settings.openai_api_key)
 
+        no_text_suffix = " I NEED this image to contain absolutely NO text, letters, numbers, or written words anywhere."
+        final_prompt = prompt + no_text_suffix
+
         response = await client.images.generate(
             model="dall-e-2",
-            prompt=prompt,
+            prompt=final_prompt,
             n=1,
             size="512x512",
             response_format="url",

--- a/backend/tests/test_image_generation.py
+++ b/backend/tests/test_image_generation.py
@@ -245,6 +245,8 @@ class TestImageGenerationService:
             call_kwargs = mock_openai.images.generate.call_args.kwargs
             assert call_kwargs.get("model") == "dall-e-2"
             assert call_kwargs.get("size") == "512x512"
+            prompt_sent = call_kwargs.get("prompt", "")
+            assert "NO text" in prompt_sent or "no text" in prompt_sent.lower()
 
         assert result.status == "ready"
         assert result.image_url == f"/api/v1/images/{result.id}/data"
@@ -338,6 +340,26 @@ class TestImageGenerationService:
             )
 
         assert existing.reuse_count == 3
+
+    def test_system_prompt_contains_no_text_rules(self):
+        """System prompt for concept extraction must contain strict no-text rules."""
+        import inspect
+
+        from app.domain.services import image_service
+
+        source = inspect.getsource(image_service)
+        assert "NEVER include any text" in source
+        assert "West African setting" in source
+        assert "flat illustration" in source
+
+    def test_dalle_prompt_suffix_enforces_no_text(self):
+        """DALL-E prompt must include the no-text enforcement suffix."""
+        import inspect
+
+        from app.domain.services import image_service
+
+        source = inspect.getsource(image_service)
+        assert "NO text, letters, numbers, or written words" in source
 
     def test_openai_api_key_not_in_frontend_accessible_code(self):
         """Verify OPENAI_API_KEY is loaded from settings (server-side), not hardcoded."""


### PR DESCRIPTION
## Summary

Improves DALL-E image generation quality by enforcing strict no-text rules in both the Claude system prompt and the DALL-E API call.

## Changes

- `backend/app/domain/services/image_service.py` — Updated `_extract_concept_and_tags` system prompt with explicit no-text rules (NEVER include labels, numbers, letters; focus on West African visual scenes; clean flat illustration style). Added no-text enforcement suffix to the `_call_dalle` prompt.
- `backend/tests/test_image_generation.py` — Added `test_system_prompt_contains_no_text_rules` and `test_dalle_prompt_suffix_enforces_no_text` to verify the prompt improvements. Also updated `test_new_generation_calls_dalle` to assert the no-text suffix is included in the DALL-E call.

## Test plan

- [x] All 24 backend tests pass (`pytest tests/test_image_generation.py`)
- [x] ruff lint passes (all checks passed)
- [ ] Manually regenerate existing images to verify no text/labels appear

Closes #482

Generated with [Claude Code](https://claude.ai/code)