### PR TITLE
fix(ci): unblock pipeline — lockfile sync, pytest loop_scope, concurrency race fix

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,11 +10,15 @@ on:
 
 concurrency:
   group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
-  # Gate: only 2 Claude runs at a time across all issues to avoid starving CI
+  # Gate: filter non-claude events early, then limit to 2 concurrent Claude runs
   gate:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && github.event.label.name == 'claude' && github.event.issue.state == 'open')
     runs-on: ubuntu-latest
     concurrency:
       group: claude-global-gate
@@ -24,10 +28,6 @@ jobs:
 
   claude:
     needs: gate
-    if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'issues' && github.event.label.name == 'claude' && github.event.issue.state == 'open')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- **claude.yml**: Add `npm install` to STEP 3 so Claude PRs commit updated lockfiles
- **claude.yml**: Move `if` condition to gate job + `cancel-in-progress: false` to fix label race that killed Claude runs
- **pyproject.toml**: Add `loop_scope = "session"` to fix async event loop mismatch in pytest
- **claude-next.yml**: Trigger on dev merges (not just main) so auto-queue chain works

## Why
Every Claude PR was failing CI because of stale lockfiles. The Claude workflow itself had a concurrency race: when issues got multiple labels simultaneously (claude + bug + priority:critical), the `cancel-in-progress: true` was killing the claude-label run in favor of a bug-label run, which then got skipped.

## Test plan
- [x] CI passes on dev (both backend + frontend)
- [ ] After merge to main, Claude workflow picks up issues #546, #547, #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)