### PR TITLE
feat(expert): expert layout, guard, and navigation

### DIFF
--- a/frontend/app/[locale]/expert/dashboard/page.tsx
+++ b/frontend/app/[locale]/expert/dashboard/page.tsx
@@ -1,0 +1,19 @@
+import { getTranslations } from "next-intl/server";
+
+interface ExpertDashboardPageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export default async function ExpertDashboardPage({ params }: ExpertDashboardPageProps) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "Expert" });
+
+  return (
+    <div className="flex flex-col gap-6 p-4 md:p-6">
+      <div>
+        <h1 className="text-2xl font-bold">{t("dashboard")}</h1>
+        <p className="text-muted-foreground">{t("dashboardDescription")}</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/[locale]/expert/layout.tsx
+++ b/frontend/app/[locale]/expert/layout.tsx
@@ -1,0 +1,23 @@
+import { ExpertGuard } from "@/components/expert/expert-guard";
+import { ExpertNav } from "@/components/expert/expert-nav";
+import { BottomNav } from "@/components/layout/bottom-nav";
+import { Header } from "@/components/layout/header";
+import { Sidebar } from "@/components/layout/sidebar";
+
+export default function ExpertLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <ExpertGuard>
+      <div className="flex h-dvh flex-col md:flex-row">
+        <Sidebar />
+        <div className="flex flex-1 flex-col min-h-0">
+          <Header />
+          <ExpertNav />
+          <main className="flex flex-col flex-1 overflow-y-auto pb-16 pt-0 md:pb-0">
+            {children}
+          </main>
+        </div>
+        <BottomNav />
+      </div>
+    </ExpertGuard>
+  );
+}

--- a/frontend/app/[locale]/expert/page.tsx
+++ b/frontend/app/[locale]/expert/page.tsx
@@ -1,0 +1,10 @@
+import { redirect } from "next/navigation";
+
+interface ExpertPageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export default async function ExpertPage({ params }: ExpertPageProps) {
+  const { locale } = await params;
+  redirect(`/${locale}/expert/dashboard`);
+}

