### PR TITLE
feat(dashboard): multi-course aware dashboard

### DIFF
--- a/frontend/app/[locale]/(app)/dashboard/dashboard-client.tsx
+++ b/frontend/app/[locale]/(app)/dashboard/dashboard-client.tsx
@@ -1,14 +1,120 @@
 'use client';
 
+import { useState, useEffect } from 'react';
+import { useTranslations, useLocale } from 'next-intl';
 import { useRouter } from '@/i18n/routing';
 import { ModuleMap } from '@/components/learning/module-map';
+import { getMyEnrollments, type CourseWithEnrollment } from '@/lib/api';
 
 export function DashboardClient() {
+  const t = useTranslations('Dashboard');
+  const locale = useLocale() as 'en' | 'fr';
   const router = useRouter();
+
+  const [enrollments, setEnrollments] = useState<CourseWithEnrollment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [expandedCourseId, setExpandedCourseId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getMyEnrollments()
+      .then((data) => {
+        if (!cancelled) {
+          setEnrollments(data);
+          if (data.length === 1) {
+            setExpandedCourseId(data[0].id);
+          }
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleModuleClick = (moduleId: string) => {
     router.push(`/modules/${moduleId}`);
   };
 
-  return <ModuleMap onModuleClick={handleModuleClick} />;
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <p className="text-stone-500 text-sm">{t('loading')}</p>
+      </div>
+    );
+  }
+
+  if (enrollments.length === 0) {
+    return (
+      <div className="rounded-lg bg-stone-50 border border-stone-200 p-8 text-center">
+        <p className="text-stone-600 text-sm">{t('noEnrollments')}</p>
+        <button
+          className="mt-4 text-teal-600 text-sm font-medium underline-offset-2 hover:underline min-h-11"
+          onClick={() => router.push('/courses')}
+        >
+          {t('browseCourses')}
+        </button>
+      </div>
+    );
+  }
+
+  if (enrollments.length === 1) {
+    return (
+      <ModuleMap
+        courseId={enrollments[0].id}
+        onModuleClick={handleModuleClick}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {enrollments.map((course) => {
+        const isExpanded = expandedCourseId === course.id;
+        const title = locale === 'fr' ? course.title_fr : course.title_en;
+
+        return (
+          <div key={course.id} className="rounded-lg border border-stone-200 overflow-hidden">
+            <button
+              className="w-full flex items-center justify-between px-4 py-4 bg-white text-left hover:bg-stone-50 transition-colors min-h-11"
+              onClick={() =>
+                setExpandedCourseId(isExpanded ? null : course.id)
+              }
+              aria-expanded={isExpanded}
+            >
+              <div className="flex-1 min-w-0">
+                <h3 className="text-base font-semibold text-stone-900 truncate">
+                  {title}
+                </h3>
+                {course.domain && (
+                  <span className="text-xs text-stone-500">{course.domain}</span>
+                )}
+              </div>
+              <span
+                className="ml-3 text-stone-400 shrink-0 transition-transform duration-200"
+                style={{ transform: isExpanded ? 'rotate(180deg)' : 'none' }}
+                aria-hidden="true"
+              >
+                ▾
+              </span>
+            </button>
+
+            {isExpanded && (
+              <div className="px-4 pb-6 pt-2 bg-white border-t border-stone-100">
+                <ModuleMap
+                  courseId={course.id}
+                  onModuleClick={handleModuleClick}
+                />
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
 }

--- a/frontend/components/learning/module-map.tsx
+++ b/frontend/components/learning/module-map.tsx
@@ -13,6 +13,7 @@ import { getAllModuleProgress, type ModuleProgressResponse } from '@/lib/api';
 
 interface ModuleMapProps {
   onModuleClick: (moduleId: string) => void;
+  courseId?: string;
 }
 
 function mergeProgressIntoModules(
@@ -45,7 +46,7 @@ function mergeProgressIntoModules(
   });
 }
 
-export function ModuleMap({ onModuleClick }: ModuleMapProps) {
+export function ModuleMap({ onModuleClick, courseId }: ModuleMapProps) {
   const t = useTranslations('ModuleMap');
   const locale = useLocale() as 'en' | 'fr';
 
@@ -55,7 +56,7 @@ export function ModuleMap({ onModuleClick }: ModuleMapProps) {
 
   useEffect(() => {
     let cancelled = false;
-    getAllModuleProgress()
+    getAllModuleProgress(courseId)
       .then((data) => {
         if (!cancelled) {
           setModules(mergeProgressIntoModules(data));
@@ -71,7 +72,7 @@ export function ModuleMap({ onModuleClick }: ModuleMapProps) {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [courseId]);
 
   const levels = [1, 2, 3, 4] as const;
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -126,6 +126,13 @@ export async function deleteTaxonomyCategory(id: string): Promise<void> {
   );
 }
 
+export async function getMyEnrollments(): Promise<CourseWithEnrollment[]> {
+  const { authClient } = await import("./auth");
+  return authClient.authenticatedFetch<CourseWithEnrollment[]>(
+    "/api/v1/courses/my-enrollments"
+  );
+}
+
 // Progress API Types
 export interface ModuleProgressResponse {
   module_id: string;
@@ -183,9 +190,12 @@ export async function getModuleProgress(moduleId: string): Promise<ModuleProgres
   );
 }
 
-export async function getAllModuleProgress(): Promise<ModuleProgressResponse[]> {
+export async function getAllModuleProgress(courseId?: string): Promise<ModuleProgressResponse[]> {
   const { authClient } = await import("./auth");
-  return authClient.authenticatedFetch<ModuleProgressResponse[]>("/api/v1/progress/modules");
+  const url = courseId
+    ? `/api/v1/progress/modules?course_id=${encodeURIComponent(courseId)}`
+    : "/api/v1/progress/modules";
+  return authClient.authenticatedFetch<ModuleProgressResponse[]>(url);
 }
 
 export async function getModuleDetailWithProgress(

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -175,7 +175,10 @@
     "errorOccurred": "An error occurred",
     "unableToLoadStats": "Unable to load dashboard statistics",
     "noQuizzesTakenYet": "No quizzes taken yet",
-    "justGettingStarted": "Just getting started"
+    "justGettingStarted": "Just getting started",
+    "loading": "Loading...",
+    "noEnrollments": "You are not enrolled in any courses yet.",
+    "browseCourses": "Browse available courses"
   },
   "ModuleCard": {
     "locked": "Locked",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -175,7 +175,10 @@
     "errorOccurred": "Une erreur s'est produite",
     "unableToLoadStats": "Impossible de charger les statistiques du tableau de bord",
     "noQuizzesTakenYet": "Aucun quiz passé",
-    "justGettingStarted": "Tout juste commencé"
+    "justGettingStarted": "Tout juste commencé",
+    "loading": "Chargement...",
+    "noEnrollments": "Vous n'êtes inscrit à aucune formation pour l'instant.",
+    "browseCourses": "Parcourir les formations disponibles"
   },
   "ModuleCard": {
     "locked": "Verrouillé",


### PR DESCRIPTION
## Summary

- Dashboard now fetches enrolled courses via `GET /api/v1/courses/my-enrollments`
- If 0 courses enrolled: shows empty state with link to course catalog
- If 1 course enrolled: renders `ModuleMap` directly (current layout preserved)
- If 2+ courses enrolled: collapsible accordion — one section per course, expand to see modules

## Changes

- `frontend/lib/api.ts` — added `getMyEnrollments()` function; updated `getAllModuleProgress()` to accept optional `courseId` query param
- `frontend/app/[locale]/(app)/dashboard/dashboard-client.tsx` — rewrote to be enrollment-aware with loading/empty/single/multi-course states
- `frontend/components/learning/module-map.tsx` — added `courseId?: string` prop; passes it to `getAllModuleProgress()` and re-fetches when it changes
- `frontend/messages/en.json` + `frontend/messages/fr.json` — added `Dashboard.loading`, `Dashboard.noEnrollments`, `Dashboard.browseCourses`

## Test plan

- [ ] Backend tests pass
- [ ] Frontend lint passes (0 errors)
- [ ] Manually verified: 0 enrollments → empty state shown
- [ ] Manually verified: 1 enrollment → ModuleMap shown directly
- [ ] Manually verified: 2+ enrollments → accordion with per-course expand/collapse
- [ ] Manually verified on mobile viewport (320px)

Closes #595

Generated with [Claude Code](https://claude.ai/code)