### PR TITLE
feat(tasks): auto-prefetch next 2 lessons on register, quiz pass, module unlock

### DIFF
--- a/backend/app/domain/services/local_auth_service.py
+++ b/backend/app/domain/services/local_auth_service.py
@@ -189,6 +189,26 @@ class LocalAuthService:
                 user.email, user.name, user.preferred_language
             )
 
+            # Kick off background prefetch of first 2 lessons for new user
+            try:
+                from app.tasks.content_generation import prefetch_next_lessons_task
+
+                prefetch_next_lessons_task.delay(
+                    user_id=str(user.id),
+                    module_id="",
+                    current_unit_id="",
+                    language=user.preferred_language,
+                    country=user.country or "SN",
+                    level=user.current_level or 1,
+                    module_number=1,
+                )
+            except Exception as prefetch_exc:
+                logger.warning(
+                    "Failed to dispatch prefetch task on registration",
+                    user_id=str(user.id),
+                    error=str(prefetch_exc),
+                )
+
             logger.info("TOTP setup verified", user_id=user_id, email=user.email)
 
             return {
@@ -695,6 +715,26 @@ class LocalAuthService:
             await self.email_service.send_welcome_email(
                 user["email"], user["name"], user["preferred_language"]
             )
+
+            # Kick off background prefetch of first 2 lessons for new user
+            try:
+                from app.tasks.content_generation import prefetch_next_lessons_task
+
+                prefetch_next_lessons_task.delay(
+                    user_id=user["id"],
+                    module_id="",
+                    current_unit_id="",
+                    language=user["preferred_language"],
+                    country=user.get("country") or "SN",
+                    level=user.get("current_level") or 1,
+                    module_number=1,
+                )
+            except Exception as prefetch_exc:
+                logger.warning(
+                    "Failed to dispatch prefetch task on email OTP registration",
+                    user_id=user["id"],
+                    error=str(prefetch_exc),
+                )
 
             logger.info("Email OTP registration completed", user_id=user["id"], email=user["email"])
 

--- a/backend/app/domain/services/progress_service.py
+++ b/backend/app/domain/services/progress_service.py
@@ -141,6 +141,10 @@ class ProgressService:
         ):
             await self._unlock_next_module(user_id, module_id)
 
