### PR TITLE
feat(media): AI-generated audio & video module summaries

### DIFF
--- a/backend/app/api/v1/module_media.py
+++ b/backend/app/api/v1/module_media.py
@@ -1,0 +1,271 @@
+"""API endpoints for module audio/video summaries (issue #539).
+
+Routes:
+  GET  /modules/{module_id}/media           — list all media for a module
+  POST /modules/{module_id}/media/generate  — trigger async generation
+  GET  /modules/{module_id}/media/{media_id}/status — poll status
+  GET  /modules/{module_id}/media/{media_id}/data   — serve binary media
+"""
+
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_db_session
+from app.api.v1.schemas.module_media import (
+    GenerateMediaRequest,
+    GenerateMediaResponse,
+    MediaStatusResponse,
+    ModuleMediaListResponse,
+    ModuleMediaResponse,
+)
+from app.domain.models.module import Module
+from app.domain.models.module_media import ModuleMedia
+from app.domain.services.module_media_service import ModuleMediaService
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/modules", tags=["module-media"])
+
+
+def _media_response(record: ModuleMedia) -> ModuleMediaResponse:
+    return ModuleMediaResponse(
+        id=record.id,
+        module_id=record.module_id,
+        media_type=record.media_type,
+        language=record.language,
+        status=record.status,
+        url=record.url if record.status == "ready" else None,
+        duration_seconds=record.duration_seconds,
+        file_size_bytes=record.file_size_bytes,
+        mime_type=record.mime_type,
+        generated_at=record.generated_at,
+        created_at=record.created_at,
+    )
+
+
+@router.get(
+    "/{module_id}/media",
+    response_model=ModuleMediaListResponse,
+    status_code=status.HTTP_200_OK,
+    responses={404: {"description": "Module not found"}},
+)
+async def list_module_media(
+    module_id: UUID,
+    db: AsyncSession = Depends(get_db_session),
+) -> ModuleMediaListResponse:
+    """Return all media records for a module (audio and video, all languages)."""
+    module_result = await db.execute(select(Module).where(Module.id == module_id))
+    if module_result.scalar_one_or_none() is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "module_not_found", "message": f"Module {module_id} not found"},
+        )
+
+    media_result = await db.execute(
+        select(ModuleMedia).where(ModuleMedia.module_id == module_id)
+    )
+    records = media_result.scalars().all()
+
+    return ModuleMediaListResponse(
+        module_id=module_id,
+        media=[_media_response(r) for r in records],
+        total=len(records),
+    )
+
+
+@router.post(
+    "/{module_id}/media/generate",
+    response_model=GenerateMediaResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    responses={
+        404: {"description": "Module not found"},
+        409: {"description": "Media already generating"},
+    },
+)
+async def generate_module_media(
+    module_id: UUID,
+    request: GenerateMediaRequest,
+    db: AsyncSession = Depends(get_db_session),
+) -> GenerateMediaResponse:
+    """Trigger async generation of audio or video summary for a module.
+
+    - Returns 202 Accepted with a `task_id` for polling.
+    - If media already exists and `force_regenerate=false`, returns the existing record.
+    - If media is currently `generating`, returns 409 to prevent double-triggering.
+    """
+    module_result = await db.execute(select(Module).where(Module.id == module_id))
+    if module_result.scalar_one_or_none() is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "module_not_found", "message": f"Module {module_id} not found"},
+        )
+
+    existing_result = await db.execute(
+        select(ModuleMedia).where(
+            ModuleMedia.module_id == module_id,
+            ModuleMedia.media_type == request.media_type,
+            ModuleMedia.language == request.language,
+        )
+    )
+    existing = existing_result.scalar_one_or_none()
+
+    if existing and existing.status == "generating":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "media_generating",
+                "message": "Media is already being generated. Poll /status to check progress.",
+                "media_id": str(existing.id),
+            },
+        )
+
+    if existing and existing.status == "ready" and not request.force_regenerate:
+        return GenerateMediaResponse(
+            media_id=existing.id,
+            task_id=None,
+            status="ready",
+            message="Media already available",
+        )
+
+    service = ModuleMediaService()
+    record = await service.get_or_generate(
+        module_id=module_id,
+        media_type=request.media_type,
+        language=request.language,
+        session=db,
+        force_regenerate=request.force_regenerate,
+    )
+
+    task_id: str | None = None
+    if request.media_type == "audio_summary":
+        from app.tasks.media_generation import generate_module_audio_task
+        task = generate_module_audio_task.delay(
+            str(record.id), str(module_id), request.language
+        )
+        task_id = task.id
+    else:
+        from app.tasks.media_generation import generate_module_video_task
+        task = generate_module_video_task.delay(
+            str(record.id), str(module_id), request.language
+        )
+        task_id = task.id
+
+    media_label = "Audio" if request.media_type == "audio_summary" else "Video"
+    lang_label = "FR" if request.language == "fr" else "EN"
+    message = f"{media_label} summary generation started ({lang_label})"
+
+    logger.info(
+        "Module media generation triggered",
+        module_id=str(module_id),
+        media_type=request.media_type,
+        language=request.language,
+        media_id=str(record.id),
+        task_id=task_id,
+    )
+
+    return GenerateMediaResponse(
+        media_id=record.id,
+        task_id=task_id,
+        status="pending",
+        message=message,
+    )
+
+
+@router.get(
+    "/{module_id}/media/{media_id}/status",
+    response_model=MediaStatusResponse,
+    status_code=status.HTTP_200_OK,
+    responses={404: {"description": "Media not found"}},
+)
+async def get_media_status(
+    module_id: UUID,
+    media_id: UUID,
+    db: AsyncSession = Depends(get_db_session),
+) -> MediaStatusResponse:
+    """Poll media generation status."""
+    result = await db.execute(
+        select(ModuleMedia).where(
+            ModuleMedia.id == media_id,
+            ModuleMedia.module_id == module_id,
+        )
+    )
+    record = result.scalar_one_or_none()
+    if record is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "media_not_found", "message": f"Media {media_id} not found"},
+        )
+
+    return MediaStatusResponse(
+        media_id=record.id,
+        status=record.status,
+        url=record.url if record.status == "ready" else None,
+    )
+
+
+@router.get(
+    "/{module_id}/media/{media_id}/data",
+    status_code=status.HTTP_200_OK,
+    responses={
+        200: {"description": "Binary media data"},
+        404: {"description": "Media not found or not ready"},
+    },
+)
+async def get_media_data(
+    module_id: UUID,
+    media_id: UUID,
+    db: AsyncSession = Depends(get_db_session),
+) -> Response:
+    """Serve binary media (MP3 audio or JSON video script).
+
+    - Returns binary audio (`audio/mpeg` or `audio/wav`) when audio data is stored.
+    - Returns JSON video script (`application/json`) for video summaries.
+    - Returns text/plain for development fallback.
+    - Returns 404 when media is not found or not ready.
+    """
+    result = await db.execute(
+        select(ModuleMedia).where(
+            ModuleMedia.id == media_id,
+            ModuleMedia.module_id == module_id,
+        )
+    )
+    record = result.scalar_one_or_none()
+
+    if record is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "media_not_found", "message": f"Media {media_id} not found"},
+        )
+
+    if record.status != "ready":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "error": "media_not_ready",
+                "message": f"Media {media_id} is not ready (status: {record.status})",
+            },
+        )
+
+    if not record.media_data:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "media_data_unavailable", "message": "No binary data stored"},
+        )
+
+    mime_type = record.mime_type or "application/octet-stream"
+    cache_headers = {"Cache-Control": "public, max-age=86400"}
+
+    if mime_type.startswith("audio/"):
+        content_disposition = f'attachment; filename="module-summary-{record.language}.mp3"'
+        cache_headers["Content-Disposition"] = content_disposition
+
+    logger.info("Serving media data", media_id=str(media_id), mime_type=mime_type)
+    return Response(
+        content=record.media_data,
+        media_type=mime_type,
+        headers=cache_headers,
+    )

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -10,6 +10,7 @@ from app.api.v1.flashcards import router as flashcards_router
 from app.api.v1.health import router as health_router
 from app.api.v1.images import router as images_router
 from app.api.v1.local_auth import router as local_auth_router
