### PR TITLE
fix(images): re-apply API_BASE prefix for lesson images

### DIFF
--- a/frontend/components/learning/lesson-image.tsx
+++ b/frontend/components/learning/lesson-image.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import { X } from 'lucide-react';
 import Image from 'next/image';
-import { getLessonImageStatus } from '@/lib/api';
+import { getLessonImageStatus, API_BASE } from '@/lib/api';
 import type { LessonImageStatus } from '@/lib/api';
 
 const POLL_INTERVAL_MS = 3000;
@@ -43,7 +43,10 @@ export function LessonImage({ lessonId, language }: LessonImageProps) {
               ? (data.alt_text_fr ?? data.alt_text ?? '')
               : (data.alt_text_en ?? data.alt_text ?? '');
           setAltText(alt);
-          setImageUrl(data.url);
+          const resolvedUrl = data.url.startsWith('/')
+            ? `${API_BASE}${data.url}`
+            : data.url;
+          setImageUrl(resolvedUrl);
           setTimeout(() => setIsVisible(true), 50);
           return;
         }

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -33,6 +33,11 @@ const nextConfig: NextConfig = {
         hostname: "**.railway.app",
         pathname: "/api/**",
       },
+      {
+        protocol: "https",
+        hostname: "api.elearning.portfolio2.kimbetien.com",
+        pathname: "/api/**",
+      },
     ],
   },
 


### PR DESCRIPTION
## Summary
Lesson images are broken in production — showing as empty placeholders. The image URL `/api/v1/images/{id}/data` is relative and hits the frontend server (404) instead of the backend API.

## Root cause
PR #499 fixed this by prepending `API_BASE`, but PR #500 (perf optimizations) was merged after and overwrote the fix when converting `<img>` to `<Image>`.

## Changes
- Re-apply `API_BASE` prefix in `lesson-image.tsx` for relative image URLs  
- Add `api.elearning.portfolio2.kimbetien.com` to `next.config.ts` `remotePatterns` so Next.js Image Optimization can proxy backend images

Closes #490