### PR TITLE
fix(courses): fix enrollment detection — enrolled users see 'Voir les modules'

### DIFF
--- a/frontend/components/learning/course-card.tsx
+++ b/frontend/components/learning/course-card.tsx
@@ -6,31 +6,29 @@ import { useRouter } from '@/i18n/routing';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { CheckCircle, Clock, BookOpen, GraduationCap } from 'lucide-react';
-import { enrollInCourse, type CourseResponse, type EnrollmentResponse } from '@/lib/api';
+import { enrollInCourse, type CourseResponse } from '@/lib/api';
 
 interface CourseCardProps {
   course: CourseResponse;
-  enrollment?: EnrollmentResponse;
 }
 
-export function CourseCard({ course, enrollment: initialEnrollment }: CourseCardProps) {
+export function CourseCard({ course }: CourseCardProps) {
   const t = useTranslations('Courses');
   const locale = useLocale() as 'en' | 'fr';
   const router = useRouter();
-  const [enrollment, setEnrollment] = useState<EnrollmentResponse | undefined>(initialEnrollment);
+  const [isEnrolled, setIsEnrolled] = useState(course.enrolled);
   const [enrolling, setEnrolling] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const title = locale === 'fr' ? course.title_fr : course.title_en;
   const description = locale === 'fr' ? course.description_fr : course.description_en;
-  const isEnrolled = !!enrollment;
 
   const handleEnroll = async () => {
     setEnrolling(true);
     setError(null);
     try {
-      const result = await enrollInCourse(course.id);
-      setEnrollment(result);
+      await enrollInCourse(course.id);
+      setIsEnrolled(true);
     } catch {
       setError(t('enrollError'));
     } finally {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -3,6 +3,7 @@ export const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:800
 // Course Catalog API Types
 export interface CourseResponse {
   id: string;
+  slug: string;
   title_fr: string;
   title_en: string;
   description_fr?: string;
@@ -12,6 +13,7 @@ export interface CourseResponse {
   module_count: number;
   cover_image_url?: string;
   is_published: boolean;
+  enrolled: boolean;
 }
 
 export interface EnrollmentResponse {


### PR DESCRIPTION
## Summary

Enrolled users were always seeing \"S'inscrire\" instead of \"Voir les modules\" on `/courses`.

**Root cause:** The `CourseResponse` TypeScript type was missing the `enrolled: boolean` field that the backend already returns in `GET /api/v1/courses`. Because `course.enrolled` was `undefined`, `CourseCard` treated every course as unenrolled.

## Changes

- `frontend/lib/api.ts` — added `enrolled: boolean` and `slug: string` to `CourseResponse` to match backend `CourseListItem` schema
- `frontend/components/learning/course-card.tsx` — derive `isEnrolled` state from `course.enrolled` directly; remove unused `enrollment` prop and `EnrollmentResponse` import

## How it works now

1. `apiFetch` already attaches the JWT `Authorization` header when a token is available
2. Backend `get_optional_user` reads the header and returns enrolled course IDs
3. `CourseResponse.enrolled` is now `true` for enrolled courses
4. `CourseCard` initialises `isEnrolled` from `course.enrolled` → correct button shown on first render

## Test plan

- [ ] Log in → go to `/fr/courses` → enrolled courses show \"Voir les modules\"
- [ ] Non-enrolled courses still show \"S'inscrire\"
- [ ] Clicking \"S'inscrire\" enrolls the user and button switches to \"Voir les modules\"
- [ ] Frontend lint: 0 errors (13 pre-existing warnings unchanged)
- [ ] TypeScript: no new errors

Closes #591

Generated with [Claude Code](https://claude.ai/code)