### PR TITLE
fix: pass session to retriever — fix Celery asyncpg conflict (#495)

### DIFF
--- a/backend/app/domain/services/flashcard_service.py
+++ b/backend/app/domain/services/flashcard_service.py
@@ -163,8 +163,9 @@ class FlashcardGenerationService:
         # Retrieve relevant chunks using RAG
         search_results = await self.semantic_retriever.search(
             query=query,
-            k=12,  # Get more chunks for comprehensive flashcard generation
+            top_k=12,  # Get more chunks for comprehensive flashcard generation
             filters={"level": {"$lte": level}},  # Only content appropriate for user's level
+            session=session,
         )
 
         if not search_results:

--- a/backend/app/domain/services/quiz_service.py
+++ b/backend/app/domain/services/quiz_service.py
@@ -100,6 +100,7 @@ class QuizService:
                 module_id=module_id,
                 unit_id=unit_id,
                 language=language,
+                session=session,
                 country=country,
                 level=level,
                 num_questions=num_questions,
@@ -189,6 +190,7 @@ class QuizService:
         country: str,
         level: int,
         num_questions: int,
+        session: AsyncSession | None = None,
     ) -> QuizContent:
         """
         Generate quiz content using RAG retrieval and Claude API.
@@ -212,6 +214,7 @@ class QuizService:
                 user_level=level,
                 user_language=language,
                 top_k=8,
+                session=session,
             )
 
             # Build context from retrieved chunks


### PR DESCRIPTION
## Summary

Fixes #495 — Celery content generation tasks crash with `asyncpg: cannot perform operation: another operation is in progress`.

The previous fix (pool_size=5) didn't work because the issue is the retriever using the **global session factory** (different event loop) instead of the Celery task's session.

**Changes:**
- `quiz_service.py` — pass `session` to `_generate_quiz_content()` and through to `search_for_module()`
- `flashcard_service.py` — pass `session` to `search()` + fix `k=12` → `top_k=12`

All 291 tests pass.

## Test plan
- [ ] Quiz generation completes successfully via Celery
- [ ] Lesson/case study generation still works
- [ ] Flashcard generation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)