### PR TITLE
fix(lesson-image): prepend API base URL to relative image src (#490)

### DIFF
--- a/frontend/components/learning/lesson-image.tsx
+++ b/frontend/components/learning/lesson-image.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import { X } from 'lucide-react';
-import { getLessonImageStatus } from '@/lib/api';
+import { getLessonImageStatus, API_BASE } from '@/lib/api';
 import type { LessonImageStatus } from '@/lib/api';
 
 const POLL_INTERVAL_MS = 3000;
@@ -42,7 +42,10 @@ export function LessonImage({ lessonId, language }: LessonImageProps) {
               ? (data.alt_text_fr ?? data.alt_text ?? '')
               : (data.alt_text_en ?? data.alt_text ?? '');
           setAltText(alt);
-          setImageUrl(data.url);
+          const resolvedUrl = data.url.startsWith('/')
+            ? `${API_BASE}${data.url}`
+            : data.url;
+          setImageUrl(resolvedUrl);
           setTimeout(() => setIsVisible(true), 50);
           return;
         }


### PR DESCRIPTION
## Summary

Lesson images were broken because the `image_url` returned by the backend (`/api/v1/images/{id}/data`) is a relative path. When set directly as `src`, the browser resolved it against the frontend host (`etutor.elearning.portfolio2.kimbetien.com`) instead of the backend API host (`api.elearning.portfolio2.kimbetien.com`), resulting in a 404.

## Changes

- `frontend/components/learning/lesson-image.tsx` — import `API_BASE` from `@/lib/api`; when the image URL starts with `/`, prepend `API_BASE` before storing in state. Absolute URLs are passed through unchanged.

```tsx
const resolvedUrl = data.url.startsWith('/')
  ? `${API_BASE}${data.url}`
  : data.url;
setImageUrl(resolvedUrl);
```

## Test plan

- [ ] Backend tests pass
- [ ] Frontend lint passes (0 errors)
- [ ] Lesson image renders correctly in production (full URL `https://api.elearning.portfolio2.kimbetien.com/api/v1/images/{id}/data`)
- [ ] Manually verified on mobile viewport (320px)

Closes #490

Generated with [Claude Code](https://claude.ai/code)