### PR TITLE
feat(rag): admin RAG indexation API — trigger, track progress, block publish

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from structlog import get_logger
 
 from app.api.deps import get_db as get_db_session
@@ -170,17 +170,170 @@ async def update_course(
     return _course_to_response(course)
 
 
+class IndexStatusResponse(BaseModel):
+    course_id: str
+    job_id: str | None
+    state: str
+    chunk_count: int | None
+    progress_pct: float
+    error_message: str | None
+    created_at: str | None
+    updated_at: str | None
+    completed_at: str | None
+
+
+class TriggerIndexResponse(BaseModel):
+    job_id: str
+    celery_task_id: str
+    state: str
+    message: str
+
+
+async def _get_latest_index_job(db, course_id: uuid.UUID) -> dict | None:
+    result = await db.execute(
+        text(
+            """
+            SELECT id, celery_task_id, state, chunk_count, progress_pct,
+                   error_message, created_at, updated_at, completed_at
+            FROM rag_indexation_jobs
+            WHERE course_id = :course_id
+            ORDER BY created_at DESC
+            LIMIT 1
+            """
+        ),
+        {"course_id": course_id},
+    )
+    row = result.mappings().one_or_none()
+    return dict(row) if row else None
+
+
+@router.post("/{course_id}/index-resources", response_model=TriggerIndexResponse)
+async def trigger_rag_indexation(
+    course_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    db=Depends(get_db_session),
+) -> TriggerIndexResponse:
+    """Trigger RAG indexation for all PDFs uploaded to this course. Admin only."""
+    result = await db.execute(select(Course).where(Course.id == course_id))
+    course = result.scalar_one_or_none()
+    if not course:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
+
+    existing_job = await _get_latest_index_job(db, course_id)
+    if existing_job and existing_job["state"] in ("pending", "extracting", "chunking", "embedding"):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Indexation already in progress (state: {existing_job['state']}). "
+            f"Job ID: {existing_job['id']}",
+        )
+
+    if not course.rag_collection_id:
+        course.rag_collection_id = str(course_id)
+        await db.commit()
+        await db.refresh(course)
+
+    job_id = str(uuid.uuid4())
+    await db.execute(
+        text(
+            """
+            INSERT INTO rag_indexation_jobs (id, course_id, state, progress_pct, created_at)
+            VALUES (:id, :course_id, 'pending', 0.0, NOW())
+            """
+        ),
+        {"id": uuid.UUID(job_id), "course_id": course_id},
+    )
+    await db.commit()
+
+    from app.tasks.rag_indexation import index_course_resources
+
+    task = index_course_resources.apply_async(
+        args=[str(course_id), job_id],
+        task_id=None,
+    )
+
+    await db.execute(
+        text("UPDATE rag_indexation_jobs SET celery_task_id = :task_id WHERE id = :job_id"),
+        {"task_id": task.id, "job_id": uuid.UUID(job_id)},
+    )
+    await db.commit()
+
+    logger.info(
+        "RAG indexation triggered",
+        course_id=str(course_id),
+        job_id=job_id,
+        celery_task_id=task.id,
+        admin_id=current_user.id,
+    )
+    return TriggerIndexResponse(
+        job_id=job_id,
+        celery_task_id=task.id,
+        state="pending",
+        message="RAG indexation started. Poll /index-status for progress.",
+    )
+
+
+@router.get("/{course_id}/index-status", response_model=IndexStatusResponse)
+async def get_index_status(
+    course_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    db=Depends(get_db_session),
+) -> IndexStatusResponse:
+    """Get RAG indexation progress for a course. Admin only."""
+    result = await db.execute(select(Course).where(Course.id == course_id))
+    course = result.scalar_one_or_none()
+    if not course:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
+
+    job = await _get_latest_index_job(db, course_id)
+    if not job:
+        return IndexStatusResponse(
+            course_id=str(course_id),
+            job_id=None,
+            state="not_started",
+            chunk_count=None,
+            progress_pct=0.0,
+            error_message=None,
+            created_at=None,
+            updated_at=None,
+            completed_at=None,
+        )
+
+    return IndexStatusResponse(
+        course_id=str(course_id),
+        job_id=str(job["id"]),
+        state=job["state"],
+        chunk_count=job["chunk_count"],
+        progress_pct=float(job["progress_pct"]),
+        error_message=job["error_message"],
+        created_at=job["created_at"].isoformat() if job["created_at"] else None,
+        updated_at=job["updated_at"].isoformat() if job["updated_at"] else None,
+        completed_at=job["completed_at"].isoformat() if job["completed_at"] else None,
+    )
+
+
 @router.post("/{course_id}/publish", response_model=CourseResponse)
 async def publish_course(
     course_id: uuid.UUID,
     current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
     db=Depends(get_db_session),
 ) -> CourseResponse:
