### PR TITLE
fix(flashcards): handle JSON arrays in generate_structured_content

### DIFF
--- a/backend/app/ai/claude_service.py
+++ b/backend/app/ai/claude_service.py
@@ -139,9 +139,16 @@ class ClaudeService:
                     if clean_text.rstrip().endswith("```"):
                         clean_text = clean_text.rstrip()[:-3]
 
-                # Look for JSON within the response text
-                json_start = clean_text.find("{")
-                json_end = clean_text.rfind("}") + 1
+                # Look for JSON within the response text (object or array)
+                obj_start = clean_text.find("{")
+                arr_start = clean_text.find("[")
+
+                if arr_start >= 0 and (obj_start < 0 or arr_start < obj_start):
+                    json_start = arr_start
+                    json_end = clean_text.rfind("]") + 1
+                else:
+                    json_start = obj_start
+                    json_end = clean_text.rfind("}") + 1
 
                 if json_start >= 0 and json_end > json_start:
                     json_text = clean_text[json_start:json_end]


### PR DESCRIPTION
## Summary

- `claude_service.generate_structured_content()` only scanned for `{` to detect JSON, missing JSON arrays `[...]`
- The flashcard system prompt asks Claude to return a JSON array of flashcard objects, so generation silently fell through to the raw-content fallback
- Now the parser picks whichever starts first — `[` or `{` — and uses the matching closing bracket

## Changes

- `backend/app/ai/claude_service.py`: Updated JSON detection logic to handle both arrays (`[...]`) and objects (`{...}`)

## Test plan

- [ ] Backend tests pass (`uv run pytest`)
- [ ] Flashcard generation no longer stuck on "Génération de vos flashcards..."
- [ ] Verified on `/fr/flashcards` and `/fr/flashcards?module=M01`

Closes #541

Generated with [Claude Code](https://claude.ai/code)