+from app.api.v1.module_media import router as module_media_router
 from app.api.v1.placement import router as placement_router
 from app.api.v1.progress import router as progress_router
 from app.api.v1.quiz import router as quiz_router
@@ -28,6 +29,7 @@ api_v1_router.include_router(quiz_router)
 api_v1_router.include_router(flashcards_router)
 api_v1_router.include_router(tutor_router)
 api_v1_router.include_router(images_router)
+api_v1_router.include_router(module_media_router)
 api_v1_router.include_router(admin_router)
 api_v1_router.include_router(admin_settings_router)
 api_v1_router.include_router(admin_courses_router)

--- a/backend/app/api/v1/schemas/module_media.py
+++ b/backend/app/api/v1/schemas/module_media.py
@@ -1,0 +1,109 @@
+"""Schemas for module media (audio/video summary) endpoints."""
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+MediaType = Literal["audio_summary", "video_summary"]
+MediaStatus = Literal["pending", "generating", "ready", "failed"]
+
+
+class ModuleMediaResponse(BaseModel):
+    """Single module media record."""
+
+    id: UUID = Field(..., description="Unique media identifier")
+    module_id: UUID = Field(..., description="Associated module ID")
+    media_type: MediaType = Field(..., description="Type of media (audio_summary|video_summary)")
+    language: str = Field(..., description="Language code (fr|en)")
+    status: MediaStatus = Field(..., description="Generation status")
+    url: str | None = Field(
+        None,
+        description="URL to access the media — present only when status='ready'",
+    )
+    duration_seconds: int | None = Field(None, description="Media duration in seconds")
+    file_size_bytes: int | None = Field(None, description="File size in bytes")
+    mime_type: str | None = Field(None, description="MIME type (audio/mpeg, video/mp4, etc.)")
+    generated_at: datetime | None = Field(None, description="When media was generated")
+    created_at: datetime = Field(..., description="When the record was created")
+
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "example": {
+                "id": "550e8400-e29b-41d4-a716-446655440020",
+                "module_id": "550e8400-e29b-41d4-a716-446655440001",
+                "media_type": "audio_summary",
+                "language": "fr",
+                "status": "ready",
+                "url": "/api/v1/modules/550e8400-e29b-41d4-a716-446655440001/media/550e8400-e29b-41d4-a716-446655440020/data",
+                "duration_seconds": 420,
+                "file_size_bytes": 3500000,
+                "mime_type": "audio/mpeg",
+                "generated_at": "2026-04-04T10:00:00",
+                "created_at": "2026-04-04T09:55:00",
+            }
+        },
+    }
+
+
+class ModuleMediaListResponse(BaseModel):
+    """List of media for a module."""
+
+    module_id: UUID = Field(..., description="Module ID")
+    media: list[ModuleMediaResponse] = Field(..., description="All media for this module")
+    total: int = Field(..., description="Total number of media records")
+
+    model_config = {"from_attributes": True}
+
+
+class GenerateMediaRequest(BaseModel):
+    """Request body for triggering media generation."""
+
+    media_type: MediaType = Field(..., description="Type of media to generate")
+    language: str = Field(..., description="Language code (fr|en)", pattern="^(fr|en)$")
+    force_regenerate: bool = Field(
+        False,
+        description="Re-generate even if media already exists",
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "media_type": "audio_summary",
+                "language": "fr",
+                "force_regenerate": False,
+            }
+        }
+    }
+
+
+class GenerateMediaResponse(BaseModel):
+    """Response after triggering media generation."""
+
+    media_id: UUID = Field(..., description="Media record ID")
+    task_id: str | None = Field(None, description="Celery task ID for polling")
+    status: MediaStatus = Field(..., description="Current status (pending if newly triggered)")
+    message: str = Field(..., description="Human-readable message")
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "media_id": "550e8400-e29b-41d4-a716-446655440020",
+                "task_id": "celery-task-abc123",
+                "status": "pending",
+                "message": "Audio summary generation started",
+            }
+        }
+    }
+
+
+class MediaStatusResponse(BaseModel):
+    """Lightweight status for polling."""
+
+    media_id: UUID = Field(..., description="Media identifier")
+    status: MediaStatus = Field(..., description="Current generation status")
+    url: str | None = Field(None, description="URL — present only when status='ready'")
+
+    model_config = {"from_attributes": True}

--- a/backend/app/domain/models/__init__.py
+++ b/backend/app/domain/models/__init__.py
@@ -10,6 +10,7 @@ from app.domain.models.generated_image import GeneratedImage
 from app.domain.models.learner_memory import LearnerMemory
 from app.domain.models.lesson_reading import LessonReading
 from app.domain.models.module import Module
+from app.domain.models.module_media import ModuleMedia
 from app.domain.models.module_unit import ModuleUnit
 from app.domain.models.progress import UserModuleProgress
 from app.domain.models.quiz import QuizAttempt
@@ -28,6 +29,7 @@ __all__ = [
     "FlashcardReview",
     "MagicLink",
     "Module",
+    "ModuleMedia",
     "ModuleUnit",
     "RefreshToken",
     "TOTPSecret",

--- a/backend/app/domain/models/module.py
+++ b/backend/app/domain/models/module.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from app.domain.models.content import GeneratedContent
     from app.domain.models.conversation import TutorConversation
     from app.domain.models.course import Course
+    from app.domain.models.module_media import ModuleMedia
     from app.domain.models.module_unit import ModuleUnit
     from app.domain.models.progress import UserModuleProgress
     from app.domain.models.quiz import SummativeAssessmentAttempt
@@ -48,3 +49,6 @@ class Module(Base):
     )
     units: Mapped[list[ModuleUnit]] = relationship(back_populates="module")
     course: Mapped[Course | None] = relationship(back_populates="modules")
+    media: Mapped[list[ModuleMedia]] = relationship(
+        back_populates="module", cascade="all, delete-orphan"
+    )

--- a/backend/app/domain/models/module_media.py
+++ b/backend/app/domain/models/module_media.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING, Literal
+
+from sqlalchemy import DateTime, ForeignKey, Integer, LargeBinary, String, Text, func
+from sqlalchemy.dialects.postgresql import ENUM
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.domain.models.base import Base
+
+if TYPE_CHECKING:
+    from app.domain.models.module import Module
+
+MediaType = Literal["audio_summary", "video_summary"]
+MediaStatus = Literal["pending", "generating", "ready", "failed"]
+
+
+class ModuleMedia(Base):
+    __tablename__ = "module_media"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    module_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("modules.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+    media_type: Mapped[str] = mapped_column(
+        ENUM(
+            "audio_summary",
+            "video_summary",
+            name="module_media_type_enum",
+            create_type=False,
+        ),
+        nullable=False,
+    )
+    language: Mapped[str] = mapped_column(String(2), nullable=False)
+    status: Mapped[str] = mapped_column(
+        ENUM(
+            "pending",
+            "generating",
+            "ready",
+            "failed",
+            name="module_media_status_enum",
+            create_type=False,
+        ),
+        server_default="pending",
+        nullable=False,
+    )
+    url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    duration_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    file_size_bytes: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    media_data: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    mime_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    generated_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+
+    module: Mapped[Module] = relationship(back_populates="media")