-    """Publish a draft course. Admin only."""
+    """Publish a draft course. Blocked if RAG indexation is not complete. Admin only."""
     result = await db.execute(select(Course).where(Course.id == course_id))
     course = result.scalar_one_or_none()
     if not course:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
+
+    job = await _get_latest_index_job(db, course_id)
+    if not job or job["state"] != "complete":
+        current_state = job["state"] if job else "not_started"
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Cannot publish: RAG indexation must be complete before publishing. "
+                f"Current state: '{current_state}'. "
+                f"Trigger indexation via POST /admin/courses/{course_id}/index-resources first."
+            ),
+        )
 
     course.status = "published"
     course.published_at = datetime.now(UTC)

--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -17,6 +17,7 @@ celery_app = Celery(
         "app.tasks.content_generation",
         "app.tasks.data_etl",
         "app.tasks.file_cleanup",
+        "app.tasks.rag_indexation",
     ],
 )
 

--- a/backend/app/tasks/rag_indexation.py
+++ b/backend/app/tasks/rag_indexation.py
@@ -1,0 +1,263 @@
+"""Celery task for RAG indexation of course PDF resources."""
+
+import asyncio
+import uuid
+from datetime import UTC, datetime
+
+import structlog
+from celery import Task
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.tasks.celery_app import celery_app
+
+logger = structlog.get_logger(__name__)
+
+RAG_SOFT_LIMIT = 1800
+RAG_HARD_LIMIT = 1860
+
+
+class RAGIndexationTask(Task):
+    def on_success(self, retval, task_id, args, kwargs):
+        logger.info("RAG indexation task completed", task_id=task_id, result=retval)
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        logger.error(
+            "RAG indexation task failed",
+            task_id=task_id,
+            exception=str(exc),
+            traceback=einfo.traceback,
+        )
+
+
+async def _update_job_status(
+    session: AsyncSession,
+    job_id: str,
+    state: str,
+    chunk_count: int | None = None,
+    progress_pct: float | None = None,
+    error_message: str | None = None,
+) -> None:
+    now = datetime.now(UTC)
+    fields = ["state = :state", "updated_at = :updated_at"]
+    params: dict = {"job_id": job_id, "state": state, "updated_at": now}
+
+    if chunk_count is not None:
+        fields.append("chunk_count = :chunk_count")
+        params["chunk_count"] = chunk_count
+
+    if progress_pct is not None:
+        fields.append("progress_pct = :progress_pct")
+        params["progress_pct"] = progress_pct
+
+    if error_message is not None:
+        fields.append("error_message = :error_message")
+        params["error_message"] = error_message
+
+    if state == "complete":
+        fields.append("completed_at = :completed_at")
+        params["completed_at"] = now
+
+    set_clause = ", ".join(fields)
+    await session.execute(
+        text(f"UPDATE rag_indexation_jobs SET {set_clause} WHERE id = :job_id"), params
+    )
+    await session.commit()
+
+
+@celery_app.task(
+    bind=True,
+    base=RAGIndexationTask,
+    soft_time_limit=RAG_SOFT_LIMIT,
+    time_limit=RAG_HARD_LIMIT,
+    rate_limit="2/m",
+    max_retries=2,
+)
+def index_course_resources(self, course_id: str, job_id: str) -> dict:
+    """Index all PDFs uploaded for a course into pgvector for RAG retrieval.
+
+    Steps:
+      1. extracting — find uploaded PDF temp files for this course
+      2. chunking   — split text into 512-token chunks
+      3. embedding  — generate OpenAI embeddings for each chunk
+      4. storing    — upsert chunks into document_chunks scoped by rag_collection_id
+      5. indexing   — create/refresh HNSW index on document_chunks
+
+    Args:
+        course_id: UUID string of the course
+        job_id: UUID string of the rag_indexation_jobs row
+
+    Returns:
+        dict with status and chunk_count
+    """
+    from app.ai.rag.embeddings import EmbeddingService
+    from app.ai.rag.pipeline import RAGPipeline
+    from app.infrastructure.config.settings import settings
+
+    logger.info(
+        "Starting RAG indexation",
+        course_id=course_id,
+        job_id=job_id,
+        task_id=self.request.id,
+    )
+
+    async def _run() -> dict:
+        engine = create_async_engine(settings.database_url, echo=False, pool_size=5, max_overflow=2)
+        session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+        try:
+            async with session_factory() as session:
+                await _update_job_status(session, job_id, "extracting", progress_pct=5.0)
+
+                result = await session.execute(
+                    text("SELECT id, slug, rag_collection_id FROM courses WHERE id = :course_id"),
+                    {"course_id": uuid.UUID(course_id)},
+                )
+                course_row = result.mappings().one_or_none()
+                if not course_row:
+                    raise ValueError(f"Course not found: {course_id}")
+
+                rag_collection_id = course_row["rag_collection_id"] or course_id
+                slug = course_row["slug"]
+
+                pdf_result = await session.execute(
+                    text(
+                        """
+                        SELECT file_path, original_name
+                        FROM uploaded_course_pdfs
+                        WHERE course_id = :course_id
+                        ORDER BY uploaded_at
+                        """
+                    ),
+                    {"course_id": uuid.UUID(course_id)},
+                )
+                pdf_rows = pdf_result.mappings().all()
+
+                await _update_job_status(session, job_id, "chunking", progress_pct=15.0)
+
+                embedding_service = EmbeddingService(
+                    api_key=settings.openai_api_key, model=settings.embedding_model
+                )
+                pipeline = RAGPipeline(embedding_service=embedding_service)
+
+                total_chunks = 0
+
+                if pdf_rows:
+                    per_pdf_progress = 70.0 / max(len(pdf_rows), 1)
+                    for i, pdf_row in enumerate(pdf_rows):
+                        source_name = f"{slug}_{pdf_row['original_name'].rsplit('.', 1)[0].lower()}"
+                        try:
+                            await _update_job_status(
+                                session,
+                                job_id,
+                                "embedding",
+                                progress_pct=15.0 + i * per_pdf_progress,
+                            )
+                            chunks = await pipeline.process_pdf_document(
+                                pdf_path=pdf_row["file_path"],
+                                source=source_name,
+                                session=session,
+                            )
+                            total_chunks += chunks
+                            logger.info(
+                                "Indexed PDF",
+                                source=source_name,
+                                chunks=chunks,
+                                job_id=job_id,
+                            )
+                        except FileNotFoundError:
+                            logger.warning(
+                                "PDF file not found, skipping",
+                                path=pdf_row["file_path"],
+                                source=source_name,
+                                job_id=job_id,
+                            )
+                else:
+                    logger.warning(
+                        "No uploaded PDFs found for course, indexing backend resources",
+                        course_id=course_id,
+                        rag_collection_id=rag_collection_id,
+                    )
+                    import os
+                    from pathlib import Path
+
+                    resources_dir = Path(os.path.dirname(__file__)).parent.parent / "resources"
+                    if resources_dir.exists():
+                        await _update_job_status(session, job_id, "embedding", progress_pct=20.0)
+                        results = await pipeline.process_resources_directory(
+                            resources_dir=resources_dir,
+                        )
+                        total_chunks = sum(results.values())
+                    else:
+                        logger.warning(
+                            "No resources directory found",
+                            resources_dir=str(resources_dir),
+                        )
+
+                await _update_job_status(
+                    session, job_id, "embedding", chunk_count=total_chunks, progress_pct=85.0
+                )
+
+                try:
+                    await session.execute(
+                        text("DROP INDEX IF EXISTS idx_document_chunks_embedding_hnsw")
+                    )
+                    await session.execute(
+                        text(
+                            "CREATE INDEX idx_document_chunks_embedding_hnsw "
+                            "ON document_chunks USING hnsw (embedding vector_cosine_ops) "
+                            "WITH (m = 16, ef_construction = 64)"
+                        )
+                    )
+                    await session.commit()
+                    logger.info("HNSW index created/refreshed", job_id=job_id)
+                except Exception as idx_exc:
+                    logger.warning(
+                        "HNSW index creation failed (non-fatal)",
+                        error=str(idx_exc),
+                        job_id=job_id,
+                    )
+                    await session.rollback()
+
+                await _update_job_status(
+                    session,
+                    job_id,
+                    "complete",
+                    chunk_count=total_chunks,
+                    progress_pct=100.0,
+                )
+
+                return {"status": "complete", "chunk_count": total_chunks, "job_id": job_id}
+
+        except Exception as exc:
+            async with session_factory() as error_session:
+                await _update_job_status(
+                    error_session,
+                    job_id,
+                    "failed",
+                    error_message=str(exc)[:500],
+                    progress_pct=0.0,
+                )
+            raise
+        finally:
+            await engine.dispose()
+
+    try:
+        result = asyncio.run(_run())
+        logger.info(
+            "RAG indexation completed",
+            course_id=course_id,
+            job_id=job_id,
+            result=result,
+            task_id=self.request.id,
+        )
+        return result
+    except Exception as exc:
+        logger.error(
+            "RAG indexation task failed",
+            course_id=course_id,
+            job_id=job_id,
+            exception=str(exc),
+            task_id=self.request.id,
+        )
+        return {"status": "failed", "error": str(exc), "job_id": job_id}

