### PR TITLE
fix(migrations): idempotent enum creation — unblock production

### DIFF
--- a/backend/migrations/versions/020_add_admin_audit_logs_table.py
+++ b/backend/migrations/versions/020_add_admin_audit_logs_table.py
@@ -20,14 +20,17 @@ depends_on: str | Sequence[str] | None = None
 def upgrade() -> None:
     op.execute(
         """
-        CREATE TYPE adminaction AS ENUM (
-            'deactivate_user',
-            'reactivate_user',
-            'promote_to_expert',
-            'promote_to_admin',
-            'demote_to_user',
-            'update_role'
-        )
+        DO $$ BEGIN
+            CREATE TYPE adminaction AS ENUM (
+                'deactivate_user',
+                'reactivate_user',
+                'promote_to_expert',
+                'promote_to_admin',
+                'demote_to_user',
+                'update_role'
+            );
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$
         """
     )
     op.create_table(

--- a/backend/migrations/versions/021_add_courses_and_enrollment.py
+++ b/backend/migrations/versions/021_add_courses_and_enrollment.py
@@ -22,12 +22,18 @@ DEFAULT_COURSE_ID = "00000000-0000-0000-0000-000000000001"
 def upgrade() -> None:
     op.execute(
         """
-        CREATE TYPE coursestatus AS ENUM ('draft', 'published', 'archived')
+        DO $$ BEGIN
+            CREATE TYPE coursestatus AS ENUM ('draft', 'published', 'archived');
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$
         """
     )
     op.execute(
         """
-        CREATE TYPE enrollmentstatus AS ENUM ('active', 'completed', 'dropped')
+        DO $$ BEGIN
+            CREATE TYPE enrollmentstatus AS ENUM ('active', 'completed', 'dropped');
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$
         """
     )
 


### PR DESCRIPTION
## Root cause
Branched migrations left orphan enum types (coursestatus, enrollmentstatus, adminaction) on production DB. Subsequent migration runs fail with DuplicateObjectError.

## Fix
Wrap CREATE TYPE in DO $$ BEGIN ... EXCEPTION WHEN duplicate_object THEN NULL; END $$ so migrations are safely re-runnable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)