### PR TITLE
feat(billing): billing endpoints — balance, packages, purchase, history, usage

### DIFF
--- a/backend/app/api/v1/billing.py
+++ b/backend/app/api/v1/billing.py
@@ -1,0 +1,235 @@
+"""Billing API — balance, packages, purchase, transaction history, usage."""
+
+from typing import Annotated
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_db
+from app.api.deps_local_auth import AuthenticatedUser, get_current_user
+from app.api.v1.schemas.billing import (
+    CreditBalanceResponse,
+    CreditPackageResponse,
+    PaginatedTransactionsResponse,
+    PurchaseRequest,
+    TransactionResponse,
+    UsageSummaryResponse,
+)
+from app.domain.services.credit_service import (
+    CreditService,
+    PackageNotFoundError,
+)
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/billing", tags=["billing"])
+
+
+def _get_credit_service(db: AsyncSession = Depends(get_db)) -> CreditService:
+    return CreditService(db)
+
+
+@router.get(
+    "/balance",
+    response_model=CreditBalanceResponse,
+    status_code=status.HTTP_200_OK,
+    responses={
+        401: {"description": "Unauthorized"},
+        500: {"description": "Internal server error"},
+    },
+)
+async def get_balance(
+    current_user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+    credit_service: Annotated[CreditService, Depends(_get_credit_service)],
+) -> CreditBalanceResponse:
+    """
+    Return the current credit balance for the authenticated user.
+
+    Includes total purchased, total spent, and total earned credits.
+    """
+    try:
+        data = await credit_service.get_balance(current_user.id)
+        return CreditBalanceResponse(**data)
+    except Exception:
+        logger.exception("Failed to retrieve credit balance", user_id=current_user.id)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={
+                "error": "balance_fetch_failed",
+                "message": "Unable to retrieve credit balance",
+            },
+        )
+
+
+@router.get(
+    "/packages",
+    response_model=list[CreditPackageResponse],
+    status_code=status.HTTP_200_OK,
+    responses={
+        401: {"description": "Unauthorized"},
+        500: {"description": "Internal server error"},
+    },
+)
+async def list_packages(
+    current_user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+    credit_service: Annotated[CreditService, Depends(_get_credit_service)],
+) -> list[CreditPackageResponse]:
+    """
+    Return all active credit packages available for purchase.
+
+    Packages are ordered by price (cheapest first).
+    Prices are given in XOF (CFA franc) and USD.
+    """
+    try:
+        packages = await credit_service.list_packages()
+        return [CreditPackageResponse.model_validate(p) for p in packages]
+    except Exception:
+        logger.exception("Failed to list credit packages", user_id=current_user.id)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"error": "packages_fetch_failed", "message": "Unable to retrieve packages"},
+        )
+
+
+@router.post(
+    "/purchase",
+    response_model=TransactionResponse,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        401: {"description": "Unauthorized"},
+        404: {"description": "Package not found or inactive"},
+        500: {"description": "Internal server error"},
+    },
+)
+async def purchase_credits(
+    body: PurchaseRequest,
+    current_user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+    credit_service: Annotated[CreditService, Depends(_get_credit_service)],
+) -> TransactionResponse:
+    """
+    Purchase a credit package (virtual payment — Paystack integration coming later).
+
+    Creates a `purchase` transaction and immediately credits the user's balance.
+    Returns the resulting transaction record.
+    """
+    try:
+        transaction = await credit_service.purchase(
+            user_id=current_user.id,
+            package_id=str(body.package_id),
+        )
+        return TransactionResponse.model_validate(transaction)
+    except PackageNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "package_not_found", "message": str(e)},
+        )
+    except Exception:
+        logger.exception(
+            "Failed to purchase credits",
+            user_id=current_user.id,
+            package_id=str(body.package_id),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"error": "purchase_failed", "message": "Unable to complete purchase"},
+        )
+
+
+@router.get(
+    "/transactions",
+    response_model=PaginatedTransactionsResponse,
+    status_code=status.HTTP_200_OK,
+    responses={
+        401: {"description": "Unauthorized"},
+        500: {"description": "Internal server error"},
+    },
+)
+async def list_transactions(
+    current_user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+    credit_service: Annotated[CreditService, Depends(_get_credit_service)],
+    page: int = Query(default=1, ge=1, description="Page number (1-indexed)"),
+    limit: int = Query(default=20, ge=1, le=100, description="Items per page"),
+    type: str | None = Query(
+        default=None,
+        description="Filter by transaction type: purchase | spend | earn | refund",
+    ),
+) -> PaginatedTransactionsResponse:
+    """
+    Return paginated credit transaction history for the authenticated user.
+
+    Supports optional `type` filter to narrow results by transaction type.
+    Ordered by most recent first.
+    """
+    try:
+        result = await credit_service.list_transactions(
+            user_id=current_user.id,
+            page=page,
+            limit=limit,
+            type_filter=type,
+        )
+        items = [TransactionResponse.model_validate(t) for t in result["items"]]
+        return PaginatedTransactionsResponse(
+            items=items,
+            total=result["total"],
+            page=result["page"],
+            limit=result["limit"],
+            has_next=result["has_next"],
+        )
+    except Exception:
+        logger.exception("Failed to list transactions", user_id=current_user.id)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={
+                "error": "transactions_fetch_failed",
+                "message": "Unable to retrieve transaction history",
+            },
+        )
+
+
+@router.get(
+    "/usage",
+    response_model=UsageSummaryResponse,
+    status_code=status.HTTP_200_OK,
+    responses={
+        401: {"description": "Unauthorized"},
+        500: {"description": "Internal server error"},
+    },
+)
+async def get_usage_summary(
+    current_user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+    credit_service: Annotated[CreditService, Depends(_get_credit_service)],
+    period: str = Query(
+        default="monthly",
+        description="Aggregation period: 'daily' (today) or 'monthly' (current month)",
+    ),
+) -> UsageSummaryResponse:
+    """
+    Return AI usage credit summary for the authenticated user.
+
+    - `daily`: aggregates usage for today only
+    - `monthly`: aggregates usage since the first day of the current month
+
+    The `breakdown` field groups credits spent by usage type
+    (e.g. lesson_generation, tutor_chat, quiz_generation).
+    """
+    if period not in ("daily", "monthly"):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "error": "invalid_period",
+                "message": "period must be 'daily' or 'monthly'",
+            },
+        )
+    try:
+        data = await credit_service.get_usage_summary(
+            user_id=current_user.id,
+            period=period,
+        )
+        return UsageSummaryResponse(**data)
+    except Exception:
+        logger.exception("Failed to retrieve usage summary", user_id=current_user.id)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"error": "usage_fetch_failed", "message": "Unable to retrieve usage summary"},
+        )

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 from app.api.v1.admin import router as admin_router
 from app.api.v1.admin_courses import router as admin_courses_router
 from app.api.v1.admin_settings import router as admin_settings_router
