### PR TITLE
feat(db): credit system tables — credit_accounts, transactions, credit_packages

### DIFF
--- a/backend/app/domain/models/__init__.py
+++ b/backend/app/domain/models/__init__.py
@@ -4,6 +4,7 @@ from app.domain.models.base import Base
 from app.domain.models.content import GeneratedContent
 from app.domain.models.conversation import TutorConversation
 from app.domain.models.course import Course, UserCourseEnrollment
+from app.domain.models.credit import CreditAccount, CreditPackage, CreditTransaction
 from app.domain.models.document_chunk import DocumentChunk
 from app.domain.models.flashcard import FlashcardReview
 from app.domain.models.generated_image import GeneratedImage
@@ -21,6 +22,9 @@ __all__ = [
     "AuditLog",
     "Base",
     "Course",
+    "CreditAccount",
+    "CreditPackage",
+    "CreditTransaction",
     "DocumentChunk",
     "GeneratedContent",
     "GeneratedImage",

--- a/backend/app/domain/models/credit.py
+++ b/backend/app/domain/models/credit.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    BIGINT,
+    NUMERIC,
+    Boolean,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.domain.models.base import Base
+
+if TYPE_CHECKING:
+    from app.domain.models.user import User
+
+
+class TransactionType(enum.StrEnum):
+    credit_purchase = "credit_purchase"
+    content_access = "content_access"
+    tutor_usage = "tutor_usage"
+    offline_download = "offline_download"
+    course_purchase = "course_purchase"
+    course_earning = "course_earning"
+    commission = "commission"
+    expert_activation = "expert_activation"
+    generation_cost = "generation_cost"
+    payout = "payout"
+    refund = "refund"
+    free_trial = "free_trial"
+
+
+class CreditAccount(Base):
+    __tablename__ = "credit_accounts"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), unique=True, index=True
+    )
+    balance: Mapped[int] = mapped_column(BIGINT, server_default="0", default=0)
+    total_purchased: Mapped[int] = mapped_column(BIGINT, server_default="0", default=0)
+    total_spent: Mapped[int] = mapped_column(BIGINT, server_default="0", default=0)
+    total_earned: Mapped[int] = mapped_column(BIGINT, server_default="0", default=0)
+    total_withdrawn: Mapped[int] = mapped_column(BIGINT, server_default="0", default=0)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    user: Mapped[User] = relationship(back_populates="credit_account")
+    transactions: Mapped[list[CreditTransaction]] = relationship(
+        back_populates="account", order_by="CreditTransaction.created_at.desc()"
+    )
+
+
+class CreditTransaction(Base):
+    __tablename__ = "transactions"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    account_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("credit_accounts.id", ondelete="CASCADE"), index=True
+    )
+    type: Mapped[TransactionType] = mapped_column(
+        Enum(TransactionType, name="transactiontype"), nullable=False
+    )
+    amount: Mapped[int] = mapped_column(BIGINT, nullable=False)
+    balance_after: Mapped[int] = mapped_column(BIGINT, nullable=False)
+    reference_id: Mapped[uuid.UUID | None] = mapped_column(nullable=True)
+    reference_type: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    metadata_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), index=True
+    )
+
+    account: Mapped[CreditAccount] = relationship(back_populates="transactions")
+
+    __table_args__ = (Index("ix_transactions_account_id_created_at", "account_id", "created_at"),)
+
+
+class CreditPackage(Base):
+    __tablename__ = "credit_packages"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    name_fr: Mapped[str] = mapped_column(String, nullable=False)
+    name_en: Mapped[str] = mapped_column(String, nullable=False)
+    credits: Mapped[int] = mapped_column(BIGINT, nullable=False)
+    price_xof: Mapped[int] = mapped_column(BIGINT, nullable=False)
+    price_usd: Mapped[float] = mapped_column(NUMERIC(10, 2), nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, server_default="true", default=True)
+    sort_order: Mapped[int] = mapped_column(Integer, server_default="0", default=0)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/domain/models/user.py
+++ b/backend/app/domain/models/user.py
@@ -20,6 +20,7 @@ class UserRole(enum.StrEnum):
 if TYPE_CHECKING:
     from app.domain.models.auth import EmailOTP, MagicLink, RefreshToken, TOTPSecret
     from app.domain.models.conversation import TutorConversation
+    from app.domain.models.credit import CreditAccount
     from app.domain.models.flashcard import FlashcardReview
     from app.domain.models.learner_memory import LearnerMemory
     from app.domain.models.lesson_reading import LessonReading
