### PR TITLE
fix(admin): role filter causes 500 error due to VARCHAR/enum type mismatch

### DIFF
--- a/backend/app/api/v1/admin.py
+++ b/backend/app/api/v1/admin.py
@@ -92,7 +92,7 @@ async def export_users_csv(
         if level is not None:
             stmt = stmt.where(User.current_level == level)
         if role is not None:
-            stmt = stmt.where(User.role == role)
+            stmt = stmt.where(User.role == role.value)
         if is_active is not None:
             stmt = stmt.where(User.is_active == is_active)
 
@@ -174,7 +174,7 @@ async def count_users(
         if level is not None:
             stmt = stmt.where(User.current_level == level)
         if role is not None:
-            stmt = stmt.where(User.role == role)
+            stmt = stmt.where(User.role == role.value)
         if is_active is not None:
             stmt = stmt.where(User.is_active == is_active)
 
@@ -212,7 +212,7 @@ async def list_users(
         if level is not None:
             stmt = stmt.where(User.current_level == level)
         if role is not None:
-            stmt = stmt.where(User.role == role)
+            stmt = stmt.where(User.role == role.value)
         if is_active is not None:
             stmt = stmt.where(User.is_active == is_active)
 


### PR DESCRIPTION
## Summary

Fixes `GET /api/v1/admin/users?role=admin` returning `{"detail":"Failed to retrieve users"}`.

When the `users.role` column exists as `VARCHAR` (e.g. added via manual `ALTER TABLE` without the `userrole` ENUM type), SQLAlchemy's `Enum` column emits a typed cast like `WHERE role = 'admin'::userrole`, which causes a PostgreSQL type mismatch error.

## Fix

Changed all 3 role filter clauses in `admin.py` from:
```python
stmt = stmt.where(User.role == role)
```
to:
```python
stmt = stmt.where(User.role == role.value)
```

Using `.value` (the raw string `"admin"`, `"expert"`, `"user"`) emits an untyped literal in the SQL query, which PostgreSQL can implicitly cast to either `VARCHAR` or `userrole` enum — making the filter work regardless of the underlying column type.

## Changes

- `backend/app/api/v1/admin.py` — fixed role filter in `list_users`, `count_users`, and `export_users_csv`

## Test plan

- [ ] Backend lint passes (`ruff check`)
- [ ] `GET /api/v1/admin/users?role=admin` returns users instead of 500
- [ ] `GET /api/v1/admin/users?role=user` and `?role=expert` also work
- [ ] Other filters (search, country, level, is_active) still work

Closes #534

Generated with [Claude Code](https://claude.ai/code)