--- a/backend/migrations/versions/022_add_rag_indexation_jobs.py
+++ b/backend/migrations/versions/022_add_rag_indexation_jobs.py
@@ -1,0 +1,77 @@
+"""Add rag_indexation_jobs table and set rag_collection_id on default course.
+
+Revision ID: 022_add_rag_indexation_jobs
+Revises: 021_add_courses_and_enrollment
+Create Date: 2026-04-04
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "022_add_rag_indexation_jobs"
+down_revision: str | None = "021_add_courses_and_enrollment"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+DEFAULT_COURSE_ID = "00000000-0000-0000-0000-000000000001"
+DEFAULT_COURSE_RAG_COLLECTION_ID = "sante-publique-aof"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "rag_indexation_jobs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "course_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("courses.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("celery_task_id", sa.String(), nullable=True),
+        sa.Column(
+            "state",
+            sa.Enum(
+                "pending",
+                "extracting",
+                "chunking",
+                "embedding",
+                "complete",
+                "failed",
+                name="ragindexationstate",
+            ),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column("chunk_count", sa.Integer(), nullable=True),
+        sa.Column("progress_pct", sa.Float(), nullable=False, server_default="0.0"),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_rag_indexation_jobs_course_id", "rag_indexation_jobs", ["course_id"])
+    op.create_index("ix_rag_indexation_jobs_state", "rag_indexation_jobs", ["state"])
+
+    op.execute(
+        f"""
+        UPDATE courses
+        SET rag_collection_id = '{DEFAULT_COURSE_RAG_COLLECTION_ID}'
+        WHERE id = '{DEFAULT_COURSE_ID}'
+          AND (rag_collection_id IS NULL OR rag_collection_id = '')
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_rag_indexation_jobs_state", table_name="rag_indexation_jobs")
+    op.drop_index("ix_rag_indexation_jobs_course_id", table_name="rag_indexation_jobs")
+    op.drop_table("rag_indexation_jobs")
+    op.execute("DROP TYPE ragindexationstate")