+from app.api.v1.billing import router as billing_router
 from app.api.v1.content import router as content_router
 from app.api.v1.courses import router as courses_router
 from app.api.v1.dashboard import router as dashboard_router
@@ -28,6 +29,7 @@ api_v1_router.include_router(quiz_router)
 api_v1_router.include_router(flashcards_router)
 api_v1_router.include_router(tutor_router)
 api_v1_router.include_router(images_router)
+api_v1_router.include_router(billing_router)
 api_v1_router.include_router(admin_router)
 api_v1_router.include_router(admin_settings_router)
 api_v1_router.include_router(admin_courses_router)

--- a/backend/app/api/v1/schemas/billing.py
+++ b/backend/app/api/v1/schemas/billing.py
@@ -1,0 +1,101 @@
+"""Billing API schemas."""
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class CreditBalanceResponse(BaseModel):
+    balance: int = Field(description="Current credit balance")
+    total_purchased: int = Field(description="Total credits purchased")
+    total_spent: int = Field(description="Total credits spent")
+    total_earned: int = Field(description="Total credits earned (bonuses, etc.)")
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "balance": 350,
+                "total_purchased": 500,
+                "total_spent": 150,
+                "total_earned": 0,
+            }
+        }
+    }
+
+
+class CreditPackageResponse(BaseModel):
+    id: uuid.UUID
+    name_fr: str
+    name_en: str
+    credits: int
+    price_xof: int
+    price_usd: float
+
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "example": {
+                "id": "10000000-0000-0000-0000-000000000002",
+                "name_fr": "Essentiel",
+                "name_en": "Essential",
+                "credits": 500,
+                "price_xof": 8000,
+                "price_usd": 12.0,
+            }
+        },
+    }
+
+
+class PurchaseRequest(BaseModel):
+    package_id: uuid.UUID = Field(description="ID of the credit package to purchase")
+
+
+class TransactionResponse(BaseModel):
+    id: uuid.UUID
+    type: str
+    amount: int
+    balance_after: int
+    description: str | None
+    created_at: datetime
+
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "example": {
+                "id": "aaaaaaaa-0000-0000-0000-000000000001",
+                "type": "purchase",
+                "amount": 500,
+                "balance_after": 500,
+                "description": "Purchase: Essentiel / Essential",
+                "created_at": "2026-04-04T11:00:00Z",
+            }
+        },
+    }
+
+
+class PaginatedTransactionsResponse(BaseModel):
+    items: list[TransactionResponse]
+    total: int
+    page: int
+    limit: int
+    has_next: bool
+
+
+class UsageSummaryResponse(BaseModel):
+    period: str = Field(description="Period: 'daily' or 'monthly'")
+    since: str = Field(description="ISO 8601 start of the period")
+    total_credits_spent: int
+    breakdown: dict[str, Any] = Field(description="Credits spent per usage type")
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "period": "monthly",
+                "since": "2026-04-01T00:00:00+00:00",
+                "total_credits_spent": 120,
+                "breakdown": {"lesson_generation": 80, "tutor_chat": 40},
+            }
+        }
+    }

