### PR TITLE
fix: repair broken Alembic migration chain — unblock all schema changes

### DIFF
--- a/backend/migrations/versions/011_add_email_otps_table.py
+++ b/backend/migrations/versions/011_add_email_otps_table.py
@@ -1,7 +1,7 @@
 """Add email_otps table
 
 Revision ID: 011_add_email_otps_table
-Revises: 9f4db5f73f90_merge_avatar_url_and_placement_test_
+Revises: 017_fix_unique_lesson_per_unit_index
 Create Date: 2026-04-01 05:40:00.000000
 
 """
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "011_add_email_otps_table"
-down_revision: str | None = "9f4db5f73f90_merge_avatar_url_and_placement_test_"
+down_revision: str | None = "017_fix_unique_lesson_per_unit_index"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/migrations/versions/013_add_learner_memory_table.py
+++ b/backend/migrations/versions/013_add_learner_memory_table.py
@@ -18,6 +18,10 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.has_table(conn, "learner_memory"):
+        return
+
     op.create_table(
         "learner_memory",
         sa.Column("id", sa.UUID(), nullable=False),

--- a/backend/migrations/versions/014_add_compacted_context_to_conversations.py
+++ b/backend/migrations/versions/014_add_compacted_context_to_conversations.py
@@ -17,6 +17,11 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
+    conn = op.get_bind()
+    columns = [c["name"] for c in sa.inspect(conn).get_columns("tutor_conversations")]
+    if "compacted_context" in columns:
+        return
+
     op.add_column(
         "tutor_conversations",
         sa.Column("compacted_context", sa.Text(), nullable=True),

--- a/backend/migrations/versions/015_add_generated_images_table.py
+++ b/backend/migrations/versions/015_add_generated_images_table.py
@@ -22,7 +22,11 @@ image_status_enum = postgresql.ENUM(
 
 
 def upgrade() -> None:
-    image_status_enum.create(op.get_bind(), checkfirst=True)
+    conn = op.get_bind()
+    if conn.dialect.has_table(conn, "generated_images"):
+        return
+
+    image_status_enum.create(conn, checkfirst=True)
 
     op.create_table(
         "generated_images",

--- a/backend/migrations/versions/016_add_image_data_bytea.py
+++ b/backend/migrations/versions/016_add_image_data_bytea.py
@@ -17,6 +17,11 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
+    conn = op.get_bind()
+    columns = [c["name"] for c in sa.inspect(conn).get_columns("generated_images")]
+    if "image_data" in columns:
+        return
+
     op.add_column(
         "generated_images",
         sa.Column("image_data", sa.LargeBinary(), nullable=True),

--- a/backend/migrations/versions/0d1135672916_add_module_units_table_with_m01_m03_.py
+++ b/backend/migrations/versions/0d1135672916_add_module_units_table_with_m01_m03_.py
@@ -18,6 +18,11 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
+    # Skip if table already exists (created by SQLAlchemy auto-create)
+    conn = op.get_bind()
+    if conn.dialect.has_table(conn, "module_units"):
+        return
+
     # Create module_units table
     op.create_table(
         "module_units",


### PR DESCRIPTION
## Summary

Fixes #487 — The entire Alembic migration chain has been broken since March 31. No migrations 011-017 ever ran on production.

**Root cause:** Migration 011 referenced `9f4db5f73f90_merge_avatar_url_and_placement_test_` as parent, but the actual revision ID is `9f4db5f73f90` (without the filename suffix). This created a broken branch → `KeyError` → all migrations fail silently.

**Changes:**
- Fix 011 `down_revision` — moved to end of chain after 017
- Add table-exists guards to 0d1135672916, 013, 015 (tables already created by SQLAlchemy auto-create)
- Add column-exists guards to 014, 016 (columns already exist)

**After deploy**, `alembic upgrade head` will:
- Skip already-existing tables/columns (guards prevent crashes)
- Apply migration 017 → fix the unique index (adds `country_context` + `level`)
- Apply migration 011 → create `email_otps` table
- Content generation will work for all countries

## Test plan

- [ ] `alembic upgrade head` runs without errors
- [ ] Chain is single-head: `011_add_email_otps_table`
- [ ] Unique index includes `country_context` and `level`
- [ ] Content generation works for country=CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)