### PR TITLE
fix(tasks): add pool_size=5, max_overflow=2 to Celery async engines

### DIFF
--- a/backend/app/tasks/content_generation.py
+++ b/backend/app/tasks/content_generation.py
@@ -246,7 +246,7 @@ def generate_lesson_task(
     )
 
     async def _run() -> dict:
-        engine = create_async_engine(settings.database_url, echo=False)
+        engine = create_async_engine(settings.database_url, echo=False, pool_size=5, max_overflow=2)
         session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
         try:
             async with session_factory() as session:
@@ -335,7 +335,7 @@ def generate_case_study_task(
     )
 
     async def _run() -> dict:
-        engine = create_async_engine(settings.database_url, echo=False)
+        engine = create_async_engine(settings.database_url, echo=False, pool_size=5, max_overflow=2)
         session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
         try:
             async with session_factory() as session:
@@ -427,7 +427,7 @@ def generate_quiz_task(
     )
 
     async def _run() -> dict:
-        engine = create_async_engine(settings.database_url, echo=False)
+        engine = create_async_engine(settings.database_url, echo=False, pool_size=5, max_overflow=2)
         session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
         try:
             async with session_factory() as session:
@@ -514,7 +514,7 @@ def generate_flashcard_task(
     )
 
     async def _run() -> dict:
-        engine = create_async_engine(settings.database_url, echo=False)
+        engine = create_async_engine(settings.database_url, echo=False, pool_size=5, max_overflow=2)
         session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
         try:
             async with session_factory() as session:
@@ -594,7 +594,7 @@ def generate_lesson_image(
     )
 
     async def _run() -> dict:
-        engine = create_async_engine(settings.database_url, echo=False)
+        engine = create_async_engine(settings.database_url, echo=False, pool_size=5, max_overflow=2)
         session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
         try:
             async with session_factory() as session:
@@ -657,7 +657,7 @@ def backfill_missing_image_data(self) -> dict:
     logger.info("Starting backfill of missing image binary data", task_id=self.request.id)
 
     async def _run() -> dict:
-        engine = create_async_engine(settings.database_url, echo=False)
+        engine = create_async_engine(settings.database_url, echo=False, pool_size=5, max_overflow=2)
         session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
         processed = 0
         succeeded = 0


### PR DESCRIPTION
## Summary
Fixes asyncpg 'another operation is in progress' error crashing all Celery content generation tasks.

## Root Cause
Each Celery task created an async engine with default pool_size=1. When `SemanticRetriever.search()` called `generate_embedding()` (async HTTP) then `session.execute()` (DB query) concurrently on the same single connection, asyncpg threw the interface error.

## Changes
- `backend/app/tasks/content_generation.py`: Added `pool_size=5, max_overflow=2` to all 6 `create_async_engine()` calls across `generate_lesson_task`, `generate_case_study_task`, `generate_quiz_task`, `generate_flashcard_task`, and two helper tasks

## Test plan
- [ ] `POST /api/v1/quiz/generate` with uncached params → 202 → poll → status: complete
- [ ] Same for lessons and case studies
- [ ] Content loads correctly after generation

Closes #495

Generated with [Claude Code](https://claude.ai/code)