--- a/backend/app/domain/models/__init__.py
+++ b/backend/app/domain/models/__init__.py
@@ -1,6 +1,7 @@
 from app.domain.models.audit_log import AuditLog
 from app.domain.models.auth import MagicLink, RefreshToken, TOTPSecret
 from app.domain.models.base import Base
+from app.domain.models.billing import ApiUsageLog, CreditPackage, CreditTransaction
 from app.domain.models.content import GeneratedContent
 from app.domain.models.conversation import TutorConversation
 from app.domain.models.course import Course, UserCourseEnrollment
@@ -16,9 +17,12 @@ from app.domain.models.quiz import QuizAttempt
 from app.domain.models.user import User
 
 __all__ = [
+    "ApiUsageLog",
     "AuditLog",
     "Base",
     "Course",
+    "CreditPackage",
+    "CreditTransaction",
     "DocumentChunk",
     "GeneratedContent",
     "GeneratedImage",

--- a/backend/app/domain/models/billing.py
+++ b/backend/app/domain/models/billing.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, Integer, Numeric, String, Text, func
+from sqlalchemy.dialects.postgresql import JSON
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.domain.models.base import Base
+
+if TYPE_CHECKING:
+    from app.domain.models.user import User
+
+
+class CreditPackage(Base):
+    __tablename__ = "credit_packages"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    name_fr: Mapped[str] = mapped_column(String(200))
+    name_en: Mapped[str] = mapped_column(String(200))
+    credits: Mapped[int] = mapped_column(Integer)
+    price_xof: Mapped[int] = mapped_column(Integer)
+    price_usd: Mapped[float] = mapped_column(Numeric(10, 2))
+    is_active: Mapped[bool] = mapped_column(server_default="true", default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    transactions: Mapped[list[CreditTransaction]] = relationship(back_populates="package")
+
+
+class CreditTransaction(Base):
+    __tablename__ = "credit_transactions"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), index=True)
+    package_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("credit_packages.id"), nullable=True
+    )
+    type: Mapped[str] = mapped_column(String(50))
+    amount: Mapped[int] = mapped_column(Integer)
+    balance_after: Mapped[int] = mapped_column(Integer)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    user: Mapped[User] = relationship(back_populates="credit_transactions")
+    package: Mapped[CreditPackage | None] = relationship(back_populates="transactions")
+
+
+class ApiUsageLog(Base):
+    __tablename__ = "api_usage_logs"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), index=True)
+    usage_type: Mapped[str] = mapped_column(String(100))
+    credits_spent: Mapped[int] = mapped_column(Integer, server_default="0")
+    extra: Mapped[dict | None] = mapped_column("metadata", JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), index=True
+    )
+
+    user: Mapped[User] = relationship(back_populates="api_usage_logs")

--- a/backend/app/domain/models/user.py
+++ b/backend/app/domain/models/user.py
@@ -19,6 +19,7 @@ class UserRole(enum.StrEnum):
 
 if TYPE_CHECKING:
     from app.domain.models.auth import EmailOTP, MagicLink, RefreshToken, TOTPSecret
+    from app.domain.models.billing import ApiUsageLog, CreditTransaction
     from app.domain.models.conversation import TutorConversation
     from app.domain.models.flashcard import FlashcardReview
     from app.domain.models.learner_memory import LearnerMemory
