### PR TITLE
fix(lesson-image): prepend API base URL to relative image src (#490)

### DIFF
--- a/frontend/components/learning/lesson-image.tsx
+++ b/frontend/components/learning/lesson-image.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import { X } from 'lucide-react';
-import { getLessonImageStatus } from '@/lib/api';
+import { getLessonImageStatus, API_BASE } from '@/lib/api';
 import type { LessonImageStatus } from '@/lib/api';
 
 const POLL_INTERVAL_MS = 3000;
@@ -42,7 +42,10 @@ export function LessonImage({ lessonId, language }: LessonImageProps) {
               ? (data.alt_text_fr ?? data.alt_text ?? '')
               : (data.alt_text_en ?? data.alt_text ?? '');
           setAltText(alt);
-          setImageUrl(data.url);
+          const resolvedUrl = data.url.startsWith('/')
+            ? `${API_BASE}${data.url}`
+            : data.url;
+          setImageUrl(resolvedUrl);
           setTimeout(() => setIsVisible(true), 50);
           return;
         }


### PR DESCRIPTION
## Summary

Lesson images were broken because the backend returns a relative path (`/api/v1/images/{id}/data`) which was used as-is in the `<img src>`, hitting the frontend server (404) instead of the backend API.

## Changes

- `frontend/components/learning/lesson-image.tsx` — import `API_BASE` from `@/lib/api`; resolve relative image URLs by prepending `API_BASE` before calling `setImageUrl`. Absolute URLs are passed through unchanged.

## Test plan

- [ ] Frontend lint passes (0 errors)
- [ ] Lesson images render correctly on the deployed site
- [ ] Manually verified on mobile viewport

Closes #490

Generated with [Claude Code](https://claude.ai/code)