### PR TITLE
fix: increase Celery timeout, max_tokens, and client timeout (#511)

### DIFF
--- a/backend/app/ai/claude_service.py
+++ b/backend/app/ai/claude_service.py
@@ -21,7 +21,10 @@ class ClaudeService:
         if not self.settings.anthropic_api_key:
             raise ValueError("ANTHROPIC_API_KEY is required")
 
-        self.client = anthropic.AsyncAnthropic(api_key=self.settings.anthropic_api_key)
+        self.client = anthropic.AsyncAnthropic(
+            api_key=self.settings.anthropic_api_key,
+            timeout=600.0,
+        )
 
     async def generate_lesson_content_stream(
         self,
@@ -41,7 +44,7 @@ class ClaudeService:
         try:
             async with self.client.messages.stream(
                 model="claude-sonnet-4-6",
-                max_tokens=4096,
+                max_tokens=64000,
                 system=system_prompt,
                 messages=[{"role": "user", "content": user_message}],
                 temperature=0.7,
@@ -72,7 +75,7 @@ class ClaudeService:
         try:
             response = await self.client.messages.create(
                 model="claude-sonnet-4-6",
-                max_tokens=4096,
+                max_tokens=64000,
                 system=system_prompt,
                 messages=[{"role": "user", "content": user_message}],
                 temperature=0.7,
@@ -103,7 +106,7 @@ class ClaudeService:
         try:
             response = await self.client.messages.create(
                 model="claude-sonnet-4-6",
-                max_tokens=4096,
+                max_tokens=64000,
                 system=system_prompt,
                 messages=[{"role": "user", "content": user_message}],
                 temperature=0.7,

--- a/backend/app/api/v1/tutor.py
+++ b/backend/app/api/v1/tutor.py
@@ -31,7 +31,7 @@ router = APIRouter(prefix="/tutor", tags=["tutor"])
 async def get_tutor_service() -> TutorService:
     """Get tutor service with dependencies."""
     settings = get_settings()
-    anthropic_client = AsyncAnthropic(api_key=settings.anthropic_api_key)
+    anthropic_client = AsyncAnthropic(api_key=settings.anthropic_api_key, timeout=600.0)
     embedding_service = EmbeddingService(api_key=settings.openai_api_key)
     semantic_retriever = SemanticRetriever(embedding_service)
 

--- a/backend/app/domain/services/image_service.py
+++ b/backend/app/domain/services/image_service.py
@@ -121,7 +121,7 @@ class ImageGenerationService:
         """Use Claude API to extract key concept, DALL-E prompt, and semantic tags."""
         import anthropic
 
-        client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key)
+        client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key, timeout=600.0)
 
         system = (
             "You are an expert in public health education for West Africa. "
@@ -204,7 +204,7 @@ class ImageGenerationService:
         """Generate bilingual alt-text for the image."""
         import anthropic
 
-        client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key)
+        client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key, timeout=600.0)
 
         message = await client.messages.create(
             model="claude-sonnet-4-6",

--- a/backend/app/tasks/content_generation.py
+++ b/backend/app/tasks/content_generation.py
@@ -9,8 +9,8 @@ from app.tasks.celery_app import celery_app
 
 logger = structlog.get_logger(__name__)
 
-POLL_SOFT_LIMIT = 180
-POLL_HARD_LIMIT = 200
+POLL_SOFT_LIMIT = 300
+POLL_HARD_LIMIT = 320
 
 
 class CallbackTask(Task):


### PR DESCRIPTION
## Summary
- Celery content-gen task limits: 3 min → **5 min** (soft 300s, hard 320s)
- Claude API `max_tokens`: 4096 → **64000** (model maximum for claude-sonnet-4-6)
- Anthropic client `timeout`: SDK default → **600s (10 min)** across all 4 instantiations

Closes #511

## Test plan
- [x] `make backend-test` — 291 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)