@@ -67,3 +68,7 @@ class User(Base):
     learner_memory: Mapped[LearnerMemory | None] = relationship(
         back_populates="user", uselist=False
     )
+
+    # Billing relationships
+    credit_transactions: Mapped[list[CreditTransaction]] = relationship(back_populates="user")
+    api_usage_logs: Mapped[list[ApiUsageLog]] = relationship(back_populates="user")

--- a/backend/app/domain/services/credit_service.py
+++ b/backend/app/domain/services/credit_service.py
@@ -1,0 +1,230 @@
+"""Credit management service — balance, packages, purchase, transactions, usage."""
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.models.billing import ApiUsageLog, CreditPackage, CreditTransaction
+
+logger = structlog.get_logger(__name__)
+
+TRANSACTION_TYPE_PURCHASE = "purchase"
+TRANSACTION_TYPE_SPEND = "spend"
+TRANSACTION_TYPE_EARN = "earn"
+TRANSACTION_TYPE_REFUND = "refund"
+
+
+class InsufficientCreditsError(Exception):
+    pass
+
+
+class PackageNotFoundError(Exception):
+    pass
+
+
+class CreditService:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_balance(self, user_id: str) -> dict[str, int]:
+        uid = uuid.UUID(user_id)
+
+        purchased_q = select(func.coalesce(func.sum(CreditTransaction.amount), 0)).where(
+            CreditTransaction.user_id == uid,
+            CreditTransaction.type == TRANSACTION_TYPE_PURCHASE,
+        )
+        earned_q = select(func.coalesce(func.sum(CreditTransaction.amount), 0)).where(
+            CreditTransaction.user_id == uid,
+            CreditTransaction.type == TRANSACTION_TYPE_EARN,
+        )
+        spent_q = select(func.coalesce(func.sum(func.abs(CreditTransaction.amount)), 0)).where(
+            CreditTransaction.user_id == uid,
+            CreditTransaction.type == TRANSACTION_TYPE_SPEND,
+        )
+
+        purchased_result = await self._session.execute(purchased_q)
+        earned_result = await self._session.execute(earned_q)
+        spent_result = await self._session.execute(spent_q)
+
+        total_purchased: int = purchased_result.scalar_one()
+        total_earned: int = earned_result.scalar_one()
+        total_spent: int = spent_result.scalar_one()
+        balance: int = total_purchased + total_earned - total_spent
+
+        return {
+            "balance": max(0, balance),
+            "total_purchased": total_purchased,
+            "total_spent": total_spent,
+            "total_earned": total_earned,
+        }
+
+    async def list_packages(self) -> list[CreditPackage]:
+        result = await self._session.execute(
+            select(CreditPackage)
+            .where(CreditPackage.is_active.is_(True))
+            .order_by(CreditPackage.price_xof.asc())
+        )
+        return list(result.scalars().all())
+
+    async def purchase(self, user_id: str, package_id: str) -> CreditTransaction:
+        uid = uuid.UUID(user_id)
+        pkg_id = uuid.UUID(package_id)
+
+        pkg_result = await self._session.execute(
+            select(CreditPackage).where(
+                CreditPackage.id == pkg_id,
+                CreditPackage.is_active.is_(True),
+            )
+        )
+        package = pkg_result.scalar_one_or_none()
+        if package is None:
+            raise PackageNotFoundError(f"Package {package_id} not found or inactive")
+
+        balance_data = await self.get_balance(user_id)
+        new_balance = balance_data["balance"] + package.credits
+
+        transaction = CreditTransaction(
+            id=uuid.uuid4(),
+            user_id=uid,
+            package_id=pkg_id,
+            type=TRANSACTION_TYPE_PURCHASE,
+            amount=package.credits,
+            balance_after=new_balance,
+            description=f"Purchase: {package.name_fr} / {package.name_en}",
+        )
+        self._session.add(transaction)
+        await self._session.commit()
+        await self._session.refresh(transaction)
+
+        logger.info(
+            "Credits purchased",
+            user_id=user_id,
+            package_id=package_id,
+            credits=package.credits,
+            new_balance=new_balance,
+        )
+        return transaction
+
+    async def spend_credits(
+        self,
+        user_id: str,
+        amount: int,
+        usage_type: str,
+        description: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> CreditTransaction:
+        uid = uuid.UUID(user_id)
+        balance_data = await self.get_balance(user_id)
+
+        if balance_data["balance"] < amount:
+            raise InsufficientCreditsError(
+                f"Insufficient credits: has {balance_data['balance']}, needs {amount}"
+            )
+
+        new_balance = balance_data["balance"] - amount
+
+        transaction = CreditTransaction(
+            id=uuid.uuid4(),
+            user_id=uid,
+            type=TRANSACTION_TYPE_SPEND,
+            amount=-amount,
+            balance_after=new_balance,
+            description=description or f"Usage: {usage_type}",
+        )
+        self._session.add(transaction)
+
+        usage_log = ApiUsageLog(
+            id=uuid.uuid4(),
+            user_id=uid,
+            usage_type=usage_type,
+            credits_spent=amount,
+            extra=metadata,
+        )
+        self._session.add(usage_log)
+
+        await self._session.commit()
+        await self._session.refresh(transaction)
+
+        logger.info(
+            "Credits spent",
+            user_id=user_id,
+            amount=amount,
+            usage_type=usage_type,
+            new_balance=new_balance,
+        )
+        return transaction
+
+    async def list_transactions(
+        self,
+        user_id: str,
+        page: int = 1,
+        limit: int = 20,
+        type_filter: str | None = None,
+    ) -> dict[str, Any]:
+        uid = uuid.UUID(user_id)
+        base_query = select(CreditTransaction).where(CreditTransaction.user_id == uid)
+
+        if type_filter:
+            base_query = base_query.where(CreditTransaction.type == type_filter)
+
+        count_query = select(func.count()).select_from(base_query.subquery())
+        count_result = await self._session.execute(count_query)
+        total: int = count_result.scalar_one()
+
+        items_query = (
+            base_query.order_by(CreditTransaction.created_at.desc())
+            .offset((page - 1) * limit)
+            .limit(limit)
+        )
+        items_result = await self._session.execute(items_query)
+        items = list(items_result.scalars().all())
+
+        return {
+            "items": items,
+            "total": total,
+            "page": page,
+            "limit": limit,
+            "has_next": (page * limit) < total,
+        }
+
+    async def get_usage_summary(
+        self,
+        user_id: str,
+        period: str = "monthly",
+    ) -> dict[str, Any]:
+        uid = uuid.UUID(user_id)
+        now = datetime.now(tz=UTC)
+
+        if period == "daily":
+            since = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        else:
+            since = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+        total_q = select(func.coalesce(func.sum(ApiUsageLog.credits_spent), 0)).where(
+            ApiUsageLog.user_id == uid,
+            ApiUsageLog.created_at >= since,
+        )
+        total_result = await self._session.execute(total_q)
+        total_credits_spent: int = total_result.scalar_one()
+
+        breakdown_q = (
+            select(ApiUsageLog.usage_type, func.sum(ApiUsageLog.credits_spent).label("total"))
+            .where(
+                ApiUsageLog.user_id == uid,
+                ApiUsageLog.created_at >= since,
+            )
+            .group_by(ApiUsageLog.usage_type)
+        )
+        breakdown_result = await self._session.execute(breakdown_q)
+        breakdown = {row.usage_type: int(row.total) for row in breakdown_result.all()}
+
+        return {
+            "period": period,
+            "since": since.isoformat(),
+            "total_credits_spent": total_credits_spent,
+            "breakdown": breakdown,
+        }

--- a/backend/migrations/versions/025_add_billing_tables.py
+++ b/backend/migrations/versions/025_add_billing_tables.py
@@ -1,0 +1,115 @@
+"""Add billing tables: credit_packages, credit_transactions, api_usage_logs.
+
+Revision ID: 025_add_billing_tables
+Revises: 024_add_course_taxonomy
+Create Date: 2026-04-04
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "025_add_billing_tables"
+down_revision: str | None = "024_add_course_taxonomy"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+DEFAULT_PACKAGES = [
+    {
+        "id": "10000000-0000-0000-0000-000000000001",
+        "name_fr": "Débutant",
+        "name_en": "Starter",
+        "credits": 100,
+        "price_xof": 2000,
+        "price_usd": 3.00,
+    },
+    {
+        "id": "10000000-0000-0000-0000-000000000002",
+        "name_fr": "Essentiel",
+        "name_en": "Essential",
+        "credits": 500,
+        "price_xof": 8000,
+        "price_usd": 12.00,
+    },
+    {
+        "id": "10000000-0000-0000-0000-000000000003",
+        "name_fr": "Professionnel",
+        "name_en": "Professional",
+        "credits": 1500,
+        "price_xof": 20000,
+        "price_usd": 30.00,
+    },
+]
+
+
+def upgrade() -> None:
+    op.create_table(
+        "credit_packages",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("name_fr", sa.String(200), nullable=False),
+        sa.Column("name_en", sa.String(200), nullable=False),
+        sa.Column("credits", sa.Integer(), nullable=False),
+        sa.Column("price_xof", sa.Integer(), nullable=False),
+        sa.Column("price_usd", sa.Numeric(10, 2), nullable=False),
+        sa.Column("is_active", sa.Boolean(), server_default="true", nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False
+        ),
+    )
+
+    op.create_table(
+        "credit_transactions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("package_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("type", sa.String(50), nullable=False),
+        sa.Column("amount", sa.Integer(), nullable=False),
+        sa.Column("balance_after", sa.Integer(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["package_id"], ["credit_packages.id"], ondelete="SET NULL"),
+    )
+    op.create_index("ix_credit_transactions_user_id", "credit_transactions", ["user_id"])
+    op.create_index("ix_credit_transactions_created_at", "credit_transactions", ["created_at"])
+
+    op.create_table(
+        "api_usage_logs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("usage_type", sa.String(100), nullable=False),
+        sa.Column("credits_spent", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("metadata", postgresql.JSON(), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+    )
+    op.create_index("ix_api_usage_logs_user_id", "api_usage_logs", ["user_id"])
+    op.create_index("ix_api_usage_logs_created_at", "api_usage_logs", ["created_at"])
+
+    op.execute(
+        f"""
+        INSERT INTO credit_packages (id, name_fr, name_en, credits, price_xof, price_usd)
+        VALUES
+            ('{DEFAULT_PACKAGES[0]["id"]}', '{DEFAULT_PACKAGES[0]["name_fr"]}',
+             '{DEFAULT_PACKAGES[0]["name_en"]}', {DEFAULT_PACKAGES[0]["credits"]},
+             {DEFAULT_PACKAGES[0]["price_xof"]}, {DEFAULT_PACKAGES[0]["price_usd"]}),
+            ('{DEFAULT_PACKAGES[1]["id"]}', '{DEFAULT_PACKAGES[1]["name_fr"]}',
+             '{DEFAULT_PACKAGES[1]["name_en"]}', {DEFAULT_PACKAGES[1]["credits"]},
+             {DEFAULT_PACKAGES[1]["price_xof"]}, {DEFAULT_PACKAGES[1]["price_usd"]}),
+            ('{DEFAULT_PACKAGES[2]["id"]}', '{DEFAULT_PACKAGES[2]["name_fr"]}',
+             '{DEFAULT_PACKAGES[2]["name_en"]}', {DEFAULT_PACKAGES[2]["credits"]},
+             {DEFAULT_PACKAGES[2]["price_xof"]}, {DEFAULT_PACKAGES[2]["price_usd"]})
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("api_usage_logs")
+    op.drop_table("credit_transactions")
+    op.drop_table("credit_packages")

--- a/backend/tests/test_billing.py
+++ b/backend/tests/test_billing.py
@@ -1,0 +1,321 @@
+"""Tests for billing endpoints: balance, packages, purchase, transactions, usage."""
+
+import uuid
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.api.v1.billing import _get_credit_service
+from app.domain.models.user import UserRole
+from app.domain.services.credit_service import PackageNotFoundError
+from app.domain.services.jwt_auth_service import JWTAuthService
+from app.main import app
+
+
+def _make_headers(role: str = "user", user_id: str | None = None) -> dict:
+    jwt_service = JWTAuthService()
+    token = jwt_service.create_access_token(
+        user_id=user_id or str(uuid.uuid4()),
+        email=f"{role}@test.com",
+        role=role,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def user_headers():
+    return _make_headers(role=UserRole.user.value)
+
+
+def _mock_txn(
+    txn_id: uuid.UUID | None = None,
+    txn_type: str = "purchase",
+    amount: int = 500,
+    balance_after: int = 500,
+    description: str = "Purchase: Essentiel / Essential",
+) -> MagicMock:
+    mock_txn = MagicMock()
+    mock_txn.id = txn_id or uuid.uuid4()
+    mock_txn.type = txn_type
+    mock_txn.amount = amount
+    mock_txn.balance_after = balance_after
+    mock_txn.description = description
+    mock_txn.created_at = datetime(2026, 4, 4, 11, 0, 0)
+    return mock_txn
+
+
+@pytest.mark.asyncio
+async def test_balance_requires_auth():
+    """GET /api/v1/billing/balance must return 401 without token."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.get("/api/v1/billing/balance")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_packages_requires_auth():
+    """GET /api/v1/billing/packages must return 401 without token."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.get("/api/v1/billing/packages")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_transactions_requires_auth():
+    """GET /api/v1/billing/transactions must return 401 without token."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.get("/api/v1/billing/transactions")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_purchase_requires_auth():
+    """POST /api/v1/billing/purchase must return 401 without token."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.post(
+            "/api/v1/billing/purchase",
+            json={"package_id": str(uuid.uuid4())},
+        )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_usage_requires_auth():
+    """GET /api/v1/billing/usage must return 401 without token."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.get("/api/v1/billing/usage")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_balance_returns_correct_schema(user_headers):
+    """GET /api/v1/billing/balance returns CreditBalanceResponse."""
+    balance_data = {
+        "balance": 350,
+        "total_purchased": 500,
+        "total_spent": 150,
+        "total_earned": 0,
+    }
+    mock_service = AsyncMock()
+    mock_service.get_balance.return_value = balance_data
+
+    app.dependency_overrides[_get_credit_service] = lambda: mock_service
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.get("/api/v1/billing/balance", headers=user_headers)
+    finally:
+        app.dependency_overrides.pop(_get_credit_service, None)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["balance"] == 350
+    assert data["total_purchased"] == 500
+    assert data["total_spent"] == 150
+    assert data["total_earned"] == 0
+
+
+@pytest.mark.asyncio
+async def test_list_packages_returns_list(user_headers):
+    """GET /api/v1/billing/packages returns a list of packages."""
+    pkg_id = uuid.uuid4()
+    mock_pkg = MagicMock()
+    mock_pkg.id = pkg_id
+    mock_pkg.name_fr = "Essentiel"
+    mock_pkg.name_en = "Essential"
+    mock_pkg.credits = 500
+    mock_pkg.price_xof = 8000
+    mock_pkg.price_usd = 12.0
+
+    mock_service = AsyncMock()
+    mock_service.list_packages.return_value = [mock_pkg]
+
+    app.dependency_overrides[_get_credit_service] = lambda: mock_service
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.get("/api/v1/billing/packages", headers=user_headers)
+    finally:
+        app.dependency_overrides.pop(_get_credit_service, None)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["name_en"] == "Essential"
+    assert data[0]["credits"] == 500
+
+
+@pytest.mark.asyncio
+async def test_purchase_creates_transaction(user_headers):
+    """POST /api/v1/billing/purchase returns 201 with transaction."""
+    pkg_id = uuid.uuid4()
+    mock_txn = _mock_txn()
+
+    mock_service = AsyncMock()
+    mock_service.purchase.return_value = mock_txn
+
+    app.dependency_overrides[_get_credit_service] = lambda: mock_service
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/billing/purchase",
+                json={"package_id": str(pkg_id)},
+                headers=user_headers,
+            )
+    finally:
+        app.dependency_overrides.pop(_get_credit_service, None)
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["type"] == "purchase"
+    assert data["amount"] == 500
+    assert data["balance_after"] == 500
+
+
+@pytest.mark.asyncio
+async def test_purchase_package_not_found_returns_404(user_headers):
+    """POST /api/v1/billing/purchase returns 404 for unknown package."""
+    mock_service = AsyncMock()
+    mock_service.purchase.side_effect = PackageNotFoundError("Package not found")
+
+    app.dependency_overrides[_get_credit_service] = lambda: mock_service
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/billing/purchase",
+                json={"package_id": str(uuid.uuid4())},
+                headers=user_headers,
+            )
+    finally:
+        app.dependency_overrides.pop(_get_credit_service, None)
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_transactions_returns_paginated(user_headers):
+    """GET /api/v1/billing/transactions returns paginated response."""
+    mock_txn = _mock_txn()
+
+    mock_service = AsyncMock()
+    mock_service.list_transactions.return_value = {
+        "items": [mock_txn],
+        "total": 1,
+        "page": 1,
+        "limit": 20,
+        "has_next": False,
+    }
+
+    app.dependency_overrides[_get_credit_service] = lambda: mock_service
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.get("/api/v1/billing/transactions", headers=user_headers)
+    finally:
+        app.dependency_overrides.pop(_get_credit_service, None)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert data["page"] == 1
+    assert data["has_next"] is False
+    assert len(data["items"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_transactions_type_filter(user_headers):
+    """GET /api/v1/billing/transactions?type=purchase passes filter to service."""
+    mock_service = AsyncMock()
+    mock_service.list_transactions.return_value = {
+        "items": [],
+        "total": 0,
+        "page": 1,
+        "limit": 20,
+        "has_next": False,
+    }
+
+    app.dependency_overrides[_get_credit_service] = lambda: mock_service
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.get(
+                "/api/v1/billing/transactions?type=purchase", headers=user_headers
+            )
+    finally:
+        app.dependency_overrides.pop(_get_credit_service, None)
+
+    assert response.status_code == 200
+    mock_service.list_transactions.assert_called_once()
+    call_kwargs = mock_service.list_transactions.call_args
+    assert call_kwargs.kwargs.get("type_filter") == "purchase"
+
+
+@pytest.mark.asyncio
+async def test_get_usage_summary_monthly(user_headers):
+    """GET /api/v1/billing/usage returns monthly usage summary."""
+    mock_service = AsyncMock()
+    mock_service.get_usage_summary.return_value = {
+        "period": "monthly",
+        "since": "2026-04-01T00:00:00+00:00",
+        "total_credits_spent": 120,
+        "breakdown": {"lesson_generation": 80, "tutor_chat": 40},
+    }
+
+    app.dependency_overrides[_get_credit_service] = lambda: mock_service
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.get("/api/v1/billing/usage?period=monthly", headers=user_headers)
+    finally:
+        app.dependency_overrides.pop(_get_credit_service, None)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["period"] == "monthly"
+    assert data["total_credits_spent"] == 120
+    assert "lesson_generation" in data["breakdown"]
+
+
+@pytest.mark.asyncio
+async def test_get_usage_summary_daily(user_headers):
+    """GET /api/v1/billing/usage?period=daily returns daily usage summary."""
+    mock_service = AsyncMock()
+    mock_service.get_usage_summary.return_value = {
+        "period": "daily",
+        "since": "2026-04-04T00:00:00+00:00",
+        "total_credits_spent": 20,
+        "breakdown": {"tutor_chat": 20},
+    }
+
+    app.dependency_overrides[_get_credit_service] = lambda: mock_service
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.get("/api/v1/billing/usage?period=daily", headers=user_headers)
+    finally:
+        app.dependency_overrides.pop(_get_credit_service, None)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["period"] == "daily"
+    assert data["total_credits_spent"] == 20
+
+
+@pytest.mark.asyncio
+async def test_get_usage_summary_invalid_period(user_headers):
+    """GET /api/v1/billing/usage with invalid period returns 422."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.get("/api/v1/billing/usage?period=yearly", headers=user_headers)
+
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary

- 5 billing endpoints at `/api/v1/billing/` (all require JWT auth)
- `CreditService` for all credit business logic
- `CreditPackage`, `CreditTransaction`, `ApiUsageLog` domain models
- Alembic migration `025_add_billing_tables` with 3 default packages seeded

## Endpoints

| Method | Path | Purpose |
|--------|------|---------|
| GET | /api/v1/billing/balance | Current credit balance (purchased, spent, earned) |
| GET | /api/v1/billing/packages | List active credit packages (XOF + USD) |
| POST | /api/v1/billing/purchase | Purchase credits (virtual; Paystack hook-ready) |
| GET | /api/v1/billing/transactions | Paginated history with optional `?type=` filter |
| GET | /api/v1/billing/usage | AI usage summary (`?period=daily\|monthly`) |

## Changes

- `backend/app/domain/models/billing.py` — 3 new SQLAlchemy models
- `backend/app/domain/services/credit_service.py` — `CreditService` (absorbs #612)
- `backend/app/api/v1/schemas/billing.py` — Pydantic V2 request/response schemas
- `backend/app/api/v1/billing.py` — FastAPI router with 5 endpoints
- `backend/app/api/v1/router.py` — registered billing router
- `backend/app/domain/models/user.py` — added billing relationships
- `backend/app/domain/models/__init__.py` — exported new models
- `backend/migrations/versions/025_add_billing_tables.py` — Alembic migration
- `backend/tests/test_billing.py` — 14 tests (auth guards + endpoint behaviour)

## Test plan

- [x] All 14 billing tests pass (`pytest tests/test_billing.py`)
- [x] Existing tests (health, RBAC) still pass
- [x] `ruff check .` — all checks passed
- [ ] Manually verify on mobile viewport once deployed

Closes #617

Generated with [Claude Code](https://claude.ai/code)