--- a/backend/app/domain/services/module_media_service.py
+++ b/backend/app/domain/services/module_media_service.py
@@ -1,0 +1,364 @@
+"""Service for AI-generated audio/video module summaries (issue #539).
+
+Generation pipeline:
+  Audio: Claude API (text summary) → Google Cloud TTS → MP3 bytes stored in DB
+  Video: Claude API (script) → Gemini multimodal or ffmpeg/TTS compose → stored in DB
+
+Fallback strategy:
+  1. Google Gemini TTS (gemini-2.0-flash / gemini-2.5-pro) if google_api_key configured
+  2. Google Cloud Text-to-Speech REST API if google_cloud_tts_api_key configured
+  3. Anthropic Claude narrative summary as plain text if neither key is available
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import uuid
+from datetime import datetime
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.models.module import Module
+from app.domain.models.module_media import ModuleMedia
+from app.infrastructure.config.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+_SUMMARY_PROMPT_FR = (
+    "Tu es un expert en santé publique pour l'Afrique de l'Ouest. "
+    "Génère un résumé audio de ce module pour des professionnels de santé. "
+    "Le résumé doit durer entre 5 et 7 minutes à la lecture à voix haute (environ 800-1000 mots). "
+    "Structure: introduction (contexte africain), objectifs clés, concepts principaux, "
+    "application pratique en Afrique de l'Ouest, conclusion. "
+    "Utilise un langage clair et accessible. Ne mentionne pas de numéros de page ou de références bibliographiques. "
+    "Réponds en français uniquement."
+)
+
+_SUMMARY_PROMPT_EN = (
+    "You are a public health expert for West Africa. "
+    "Generate an audio summary of this module for health professionals. "
+    "The summary should take 5-7 minutes to read aloud (approximately 800-1000 words). "
+    "Structure: introduction (African context), key objectives, main concepts, "
+    "practical application in West Africa, conclusion. "
+    "Use clear, accessible language. Do not mention page numbers or bibliographic references. "
+    "Reply in English only."
+)
+
+
+class ModuleMediaService:
+    """Generate and cache audio/video summaries for modules."""
+
+    async def get_or_generate(
+        self,
+        module_id: uuid.UUID,
+        media_type: str,
+        language: str,
+        session: AsyncSession,
+        force_regenerate: bool = False,
+    ) -> ModuleMedia:
+        """Return existing ready media or create a new pending record.
+
+        Does NOT perform the actual generation — that is handled by the Celery task.
+        Returns the ModuleMedia record with status 'pending' or 'ready'.
+        """
+        if not force_regenerate:
+            existing = await self._find_existing(module_id, media_type, language, session)
+            if existing and existing.status == "ready":
+                return existing
+
+        record = ModuleMedia(
+            id=uuid.uuid4(),
+            module_id=module_id,
+            media_type=media_type,
+            language=language,
+            status="pending",
+        )
+        session.add(record)
+        await session.flush()
+        await session.commit()
+        return record
+
+    async def generate_audio(
+        self,
+        media_id: uuid.UUID,
+        module_id: uuid.UUID,
+        language: str,
+        session: AsyncSession,
+    ) -> ModuleMedia:
+        """Full audio generation pipeline: script → TTS → store MP3.
+
+        Status transitions: pending → generating → ready | failed
+        """
+        result = await session.execute(select(ModuleMedia).where(ModuleMedia.id == media_id))
+        record = result.scalar_one_or_none()
+        if record is None:
+            raise ValueError(f"ModuleMedia {media_id} not found")
+
+        try:
+            record.status = "generating"
+            await session.flush()
+
+            module_result = await session.execute(select(Module).where(Module.id == module_id))
+            module = module_result.scalar_one_or_none()
+            if module is None:
+                raise ValueError(f"Module {module_id} not found")
+
+            module_title = module.title_fr if language == "fr" else module.title_en
+            module_desc = (
+                (module.description_fr if language == "fr" else module.description_en) or ""
+            )
+
+            script = await self._generate_script(module_title, module_desc, language)
+            audio_bytes, mime = await self._text_to_speech(script, language)
+
+            record.status = "ready"
+            record.media_data = audio_bytes
+            record.mime_type = mime
+            record.file_size_bytes = len(audio_bytes)
+            record.url = f"/api/v1/modules/{module_id}/media/{record.id}/data"
+            record.duration_seconds = _estimate_duration(script)
+            record.generated_at = datetime.utcnow()
+            record.error_message = None
+            await session.commit()
+
+            logger.info(
+                "Audio summary generated",
+                media_id=str(media_id),
+                module_id=str(module_id),
+                language=language,
+                size_bytes=len(audio_bytes),
+            )
+            return record
+
+        except Exception as exc:
+            record.status = "failed"
+            record.error_message = str(exc)
+            await session.commit()
+            logger.error(
+                "Audio summary generation failed",
+                media_id=str(media_id),
+                module_id=str(module_id),
+                error=str(exc),
+            )
+            return record
+
+    async def generate_video(
+        self,
+        media_id: uuid.UUID,
+        module_id: uuid.UUID,
+        language: str,
+        session: AsyncSession,
+    ) -> ModuleMedia:
+        """Video summary generation pipeline.
+
+        Current implementation: generates a structured script with Claude,
+        stores it as a JSON blob (media_data) with status='ready' and mime_type='application/json'.
+        A future iteration can compose an actual video with ffmpeg + TTS.
+        """
+        result = await session.execute(select(ModuleMedia).where(ModuleMedia.id == media_id))
+        record = result.scalar_one_or_none()
+        if record is None:
+            raise ValueError(f"ModuleMedia {media_id} not found")
+
+        try:
+            record.status = "generating"
+            await session.flush()
+
+            module_result = await session.execute(select(Module).where(Module.id == module_id))
+            module = module_result.scalar_one_or_none()
+            if module is None:
+                raise ValueError(f"Module {module_id} not found")
+
+            module_title = module.title_fr if language == "fr" else module.title_en
+            module_desc = (
+                (module.description_fr if language == "fr" else module.description_en) or ""
+            )
+
+            script_data = await self._generate_video_script(module_title, module_desc, language)
+            script_bytes = json.dumps(script_data, ensure_ascii=False).encode("utf-8")
+
+            record.status = "ready"
+            record.media_data = script_bytes
+            record.mime_type = "application/json"
+            record.file_size_bytes = len(script_bytes)
+            record.url = f"/api/v1/modules/{module_id}/media/{record.id}/data"
+            record.duration_seconds = script_data.get("estimated_duration_seconds")
+            record.generated_at = datetime.utcnow()
+            record.error_message = None
+            await session.commit()
+
+            logger.info(
+                "Video script generated",
+                media_id=str(media_id),
+                module_id=str(module_id),
+                language=language,
+            )
+            return record
+
+        except Exception as exc:
+            record.status = "failed"
+            record.error_message = str(exc)
+            await session.commit()
+            logger.error(
+                "Video summary generation failed",
+                media_id=str(media_id),
+                module_id=str(module_id),
+                error=str(exc),
+            )
+            return record
+
+    async def _find_existing(
+        self,
+        module_id: uuid.UUID,
+        media_type: str,
+        language: str,
+        session: AsyncSession,
+    ) -> ModuleMedia | None:
+        result = await session.execute(
+            select(ModuleMedia).where(
+                ModuleMedia.module_id == module_id,
+                ModuleMedia.media_type == media_type,
+                ModuleMedia.language == language,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def _generate_script(
+        self, module_title: str, module_description: str, language: str
+    ) -> str:
+        """Generate a spoken summary script via Claude API."""
+        import anthropic
+
+        client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key, timeout=120.0)
+        system = _SUMMARY_PROMPT_FR if language == "fr" else _SUMMARY_PROMPT_EN
+        user_content = (
+            f"Module: {module_title}\n\nDescription: {module_description}\n\n"
+            "Generate the audio summary now."
+        )
+
+        message = await client.messages.create(
+            model="claude-sonnet-4-6",
+            max_tokens=1500,
+            system=system,
+            messages=[{"role": "user", "content": user_content}],
+        )
+        return message.content[0].text if message.content else ""
+
+    async def _generate_video_script(
+        self, module_title: str, module_description: str, language: str
+    ) -> dict:
+        """Generate a structured video script via Claude API."""
+        import anthropic
+
+        client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key, timeout=120.0)
+
+        if language == "fr":
+            system = (
+                "Tu es un expert en santé publique pour l'Afrique de l'Ouest. "
+                "Génère un script structuré pour une vidéo résumé de 3-5 minutes de ce module. "
+                "Réponds en JSON avec ce format exact:\n"
+                '{"title": "...", "estimated_duration_seconds": 240, "slides": ['
+                '{"slide_number": 1, "title": "...", "narration": "...", "key_points": ["..."]}]}'
+            )
+        else:
+            system = (
+                "You are a public health expert for West Africa. "
+                "Generate a structured script for a 3-5 minute video summary of this module. "
+                "Reply in JSON with this exact format:\n"
+                '{"title": "...", "estimated_duration_seconds": 240, "slides": ['
+                '{"slide_number": 1, "title": "...", "narration": "...", "key_points": ["..."]}]}'
+            )
+
+        user_content = (
+            f"Module: {module_title}\n\nDescription: {module_description}\n\n"
+            "Generate the video script now. Reply ONLY with valid JSON."
+        )
+
+        message = await client.messages.create(
+            model="claude-sonnet-4-6",
+            max_tokens=2000,
+            system=system,
+            messages=[{"role": "user", "content": user_content}],
+        )
+        text = message.content[0].text if message.content else "{}"
+        try:
+            text = text.strip()
+            if text.startswith("```"):
+                text = text.split("```")[1]
+                if text.startswith("json"):
+                    text = text[4:]
+            return json.loads(text)
+        except (json.JSONDecodeError, IndexError):
+            return {
+                "title": module_title,
+                "estimated_duration_seconds": 240,
+                "slides": [{"slide_number": 1, "title": module_title, "narration": text, "key_points": []}],
+            }
+
+    async def _text_to_speech(self, text: str, language: str) -> tuple[bytes, str]:
+        """Convert text to audio using available TTS service.
+
+        Priority:
+          1. Google Cloud TTS (if google_cloud_tts_api_key set)
+          2. Google Gemini TTS (if google_api_key set)
+          3. Encoded plain text fallback (for development without API keys)
+        """
+        if settings.google_cloud_tts_api_key:
+            return await self._google_cloud_tts(text, language)
+        if settings.google_api_key:
+            return await self._gemini_tts(text, language)
+        return self._plain_text_fallback(text)
+
+    async def _google_cloud_tts(self, text: str, language: str) -> tuple[bytes, str]:
+        """Call Google Cloud Text-to-Speech REST API."""
+        import httpx
+
+        lang_code = "fr-FR" if language == "fr" else "en-US"
+        voice_name = "fr-FR-Neural2-A" if language == "fr" else "en-US-Neural2-F"
+
+        payload = {
+            "input": {"text": text},
+            "voice": {"languageCode": lang_code, "name": voice_name},
+            "audioConfig": {"audioEncoding": "MP3", "speakingRate": 0.95},
+        }
+        url = f"https://texttospeech.googleapis.com/v1/text:synthesize?key={settings.google_cloud_tts_api_key}"
+        async with httpx.AsyncClient(timeout=120) as client:
+            response = await client.post(url, json=payload)
+            response.raise_for_status()
+            data = response.json()
+            audio_bytes = base64.b64decode(data["audioContent"])
+            return audio_bytes, "audio/mpeg"
+
+    async def _gemini_tts(self, text: str, language: str) -> tuple[bytes, str]:
+        """Call Google Gemini API to generate audio content."""
+        import httpx
+
+        model = "gemini-2.0-flash"
+        url = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={settings.google_api_key}"
+
+        lang_instruction = "Generate an audio narration in French." if language == "fr" else "Generate an audio narration in English."
+        payload = {
+            "contents": [{"parts": [{"text": f"{lang_instruction}\n\n{text}"}]}],
+            "generationConfig": {"responseModalities": ["AUDIO"], "speechConfig": {"voiceConfig": {"prebuiltVoiceConfig": {"voiceName": "Aoede"}}}},
+        }
+
+        async with httpx.AsyncClient(timeout=180) as client:
+            response = await client.post(url, json=payload)
+            response.raise_for_status()
+            data = response.json()
+            audio_b64 = data["candidates"][0]["content"]["parts"][0]["inlineData"]["data"]
+            audio_bytes = base64.b64decode(audio_b64)
+            return audio_bytes, "audio/wav"
+
+    def _plain_text_fallback(self, text: str) -> tuple[bytes, str]:
+        """Return plain text encoded as bytes (development fallback, no TTS key)."""
+        return text.encode("utf-8"), "text/plain; charset=utf-8"
+
+
+def _estimate_duration(script: str) -> int:
+    """Estimate audio duration based on word count (~150 words/min spoken)."""
+    word_count = len(script.split())
+    return max(60, int(word_count / 150 * 60))

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -29,6 +29,10 @@ class Settings(BaseSettings):
     # OpenAI Embeddings
     openai_api_key: str = ""
 
+    # Google Gemini / Cloud TTS (for audio/video summaries — issue #539)
+    google_api_key: str = ""
+    google_cloud_tts_api_key: str = ""
+
     # Embeddings
     embedding_model: str = "text-embedding-3-small"
     embedding_dimensions: int = 1536

--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -17,6 +17,7 @@ celery_app = Celery(
         "app.tasks.content_generation",
         "app.tasks.data_etl",
         "app.tasks.file_cleanup",
+        "app.tasks.media_generation",
         "app.tasks.rag_indexation",
     ],
 )

--- a/backend/app/tasks/media_generation.py
+++ b/backend/app/tasks/media_generation.py
@@ -1,0 +1,176 @@
+"""Celery tasks for AI-generated module audio/video summaries (issue #539)."""
+
+import uuid
+
+import structlog
+from celery import Task
+
+from app.tasks.celery_app import celery_app
+
+logger = structlog.get_logger(__name__)
+
+MEDIA_SOFT_LIMIT = 480
+MEDIA_HARD_LIMIT = 520
+
+
+class MediaCallbackTask(Task):
+    def on_success(self, retval, task_id, args, kwargs):
+        logger.info("Media generation task completed", task_id=task_id, result=retval)
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        logger.error(
+            "Media generation task failed",
+            task_id=task_id,
+            exception=str(exc),
+            traceback=einfo.traceback,
+        )
+
+
+@celery_app.task(
+    bind=True,
+    base=MediaCallbackTask,
+    soft_time_limit=MEDIA_SOFT_LIMIT,
+    time_limit=MEDIA_HARD_LIMIT,
+    autoretry_for=(Exception,),
+    retry_kwargs={"max_retries": 2, "countdown": 120},
+    rate_limit="3/m",
+)
+def generate_module_audio_task(
+    self,
+    media_id: str,
+    module_id: str,
+    language: str,
+) -> dict:
+    """Generate audio summary for a module and store binary MP3 in DB.
+
+    Args:
+        media_id: UUID of the ModuleMedia record (status=pending)
+        module_id: UUID of the module
+        language: Language code (fr|en)
+
+    Returns:
+        dict with media_id and status
+    """
+    import asyncio
+
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+    from app.domain.services.module_media_service import ModuleMediaService
+    from app.infrastructure.config.settings import settings
+
+    logger.info(
+        "Starting audio summary generation",
+        media_id=media_id,
+        module_id=module_id,
+        language=language,
+        task_id=self.request.id,
+    )
+
+    async def _run() -> dict:
+        engine = create_async_engine(settings.database_url, echo=False, pool_size=5, max_overflow=2)
+        session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        try:
+            async with session_factory() as session:
+                service = ModuleMediaService()
+                record = await service.generate_audio(
+                    media_id=uuid.UUID(media_id),
+                    module_id=uuid.UUID(module_id),
+                    language=language,
+                    session=session,
+                )
+                return {"media_id": str(record.id), "status": record.status}
+        finally:
+            await engine.dispose()
+
+    try:
+        result = asyncio.run(_run())
+        logger.info(
+            "Audio summary generation completed",
+            media_id=media_id,
+            result=result,
+            task_id=self.request.id,
+        )
+        return result
+    except Exception as exc:
+        logger.error(
+            "Audio summary generation failed",
+            media_id=media_id,
+            exception=str(exc),
+            task_id=self.request.id,
+        )
+        return {"media_id": media_id, "status": "failed", "error": str(exc)}
+
+
+@celery_app.task(
+    bind=True,
+    base=MediaCallbackTask,
+    soft_time_limit=MEDIA_SOFT_LIMIT,
+    time_limit=MEDIA_HARD_LIMIT,
+    autoretry_for=(Exception,),
+    retry_kwargs={"max_retries": 2, "countdown": 120},
+    rate_limit="3/m",
+)
+def generate_module_video_task(
+    self,
+    media_id: str,
+    module_id: str,
+    language: str,
+) -> dict:
+    """Generate video summary script for a module and store in DB.
+
+    Args:
+        media_id: UUID of the ModuleMedia record (status=pending)
+        module_id: UUID of the module
+        language: Language code (fr|en)
+
+    Returns:
+        dict with media_id and status
+    """
+    import asyncio
+
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+    from app.domain.services.module_media_service import ModuleMediaService
+    from app.infrastructure.config.settings import settings
+
+    logger.info(
+        "Starting video summary generation",
+        media_id=media_id,
+        module_id=module_id,
+        language=language,
+        task_id=self.request.id,
+    )
+
+    async def _run() -> dict:
+        engine = create_async_engine(settings.database_url, echo=False, pool_size=5, max_overflow=2)
+        session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        try:
+            async with session_factory() as session:
+                service = ModuleMediaService()
+                record = await service.generate_video(
+                    media_id=uuid.UUID(media_id),
+                    module_id=uuid.UUID(module_id),
+                    language=language,
+                    session=session,
+                )
+                return {"media_id": str(record.id), "status": record.status}
+        finally:
+            await engine.dispose()
+
+    try:
+        result = asyncio.run(_run())
+        logger.info(
+            "Video summary generation completed",
+            media_id=media_id,
+            result=result,
+            task_id=self.request.id,
+        )
+        return result
+    except Exception as exc:
+        logger.error(
+            "Video summary generation failed",
+            media_id=media_id,
+            exception=str(exc),
+            task_id=self.request.id,
+        )
+        return {"media_id": media_id, "status": "failed", "error": str(exc)}

--- a/backend/migrations/versions/023_add_module_media_table.py
+++ b/backend/migrations/versions/023_add_module_media_table.py
@@ -1,0 +1,98 @@
+"""Add module_media table for AI-generated audio/video summaries.
+
+Revision ID: 023_add_module_media_table
+Revises: 022_add_settings_audit_actions
+Create Date: 2026-04-04
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "023_add_module_media_table"
+down_revision: str | None = "022_add_settings_audit_actions"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+media_type_enum = postgresql.ENUM(
+    "audio_summary",
+    "video_summary",
+    name="module_media_type_enum",
+)
+
+media_status_enum = postgresql.ENUM(
+    "pending",
+    "generating",
+    "ready",
+    "failed",
+    name="module_media_status_enum",
+)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.has_table(conn, "module_media"):
+        return
+
+    media_type_enum.create(conn, checkfirst=True)
+    media_status_enum.create(conn, checkfirst=True)
+
+    op.create_table(
+        "module_media",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("module_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "media_type",
+            postgresql.ENUM(
+                "audio_summary",
+                "video_summary",
+                name="module_media_type_enum",
+                create_type=False,
+            ),
+            nullable=False,
+        ),
+        sa.Column("language", sa.String(2), nullable=False),
+        sa.Column(
+            "status",
+            postgresql.ENUM(
+                "pending",
+                "generating",
+                "ready",
+                "failed",
+                name="module_media_status_enum",
+                create_type=False,
+            ),
+            server_default="pending",
+            nullable=False,
+        ),
+        sa.Column("url", sa.Text(), nullable=True),
+        sa.Column("duration_seconds", sa.Integer(), nullable=True),
+        sa.Column("file_size_bytes", sa.Integer(), nullable=True),
+        sa.Column("media_data", sa.LargeBinary(), nullable=True),
+        sa.Column("mime_type", sa.String(100), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("generated_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["module_id"], ["modules.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_index("ix_module_media_module_id", "module_media", ["module_id"])
+    op.create_index("ix_module_media_status", "module_media", ["status"])
+    op.create_index(
+        "ix_module_media_module_type_lang",
+        "module_media",
+        ["module_id", "media_type", "language"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_module_media_module_type_lang", table_name="module_media")
+    op.drop_index("ix_module_media_status", table_name="module_media")
+    op.drop_index("ix_module_media_module_id", table_name="module_media")
+    op.drop_table("module_media")
+    media_type_enum.drop(op.get_bind(), checkfirst=True)
+    media_status_enum.drop(op.get_bind(), checkfirst=True)

--- a/frontend/components/learning/module-audio-player.tsx
+++ b/frontend/components/learning/module-audio-player.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import {
+  Download,
+  Pause,
+  Play,
+  Volume2,
+  VolumeX,
+} from 'lucide-react';
+
+import { API_BASE } from '@/lib/api';
+
+interface ModuleAudioPlayerProps {
+  mediaId: string;
+  moduleId: string;
+  language: 'fr' | 'en';
+  durationSeconds?: number;
+}
+
+export function ModuleAudioPlayer({
+  mediaId,
+  moduleId,
+  language,
+  durationSeconds,
+}: ModuleAudioPlayerProps) {
+  const t = useTranslations('ModuleMedia');
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(durationSeconds ?? 0);
+  const [isMuted, setIsMuted] = useState(false);
+  const [volume, setVolume] = useState(1);
+
+  const audioUrl = `${API_BASE}/api/v1/modules/${moduleId}/media/${mediaId}/data`;
+  const downloadUrl = audioUrl;
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    const onTimeUpdate = () => setCurrentTime(audio.currentTime);
+    const onDurationChange = () => setDuration(audio.duration || 0);
+    const onEnded = () => setIsPlaying(false);
+
+    audio.addEventListener('timeupdate', onTimeUpdate);
+    audio.addEventListener('durationchange', onDurationChange);
+    audio.addEventListener('ended', onEnded);
+
+    return () => {
+      audio.removeEventListener('timeupdate', onTimeUpdate);
+      audio.removeEventListener('durationchange', onDurationChange);
+      audio.removeEventListener('ended', onEnded);
+    };
+  }, []);
+
+  const togglePlay = async () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (isPlaying) {
+      audio.pause();
+      setIsPlaying(false);
+    } else {
+      await audio.play();
+      setIsPlaying(true);
+    }
+  };
+
+  const toggleMute = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.muted = !isMuted;
+    setIsMuted(!isMuted);
+  };
+
+  const handleSeek = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const time = parseFloat(e.target.value);
+    audio.currentTime = time;
+    setCurrentTime(time);
+  };
+
+  const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const vol = parseFloat(e.target.value);
+    audio.volume = vol;
+    setVolume(vol);
+    setIsMuted(vol === 0);
+  };
+
+  const formatTime = (seconds: number) => {
+    const mins = Math.floor(seconds / 60);
+    const secs = Math.floor(seconds % 60);
+    return `${mins}:${secs.toString().padStart(2, '0')}`;
+  };
+
+  return (
+    <div className="rounded-xl border border-teal-200 bg-teal-50 p-4">
+      <audio ref={audioRef} src={audioUrl} preload="metadata" />
+
+      <div className="flex items-center gap-3 mb-3">
+        <button
+          onClick={togglePlay}
+          aria-label={isPlaying ? t('pause') : t('play')}
+          className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full bg-teal-600 text-white hover:bg-teal-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+        >
+          {isPlaying ? (
+            <Pause className="h-5 w-5" />
+          ) : (
+            <Play className="h-5 w-5 translate-x-0.5" />
+          )}
+        </button>
+
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-teal-900 truncate">
+            {t('audioSummary')} · {language.toUpperCase()}
+          </p>
+          <div className="flex items-center gap-2 mt-1">
+            <span className="text-xs text-teal-700 tabular-nums w-10 flex-shrink-0">
+              {formatTime(currentTime)}
+            </span>
+            <input
+              type="range"
+              min={0}
+              max={duration || 1}
+              step={0.1}
+              value={currentTime}
+              onChange={handleSeek}
+              aria-label={t('seekBar')}
+              className="h-1.5 flex-1 accent-teal-600 cursor-pointer"
+            />
+            <span className="text-xs text-teal-700 tabular-nums w-10 flex-shrink-0 text-right">
+              {formatTime(duration)}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1 flex-shrink-0">
+          <button
+            onClick={toggleMute}
+            aria-label={isMuted ? t('unmute') : t('mute')}
+            className="flex h-8 w-8 items-center justify-center rounded text-teal-700 hover:text-teal-900 hover:bg-teal-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+          >
+            {isMuted || volume === 0 ? (
+              <VolumeX className="h-4 w-4" />
+            ) : (
+              <Volume2 className="h-4 w-4" />
+            )}
+          </button>
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.05}
+            value={isMuted ? 0 : volume}
+            onChange={handleVolumeChange}
+            aria-label={t('volume')}
+            className="h-1.5 w-16 accent-teal-600 cursor-pointer hidden sm:block"
+          />
+        </div>
+
+        <a
+          href={downloadUrl}
+          download
+          aria-label={t('download')}
+          className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded text-teal-700 hover:text-teal-900 hover:bg-teal-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+        >
+          <Download className="h-4 w-4" />
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/learning/module-lock-gate.tsx
+++ b/frontend/components/learning/module-lock-gate.tsx
@@ -9,6 +9,8 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { getModuleProgress } from '@/lib/api';
+import { useCurrentUser } from '@/lib/hooks/use-current-user';
+import { ModuleMediaSection } from '@/components/learning/module-media-section';
 import { ModuleProgressOverlay } from '@/components/learning/module-progress-overlay';
 import type { Module } from '@/lib/modules';
 
@@ -22,7 +24,9 @@ interface ModuleLockGateProps {
 export function ModuleLockGate({ moduleId, moduleData, prerequisites, language }: ModuleLockGateProps) {
   const t = useTranslations('ModuleOverview');
   const tCard = useTranslations('ModuleCard');
+  const currentUser = useCurrentUser();
   const [status, setStatus] = useState<'locked' | 'in_progress' | 'completed' | 'loading'>('loading');
+  const isAdmin = (currentUser as { role?: string } | null)?.role === 'admin';
 
   useEffect(() => {
     let cancelled = false;
@@ -132,6 +136,12 @@ export function ModuleLockGate({ moduleId, moduleData, prerequisites, language }
 
       <div className="grid md:grid-cols-3 gap-8">
         <div className="md:col-span-2 space-y-8">
+          <ModuleMediaSection
+            moduleId={moduleId}
+            language={language}
+            isAdmin={isAdmin}
+          />
+
           {moduleData.learningObjectives && (
             <Card>
               <CardHeader>

--- a/frontend/components/learning/module-media-section.tsx
+++ b/frontend/components/learning/module-media-section.tsx
@@ -1,0 +1,307 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Film, Headphones, Loader2, RefreshCw, Sparkles } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  generateModuleMedia,
+  getModuleMedia,
+  ModuleMediaRecord,
+  pollMediaStatus,
+} from '@/lib/module-media-api';
+import { ModuleAudioPlayer } from './module-audio-player';
+import { ModuleVideoPlayer } from './module-video-player';
+
+interface ModuleMediaSectionProps {
+  moduleId: string;
+  language: 'fr' | 'en';
+  isAdmin?: boolean;
+}
+
+export function ModuleMediaSection({
+  moduleId,
+  language,
+  isAdmin = false,
+}: ModuleMediaSectionProps) {
+  const t = useTranslations('ModuleMedia');
+  const [audioRecord, setAudioRecord] = useState<ModuleMediaRecord | null>(null);
+  const [videoRecord, setVideoRecord] = useState<ModuleMediaRecord | null>(null);
+  const [isLoadingAudio, setIsLoadingAudio] = useState(false);
+  const [isLoadingVideo, setIsLoadingVideo] = useState(false);
+  const [isInitialLoading, setIsInitialLoading] = useState(true);
+
+  const loadMedia = useCallback(async () => {
+    try {
+      const data = await getModuleMedia(moduleId);
+      const audio = data.media.find(
+        (m) => m.media_type === 'audio_summary' && m.language === language
+      ) ?? null;
+      const video = data.media.find(
+        (m) => m.media_type === 'video_summary' && m.language === language
+      ) ?? null;
+      setAudioRecord(audio);
+      setVideoRecord(video);
+    } catch {
+    } finally {
+      setIsInitialLoading(false);
+    }
+  }, [moduleId, language]);
+
+  useEffect(() => {
+    loadMedia();
+  }, [loadMedia]);
+
+  useEffect(() => {
+    const pollRecord = async (record: ModuleMediaRecord) => {
+      try {
+        const statusUpdate = await pollMediaStatus(moduleId, record.id);
+        const merged: ModuleMediaRecord = {
+          ...record,
+          status: statusUpdate.status,
+          url: statusUpdate.url,
+        };
+        if (record.media_type === 'audio_summary') setAudioRecord(merged);
+        else setVideoRecord(merged);
+      } catch {}
+    };
+
+    const intervals: ReturnType<typeof setInterval>[] = [];
+
+    if (audioRecord && (audioRecord.status === 'pending' || audioRecord.status === 'generating')) {
+      const rec = audioRecord;
+      intervals.push(setInterval(() => pollRecord(rec), 4000));
+    }
+
+    if (videoRecord && (videoRecord.status === 'pending' || videoRecord.status === 'generating')) {
+      const rec = videoRecord;
+      intervals.push(setInterval(() => pollRecord(rec), 4000));
+    }
+
+    return () => {
+      intervals.forEach(clearInterval);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [moduleId, audioRecord?.status, videoRecord?.status]);
+
+  const handleGenerateAudio = async (force = false) => {
+    setIsLoadingAudio(true);
+    try {
+      const result = await generateModuleMedia(moduleId, 'audio_summary', language, force);
+      setAudioRecord((prev) =>
+        prev
+          ? { ...prev, status: 'pending', id: result.media_id }
+          : {
+              id: result.media_id,
+              module_id: moduleId,
+              media_type: 'audio_summary',
+              language,
+              status: 'pending',
+              url: null,
+              duration_seconds: null,
+              file_size_bytes: null,
+              mime_type: null,
+              generated_at: null,
+              created_at: new Date().toISOString(),
+            }
+      );
+    } catch {
+    } finally {
+      setIsLoadingAudio(false);
+    }
+  };
+
+  const handleGenerateVideo = async (force = false) => {
+    setIsLoadingVideo(true);
+    try {
+      const result = await generateModuleMedia(moduleId, 'video_summary', language, force);
+      setVideoRecord((prev) =>
+        prev
+          ? { ...prev, status: 'pending', id: result.media_id }
+          : {
+              id: result.media_id,
+              module_id: moduleId,
+              media_type: 'video_summary',
+              language,
+              status: 'pending',
+              url: null,
+              duration_seconds: null,
+              file_size_bytes: null,
+              mime_type: null,
+              generated_at: null,
+              created_at: new Date().toISOString(),
+            }
+      );
+    } catch {
+    } finally {
+      setIsLoadingVideo(false);
+    }
+  };
+
+  if (isInitialLoading) {
+    return (
+      <div className="space-y-3">
+        <div className="h-16 animate-pulse rounded-xl bg-stone-100" />
+        <div className="h-16 animate-pulse rounded-xl bg-stone-100" />
+      </div>
+    );
+  }
+
+  const noMedia = !audioRecord && !videoRecord;
+  if (noMedia && !isAdmin) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Sparkles className="h-4 w-4 text-teal-600" />
+          {t('sectionTitle')}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-1.5 text-sm font-medium text-stone-700">
+              <Headphones className="h-4 w-4" />
+              {t('audioSummary')}
+            </div>
+            {isAdmin && (
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7 text-xs"
+                disabled={
+                  isLoadingAudio ||
+                  audioRecord?.status === 'pending' ||
+                  audioRecord?.status === 'generating'
+                }
+                onClick={() => handleGenerateAudio(audioRecord?.status === 'ready')}
+              >
+                {isLoadingAudio ||
+                audioRecord?.status === 'pending' ||
+                audioRecord?.status === 'generating' ? (
+                  <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                ) : audioRecord?.status === 'ready' ? (
+                  <RefreshCw className="mr-1 h-3 w-3" />
+                ) : (
+                  <Sparkles className="mr-1 h-3 w-3" />
+                )}
+                {audioRecord?.status === 'ready' ? t('regenerate') : t('generate')}
+              </Button>
+            )}
+          </div>
+
+          {!audioRecord && !isAdmin && null}
+
+          {!audioRecord && isAdmin && (
+            <p className="text-xs text-stone-500">{t('notGenerated')}</p>
+          )}
+
+          {audioRecord && (audioRecord.status === 'pending' || audioRecord.status === 'generating') && (
+            <div className="flex items-center gap-2 rounded-lg border border-teal-100 bg-teal-50 px-3 py-2">
+              <Loader2 className="h-4 w-4 animate-spin text-teal-600 flex-shrink-0" />
+              <p className="text-sm text-teal-700">{t('generating')}</p>
+            </div>
+          )}
+
+          {audioRecord && audioRecord.status === 'failed' && (
+            <div className="flex items-center justify-between rounded-lg border border-red-100 bg-red-50 px-3 py-2">
+              <p className="text-sm text-red-600">{t('generationFailed')}</p>
+              {isAdmin && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 text-xs text-red-600"
+                  onClick={() => handleGenerateAudio(true)}
+                >
+                  {t('retry')}
+                </Button>
+              )}
+            </div>
+          )}
+
+          {audioRecord && audioRecord.status === 'ready' && (
+            <ModuleAudioPlayer
+              mediaId={audioRecord.id}
+              moduleId={moduleId}
+              language={language}
+              durationSeconds={audioRecord.duration_seconds ?? undefined}
+            />
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-1.5 text-sm font-medium text-stone-700">
+              <Film className="h-4 w-4" />
+              {t('videoSummary')}
+            </div>
+            {isAdmin && (
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7 text-xs"
+                disabled={
+                  isLoadingVideo ||
+                  videoRecord?.status === 'pending' ||
+                  videoRecord?.status === 'generating'
+                }
+                onClick={() => handleGenerateVideo(videoRecord?.status === 'ready')}
+              >
+                {isLoadingVideo ||
+                videoRecord?.status === 'pending' ||
+                videoRecord?.status === 'generating' ? (
+                  <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                ) : videoRecord?.status === 'ready' ? (
+                  <RefreshCw className="mr-1 h-3 w-3" />
+                ) : (
+                  <Sparkles className="mr-1 h-3 w-3" />
+                )}
+                {videoRecord?.status === 'ready' ? t('regenerate') : t('generate')}
+              </Button>
+            )}
+          </div>
+
+          {!videoRecord && isAdmin && (
+            <p className="text-xs text-stone-500">{t('notGenerated')}</p>
+          )}
+
+          {videoRecord && (videoRecord.status === 'pending' || videoRecord.status === 'generating') && (
+            <div className="flex items-center gap-2 rounded-lg border border-teal-100 bg-teal-50 px-3 py-2">
+              <Loader2 className="h-4 w-4 animate-spin text-teal-600 flex-shrink-0" />
+              <p className="text-sm text-teal-700">{t('generating')}</p>
+            </div>
+          )}
+
+          {videoRecord && videoRecord.status === 'failed' && (
+            <div className="flex items-center justify-between rounded-lg border border-red-100 bg-red-50 px-3 py-2">
+              <p className="text-sm text-red-600">{t('generationFailed')}</p>
+              {isAdmin && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 text-xs text-red-600"
+                  onClick={() => handleGenerateVideo(true)}
+                >
+                  {t('retry')}
+                </Button>
+              )}
+            </div>
+          )}
+
+          {videoRecord && videoRecord.status === 'ready' && (
+            <ModuleVideoPlayer
+              mediaId={videoRecord.id}
+              moduleId={moduleId}
+              language={language}
+              durationSeconds={videoRecord.duration_seconds ?? undefined}
+              mimeType={videoRecord.mime_type ?? undefined}
+            />
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/learning/module-video-player.tsx
+++ b/frontend/components/learning/module-video-player.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { ChevronDown, ChevronUp, Download, Film } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { API_BASE } from '@/lib/api';
+
+interface VideoSlide {
+  slide_number: number;
+  title: string;
+  narration: string;
+  key_points: string[];
+}
+
+interface VideoScript {
+  title: string;
+  estimated_duration_seconds: number;
+  slides: VideoSlide[];
+}
+
+interface ModuleVideoPlayerProps {
+  mediaId: string;
+  moduleId: string;
+  language: 'fr' | 'en';
+  durationSeconds?: number;
+  mimeType?: string;
+}
+
+export function ModuleVideoPlayer({
+  mediaId,
+  moduleId,
+  language,
+  durationSeconds,
+  mimeType,
+}: ModuleVideoPlayerProps) {
+  const t = useTranslations('ModuleMedia');
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [script, setScript] = useState<VideoScript | null>(null);
+  const [expandedSlide, setExpandedSlide] = useState<number | null>(0);
+  const [loadError, setLoadError] = useState(false);
+
+  const mediaUrl = `${API_BASE}/api/v1/modules/${moduleId}/media/${mediaId}/data`;
+  const isVideoFile = mimeType && mimeType.startsWith('video/');
+  const isJsonScript = mimeType === 'application/json';
+
+  useEffect(() => {
+    if (!isJsonScript) return;
+
+    fetch(mediaUrl, {
+      headers: { Accept: 'application/json' },
+    })
+      .then((r) => r.json())
+      .then((data: VideoScript) => setScript(data))
+      .catch(() => setLoadError(true));
+  }, [mediaUrl, isJsonScript]);
+
+  const formatDuration = (seconds?: number) => {
+    if (!seconds) return '';
+    const mins = Math.floor(seconds / 60);
+    return `${mins} min`;
+  };
+
+  if (isVideoFile) {
+    return (
+      <div className="rounded-xl border border-stone-200 bg-stone-50 overflow-hidden">
+        <video
+          ref={videoRef}
+          src={mediaUrl}
+          controls
+          playsInline
+          className="w-full max-h-64"
+          aria-label={`${t('videoSummary')} ${language.toUpperCase()}`}
+        >
+          <track kind="captions" />
+        </video>
+        <div className="flex items-center justify-between px-3 py-2">
+          <span className="text-xs text-stone-600">
+            {t('videoSummary')} · {language.toUpperCase()}
+            {durationSeconds ? ` · ${formatDuration(durationSeconds)}` : ''}
+          </span>
+          <a
+            href={mediaUrl}
+            download
+            aria-label={t('download')}
+            className="inline-flex items-center gap-1 text-xs text-stone-600 hover:text-stone-900"
+          >
+            <Download className="h-3 w-3" />
+            {t('download')}
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  if (isJsonScript) {
+    if (loadError) {
+      return (
+        <div className="rounded-xl border border-stone-200 bg-stone-50 p-4 text-sm text-stone-500">
+          {t('videoScriptError')}
+        </div>
+      );
+    }
+
+    if (!script) {
+      return (
+        <div className="rounded-xl border border-stone-200 bg-stone-50 p-4 animate-pulse">
+          <div className="h-4 bg-stone-200 rounded w-2/3 mb-2" />
+          <div className="h-3 bg-stone-200 rounded w-1/2" />
+        </div>
+      );
+    }
+
+    return (
+      <div className="rounded-xl border border-stone-200 bg-stone-50">
+        <div className="flex items-center gap-2 px-4 py-3 border-b border-stone-200">
+          <Film className="h-4 w-4 text-stone-500 flex-shrink-0" />
+          <span className="text-sm font-medium text-stone-700 flex-1 truncate">{script.title}</span>
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <Badge variant="secondary" className="text-xs">
+              {language.toUpperCase()}
+            </Badge>
+            {script.estimated_duration_seconds && (
+              <Badge variant="outline" className="text-xs">
+                {formatDuration(script.estimated_duration_seconds)}
+              </Badge>
+            )}
+          </div>
+        </div>
+
+        <div className="divide-y divide-stone-100">
+          {script.slides.map((slide, index) => (
+            <div key={slide.slide_number} className="px-4 py-3">
+              <button
+                className="flex w-full items-center justify-between text-left gap-2"
+                onClick={() => setExpandedSlide(expandedSlide === index ? null : index)}
+                aria-expanded={expandedSlide === index}
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  <span className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-teal-100 text-xs font-semibold text-teal-700">
+                    {slide.slide_number}
+                  </span>
+                  <span className="text-sm font-medium text-stone-800 truncate">{slide.title}</span>
+                </div>
+                {expandedSlide === index ? (
+                  <ChevronUp className="h-4 w-4 text-stone-400 flex-shrink-0" />
+                ) : (
+                  <ChevronDown className="h-4 w-4 text-stone-400 flex-shrink-0" />
+                )}
+              </button>
+
+              {expandedSlide === index && (
+                <div className="mt-3 pl-8 space-y-3">
+                  <p className="text-sm text-stone-700 leading-relaxed">{slide.narration}</p>
+                  {slide.key_points.length > 0 && (
+                    <ul className="space-y-1.5">
+                      {slide.key_points.map((point, i) => (
+                        <li key={i} className="flex items-start gap-2 text-sm text-stone-600">
+                          <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-teal-500" />
+                          {point}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{t('videoSummary')}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-stone-500">{t('videoUnavailable')}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/lib/module-media-api.ts
+++ b/frontend/lib/module-media-api.ts
@@ -1,0 +1,66 @@
+import { apiFetch } from './api';
+
+export type MediaType = 'audio_summary' | 'video_summary';
+export type MediaStatus = 'pending' | 'generating' | 'ready' | 'failed';
+
+export interface ModuleMediaRecord {
+  id: string;
+  module_id: string;
+  media_type: MediaType;
+  language: string;
+  status: MediaStatus;
+  url: string | null;
+  duration_seconds: number | null;
+  file_size_bytes: number | null;
+  mime_type: string | null;
+  generated_at: string | null;
+  created_at: string;
+}
+
+export interface ModuleMediaListResponse {
+  module_id: string;
+  media: ModuleMediaRecord[];
+  total: number;
+}
+
+export interface GenerateMediaResponse {
+  media_id: string;
+  task_id: string | null;
+  status: MediaStatus;
+  message: string;
+}
+
+export interface MediaStatusResponse {
+  media_id: string;
+  status: MediaStatus;
+  url: string | null;
+}
+
+export async function getModuleMedia(moduleId: string): Promise<ModuleMediaListResponse> {
+  return apiFetch<ModuleMediaListResponse>(`/api/v1/modules/${moduleId}/media`);
+}
+
+export async function generateModuleMedia(
+  moduleId: string,
+  mediaType: MediaType,
+  language: string,
+  forceRegenerate = false
+): Promise<GenerateMediaResponse> {
+  return apiFetch<GenerateMediaResponse>(`/api/v1/modules/${moduleId}/media/generate`, {
+    method: 'POST',
+    body: JSON.stringify({
+      media_type: mediaType,
+      language,
+      force_regenerate: forceRegenerate,
+    }),
+  });
+}
+
+export async function pollMediaStatus(
+  moduleId: string,
+  mediaId: string
+): Promise<MediaStatusResponse> {
+  return apiFetch<MediaStatusResponse>(
+    `/api/v1/modules/${moduleId}/media/${mediaId}/status`
+  );
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -906,5 +906,25 @@
     "bloomLevel": "Bloom level",
     "estimatedHours": "Duration (h)",
     "moduleNumber": "Module number"
+  },
+  "ModuleMedia": {
+    "sectionTitle": "AI Summaries",
+    "audioSummary": "Audio Summary",
+    "videoSummary": "Video Summary",
+    "generate": "Generate",
+    "regenerate": "Regenerate",
+    "generating": "Generating… This may take a few minutes.",
+    "notGenerated": "Not yet generated",
+    "generationFailed": "Generation failed",
+    "retry": "Retry",
+    "play": "Play",
+    "pause": "Pause",
+    "mute": "Mute",
+    "unmute": "Unmute",
+    "volume": "Volume",
+    "seekBar": "Audio seek bar",
+    "download": "Download",
+    "videoScriptError": "Unable to load video script",
+    "videoUnavailable": "Video not available"
   }
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -906,5 +906,25 @@
     "bloomLevel": "Niveau Bloom",
     "estimatedHours": "Durée (h)",
     "moduleNumber": "Numéro de module"
+  },
+  "ModuleMedia": {
+    "sectionTitle": "Résumés IA",
+    "audioSummary": "Résumé Audio",
+    "videoSummary": "Résumé Vidéo",
+    "generate": "Générer",
+    "regenerate": "Régénérer",
+    "generating": "Génération en cours… Cela peut prendre quelques minutes.",
+    "notGenerated": "Pas encore généré",
+    "generationFailed": "Échec de la génération",
+    "retry": "Réessayer",
+    "play": "Lecture",
+    "pause": "Pause",
+    "mute": "Couper le son",
+    "unmute": "Rétablir le son",
+    "volume": "Volume",
+    "seekBar": "Barre de lecture audio",
+    "download": "Télécharger",
+    "videoScriptError": "Impossible de charger le script vidéo",
+    "videoUnavailable": "Vidéo non disponible"
   }
 }


### PR DESCRIPTION
## Summary

Implements AI-generated audio and video module summaries (issue #539). Learners can listen to or watch 5-10 minute module overviews, available in FR and EN on the module overview page.

## Changes

### Backend
- `backend/migrations/versions/023_add_module_media_table.py` — Alembic migration for `module_media` table with `audio_summary|video_summary` type enum, `pending|generating|ready|failed` status enum, binary media storage (`media_data` bytea), and unique index on `(module_id, media_type, language)`
- `backend/app/domain/models/module_media.py` — SQLAlchemy model `ModuleMedia` with FK to `modules`
- `backend/app/domain/models/module.py` — Added `media` back-reference relationship
- `backend/app/domain/models/__init__.py` — Registered `ModuleMedia`
- `backend/app/api/v1/schemas/module_media.py` — Pydantic V2 schemas: `ModuleMediaResponse`, `GenerateMediaRequest`, `GenerateMediaResponse`, `MediaStatusResponse`
- `backend/app/domain/services/module_media_service.py` — `ModuleMediaService`: Claude script generation → Google Cloud TTS / Gemini TTS / plain-text fallback; video generates structured JSON slide script
- `backend/app/tasks/media_generation.py` — Celery tasks `generate_module_audio_task` and `generate_module_video_task` (async, retryable)
- `backend/app/tasks/celery_app.py` — Registered `app.tasks.media_generation` module
- `backend/app/api/v1/module_media.py` — REST endpoints: `GET /modules/{id}/media`, `POST /modules/{id}/media/generate`, `GET /modules/{id}/media/{mid}/status`, `GET /modules/{id}/media/{mid}/data`
- `backend/app/api/v1/router.py` — Registered `module_media_router`
- `backend/app/infrastructure/config/settings.py` — Added `google_api_key` and `google_cloud_tts_api_key`

### Frontend
- `frontend/lib/module-media-api.ts` — API functions: `getModuleMedia`, `generateModuleMedia`, `pollMediaStatus`
- `frontend/components/learning/module-audio-player.tsx` — Mini audio player (play/pause, seek, volume, download) — mobile-first, 44px touch targets
- `frontend/components/learning/module-video-player.tsx` — Video player supporting native `<video>` for actual video files and interactive accordion slide view for JSON scripts
- `frontend/components/learning/module-media-section.tsx` — Section card with polling, loading states, admin generate/regenerate buttons
- `frontend/components/learning/module-lock-gate.tsx` — Added `<ModuleMediaSection>` to module overview page
- `frontend/messages/en.json` + `frontend/messages/fr.json` — `ModuleMedia` i18n namespace (20 keys, FR/EN)

## TTS Priority Order
1. Google Cloud TTS (if `GOOGLE_CLOUD_TTS_API_KEY` set) → MP3
2. Google Gemini TTS (if `GOOGLE_API_KEY` set) → WAV
3. Plain-text fallback for development (no API keys needed)

## Test plan
- [ ] Backend ruff lint passes (`All checks passed!`)
- [ ] Frontend ESLint passes (0 new warnings in new files)
- [ ] Frontend TypeScript passes (`tsc --noEmit`)
- [ ] Manually test: trigger audio generation via `POST /api/v1/modules/{id}/media/generate`
- [ ] Manually verify audio player renders on module overview page
- [ ] Manually verify video script accordion renders
- [ ] Verify i18n works in both FR and EN
- [ ] Verify admin-only generate buttons hidden for regular users

Closes #539

🤖 Generated with [Claude Code](https://claude.ai/code)