--- a/frontend/components/expert/expert-guard.tsx
+++ b/frontend/components/expert/expert-guard.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { startTransition, useEffect, useState } from "react";
+import { useRouter, usePathname } from "next/navigation";
+import { useLocale } from "next-intl";
+
+function parseJwtPayload(token: string): Record<string, unknown> | null {
+  try {
+    const base64Url = token.split(".")[1];
+    if (!base64Url) return null;
+    const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+    return JSON.parse(atob(base64));
+  } catch {
+    return null;
+  }
+}
+
+function getStoredToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem("access_token");
+}
+
+export function ExpertGuard({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const locale = useLocale();
+  const pathname = usePathname();
+  const [authorized, setAuthorized] = useState(false);
+
+  useEffect(() => {
+    const token = getStoredToken();
+    if (!token) {
+      router.replace(`/${locale}/dashboard`);
+      return;
+    }
+    const payload = parseJwtPayload(token);
+    const role = payload?.role as string | undefined;
+    if (role === "expert" || role === "admin") {
+      startTransition(() => setAuthorized(true));
+    } else {
+      router.replace(`/${locale}/expert/activation`);
+    }
+  }, [locale, pathname, router]);
+
+  if (!authorized) return null;
+
+  return <>{children}</>;
+}

--- a/frontend/components/expert/expert-nav.tsx
+++ b/frontend/components/expert/expert-nav.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useTranslations, useLocale } from "next-intl";
+import { cn } from "@/lib/utils";
+
+export function ExpertNav() {
+  const t = useTranslations("Expert");
+  const locale = useLocale();
+  const pathname = usePathname();
+
+  const items = [
+    { href: `/${locale}/expert/dashboard`, label: t("dashboard") },
+    { href: `/${locale}/expert/courses`, label: t("myCourses") },
+    { href: `/${locale}/expert/revenue`, label: t("revenue") },
+    { href: `/${locale}/expert/credits`, label: t("credits") },
+  ];
+
+  return (
+    <nav className="flex gap-1 border-b px-4 md:px-6 overflow-x-auto" aria-label="Expert navigation">
+      {items.map((item) => {
+        const isActive = pathname.startsWith(item.href);
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={cn(
+              "shrink-0 border-b-2 px-3 py-3 text-sm font-medium transition-colors",
+              isActive
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            )}
+            aria-current={isActive ? "page" : undefined}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/components/layout/bottom-nav.tsx
+++ b/frontend/components/layout/bottom-nav.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { startTransition, useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 import { useTranslations, useLocale } from "next-intl";
 import {
@@ -9,13 +10,36 @@ import {
   CreditCard,
   Bot,
   Settings,
+  Star,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+
+function getUserRole(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const token = localStorage.getItem("access_token");
+    if (!token) return null;
+    const base64Url = token.split(".")[1];
+    if (!base64Url) return null;
+    const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+    const payload = JSON.parse(atob(base64)) as Record<string, unknown>;
+    return typeof payload?.role === "string" ? payload.role : null;
+  } catch {
+    return null;
+  }
+}
 
 export function BottomNav() {
   const t = useTranslations("Navigation");
   const pathname = usePathname();
   const locale = useLocale();
+  const [userRole, setUserRole] = useState<string | null>(null);
+
+  useEffect(() => {
+    startTransition(() => setUserRole(getUserRole()));
+  }, []);
+
+  const isExpertOrAdmin = userRole === "expert" || userRole === "admin";
 
   const navItems = [
     {
@@ -42,12 +66,23 @@ export function BottomNav() {
       icon: Bot,
       description: t("tutorDescription")
     },
-    {
-      href: `/${locale}/settings`,
-      label: t("settings"),
-      icon: Settings,
-      description: t("settingsDescription")
-    },
+    ...(isExpertOrAdmin
+      ? [
+          {
+            href: `/${locale}/expert/dashboard`,
+            label: t("expertDashboard"),
+            icon: Star,
+            description: t("expertDashboardDescription"),
+          },
+        ]
+      : [
+          {
+            href: `/${locale}/settings`,
+            label: t("settings"),
+            icon: Settings,
+            description: t("settingsDescription"),
+          },
+        ]),
   ];
 
   return (

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -17,6 +17,7 @@ import {
   Menu,
   LogOut,
   ShieldCheck,
+  Star,
 } from "lucide-react";
 import { LocaleSwitcher } from "@/components/shared/locale-switcher";
 import { Button } from "@/components/ui/button";
@@ -108,7 +109,24 @@ export function Sidebar() {
       icon: Settings,
       description: t("settingsDescription")
     },
-    ...(userRole === "admin" || userRole === "expert"
+    ...(userRole === "expert" || userRole === "admin"
+      ? [
+          {
+            href: `/${locale}/expert/dashboard`,
+            label: t("expertDashboard"),
+            icon: Star,
+            description: t("expertDashboardDescription"),
+          },
+        ]
+      : [
+          {
+            href: `/${locale}/expert/activation`,
+            label: t("becomeExpert"),
+            icon: Star,
+            description: t("becomeExpertDescription"),
+          },
+        ]),
+    ...(userRole === "admin"
       ? [
           {
             href: `/${locale}/admin/users`,

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -39,7 +39,25 @@
     "logout": "Log out",
     "logoutDescription": "Sign out of your account",
     "admin": "Administration",
-    "adminDescription": "Access the administration panel"
+    "adminDescription": "Access the administration panel",
+    "expertDashboard": "Expert Dashboard",
+    "expertDashboardDescription": "Access your expert dashboard",
+    "becomeExpert": "Become Expert",
+    "becomeExpertDescription": "Apply to become a course expert"
+  },
+  "Expert": {
+    "dashboard": "Overview",
+    "dashboardDescription": "View your expert dashboard overview",
+    "myCourses": "My Courses",
+    "myCoursesDescription": "Manage the courses you created",
+    "revenue": "Revenue",
+    "revenueDescription": "View your revenue and earnings",
+    "credits": "Credits",
+    "creditsDescription": "Manage your teaching credits",
+    "becomeExpert": "Become Expert",
+    "becomeExpertDescription": "Apply to become a course expert on this platform",
+    "activation": "Expert Activation",
+    "activationDescription": "Complete your expert profile to start creating courses"
   },
   "Auth": {
     "login": "Sign in",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -39,7 +39,25 @@
     "logout": "Déconnexion",
     "logoutDescription": "Se déconnecter de votre compte",
     "admin": "Administration",
-    "adminDescription": "Accéder au panneau d'administration"
+    "adminDescription": "Accéder au panneau d'administration",
+    "expertDashboard": "Tableau Expert",
+    "expertDashboardDescription": "Accéder à votre tableau de bord expert",
+    "becomeExpert": "Devenir Expert",
+    "becomeExpertDescription": "Postuler pour devenir un expert de cours"
+  },
+  "Expert": {
+    "dashboard": "Vue d'ensemble",
+    "dashboardDescription": "Voir la vue d'ensemble de votre tableau de bord expert",
+    "myCourses": "Mes Cours",
+    "myCoursesDescription": "Gérer les cours que vous avez créés",
+    "revenue": "Revenus",
+    "revenueDescription": "Consulter vos revenus et gains",
+    "credits": "Crédits",
+    "creditsDescription": "Gérer vos crédits d'enseignement",
+    "becomeExpert": "Devenir Expert",
+    "becomeExpertDescription": "Postuler pour devenir un expert de cours sur cette plateforme",
+    "activation": "Activation Expert",
+    "activationDescription": "Complétez votre profil expert pour commencer à créer des cours"
   },
   "Auth": {
     "login": "Se connecter",


### PR DESCRIPTION
## Summary

Implements the expert dashboard section with layout, role guard, and navigation components as specified in issue #629.

## Changes

- **`frontend/components/expert/expert-guard.tsx`** — New `ExpertGuard` component that reads JWT role from `localStorage`, redirects non-experts to `/expert/activation`, and redirects unauthenticated users to `/dashboard`
- **`frontend/components/expert/expert-nav.tsx`** — New `ExpertNav` tab navigation component with: Overview, My Courses, Revenue, Credits — active state based on pathname
- **`frontend/app/[locale]/expert/layout.tsx`** — Expert route group layout wrapping with `ExpertGuard` + `Sidebar` + `Header` + `ExpertNav`
- **`frontend/app/[locale]/expert/page.tsx`** — Redirect page sending `/expert` → `/expert/dashboard`
- **`frontend/app/[locale]/expert/dashboard/page.tsx`** — Placeholder overview page
- **`frontend/components/layout/sidebar.tsx`** — Modified: shows "Expert Dashboard" link for expert/admin roles, "Become Expert" link for regular users
- **`frontend/components/layout/bottom-nav.tsx`** — Modified: role-aware, replaces "Settings" with "Expert Dashboard" for expert/admin users
- **`frontend/messages/en.json`** + **`frontend/messages/fr.json`** — Added `Expert.*` namespace and new `Navigation.expertDashboard`, `Navigation.becomeExpert` i18n keys

## Test plan

- [ ] Expert layout renders correctly for expert/admin users
- [ ] Non-experts are redirected to `/expert/activation`
- [ ] ExpertNav tabs navigate and show correct active state
- [ ] Sidebar shows "Expert Dashboard" for expert/admin, "Become Expert" for regular users
- [ ] BottomNav shows "Expert Dashboard" tab for expert/admin users
- [ ] All text bilingual (FR/EN)
- [ ] Frontend lint passes (no new errors)

Closes #629

Generated with [Claude Code](https://claude.ai/code)