+        # Prefetch next 2 lessons in background if quiz was passed
+        if passed:
+            await self._dispatch_prefetch_after_quiz(user_id, module_id, unit_id)
+
         logger.info(
             "Progress updated after quiz",
             user_id=str(user_id),
@@ -373,6 +377,40 @@ class ProgressService:
                 "Next module status updated to in_progress",
                 user_id=str(user_id),
                 module_number=next_module.module_number,
+            )
+
+        # Prefetch first 2 lessons of the newly unlocked module
+        self._dispatch_prefetch(user_id, str(next_module.id), "")
+
+    async def _dispatch_prefetch_after_quiz(
+        self, user_id: UUID, module_id: UUID, unit_id: str
+    ) -> None:
+        """Dispatch background prefetch of the next 2 lessons after quiz pass."""
+        self._dispatch_prefetch(user_id, str(module_id), unit_id)
+
+    def _dispatch_prefetch(self, user_id: UUID, module_id: str, current_unit_id: str) -> None:
+        """Fire-and-forget Celery task to prefetch next 2 lessons."""
+        try:
+            from app.tasks.content_generation import prefetch_next_lessons_task
+
+            prefetch_next_lessons_task.apply_async(
+                kwargs={
+                    "user_id": str(user_id),
+                    "module_id": module_id,
+                    "current_unit_id": current_unit_id,
+                    "language": "fr",
+                    "country": "SN",
+                    "level": 1,
+                },
+                priority=3,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to dispatch prefetch task",
+                user_id=str(user_id),
+                module_id=module_id,
+                unit_id=current_unit_id,
+                error=str(exc),
             )
 
     async def _get_or_create_progress(

--- a/backend/app/tasks/content_generation.py
+++ b/backend/app/tasks/content_generation.py
@@ -632,6 +632,256 @@ def generate_lesson_image(
 @celery_app.task(
     bind=True,
     base=CallbackTask,
+    soft_time_limit=360,
+    time_limit=400,
+    rate_limit="3/m",
+    priority=3,
+)
+def prefetch_next_lessons_task(
+    self,
+    user_id: str,
+    module_id: str,
+    current_unit_id: str,
+    language: str,
+    country: str,
+    level: int,
+    module_number: int | None = None,
+) -> dict:
+    """Pre-generate the next 2 lessons after current_unit_id for a learner.
+
+    Called after registration, quiz pass, or module unlock to eliminate
+    the 'Génération du contenu...' wait on first access.
+
+    Args:
+        user_id: UUID of the learner
+        module_id: UUID string of the current module, or empty string if module_number given
+        current_unit_id: Unit ID like 'M01-U01'; empty string means start of module
+        language: Content language (fr/en)
+        country: Country code for contextualization
+        level: User competency level (1-4)
+        module_number: Module number (e.g. 1 for M01); used when module_id is empty
+
+    Returns:
+        dict with prefetched unit_ids, skipped (already cached), and errors
+    """
+    import asyncio
+
+    from sqlalchemy import select
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+    from app.ai.claude_service import ClaudeService
+    from app.ai.rag.embeddings import EmbeddingService
+    from app.ai.rag.retriever import SemanticRetriever
+    from app.domain.models.content import GeneratedContent
+    from app.domain.models.module import Module
+    from app.domain.models.module_unit import ModuleUnit
+    from app.domain.services.lesson_service import LessonGenerationService
+    from app.infrastructure.config.settings import settings
+
+    logger.info(
+        "Starting lesson prefetch",
+        user_id=user_id,
+        module_id=module_id,
+        current_unit_id=current_unit_id,
+        language=language,
+        country=country,
+        level=level,
+        task_id=self.request.id,
+    )
+
+    async def _get_next_lesson_unit_ids(
+        session: AsyncSession,
+        module_uuid: uuid.UUID,
+        current_unit_id: str,
+        count: int = 2,
+    ) -> list[str]:
+        """Return unit IDs for the next N lesson-type units after current_unit_id."""
+        module_result = await session.execute(select(Module).where(Module.id == module_uuid))
+        module = module_result.scalar_one_or_none()
+        if not module:
+            return []
+
+        units_result = await session.execute(
+            select(ModuleUnit)
+            .where(ModuleUnit.module_id == module_uuid)
+            .order_by(ModuleUnit.order_index)
+        )
+        all_units = list(units_result.scalars().all())
+
+        current_idx = -1
+        if current_unit_id:
+            for i, u in enumerate(all_units):
+                uid = f"M{module.module_number:02d}-U{u.order_index + 1:02d}"
+                has_dot = "." in u.unit_number
+                ordinal = int(u.unit_number.split(".")[-1]) if has_dot else 0
+                alt_uid = f"M{module.module_number:02d}-U{ordinal:02d}" if has_dot else uid
+                if uid == current_unit_id or alt_uid == current_unit_id:
+                    current_idx = i
+                    break
+
+        next_lessons = []
+        for u in all_units[current_idx + 1 :]:
+            title = (u.title_fr or u.title_en or "").lower()
+            is_quiz_or_case = any(
+                kw in title
+                for kw in ("quiz", "évaluation", "evaluation", "étude de cas", "case study")
+            )
+            if not is_quiz_or_case:
+                uid = f"M{module.module_number:02d}-U{u.order_index + 1:02d}"
+                next_lessons.append(uid)
+            if len(next_lessons) >= count:
+                break
+
+        return next_lessons
+
+    async def _is_cached(
+        session: AsyncSession,
+        module_uuid: uuid.UUID,
+        unit_id: str,
+        language: str,
+        level: int,
+        country: str,
+    ) -> bool:
+        """Return True if lesson content already exists in generated_content cache."""
+        result = await session.execute(
+            select(GeneratedContent.id).where(
+                GeneratedContent.module_id == module_uuid,
+                GeneratedContent.content_type == "lesson",
+                GeneratedContent.language == language,
+                GeneratedContent.content["unit_id"].astext == unit_id,
+            )
+        )
+        return result.scalar_one_or_none() is not None
+
+    async def _run() -> dict:
+        engine = create_async_engine(settings.database_url, echo=False, pool_size=5, max_overflow=2)
+        session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        prefetched: list[str] = []
+        skipped: list[str] = []
+        errors: list[str] = []
+
+        try:
+            async with session_factory() as session:
+                if module_id:
+                    module_uuid = uuid.UUID(module_id)
+                elif module_number is not None:
+                    mod_result = await session.execute(
+                        select(Module).where(Module.module_number == module_number)
+                    )
+                    mod = mod_result.scalar_one_or_none()
+                    if not mod:
+                        logger.warning(
+                            "Module not found for prefetch",
+                            module_number=module_number,
+                            user_id=user_id,
+                        )
+                        return {
+                            "status": "skipped",
+                            "reason": "module_not_found",
+                            "prefetched": [],
+                            "skipped": [],
+                            "errors": [],
+                        }
+                    module_uuid = mod.id
+                else:
+                    logger.warning(
+                        "prefetch_next_lessons_task called with no module_id or module_number",
+                        user_id=user_id,
+                    )
+                    return {
+                        "status": "skipped",
+                        "reason": "no_module",
+                        "prefetched": [],
+                        "skipped": [],
+                        "errors": [],
+                    }
+
+                next_unit_ids = await _get_next_lesson_unit_ids(
+                    session, module_uuid, current_unit_id
+                )
+
+                logger.info(
+                    "Pre-fetching lessons",
+                    user_id=user_id,
+                    units=next_unit_ids,
+                )
+
+                embedding_service = EmbeddingService(
+                    api_key=settings.openai_api_key, model=settings.embedding_model
+                )
+                retriever = SemanticRetriever(embedding_service)
+                lesson_service = LessonGenerationService(ClaudeService(), retriever)
+
+                for unit_id_str in next_unit_ids:
+                    try:
+                        cached = await _is_cached(
+                            session, module_uuid, unit_id_str, language, level, country
+                        )
+                        if cached:
+                            skipped.append(unit_id_str)
+                            logger.info(
+                                "Skipping already cached lesson",
+                                unit_id=unit_id_str,
+                                user_id=user_id,
+                            )
+                            continue
+
+                        await lesson_service.get_or_generate_lesson(
+                            module_id=module_uuid,
+                            unit_id=unit_id_str,
+                            language=language,
+                            country=country,
+                            level=level,
+                            session=session,
+                        )
+                        prefetched.append(unit_id_str)
+                        logger.info(
+                            "Lesson pre-fetched",
+                            unit_id=unit_id_str,
+                            user_id=user_id,
+                        )
+                    except Exception as exc:
+                        errors.append(unit_id_str)
+                        logger.error(
+                            "Failed to pre-fetch lesson",
+                            unit_id=unit_id_str,
+                            user_id=user_id,
+                            error=str(exc),
+                        )
+        finally:
+            await engine.dispose()
+
+        return {
+            "status": "complete",
+            "prefetched": prefetched,
+            "skipped": skipped,
+            "errors": errors,
+        }
+
+    try:
+        result = asyncio.run(_run())
+        logger.info(
+            "Lesson prefetch completed",
+            user_id=user_id,
+            module_id=module_id,
+            result=result,
+            task_id=self.request.id,
+        )
+        return result
+    except Exception as exc:
+        logger.error(
+            "Lesson prefetch task failed",
+            user_id=user_id,
+            module_id=module_id,
+            exception=str(exc),
+            task_id=self.request.id,
+        )
+        return {"status": "failed", "error": str(exc)}
+
+
+@celery_app.task(
+    bind=True,
+    base=CallbackTask,
     soft_time_limit=600,
     time_limit=660,
     rate_limit="1/m",

--- a/backend/tests/test_prefetch_lessons.py
+++ b/backend/tests/test_prefetch_lessons.py
@@ -1,0 +1,213 @@
+"""Tests for lesson prefetch feature: task helpers and progress service dispatch."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.domain.models.module import Module
+from app.domain.models.progress import UserModuleProgress
+from app.domain.services.progress_service import ProgressService
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def user_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def module_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def mock_db():
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    return db
+
+
+@pytest.fixture
+def progress_service(mock_db):
+    return ProgressService(mock_db)
+
+
+# ---------------------------------------------------------------------------
+# Tests: _dispatch_prefetch does not raise even if Celery is unavailable
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchPrefetch:
+    def test_dispatch_prefetch_does_not_raise_on_celery_error(
+        self, progress_service, user_id, module_id
+    ):
+        with patch("app.tasks.content_generation.prefetch_next_lessons_task") as mock_task:
+            mock_task.apply_async.side_effect = Exception("Celery unavailable")
+            progress_service._dispatch_prefetch(user_id, str(module_id), "M01-U01")
+
+    def test_dispatch_prefetch_calls_apply_async(self, progress_service, user_id, module_id):
+        with patch(
+            "app.domain.services.progress_service.prefetch_next_lessons_task",
+            create=True,
+        ) as mock_task:
+            mock_task.apply_async = MagicMock()
+
+            with patch(
+                "app.tasks.content_generation.prefetch_next_lessons_task",
+                mock_task,
+            ):
+                progress_service._dispatch_prefetch(user_id, str(module_id), "M01-U01")
+
+
+# ---------------------------------------------------------------------------
+# Tests: update_progress_after_quiz dispatches prefetch when passed=True
+# ---------------------------------------------------------------------------
+
+
+class TestPrefetchDispatchedOnQuizPass:
+    async def test_prefetch_dispatched_when_quiz_passed(
+        self, progress_service, mock_db, user_id, module_id
+    ):
+        existing_progress = UserModuleProgress(
+            user_id=user_id,
+            module_id=module_id,
+            status="in_progress",
+            completion_pct=0.0,
+            quiz_score_avg=None,
+            time_spent_minutes=0,
+            last_accessed=None,
+        )
+
+        call_count = 0
+
+        async def mock_execute(query):
+            nonlocal call_count
+            call_count += 1
+            mock_result = MagicMock()
+            if call_count == 1:
+                mock_result.scalar_one_or_none = MagicMock(return_value=existing_progress)
+            elif call_count == 2:
+                mock_result.scalar = MagicMock(return_value=1)
+            elif call_count == 3:
+                mock_result.all = MagicMock(return_value=[])
+            else:
+                mock_result.scalar_one_or_none = MagicMock(return_value=None)
+                mock_result.scalar = MagicMock(return_value=None)
+            return mock_result
+
+        mock_db.execute = mock_execute
+        dispatch_calls = []
+
+        def capture_dispatch(uid, mid, cuid):
+            dispatch_calls.append((uid, mid, cuid))
+
+        progress_service._dispatch_prefetch = capture_dispatch
+
+        await progress_service.update_progress_after_quiz(
+            user_id=user_id,
+            module_id=module_id,
+            unit_id="M01-U01",
+            score=85.0,
+            passed=True,
+        )
+
+        assert len(dispatch_calls) == 1
+        assert dispatch_calls[0][2] == "M01-U01"
+
+    async def test_prefetch_not_dispatched_when_quiz_failed(
+        self, progress_service, mock_db, user_id, module_id
+    ):
+        existing_progress = UserModuleProgress(
+            user_id=user_id,
+            module_id=module_id,
+            status="in_progress",
+            completion_pct=0.0,
+            quiz_score_avg=None,
+            time_spent_minutes=0,
+            last_accessed=None,
+        )
+        mock_db.execute = AsyncMock(
+            return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=existing_progress))
+        )
+        dispatch_calls = []
+
+        def capture_dispatch(uid, mid, cuid):
+            dispatch_calls.append((uid, mid, cuid))
+
+        progress_service._dispatch_prefetch = capture_dispatch
+
+        await progress_service.update_progress_after_quiz(
+            user_id=user_id,
+            module_id=module_id,
+            unit_id="M01-U01",
+            score=60.0,
+            passed=False,
+        )
+
+        assert len(dispatch_calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: _unlock_next_module dispatches prefetch for the new module
+# ---------------------------------------------------------------------------
+
+
+class TestPrefetchDispatchedOnModuleUnlock:
+    async def test_prefetch_dispatched_when_next_module_unlocked(
+        self, progress_service, mock_db, user_id, module_id
+    ):
+        next_module_id = uuid.uuid4()
+        current_module = Module(
+            id=module_id,
+            module_number=1,
+            level=1,
+            title_fr="M01",
+            title_en="M01",
+            estimated_hours=20,
+        )
+        next_module = Module(
+            id=next_module_id,
+            module_number=2,
+            level=1,
+            title_fr="M02",
+            title_en="M02",
+            estimated_hours=20,
+        )
+
+        call_count = 0
+
+        async def mock_execute(query):
+            nonlocal call_count
+            call_count += 1
+            mock_result = MagicMock()
+            if call_count == 1:
+                mock_result.scalar_one_or_none = MagicMock(return_value=current_module)
+            elif call_count == 2:
+                mock_result.scalar_one_or_none = MagicMock(return_value=next_module)
+            elif call_count == 3:
+                mock_result.scalar_one_or_none = MagicMock(return_value=None)
+            else:
+                mock_result.scalar_one_or_none = MagicMock(return_value=None)
+            return mock_result
+
+        mock_db.execute = mock_execute
+
+        dispatch_calls = []
+
+        def capture_dispatch(uid, mid, cuid):
+            dispatch_calls.append((uid, mid, cuid))
+
+        progress_service._dispatch_prefetch = capture_dispatch
+
+        await progress_service._unlock_next_module(user_id, module_id)
+
+        assert len(dispatch_calls) == 1
+        assert dispatch_calls[0][1] == str(next_module_id)
+        assert dispatch_calls[0][2] == ""


### PR DESCRIPTION
## Summary

- Adds `prefetch_next_lessons_task` Celery task to pre-generate the next 2 lessons for a learner, eliminating the "Génération du contenu..." wait on first access
- Triggers on registration (both TOTP and email OTP flows), on quiz pass, and when a new module is unlocked
- Already-cached content is skipped; all dispatch errors are caught and logged as warnings (never raised)

## Changes

- `backend/app/tasks/content_generation.py` — new `prefetch_next_lessons_task` with `_get_next_lesson_unit_ids` and `_is_cached` inner helpers; supports module lookup by UUID or module_number
- `backend/app/domain/services/local_auth_service.py` — dispatch prefetch in `verify_totp_setup` and `verify_email_otp_registration` (M01, first 2 lessons)
- `backend/app/domain/services/progress_service.py` — `_dispatch_prefetch` (fire-and-forget), `_dispatch_prefetch_after_quiz`, triggered from `update_progress_after_quiz` and `_unlock_next_module`
- `backend/tests/test_prefetch_lessons.py` — 5 new unit tests

## Test plan

- [x] Backend lint (`ruff check`) passes with 0 errors
- [x] All 34 tests pass (`pytest tests/test_prefetch_lessons.py tests/test_progress_service.py`)
- [ ] Manually verify: register a new user → Celery logs show `prefetch_next_lessons_task` dispatched for M01
- [ ] Manually verify: pass a quiz → task dispatched with current unit_id
- [ ] Manually verify: complete a module → task dispatched for next module's first 2 lessons
- [ ] Manually verify: already-cached lesson → skipped (no duplicate Claude API call)

Closes #514

Generated with [Claude Code](https://claude.ai/code)