### PR TITLE
fix(chat): persist tutorMode in localStorage across page reloads

### DIFF
--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -70,7 +70,12 @@ export function ChatPanel({
   const [activeConversationId, setActiveConversationId] = useState<string | null>(
     conversationId ?? null
   );
-  const [tutorMode, setTutorMode] = useState<'socratic' | 'explanatory'>('socratic');
+  const [tutorMode, setTutorMode] = useState<'socratic' | 'explanatory'>(() => {
+    if (typeof window !== 'undefined') {
+      return (localStorage.getItem('tutorMode') as 'socratic' | 'explanatory') || 'socratic';
+    }
+    return 'socratic';
+  });
   const scrollAreaRef = useRef<HTMLDivElement>(null);
 
   const isLimitReached = currentUsage >= maxDailyUsage;
@@ -81,6 +86,10 @@ export function ChatPanel({
     isUser: false,
     timestamp: new Date(),
   };
+
+  useEffect(() => {
+    localStorage.setItem('tutorMode', tutorMode);
+  }, [tutorMode]);
 
   useEffect(() => {
     fetchTutorStats()


### PR DESCRIPTION
## Summary
Persists the tutor chat mode selection (Socratic/Explanatory) in localStorage so it survives page reloads.

## Changes
- `frontend/components/chat/chat-panel.tsx`: lazy `useState` initializer reads from `localStorage` (SSR-safe); `useEffect` syncs on change

## Test plan
- [ ] Frontend lint passes (0 errors)
- [ ] Select Explanatory mode, reload page — mode persists
- [ ] Works correctly on mobile viewport

Closes #450

Generated with [Claude Code](https://claude.ai/code)