### PR TITLE
feat(admin): course management UI — list, create, publish, archive, AI generate

### DIFF
--- a/frontend/app/[locale]/admin/courses/page.tsx
+++ b/frontend/app/[locale]/admin/courses/page.tsx
@@ -1,0 +1,23 @@
+import { getTranslations } from 'next-intl/server';
+import { CoursesClient } from '@/components/admin/courses-client';
+
+export async function generateMetadata() {
+  const t = await getTranslations('AdminCourses');
+  return {
+    title: t('pageTitle'),
+    description: t('pageDescription'),
+  };
+}
+
+export default async function AdminCoursesPage() {
+  const t = await getTranslations('AdminCourses');
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <div className="border-b bg-background p-4 shrink-0">
+        <h1 className="text-2xl font-bold">{t('pageTitle')}</h1>
+        <p className="text-muted-foreground mt-1">{t('pageDescription')}</p>
+      </div>
+      <CoursesClient />
+    </div>
+  );
+}

--- a/frontend/components/admin/admin-nav.tsx
+++ b/frontend/components/admin/admin-nav.tsx
@@ -12,6 +12,8 @@ export function AdminNav() {
 
   const items = [
     { href: `/${locale}/admin/users`, label: t("users.title") },
+    { href: `/${locale}/admin/courses`, label: t("courses.title") },
+    { href: `/${locale}/admin/syllabus`, label: t("syllabus.title") },
     { href: `/${locale}/admin/settings`, label: t("settings.title") },
     { href: `/${locale}/admin/audit-logs`, label: t("auditLog.title") },
   ];

--- a/frontend/components/admin/course-form.tsx
+++ b/frontend/components/admin/course-form.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
+import { X, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { apiFetch } from '@/lib/api';
+import { authClient, AuthError } from '@/lib/auth';
+import type { AdminCourse } from './courses-client';
+
+interface CourseFormProps {
+  course: AdminCourse | null;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+interface CoursePayload {
+  title_fr: string;
+  title_en: string;
+  domain: string;
+  target_audience: string;
+  estimated_hours: number;
+  cover_image_url: string;
+}
+
+export function CourseForm({ course, onClose, onSaved }: CourseFormProps) {
+  const t = useTranslations('AdminCourses');
+  const router = useRouter();
+
+  const [titleFr, setTitleFr] = useState(course?.title_fr ?? '');
+  const [titleEn, setTitleEn] = useState(course?.title_en ?? '');
+  const [domain, setDomain] = useState(course?.domain ?? '');
+  const [targetAudience, setTargetAudience] = useState(course?.target_audience ?? '');
+  const [estimatedHours, setEstimatedHours] = useState<string>(
+    course ? String(course.estimated_hours) : ''
+  );
+  const [coverImageUrl, setCoverImageUrl] = useState(course?.cover_image_url ?? '');
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  const validate = () => {
+    const errors: Record<string, string> = {};
+    if (!titleFr.trim()) errors.titleFr = t('fieldRequired');
+    if (!titleEn.trim()) errors.titleEn = t('fieldRequired');
+    const hours = parseFloat(estimatedHours);
+    if (!estimatedHours || isNaN(hours) || hours <= 0) {
+      errors.estimatedHours = t('fieldInvalidHours');
+    }
+    return errors;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaveError(null);
+    const errors = validate();
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return;
+    }
+    setFieldErrors({});
+    setIsSaving(true);
+
+    const payload: CoursePayload = {
+      title_fr: titleFr.trim(),
+      title_en: titleEn.trim(),
+      domain: domain.trim(),
+      target_audience: targetAudience.trim(),
+      estimated_hours: parseFloat(estimatedHours),
+      cover_image_url: coverImageUrl.trim(),
+    };
+
+    try {
+      let token: string;
+      try {
+        token = await authClient.getValidToken();
+      } catch (err) {
+        if (err instanceof AuthError && err.status === 401) {
+          router.push('/login');
+          return;
+        }
+        throw err;
+      }
+
+      const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+      if (course) {
+        await fetch(`${API_BASE}/api/v1/admin/courses/${course.id}`, {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(payload),
+        }).then(async (res) => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        });
+      } else {
+        await apiFetch('/api/v1/admin/courses', {
+          method: 'POST',
+          body: JSON.stringify(payload),
+        });
+      }
+
+      onSaved();
+    } catch {
+      setSaveError(t('saveError'));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-label={course ? t('editCourse') : t('createCourse')}
+    >
+      <div
+        className="fixed inset-0 bg-black/40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div className="relative z-10 w-full max-w-lg bg-background rounded-t-2xl sm:rounded-2xl shadow-xl flex flex-col max-h-[90dvh]">
+        <div className="flex items-center justify-between px-4 pt-4 pb-3 border-b shrink-0">
+          <h2 className="text-base font-semibold">
+            {course ? t('editCourse') : t('createCourse')}
+          </h2>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="min-h-11 min-w-11 p-2"
+            onClick={onClose}
+            aria-label={t('close')}
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </Button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0 overflow-y-auto p-4 gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="course-title-fr">{t('titleFr')}</Label>
+            <Input
+              id="course-title-fr"
+              value={titleFr}
+              onChange={(e) => setTitleFr(e.target.value)}
+              placeholder={t('titleFrPlaceholder')}
+              className="min-h-11"
+              aria-describedby={fieldErrors.titleFr ? 'error-title-fr' : undefined}
+              aria-invalid={!!fieldErrors.titleFr}
+            />
+            {fieldErrors.titleFr && (
+              <p id="error-title-fr" className="text-xs text-destructive" role="alert">
+                {fieldErrors.titleFr}
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="course-title-en">{t('titleEn')}</Label>
+            <Input
+              id="course-title-en"
+              value={titleEn}
+              onChange={(e) => setTitleEn(e.target.value)}
+              placeholder={t('titleEnPlaceholder')}
+              className="min-h-11"
+              aria-describedby={fieldErrors.titleEn ? 'error-title-en' : undefined}
+              aria-invalid={!!fieldErrors.titleEn}
+            />
+            {fieldErrors.titleEn && (
+              <p id="error-title-en" className="text-xs text-destructive" role="alert">
+                {fieldErrors.titleEn}
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="course-domain">{t('domain')}</Label>
+            <Input
+              id="course-domain"
+              value={domain}
+              onChange={(e) => setDomain(e.target.value)}
+              placeholder={t('domainPlaceholder')}
+              className="min-h-11"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="course-audience">{t('targetAudience')}</Label>
+            <Input
+              id="course-audience"
+              value={targetAudience}
+              onChange={(e) => setTargetAudience(e.target.value)}
+              placeholder={t('targetAudiencePlaceholder')}
+              className="min-h-11"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="course-hours">{t('estimatedHoursField')}</Label>
+            <Input
+              id="course-hours"
+              type="number"
+              min="1"
+              step="0.5"
+              value={estimatedHours}
+              onChange={(e) => setEstimatedHours(e.target.value)}
+              placeholder="40"
+              className="min-h-11"
+              aria-describedby={fieldErrors.estimatedHours ? 'error-hours' : undefined}
+              aria-invalid={!!fieldErrors.estimatedHours}
+            />
+            {fieldErrors.estimatedHours && (
+              <p id="error-hours" className="text-xs text-destructive" role="alert">
+                {fieldErrors.estimatedHours}
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="course-cover">{t('coverImageUrl')}</Label>
+            <Input
+              id="course-cover"
+              value={coverImageUrl}
+              onChange={(e) => setCoverImageUrl(e.target.value)}
+              placeholder="https://..."
+              className="min-h-11"
+            />
+          </div>
+
+          {saveError && (
+            <p className="text-sm text-destructive" role="alert">{saveError}</p>
+          )}
+
+          <div className="flex justify-end gap-3 pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              className="min-h-11"
+            >
+              {t('cancel')}
+            </Button>
+            <Button
+              type="submit"
+              disabled={isSaving}
+              className="min-h-11 gap-2"
+            >
+              {isSaving && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
+              {t('save')}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/admin/courses-client.tsx
+++ b/frontend/components/admin/courses-client.tsx
@@ -1,0 +1,412 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useTranslations, useLocale } from 'next-intl';
+import { useRouter } from 'next/navigation';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  Plus,
+  MoreVertical,
+  Globe,
+  Archive,
+  Sparkles,
+  Loader2,
+  AlertCircle,
+  BookOpen,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+} from '@/components/ui/alert-dialog';
+import { apiFetch } from '@/lib/api';
+import { authClient, AuthError } from '@/lib/auth';
+import { CourseForm } from '@/components/admin/course-form';
+
+export interface AdminCourse {
+  id: string;
+  title_fr: string;
+  title_en: string;
+  domain: string | null;
+  target_audience: string | null;
+  estimated_hours: number;
+  cover_image_url: string | null;
+  status: 'draft' | 'published' | 'archived';
+  created_at: string;
+  updated_at: string;
+  module_count?: number;
+}
+
+type PendingAction =
+  | { type: 'publish'; course: AdminCourse }
+  | { type: 'archive'; course: AdminCourse }
+  | { type: 'generate'; course: AdminCourse };
+
+function useAdminCourses() {
+  return useQuery<AdminCourse[]>({
+    queryKey: ['admin', 'courses'],
+    queryFn: () => apiFetch<AdminCourse[]>('/api/v1/admin/courses'),
+  });
+}
+
+export function CoursesClient() {
+  const t = useTranslations('AdminCourses');
+  const locale = useLocale();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingCourse, setEditingCourse] = useState<AdminCourse | null>(null);
+  const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [generatingId, setGeneratingId] = useState<string | null>(null);
+
+  const { data: courses, isLoading, error, refetch } = useAdminCourses();
+
+  const publishMutation = useMutation({
+    mutationFn: (courseId: string) =>
+      apiFetch(`/api/v1/admin/courses/${courseId}/publish`, { method: 'POST' }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'courses'] });
+      setPendingAction(null);
+      setActionError(null);
+    },
+    onError: () => setActionError(t('actionError')),
+  });
+
+  const archiveMutation = useMutation({
+    mutationFn: (courseId: string) =>
+      apiFetch(`/api/v1/admin/courses/${courseId}/archive`, { method: 'POST' }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'courses'] });
+      setPendingAction(null);
+      setActionError(null);
+    },
+    onError: () => setActionError(t('actionError')),
+  });
+
+  const handleConfirmAction = () => {
+    if (!pendingAction) return;
+    if (pendingAction.type === 'publish') {
+      publishMutation.mutate(pendingAction.course.id);
+    } else if (pendingAction.type === 'archive') {
+      archiveMutation.mutate(pendingAction.course.id);
+    }
+  };
+
+  const handleGenerateStructure = useCallback(
+    async (course: AdminCourse) => {
+      setGeneratingId(course.id);
+      setActionError(null);
+      try {
+        let token: string;
+        try {
+          token = await authClient.getValidToken();
+        } catch (err) {
+          if (err instanceof AuthError && err.status === 401) {
+            router.push(`/${locale}/login`);
+            return;
+          }
+          throw err;
+        }
+        const res = await fetch(
+          `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/v1/admin/courses/${course.id}/generate-structure`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${token}`,
+              'Content-Type': 'application/json',
+            },
+          }
+        );
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        queryClient.invalidateQueries({ queryKey: ['admin', 'courses'] });
+      } catch {
+        setActionError(t('generateError'));
+      } finally {
+        setGeneratingId(null);
+        setPendingAction(null);
+      }
+    },
+    [router, locale, queryClient, t]
+  );
+
+  const handleFormSaved = () => {
+    setFormOpen(false);
+    setEditingCourse(null);
+    queryClient.invalidateQueries({ queryKey: ['admin', 'courses'] });
+  };
+
+  const confirmTitle =
+    pendingAction?.type === 'publish'
+      ? t('confirmPublish')
+      : pendingAction?.type === 'archive'
+        ? t('confirmArchive')
+        : t('confirmGenerate');
+
+  const confirmDesc =
+    pendingAction?.type === 'publish'
+      ? t('confirmPublishDesc')
+      : pendingAction?.type === 'archive'
+        ? t('confirmArchiveDesc')
+        : t('confirmGenerateDesc');
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-8">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
+        <AlertCircle className="h-10 w-10 text-destructive" />
+        <p className="text-sm text-muted-foreground">{t('errorLoading')}</p>
+        <Button variant="outline" onClick={() => refetch()}>
+          {t('retry')}
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-4">
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-sm text-muted-foreground">
+            {t('courseCount', { count: courses?.length ?? 0 })}
+          </p>
+          <Button
+            onClick={() => { setEditingCourse(null); setFormOpen(true); }}
+            className="gap-2 min-h-11"
+          >
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            {t('createCourse')}
+          </Button>
+        </div>
+
+        {actionError && (
+          <p className="text-sm text-destructive" role="alert">{actionError}</p>
+        )}
+
+        {!courses || courses.length === 0 ? (
+          <div className="py-16 text-center">
+            <BookOpen className="h-12 w-12 text-muted-foreground mx-auto mb-4" aria-hidden="true" />
+            <p className="font-medium text-muted-foreground">{t('noCourses')}</p>
+            <p className="text-sm text-muted-foreground mt-1">{t('noCoursesDescription')}</p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {courses.map((course) => (
+              <CourseRow
+                key={course.id}
+                course={course}
+                generatingId={generatingId}
+                onPublish={(c) => setPendingAction({ type: 'publish', course: c })}
+                onArchive={(c) => setPendingAction({ type: 'archive', course: c })}
+                onGenerateStructure={(c) => setPendingAction({ type: 'generate', course: c })}
+                onEdit={(c) => { setEditingCourse(c); setFormOpen(true); }}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {formOpen && (
+        <CourseForm
+          course={editingCourse}
+          onClose={() => { setFormOpen(false); setEditingCourse(null); }}
+          onSaved={handleFormSaved}
+        />
+      )}
+
+      <AlertDialog
+        open={pendingAction !== null && pendingAction.type !== 'generate'}
+        onOpenChange={(open) => !open && setPendingAction(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogTitle>{confirmTitle}</AlertDialogTitle>
+          <AlertDialogDescription>{confirmDesc}</AlertDialogDescription>
+          <div className="flex justify-end gap-3 mt-4">
+            <AlertDialogCancel onClick={() => setPendingAction(null)}>
+              {t('cancel')}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmAction}
+              disabled={publishMutation.isPending || archiveMutation.isPending}
+            >
+              {t('confirm')}
+            </AlertDialogAction>
+          </div>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={pendingAction?.type === 'generate'}
+        onOpenChange={(open) => !open && setPendingAction(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogTitle>{confirmTitle}</AlertDialogTitle>
+          <AlertDialogDescription>{confirmDesc}</AlertDialogDescription>
+          <div className="flex justify-end gap-3 mt-4">
+            <AlertDialogCancel onClick={() => setPendingAction(null)}>
+              {t('cancel')}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (pendingAction?.type === 'generate') {
+                  handleGenerateStructure(pendingAction.course);
+                }
+              }}
+              disabled={generatingId !== null}
+            >
+              {generatingId !== null ? (
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+              ) : (
+                t('confirm')
+              )}
+            </AlertDialogAction>
+          </div>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+function CourseRow({
+  course,
+  generatingId,
+  onPublish,
+  onArchive,
+  onGenerateStructure,
+  onEdit,
+}: {
+  course: AdminCourse;
+  generatingId: string | null;
+  onPublish: (c: AdminCourse) => void;
+  onArchive: (c: AdminCourse) => void;
+  onGenerateStructure: (c: AdminCourse) => void;
+  onEdit: (c: AdminCourse) => void;
+}) {
+  const t = useTranslations('AdminCourses');
+  const locale = useLocale();
+
+  const title = locale === 'fr' ? course.title_fr : course.title_en;
+
+  const statusVariant =
+    course.status === 'published'
+      ? 'default'
+      : course.status === 'archived'
+        ? 'secondary'
+        : 'outline';
+
+  const isGenerating = generatingId === course.id;
+
+  return (
+    <Card className="p-4">
+      <div className="flex items-start justify-between gap-3">
+        <button
+          className="flex flex-col gap-1 text-left min-w-0 flex-1"
+          onClick={() => onEdit(course)}
+          aria-label={t('editCourse')}
+        >
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-medium text-sm truncate">{title}</span>
+            <Badge variant={statusVariant}>{t(`status.${course.status}`)}</Badge>
+          </div>
+          {course.domain && (
+            <span className="text-xs text-muted-foreground">{course.domain}</span>
+          )}
+          <div className="flex items-center gap-3 mt-1 flex-wrap">
+            <span className="text-xs text-muted-foreground">
+              {t('estimatedHours', { hours: course.estimated_hours })}
+            </span>
+            {course.module_count !== undefined && (
+              <span className="text-xs text-muted-foreground">
+                {t('moduleCount', { count: course.module_count })}
+              </span>
+            )}
+          </div>
+        </button>
+
+        <div className="flex items-center gap-2 shrink-0">
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1.5 min-h-11 hidden sm:flex"
+            onClick={() => onGenerateStructure(course)}
+            disabled={isGenerating}
+            aria-label={t('generateStructure')}
+          >
+            {isGenerating ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <Sparkles className="h-4 w-4" aria-hidden="true" />
+            )}
+            <span className="hidden md:inline">{t('generateStructure')}</span>
+          </Button>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="min-h-11 min-w-11 p-2 shrink-0"
+                  aria-label={t('actions')}
+                />
+              }
+            >
+              <MoreVertical className="h-4 w-4" aria-hidden="true" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => onEdit(course)}>
+                <BookOpen className="mr-2 h-4 w-4" />
+                {t('editCourse')}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="sm:hidden"
+                onClick={() => onGenerateStructure(course)}
+                disabled={isGenerating}
+              >
+                <Sparkles className="mr-2 h-4 w-4" />
+                {t('generateStructure')}
+              </DropdownMenuItem>
+              {course.status !== 'published' && (
+                <DropdownMenuItem onClick={() => onPublish(course)}>
+                  <Globe className="mr-2 h-4 w-4" />
+                  {t('publish')}
+                </DropdownMenuItem>
+              )}
+              {course.status !== 'archived' && (
+                <DropdownMenuItem
+                  onClick={() => onArchive(course)}
+                  className="text-destructive"
+                >
+                  <Archive className="mr-2 h-4 w-4" />
+                  {t('archive')}
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -771,6 +771,12 @@
     "admin": "Administrator"
   },
   "Admin": {
+    "courses": {
+      "title": "Courses"
+    },
+    "syllabus": {
+      "title": "Syllabus"
+    },
     "settings": {
       "title": "Platform Settings",
       "subtitle": "Configure platform-wide parameters",
@@ -869,6 +875,53 @@
         "update_role": "Updated role"
       }
     }
+  },
+  "AdminCourses": {
+    "pageTitle": "Course Management",
+    "pageDescription": "Create, publish and manage courses with AI",
+    "createCourse": "Create course",
+    "editCourse": "Edit course",
+    "courseCount": "{count, plural, one {# course} other {# courses}}",
+    "noCourses": "No courses yet",
+    "noCoursesDescription": "Create your first course to get started.",
+    "status": {
+      "draft": "Draft",
+      "published": "Published",
+      "archived": "Archived"
+    },
+    "estimatedHours": "{hours} h estimated",
+    "moduleCount": "{count, plural, one {# module} other {# modules}}",
+    "generateStructure": "Generate structure",
+    "generateError": "Generation failed. Please try again.",
+    "publish": "Publish",
+    "archive": "Archive",
+    "actions": "Actions",
+    "cancel": "Cancel",
+    "confirm": "Confirm",
+    "save": "Save",
+    "close": "Close",
+    "titleFr": "Title (FR)",
+    "titleEn": "Title (EN)",
+    "titleFrPlaceholder": "e.g. Épidémiologie en Afrique de l'Ouest",
+    "titleEnPlaceholder": "e.g. Epidemiology in West Africa",
+    "domain": "Domain",
+    "domainPlaceholder": "e.g. Epidemiology, Biostatistics",
+    "targetAudience": "Target audience",
+    "targetAudiencePlaceholder": "e.g. Community health workers",
+    "estimatedHoursField": "Estimated duration (hours)",
+    "coverImageUrl": "Cover image URL",
+    "fieldRequired": "This field is required.",
+    "fieldInvalidHours": "Please enter a valid number of hours.",
+    "saveError": "Failed to save. Please try again.",
+    "errorLoading": "Failed to load courses.",
+    "retry": "Retry",
+    "actionError": "Action failed. Please try again.",
+    "confirmPublish": "Publish course?",
+    "confirmPublishDesc": "The course will be visible to all learners.",
+    "confirmArchive": "Archive course?",
+    "confirmArchiveDesc": "The course will no longer be accessible to learners.",
+    "confirmGenerate": "Generate AI structure?",
+    "confirmGenerateDesc": "The AI will automatically create a module outline for this course. This may take a few seconds."
   },
   "AdminSyllabus": {
     "pageTitle": "Syllabus Management",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -771,6 +771,12 @@
     "admin": "Administrateur"
   },
   "Admin": {
+    "courses": {
+      "title": "Formations"
+    },
+    "syllabus": {
+      "title": "Syllabus"
+    },
     "settings": {
       "title": "Paramètres de la plateforme",
       "subtitle": "Configurer les paramètres globaux",
@@ -869,6 +875,53 @@
         "update_role": "Rôle mis à jour"
       }
     }
+  },
+  "AdminCourses": {
+    "pageTitle": "Gestion des formations",
+    "pageDescription": "Créez, publiez et gérez les formations avec l'IA",
+    "createCourse": "Créer une formation",
+    "editCourse": "Modifier la formation",
+    "courseCount": "{count, plural, one {# formation} other {# formations}}",
+    "noCourses": "Aucune formation",
+    "noCoursesDescription": "Créez votre première formation pour commencer.",
+    "status": {
+      "draft": "Brouillon",
+      "published": "Publié",
+      "archived": "Archivé"
+    },
+    "estimatedHours": "{hours} h estimées",
+    "moduleCount": "{count, plural, one {# module} other {# modules}}",
+    "generateStructure": "Générer la structure",
+    "generateError": "La génération a échoué. Veuillez réessayer.",
+    "publish": "Publier",
+    "archive": "Archiver",
+    "actions": "Actions",
+    "cancel": "Annuler",
+    "confirm": "Confirmer",
+    "save": "Enregistrer",
+    "close": "Fermer",
+    "titleFr": "Titre (FR)",
+    "titleEn": "Titre (EN)",
+    "titleFrPlaceholder": "ex. Épidémiologie en Afrique de l'Ouest",
+    "titleEnPlaceholder": "e.g. Epidemiology in West Africa",
+    "domain": "Domaine",
+    "domainPlaceholder": "ex. Épidémiologie, Biostatistiques",
+    "targetAudience": "Public cible",
+    "targetAudiencePlaceholder": "ex. Agents de santé communautaire",
+    "estimatedHoursField": "Durée estimée (heures)",
+    "coverImageUrl": "URL de l'image de couverture",
+    "fieldRequired": "Ce champ est requis.",
+    "fieldInvalidHours": "Veuillez entrer un nombre d'heures valide.",
+    "saveError": "Erreur lors de l'enregistrement. Veuillez réessayer.",
+    "errorLoading": "Erreur lors du chargement des formations.",
+    "retry": "Réessayer",
+    "actionError": "L'action a échoué. Veuillez réessayer.",
+    "confirmPublish": "Publier la formation ?",
+    "confirmPublishDesc": "La formation sera visible par tous les apprenants.",
+    "confirmArchive": "Archiver la formation ?",
+    "confirmArchiveDesc": "La formation ne sera plus accessible aux apprenants.",
+    "confirmGenerate": "Générer la structure IA ?",
+    "confirmGenerateDesc": "L'IA va créer automatiquement un plan de modules pour cette formation. Cela peut prendre quelques secondes."
   },
   "AdminSyllabus": {
     "pageTitle": "Gestion du syllabus",


### PR DESCRIPTION
## Summary
- New `/[locale]/admin/courses` page for admin course management
- Course list with status badges (draft/published/archived), publish/archive with confirmation dialogs
- Create/edit course form (slide-up overlay): title FR/EN, domain, target audience, estimated hours, cover image URL
- "Generate Structure" AI button calls `POST /api/v1/admin/courses/{id}/generate-structure` with loading state
- Admin nav updated with Courses and Syllabus links
- Full FR/EN i18n via next-intl (`AdminCourses` namespace)
- Mobile-first: 320px+, touch targets ≥ 44×44px

## Changes
- `frontend/app/[locale]/admin/courses/page.tsx` — new server component page
- `frontend/components/admin/courses-client.tsx` — client component: list, actions, dialogs
- `frontend/components/admin/course-form.tsx` — create/edit overlay panel
- `frontend/components/admin/admin-nav.tsx` — added Courses + Syllabus nav items
- `frontend/messages/fr.json` + `frontend/messages/en.json` — `AdminCourses` translations

## Test plan
- [ ] Backend tests pass
- [ ] Frontend lint passes (0 errors in new files)
- [ ] `/fr/admin/courses` and `/en/admin/courses` render correctly
- [ ] Create course form opens, validates required fields, submits
- [ ] Publish/archive confirmation dialogs work
- [ ] Generate Structure button shows loading state and calls AI endpoint
- [ ] Mobile viewport (320px) — touch targets, no overflow

Closes #566

Generated with [Claude Code](https://claude.ai/code)