### PR TITLE
feat(media): module audio player UI + admin generate button

### DIFF
--- a/frontend/components/learning/module-lock-gate.tsx
+++ b/frontend/components/learning/module-lock-gate.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { getModuleProgress } from '@/lib/api';
 import { ModuleProgressOverlay } from '@/components/learning/module-progress-overlay';
+import { ModuleMediaPlayer } from '@/components/learning/module-media-player';
 import type { Module } from '@/lib/modules';
 
 interface ModuleLockGateProps {
@@ -132,6 +133,8 @@ export function ModuleLockGate({ moduleId, moduleData, prerequisites, language }
 
       <div className="grid md:grid-cols-3 gap-8">
         <div className="md:col-span-2 space-y-8">
+          <ModuleMediaPlayer moduleId={moduleId} language={language} />
+
           {moduleData.learningObjectives && (
             <Card>
               <CardHeader>

--- a/frontend/components/learning/module-media-player.tsx
+++ b/frontend/components/learning/module-media-player.tsx
@@ -1,0 +1,353 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useTranslations } from 'next-intl';
+import { Play, Pause, Download, Loader2, Music, AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { getModuleMedia, generateModuleMedia } from '@/lib/api';
+import type { ModuleMediaResponse, MediaStatus } from '@/lib/api';
+
+const POLL_INTERVAL_MS = 4000;
+const MAX_POLL_ATTEMPTS = 60;
+
+function parseJwtPayload(token: string): Record<string, unknown> | null {
+  try {
+    const base64Url = token.split('.')[1];
+    if (!base64Url) return null;
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    return JSON.parse(atob(base64));
+  } catch {
+    return null;
+  }
+}
+
+function isAdminOrExpert(): boolean {
+  if (typeof window === 'undefined') return false;
+  const token = localStorage.getItem('access_token');
+  if (!token) return false;
+  const payload = parseJwtPayload(token);
+  const role = payload?.role as string | undefined;
+  return role === 'admin' || role === 'expert';
+}
+
+function formatDuration(seconds: number): { minutes: string; seconds: string } {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return {
+    minutes: String(m).padStart(2, '0'),
+    seconds: String(s).padStart(2, '0'),
+  };
+}
+
+interface ModuleMediaPlayerProps {
+  moduleId: string;
+  language: 'fr' | 'en';
+}
+
+export function ModuleMediaPlayer({ moduleId, language }: ModuleMediaPlayerProps) {
+  const t = useTranslations('ModuleMediaPlayer');
+
+  const [audioMedia, setAudioMedia] = useState<ModuleMediaResponse | null>(null);
+  const [status, setStatus] = useState<MediaStatus | 'loading' | 'error'>('loading');
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [generateError, setGenerateError] = useState(false);
+
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    setIsAdmin(isAdminOrExpert());
+  }, []);
+
+  const fetchMedia = useCallback(async () => {
+    try {
+      const items = await getModuleMedia(moduleId);
+      const audio = items.find(
+        (m) => m.media_type === 'audio' && m.language === language
+      );
+      if (audio) {
+        setAudioMedia(audio);
+        setStatus(audio.status);
+        return audio;
+      } else {
+        setAudioMedia(null);
+        setStatus('pending');
+        return null;
+      }
+    } catch {
+      setStatus('error');
+      return null;
+    }
+  }, [moduleId, language]);
+
+  const startPolling = useCallback(
+    (mediaId: string) => {
+      let attempts = 0;
+
+      const tick = async () => {
+        if (attempts >= MAX_POLL_ATTEMPTS) {
+          setStatus('failed');
+          setIsGenerating(false);
+          return;
+        }
+        attempts++;
+
+        try {
+          const items = await getModuleMedia(moduleId);
+          const audio = items.find((m) => m.id === mediaId);
+          if (audio) {
+            setAudioMedia(audio);
+            setStatus(audio.status);
+            if (audio.status === 'ready' || audio.status === 'failed') {
+              setIsGenerating(false);
+              return;
+            }
+          }
+        } catch {
+          // keep polling
+        }
+
+        pollTimerRef.current = setTimeout(tick, POLL_INTERVAL_MS);
+      };
+
+      pollTimerRef.current = setTimeout(tick, POLL_INTERVAL_MS);
+    },
+    [moduleId]
+  );
+
+  useEffect(() => {
+    fetchMedia();
+    return () => {
+      if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
+    };
+  }, [fetchMedia]);
+
+  const handleGenerate = async () => {
+    setIsGenerating(true);
+    setGenerateError(false);
+    try {
+      const media = await generateModuleMedia(moduleId, 'audio', language);
+      setAudioMedia(media);
+      setStatus(media.status);
+      if (media.status !== 'ready') {
+        startPolling(media.id);
+      } else {
+        setIsGenerating(false);
+      }
+    } catch {
+      setGenerateError(true);
+      setIsGenerating(false);
+    }
+  };
+
+  const handlePlayPause = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (isPlaying) {
+      audio.pause();
+    } else {
+      audio.play().catch(() => {});
+    }
+  };
+
+  const handleTimeUpdate = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    setCurrentTime(audio.currentTime);
+  };
+
+  const handleLoadedMetadata = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    setDuration(audio.duration);
+  };
+
+  const handleSeek = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const newTime = Number(e.target.value);
+    audio.currentTime = newTime;
+    setCurrentTime(newTime);
+  };
+
+  const progressPercent = duration > 0 ? (currentTime / duration) * 100 : 0;
+  const currentFmt = formatDuration(currentTime);
+  const durationFmt = formatDuration(duration);
+
+  if (status === 'loading') {
+    return (
+      <Card className="w-full">
+        <CardContent className="p-4">
+          <div className="animate-pulse flex items-center gap-3">
+            <div className="w-11 h-11 rounded-full bg-stone-200 flex-shrink-0" />
+            <div className="flex-1 space-y-2">
+              <div className="h-4 bg-stone-200 rounded w-1/3" />
+              <div className="h-2 bg-stone-200 rounded" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <Card className="w-full">
+        <CardContent className="p-4">
+          <div className="flex items-center gap-3 text-stone-500">
+            <AlertCircle className="w-5 h-5 flex-shrink-0" aria-hidden="true" />
+            <span className="text-sm">{t('errorLoading')}</span>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="ml-auto min-h-11 min-w-11"
+              onClick={() => { setStatus('loading'); fetchMedia(); }}
+            >
+              {t('retry')}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const hasAudio = status === 'ready' && audioMedia?.url;
+  const isCurrentlyGenerating = status === 'generating' || isGenerating;
+
+  return (
+    <Card className="w-full">
+      <CardContent className="p-4">
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-3">
+            <div
+              className="w-11 h-11 rounded-full bg-teal-50 flex items-center justify-center flex-shrink-0"
+              aria-hidden="true"
+            >
+              <Music className="w-5 h-5 text-teal-600" />
+            </div>
+
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-stone-900 truncate">
+                {t('listenToSummary')}
+              </p>
+              <p className="text-xs text-stone-500">
+                {isCurrentlyGenerating
+                  ? t('mediaGenerating')
+                  : hasAudio
+                  ? t('mediaReady')
+                  : t('mediaNotAvailable')}
+              </p>
+            </div>
+
+            {isCurrentlyGenerating && (
+              <Loader2
+                className="w-5 h-5 text-teal-600 animate-spin flex-shrink-0"
+                aria-hidden="true"
+              />
+            )}
+
+            {isAdmin && !hasAudio && !isCurrentlyGenerating && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="min-h-11 flex-shrink-0"
+                onClick={handleGenerate}
+                disabled={isGenerating}
+              >
+                {t('generateAudio')}
+              </Button>
+            )}
+          </div>
+
+          {generateError && (
+            <p className="text-xs text-red-600" role="alert">
+              {t('errorGenerating')}
+            </p>
+          )}
+
+          {isCurrentlyGenerating && (
+            <div className="flex items-center gap-2 text-xs text-stone-500">
+              <Loader2 className="w-3 h-3 animate-spin" aria-hidden="true" />
+              <span>{t('generating')}</span>
+            </div>
+          )}
+
+          {hasAudio && audioMedia?.url && (
+            <>
+              <audio
+                ref={audioRef}
+                src={audioMedia.url}
+                onTimeUpdate={handleTimeUpdate}
+                onLoadedMetadata={handleLoadedMetadata}
+                onPlay={() => setIsPlaying(true)}
+                onPause={() => setIsPlaying(false)}
+                onEnded={() => setIsPlaying(false)}
+                preload="metadata"
+              />
+
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  onClick={handlePlayPause}
+                  className="w-11 h-11 min-w-11 min-h-11 rounded-full bg-teal-600 hover:bg-teal-700 flex items-center justify-center text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-2 flex-shrink-0"
+                  aria-label={isPlaying ? t('pause') : t('play')}
+                >
+                  {isPlaying ? (
+                    <Pause className="w-5 h-5" aria-hidden="true" />
+                  ) : (
+                    <Play className="w-5 h-5 ml-0.5" aria-hidden="true" />
+                  )}
+                </button>
+
+                <div className="flex-1 flex flex-col gap-1 min-w-0">
+                  <input
+                    type="range"
+                    min={0}
+                    max={duration || 0}
+                    step={0.1}
+                    value={currentTime}
+                    onChange={handleSeek}
+                    className="w-full h-2 accent-teal-600 cursor-pointer"
+                    aria-label={t('listenToSummary')}
+                    style={{
+                      background: `linear-gradient(to right, #0d9488 ${progressPercent}%, #e7e5e4 ${progressPercent}%)`,
+                    }}
+                  />
+                  <div className="flex justify-between text-xs text-stone-500">
+                    <span>
+                      {t('duration', {
+                        minutes: currentFmt.minutes,
+                        seconds: currentFmt.seconds,
+                      })}
+                    </span>
+                    <span>
+                      {t('duration', {
+                        minutes: durationFmt.minutes,
+                        seconds: durationFmt.seconds,
+                      })}
+                    </span>
+                  </div>
+                </div>
+
+                <a
+                  href={audioMedia.url}
+                  download
+                  className="w-11 h-11 min-w-11 min-h-11 rounded-full border border-stone-200 flex items-center justify-center text-stone-600 hover:bg-stone-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-2 flex-shrink-0"
+                  aria-label={t('downloadMedia')}
+                >
+                  <Download className="w-4 h-4" aria-hidden="true" />
+                </a>
+              </div>
+            </>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -564,6 +564,47 @@ export async function submitSummativeAssessmentAttempt(
   });
 }
 
+// ── Module Media API ──────────────────────────────────────────
+
+export type MediaType = 'audio' | 'video';
+export type MediaStatus = 'pending' | 'generating' | 'ready' | 'failed';
+
+export interface ModuleMediaResponse {
+  id: string;
+  module_id: string;
+  media_type: MediaType;
+  language: string;
+  status: MediaStatus;
+  url?: string;
+  duration_seconds?: number;
+  file_size_bytes?: number;
+  generated_at?: string;
+}
+
+export interface GenerateModuleMediaRequest {
+  media_type: MediaType;
+  language: string;
+}
+
+export async function getModuleMedia(moduleId: string): Promise<ModuleMediaResponse[]> {
+  return apiFetch<ModuleMediaResponse[]>(`/api/v1/modules/${moduleId}/media`);
+}
+
+export async function generateModuleMedia(
+  moduleId: string,
+  mediaType: MediaType,
+  language: string
+): Promise<ModuleMediaResponse> {
+  return apiFetch<ModuleMediaResponse>(`/api/v1/modules/${moduleId}/media/generate`, {
+    method: 'POST',
+    body: JSON.stringify({ media_type: mediaType, language } satisfies GenerateModuleMediaRequest),
+  });
+}
+
+export async function deleteModuleMedia(moduleId: string, mediaId: string): Promise<void> {
+  await apiFetch<void>(`/api/v1/modules/${moduleId}/media/${mediaId}`, { method: 'DELETE' });
+}
+
 // ── Platform Settings ─────────────────────────────────────────
 
 export interface PlatformSetting {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -637,6 +637,23 @@
     "imageViewFullscreen": "View fullscreen",
     "imageCloseFullscreen": "Close fullscreen"
   },
+  "ModuleMediaPlayer": {
+    "listenToSummary": "Listen to summary",
+    "watchSummary": "Watch summary",
+    "downloadMedia": "Download",
+    "generateAudio": "Generate audio",
+    "generateVideo": "Generate video",
+    "mediaGenerating": "Generating...",
+    "mediaReady": "Available",
+    "mediaNotAvailable": "Not yet available",
+    "generating": "Generation in progress...",
+    "errorGenerating": "Generation failed. Please try again.",
+    "errorLoading": "Error loading media.",
+    "retry": "Retry",
+    "play": "Play",
+    "pause": "Pause",
+    "duration": "{minutes}:{seconds}"
+  },
   "CaseStudyViewer": {
     "error": "An error occurred",
     "streamError": "Streaming error occurred",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -637,6 +637,23 @@
     "imageViewFullscreen": "Voir en plein écran",
     "imageCloseFullscreen": "Fermer le plein écran"
   },
+  "ModuleMediaPlayer": {
+    "listenToSummary": "Écouter le résumé",
+    "watchSummary": "Regarder le résumé",
+    "downloadMedia": "Télécharger",
+    "generateAudio": "Générer l'audio",
+    "generateVideo": "Générer la vidéo",
+    "mediaGenerating": "Génération en cours...",
+    "mediaReady": "Disponible",
+    "mediaNotAvailable": "Pas encore disponible",
+    "generating": "Génération en cours...",
+    "errorGenerating": "Échec de la génération. Veuillez réessayer.",
+    "errorLoading": "Erreur lors du chargement du média.",
+    "retry": "Réessayer",
+    "play": "Lire",
+    "pause": "Pause",
+    "duration": "{minutes}:{seconds}"
+  },
   "CaseStudyViewer": {
     "error": "Une erreur est survenue",
     "streamError": "Erreur lors de la diffusion en continu",


### PR DESCRIPTION
## Summary

- New `ModuleMediaPlayer` component with HTML5 audio player (play/pause, progress bar, duration display, download)
- Admin/expert-only "Generate audio" button visible when no audio exists for the module
- Generating state with spinner + polling until audio is ready or failed
- Fully bilingual (FR/EN) via next-intl, mobile-first, 44×44px touch targets

## Changes

- `frontend/components/learning/module-media-player.tsx` — new component
- `frontend/components/learning/module-lock-gate.tsx` — integrates `<ModuleMediaPlayer>` on module overview
- `frontend/lib/api.ts` — adds `getModuleMedia`, `generateModuleMedia`, `deleteModuleMedia` + TypeScript types
- `frontend/messages/en.json` + `fr.json` — adds `ModuleMediaPlayer` i18n namespace

## Test plan

- [ ] Audio player visible on module overview page
- [ ] Plays audio from URL
- [ ] Download button saves file locally
- [ ] Admin/expert sees "Generate audio" button; regular users don't
- [ ] Generating state shows spinner and polls for completion
- [ ] Mobile-first, touch targets ≥ 44px
- [ ] i18n works in FR and EN
- [ ] Frontend lint passes (`npm run lint`)

Closes #601

Generated with [Claude Code](https://claude.ai/code)