--- a/backend/tests/test_rag_indexation.py
+++ b/backend/tests/test_rag_indexation.py
@@ -1,0 +1,285 @@
+"""Tests for admin RAG indexation API endpoints."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.domain.models.user import UserRole
+from app.domain.services.jwt_auth_service import JWTAuthService
+from app.main import app
+
+
+def _make_headers(role: str = "user", user_id: str | None = None) -> dict:
+    jwt_service = JWTAuthService()
+    token = jwt_service.create_access_token(
+        user_id=user_id or str(uuid.uuid4()),
+        email=f"{role}@example.com",
+        role=role,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def admin_headers():
+    return _make_headers(role=UserRole.admin.value, user_id=str(uuid.uuid4()))
+
+
+@pytest.fixture
+def user_headers():
+    return _make_headers(role=UserRole.user.value)
+
+
+@pytest.mark.asyncio
+async def test_trigger_indexation_requires_admin(user_headers):
+    """POST /api/v1/admin/courses/{id}/index-resources returns 403 for non-admin."""
+    course_id = str(uuid.uuid4())
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.post(
+            f"/api/v1/admin/courses/{course_id}/index-resources",
+            headers=user_headers,
+        )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_index_status_requires_admin(user_headers):
+    """GET /api/v1/admin/courses/{id}/index-status returns 403 for non-admin."""
+    course_id = str(uuid.uuid4())
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.get(
+            f"/api/v1/admin/courses/{course_id}/index-status",
+            headers=user_headers,
+        )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_trigger_indexation_404_on_missing_course(admin_headers):
+    """POST /index-resources returns 404 when course does not exist."""
+    course_id = str(uuid.uuid4())
+    mock_db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_db.execute.return_value = mock_result
+
+    from app.api.deps import get_db
+
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.post(
+                f"/api/v1/admin/courses/{course_id}/index-resources",
+                headers=admin_headers,
+            )
+        assert response.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_get_index_status_404_on_missing_course(admin_headers):
+    """GET /index-status returns 404 when course does not exist."""
+    course_id = str(uuid.uuid4())
+    mock_db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_db.execute.return_value = mock_result
+
+    from app.api.deps import get_db
+
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.get(
+                f"/api/v1/admin/courses/{course_id}/index-status",
+                headers=admin_headers,
+            )
+        assert response.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_publish_blocked_when_not_indexed(admin_headers):
+    """POST /publish returns 400 when RAG indexation is not complete."""
+    from app.domain.models.course import Course
+
+    course_id = uuid.uuid4()
+    mock_course = Course(
+        id=course_id,
+        slug="test-course",
+        title_fr="Test FR",
+        title_en="Test EN",
+        status="draft",
+        languages="fr,en",
+        estimated_hours=20,
+        module_count=0,
+        rag_collection_id="test-collection",
+    )
+
+    mock_db = AsyncMock()
+    call_count = 0
+
+    async def mock_execute(query, params=None):
+        nonlocal call_count
+        call_count += 1
+        mock_result = MagicMock()
+        if call_count == 1:
+            mock_result.scalar_one_or_none.return_value = mock_course
+        elif call_count == 2:
+            mock_result.mappings.return_value.one_or_none.return_value = None
+        return mock_result
+
+    mock_db.execute = mock_execute
+
+    from app.api.deps import get_db
+
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.post(
+                f"/api/v1/admin/courses/{course_id}/publish",
+                headers=admin_headers,
+            )
+        assert response.status_code == 400
+        data = response.json()
+        assert "RAG indexation" in data["detail"]
+        assert "not_started" in data["detail"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_get_index_status_returns_not_started_when_no_job(admin_headers):
+    """GET /index-status returns state=not_started when no jobs exist for course."""
+    from app.domain.models.course import Course
+
+    course_id = uuid.uuid4()
+    mock_course = Course(
+        id=course_id,
+        slug="test-course",
+        title_fr="Test FR",
+        title_en="Test EN",
+        status="draft",
+        languages="fr,en",
+        estimated_hours=20,
+        module_count=0,
+        rag_collection_id="test-collection",
+    )
+
+    mock_db = AsyncMock()
+    call_count = 0
+
+    async def mock_execute(query, params=None):
+        nonlocal call_count
+        call_count += 1
+        mock_result = MagicMock()
+        if call_count == 1:
+            mock_result.scalar_one_or_none.return_value = mock_course
+        else:
+            mock_result.mappings.return_value.one_or_none.return_value = None
+        return mock_result
+
+    mock_db.execute = mock_execute
+
+    from app.api.deps import get_db
+
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.get(
+                f"/api/v1/admin/courses/{course_id}/index-status",
+                headers=admin_headers,
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["state"] == "not_started"
+        assert data["job_id"] is None
+        assert data["progress_pct"] == 0.0
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_trigger_indexation_409_when_already_in_progress(admin_headers):
+    """POST /index-resources returns 409 when indexation is already running."""
+    from app.domain.models.course import Course
+
+    course_id = uuid.uuid4()
+    job_id = uuid.uuid4()
+    mock_course = Course(
+        id=course_id,
+        slug="test-course",
+        title_fr="Test FR",
+        title_en="Test EN",
+        status="draft",
+        languages="fr,en",
+        estimated_hours=20,
+        module_count=0,
+        rag_collection_id="test-collection",
+    )
+
+    existing_job = {
+        "id": job_id,
+        "celery_task_id": "task-123",
+        "state": "embedding",
+        "chunk_count": None,
+        "progress_pct": 50.0,
+        "error_message": None,
+        "created_at": None,
+        "updated_at": None,
+        "completed_at": None,
+    }
+
+    mock_db = AsyncMock()
+    call_count = 0
+
+    async def mock_execute(query, params=None):
+        nonlocal call_count
+        call_count += 1
+        mock_result = MagicMock()
+        if call_count == 1:
+            mock_result.scalar_one_or_none.return_value = mock_course
+        else:
+            mock_result.mappings.return_value.one_or_none.return_value = existing_job
+        return mock_result
+
+    mock_db.execute = mock_execute
+
+    from app.api.deps import get_db
+
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.post(
+                f"/api/v1/admin/courses/{course_id}/index-resources",
+                headers=admin_headers,
+            )
+        assert response.status_code == 409
+        assert "already in progress" in response.json()["detail"]
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

- **POST** `/api/v1/admin/courses/{id}/index-resources` — triggers a Celery background task that runs the full RAG pipeline (extract → chunk → embed → pgvector) on all uploaded PDFs for a course
- **GET** `/api/v1/admin/courses/{id}/index-status` — returns current indexation state (`pending` → `extracting` → `chunking` → `embedding` → `complete` / `failed`) with progress %, chunk count, and timestamps
- **POST** `/api/v1/admin/courses/{id}/publish` — now blocked with HTTP 400 if RAG indexation is not complete; returns HTTP 409 if indexation is already in progress

## Changes

- `backend/app/tasks/rag_indexation.py` — new Celery task `index_course_resources` with full pipeline + auto HNSW index creation
- `backend/app/api/v1/admin_courses.py` — two new endpoints + updated publish to check RAG state
- `backend/app/tasks/celery_app.py` — registers the new task module
- `backend/migrations/versions/022_add_rag_indexation_jobs.py` — new `rag_indexation_jobs` table (state, progress_pct, chunk_count, error_message, timestamps); sets `rag_collection_id` on the default SantePublique AOF course
- `backend/tests/test_rag_indexation.py` — 7 unit tests (RBAC, 404, 409, publish-blocked, not_started)

## Test plan

- [x] Backend tests pass (338 passed, 7 pre-existing skips)
- [x] ruff lint + format clean
- [ ] Manually verify on staging: trigger indexation → poll status → publish blocked until complete

Closes #576

Generated with [Claude Code](https://claude.ai/code)