@@ -65,5 +66,8 @@ class User(Base):
     lesson_readings: Mapped[list[LessonReading]] = relationship(back_populates="user")
     tutor_conversations: Mapped[list[TutorConversation]] = relationship(back_populates="user")
     learner_memory: Mapped[LearnerMemory | None] = relationship(
+        back_populates="user", uselist=False
+    )
+    credit_account: Mapped[CreditAccount | None] = relationship(
         back_populates="user", uselist=False
     )

--- a/backend/migrations/versions/025_marketplace_and_credits.py
+++ b/backend/migrations/versions/025_marketplace_and_credits.py
@@ -1,0 +1,105 @@
+"""Create credit system tables: credit_accounts, transactions, credit_packages.
+
+Implements the unified credit economy for Phase 2 billing.
+
+Revision ID: 025_marketplace_and_credits
+Revises: 024_add_course_taxonomy
+Create Date: 2026-04-04
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "025_marketplace_and_credits"
+down_revision: str | None = "024_add_course_taxonomy"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DO $$ BEGIN
+            CREATE TYPE transactiontype AS ENUM (
+                'credit_purchase',
+                'content_access',
+                'tutor_usage',
+                'offline_download',
+                'course_purchase',
+                'course_earning',
+                'commission',
+                'expert_activation',
+                'generation_cost',
+                'payout',
+                'refund',
+                'free_trial'
+            );
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS credit_accounts (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            balance BIGINT NOT NULL DEFAULT 0,
+            total_purchased BIGINT NOT NULL DEFAULT 0,
+            total_spent BIGINT NOT NULL DEFAULT 0,
+            total_earned BIGINT NOT NULL DEFAULT 0,
+            total_withdrawn BIGINT NOT NULL DEFAULT 0,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CONSTRAINT uq_credit_accounts_user_id UNIQUE (user_id)
+        )
+        """
+    )
+    op.execute("CREATE INDEX IF NOT EXISTS ix_credit_accounts_user_id ON credit_accounts (user_id)")
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS transactions (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            account_id UUID NOT NULL REFERENCES credit_accounts(id) ON DELETE CASCADE,
+            type transactiontype NOT NULL,
+            amount BIGINT NOT NULL,
+            balance_after BIGINT NOT NULL,
+            reference_id UUID,
+            reference_type VARCHAR(50),
+            description TEXT NOT NULL,
+            metadata_json JSONB,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+    op.execute("CREATE INDEX IF NOT EXISTS ix_transactions_account_id ON transactions (account_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_transactions_created_at ON transactions (created_at)")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_transactions_account_id_created_at "
+        "ON transactions (account_id, created_at)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS credit_packages (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            name_fr VARCHAR NOT NULL,
+            name_en VARCHAR NOT NULL,
+            credits BIGINT NOT NULL,
+            price_xof BIGINT NOT NULL,
+            price_usd NUMERIC(10, 2) NOT NULL,
+            is_active BOOLEAN NOT NULL DEFAULT true,
+            sort_order INTEGER NOT NULL DEFAULT 0,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS transactions")
+    op.execute("DROP TABLE IF EXISTS credit_accounts")
+    op.execute("DROP TABLE IF EXISTS credit_packages")
+    op.execute("DROP TYPE IF EXISTS transactiontype")


### PR DESCRIPTION
## Summary

Creates the core credit system database tables for the unified credit economy (Phase 2 billing).

## Changes

- `backend/app/domain/models/credit.py` — Three new SQLAlchemy models:
  - `CreditAccount`: per-user balance with lifetime stats (total_purchased, total_spent, total_earned, total_withdrawn)
  - `CreditTransaction`: full audit log with 12-value `TransactionType` enum, balance snapshot, nullable reference_id/reference_type, JSONB metadata
  - `CreditPackage`: purchasable credit bundles with bilingual names (FR/EN), prices in XOF and USD
- `backend/app/domain/models/__init__.py` — registered all 3 new models
- `backend/app/domain/models/user.py` — added `credit_account` one-to-one relationship
- `backend/migrations/versions/025_marketplace_and_credits.py` — Alembic migration (revises 024_add_course_taxonomy):
  - Creates `transactiontype` ENUM
  - Creates `credit_accounts`, `transactions`, `credit_packages` tables
  - Adds indexes on `transactions(account_id)`, `transactions(created_at)`, composite `(account_id, created_at)`
  - Full `downgrade()` drops tables and enum

## Test plan
- [ ] Backend tests pass (`uv run pytest`)
- [ ] `alembic upgrade head` runs cleanly
- [ ] `alembic downgrade -1` runs cleanly
- [ ] All transaction type values present in enum

Closes #608

Generated with [Claude Code](https://claude.ai/code)