### PR TITLE
feat(marketplace): browse, purchase, review endpoints (#621)

### DIFF
--- a/backend/app/api/v1/marketplace.py
+++ b/backend/app/api/v1/marketplace.py
@@ -1,0 +1,261 @@
+"""Marketplace API endpoints — browse, purchase, review."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from app.api.deps import get_db as get_db_session
+from app.api.deps_local_auth import get_current_user, get_optional_user
+from app.domain.services.marketplace_service import MarketplaceService
+
+logger = get_logger(__name__)
+router = APIRouter(prefix="/marketplace", tags=["Marketplace"])
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class MarketplaceCourseItem(BaseModel):
+    id: str
+    slug: str
+    title_fr: str
+    title_en: str
+    description_fr: str | None
+    description_en: str | None
+    course_domain: list[str]
+    course_level: list[str]
+    audience_type: list[str]
+    estimated_hours: int
+    module_count: int
+    cover_image_url: str | None
+    languages: str
+    price_credits: int
+    avg_rating: float
+    review_count: int
+    enrollment_count: int
+    expert_name: str | None
+    expert_avatar: str | None
+    is_enrolled: bool = False
+
+
+class MarketplaceCourseDetail(MarketplaceCourseItem):
+    modules_preview: list[dict]
+    enrollment_status: str | None = None
+
+
+class BrowseResponse(BaseModel):
+    total: int
+    items: list[MarketplaceCourseItem]
+
+
+class PurchaseResponse(BaseModel):
+    course_id: str
+    user_id: str
+    status: str
+    enrolled_at: str
+    credits_spent: int
+
+
+class ReviewRequest(BaseModel):
+    rating: int = Field(..., ge=1, le=5)
+    comment: str | None = None
+
+
+class ReviewResponse(BaseModel):
+    id: str
+    listing_id: str
+    user_id: str
+    rating: int
+    comment: str | None
+    created_at: str
+
+
+class ReviewItem(BaseModel):
+    id: str
+    rating: int
+    comment: str | None
+    created_at: str
+    reviewer_name: str | None
+    reviewer_avatar: str | None
+
+
+class ReviewListResponse(BaseModel):
+    total: int
+    items: list[ReviewItem]
+
+
+# ---------------------------------------------------------------------------
+# Dependency
+# ---------------------------------------------------------------------------
+
+
+async def get_marketplace_service(
+    db: AsyncSession = Depends(get_db_session),
+) -> MarketplaceService:
+    return MarketplaceService(db)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/courses", response_model=BrowseResponse)
+async def browse_marketplace_courses(
+    course_domain: str | None = Query(None),
+    course_level: str | None = Query(None),
+    audience_type: str | None = Query(None),
+    search: str | None = Query(None),
+    price_min: int | None = Query(None, ge=0),
+    price_max: int | None = Query(None, ge=0),
+    sort: str = Query(
+        "newest",
+        pattern="^(newest|popular|highest_rated|price_asc|price_desc)$",
+    ),
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    current_user=Depends(get_optional_user),
+    service: MarketplaceService = Depends(get_marketplace_service),
+) -> BrowseResponse:
+    """Browse published marketplace courses. Auth optional."""
+    result = await service.browse_courses(
+        course_domain=course_domain,
+        course_level=course_level,
+        audience_type=audience_type,
+        search=search,
+        price_min=price_min,
+        price_max=price_max,
+        sort=sort,
+        limit=limit,
+        offset=offset,
+        current_user_id=current_user.id if current_user else None,
+    )
+    return BrowseResponse(**result)
+
+
+@router.get("/courses/{slug}", response_model=MarketplaceCourseDetail)
+async def get_marketplace_course(
+    slug: str,
+    current_user=Depends(get_optional_user),
+    service: MarketplaceService = Depends(get_marketplace_service),
+) -> MarketplaceCourseDetail:
+    """Get marketplace course detail by slug. Auth optional."""
+    detail = await service.get_course_detail(
+        slug=slug,
+        current_user_id=current_user.id if current_user else None,
+    )
+    if detail is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Course not found in marketplace",
+        )
+    return MarketplaceCourseDetail(**detail)
+
+
+@router.post("/courses/{course_id}/purchase", response_model=PurchaseResponse)
+async def purchase_course(
+    course_id: uuid.UUID,
+    current_user=Depends(get_current_user),
+    service: MarketplaceService = Depends(get_marketplace_service),
+) -> PurchaseResponse:
+    """Purchase a marketplace course with credits and auto-enroll. Auth required."""
+    try:
+        result = await service.purchase_course(
+            course_id=course_id,
+            user_id=current_user.id,
+        )
+    except ValueError as exc:
+        error = str(exc)
+        if error == "course_not_found":
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Course not found in marketplace",
+            )
+        if error == "already_enrolled":
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Already enrolled in this course",
+            )
+        if error == "insufficient_credits":
+            raise HTTPException(
+                status_code=status.HTTP_402_PAYMENT_REQUIRED,
+                detail="Insufficient credits",
+            )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Purchase failed",
+        )
+
+    logger.info(
+        "Course purchased",
+        user_id=current_user.id,
+        course_id=str(course_id),
+    )
+    return PurchaseResponse(**result)
+
+
+@router.post(
+    "/courses/{course_id}/review",
+    response_model=ReviewResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_review(
+    course_id: uuid.UUID,
+    body: ReviewRequest,
+    current_user=Depends(get_current_user),
+    service: MarketplaceService = Depends(get_marketplace_service),
+) -> ReviewResponse:
+    """Leave a review for a marketplace course. Must be enrolled. Auth required."""
+    try:
+        result = await service.create_review(
+            course_id=course_id,
+            user_id=current_user.id,
+            rating=body.rating,
+            comment=body.comment,
+        )
+    except ValueError as exc:
+        error = str(exc)
+        if error == "listing_not_found":
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Course not found in marketplace",
+            )
+        if error == "not_enrolled":
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You must be enrolled to review this course",
+            )
+        if error == "review_exists":
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="You have already reviewed this course",
+            )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Failed to create review",
+        )
+
+    return ReviewResponse(**result)
+
+
+@router.get("/courses/{course_id}/reviews", response_model=ReviewListResponse)
+async def list_reviews(
+    course_id: uuid.UUID,
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    service: MarketplaceService = Depends(get_marketplace_service),
+) -> ReviewListResponse:
+    """List reviews for a marketplace course. Public."""
+    result = await service.list_reviews(
+        course_id=course_id,
+        limit=limit,
+        offset=offset,
+    )
+    return ReviewListResponse(**result)

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -10,6 +10,7 @@ from app.api.v1.flashcards import router as flashcards_router
 from app.api.v1.health import router as health_router
 from app.api.v1.images import router as images_router
 from app.api.v1.local_auth import router as local_auth_router
+from app.api.v1.marketplace import router as marketplace_router
 from app.api.v1.placement import router as placement_router
 from app.api.v1.progress import router as progress_router
 from app.api.v1.quiz import router as quiz_router
@@ -32,3 +33,4 @@ api_v1_router.include_router(admin_router)
 api_v1_router.include_router(admin_settings_router)
 api_v1_router.include_router(admin_courses_router)
 api_v1_router.include_router(courses_router)
+api_v1_router.include_router(marketplace_router)

--- a/backend/app/domain/models/marketplace.py
+++ b/backend/app/domain/models/marketplace.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.domain.models.base import Base
+
+
+class CourseMarketplaceListing(Base):
+    __tablename__ = "course_marketplace_listings"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    course_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("courses.id", ondelete="CASCADE"), unique=True, index=True
+    )
+    price_credits: Mapped[int] = mapped_column(Integer, server_default="0")
+    is_listed: Mapped[bool] = mapped_column(server_default="true")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    course: Mapped[Course] = relationship("Course", foreign_keys=[course_id])
+    reviews: Mapped[list[CourseReview]] = relationship(
+        "CourseReview", back_populates="listing", cascade="all, delete-orphan"
+    )
+
+
+class CourseReview(Base):
+    __tablename__ = "course_reviews"
+
+    __table_args__ = (UniqueConstraint("user_id", "listing_id", name="uq_review_user_listing"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    listing_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("course_marketplace_listings.id", ondelete="CASCADE"), index=True
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    rating: Mapped[int] = mapped_column(Integer)
+    comment: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    listing: Mapped[CourseMarketplaceListing] = relationship(
+        "CourseMarketplaceListing", back_populates="reviews"
+    )
+    reviewer: Mapped[User] = relationship("User", foreign_keys=[user_id])
+
+
+class UserCreditBalance(Base):
+    __tablename__ = "user_credit_balances"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    balance: Mapped[int] = mapped_column(Integer, server_default="0")
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    user: Mapped[User] = relationship("User", foreign_keys=[user_id])
+
+
+class CreditTransaction(Base):
+    __tablename__ = "credit_transactions"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    amount: Mapped[int] = mapped_column(Integer)
+    transaction_type: Mapped[str] = mapped_column(String(50))
+    reference_id: Mapped[uuid.UUID | None] = mapped_column(nullable=True)
+    description: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    user: Mapped[User] = relationship("User", foreign_keys=[user_id])
+
+
+from app.domain.models.course import Course  # noqa: E402
+from app.domain.models.user import User  # noqa: E402

--- a/backend/app/domain/services/marketplace_service.py
+++ b/backend/app/domain/services/marketplace_service.py
@@ -1,0 +1,502 @@
+"""Marketplace service — browse, purchase, review."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from app.domain.models.course import Course, UserCourseEnrollment
+from app.domain.models.marketplace import (
+    CourseMarketplaceListing,
+    CourseReview,
+    CreditTransaction,
+    UserCreditBalance,
+)
+from app.domain.models.module import Module
+from app.domain.models.progress import UserModuleProgress
+from app.domain.models.user import User
+
+logger = get_logger(__name__)
+
+
+class MarketplaceService:
+    def __init__(self, db: AsyncSession) -> None:
+        self._db = db
+
+    # ------------------------------------------------------------------
+    # Browse
+    # ------------------------------------------------------------------
+
+    async def browse_courses(
+        self,
+        *,
+        course_domain: str | None = None,
+        course_level: str | None = None,
+        audience_type: str | None = None,
+        search: str | None = None,
+        price_min: int | None = None,
+        price_max: int | None = None,
+        sort: str = "newest",
+        limit: int = 20,
+        offset: int = 0,
+        current_user_id: str | None = None,
+    ) -> dict[str, Any]:
+        stmt = (
+            select(
+                Course,
+                CourseMarketplaceListing,
+                User.name.label("expert_name"),
+                User.avatar_url.label("expert_avatar"),
+                func.coalesce(func.avg(CourseReview.rating), 0).label("avg_rating"),
+                func.count(CourseReview.id.distinct()).label("review_count"),
+                func.count(UserCourseEnrollment.user_id.distinct()).label("enrollment_count"),
+            )
+            .join(
+                CourseMarketplaceListing,
+                CourseMarketplaceListing.course_id == Course.id,
+            )
+            .outerjoin(User, User.id == Course.created_by)
+            .outerjoin(
+                CourseReview,
+                CourseReview.listing_id == CourseMarketplaceListing.id,
+            )
+            .outerjoin(
+                UserCourseEnrollment,
+                UserCourseEnrollment.course_id == Course.id,
+            )
+            .where(
+                Course.status == "published",
+                CourseMarketplaceListing.is_listed.is_(True),
+            )
+            .group_by(
+                Course.id,
+                CourseMarketplaceListing.id,
+                User.name,
+                User.avatar_url,
+            )
+        )
+
+        if course_domain:
+            stmt = stmt.where(Course.course_domain.any(course_domain))
+        if course_level:
+            stmt = stmt.where(Course.course_level.any(course_level))
+        if audience_type:
+            stmt = stmt.where(Course.audience_type.any(audience_type))
+        if search:
+            q = f"%{search.lower()}%"
+            stmt = stmt.where(
+                func.lower(Course.title_fr).like(q) | func.lower(Course.title_en).like(q)
+            )
+        if price_min is not None:
+            stmt = stmt.where(CourseMarketplaceListing.price_credits >= price_min)
+        if price_max is not None:
+            stmt = stmt.where(CourseMarketplaceListing.price_credits <= price_max)
+
+        if sort == "newest":
+            stmt = stmt.order_by(Course.published_at.desc())
+        elif sort == "popular":
+            stmt = stmt.order_by(func.count(UserCourseEnrollment.user_id.distinct()).desc())
+        elif sort == "highest_rated":
+            stmt = stmt.order_by(func.coalesce(func.avg(CourseReview.rating), 0).desc())
+        elif sort == "price_asc":
+            stmt = stmt.order_by(CourseMarketplaceListing.price_credits.asc())
+        elif sort == "price_desc":
+            stmt = stmt.order_by(CourseMarketplaceListing.price_credits.desc())
+        else:
+            stmt = stmt.order_by(Course.published_at.desc())
+
+        count_stmt = select(func.count()).select_from(stmt.subquery())
+        total_result = await self._db.execute(count_stmt)
+        total = total_result.scalar_one()
+
+        stmt = stmt.offset(offset).limit(limit)
+        rows = (await self._db.execute(stmt)).all()
+
+        enrolled_ids: set[str] = set()
+        if current_user_id:
+            enroll_res = await self._db.execute(
+                select(UserCourseEnrollment.course_id).where(
+                    UserCourseEnrollment.user_id == uuid.UUID(current_user_id),
+                    UserCourseEnrollment.status == "active",
+                )
+            )
+            enrolled_ids = {str(r[0]) for r in enroll_res.all()}
+
+        items = [self._row_to_summary(row, enrolled_ids=enrolled_ids) for row in rows]
+        return {"total": total, "items": items}
+
+    # ------------------------------------------------------------------
+    # Course detail
+    # ------------------------------------------------------------------
+
+    async def get_course_detail(
+        self,
+        slug: str,
+        current_user_id: str | None = None,
+    ) -> dict[str, Any] | None:
+        stmt = (
+            select(
+                Course,
+                CourseMarketplaceListing,
+                User.name.label("expert_name"),
+                User.avatar_url.label("expert_avatar"),
+                func.coalesce(func.avg(CourseReview.rating), 0).label("avg_rating"),
+                func.count(CourseReview.id.distinct()).label("review_count"),
+                func.count(UserCourseEnrollment.user_id.distinct()).label("enrollment_count"),
+            )
+            .join(
+                CourseMarketplaceListing,
+                CourseMarketplaceListing.course_id == Course.id,
+            )
+            .outerjoin(User, User.id == Course.created_by)
+            .outerjoin(
+                CourseReview,
+                CourseReview.listing_id == CourseMarketplaceListing.id,
+            )
+            .outerjoin(
+                UserCourseEnrollment,
+                UserCourseEnrollment.course_id == Course.id,
+            )
+            .where(
+                Course.slug == slug,
+                Course.status == "published",
+                CourseMarketplaceListing.is_listed.is_(True),
+            )
+            .group_by(
+                Course.id,
+                CourseMarketplaceListing.id,
+                User.name,
+                User.avatar_url,
+            )
+        )
+
+        row = (await self._db.execute(stmt)).one_or_none()
+        if row is None:
+            return None
+
+        course, listing, expert_name, expert_avatar, avg_rating, review_count, enrollment_count = (
+            row
+        )
+
+        modules_res = await self._db.execute(
+            select(Module).where(Module.course_id == course.id).order_by(Module.position).limit(5)
+        )
+        modules_preview = [
+            {
+                "id": str(m.id),
+                "title_fr": m.title_fr,
+                "title_en": m.title_en,
+                "position": m.position,
+            }
+            for m in modules_res.scalars().all()
+        ]
+
+        is_enrolled = False
+        enrollment_status: str | None = None
+        if current_user_id:
+            enroll_res = await self._db.execute(
+                select(UserCourseEnrollment).where(
+                    UserCourseEnrollment.user_id == uuid.UUID(current_user_id),
+                    UserCourseEnrollment.course_id == course.id,
+                )
+            )
+            enrollment = enroll_res.scalar_one_or_none()
+            if enrollment:
+                is_enrolled = enrollment.status == "active"
+                enrollment_status = enrollment.status
+
+        return {
+            "id": str(course.id),
+            "slug": course.slug,
+            "title_fr": course.title_fr,
+            "title_en": course.title_en,
+            "description_fr": course.description_fr,
+            "description_en": course.description_en,
+            "course_domain": list(course.course_domain or []),
+            "course_level": list(course.course_level or []),
+            "audience_type": list(course.audience_type or []),
+            "estimated_hours": course.estimated_hours,
+            "module_count": course.module_count,
+            "cover_image_url": course.cover_image_url,
+            "languages": course.languages,
+            "price_credits": listing.price_credits,
+            "avg_rating": float(avg_rating),
+            "review_count": int(review_count),
+            "enrollment_count": int(enrollment_count),
+            "expert_name": expert_name,
+            "expert_avatar": expert_avatar,
+            "modules_preview": modules_preview,
+            "is_enrolled": is_enrolled,
+            "enrollment_status": enrollment_status,
+        }
+
+    # ------------------------------------------------------------------
+    # Purchase
+    # ------------------------------------------------------------------
+
+    async def purchase_course(
+        self,
+        course_id: uuid.UUID,
+        user_id: str,
+    ) -> dict[str, Any]:
+        listing_res = await self._db.execute(
+            select(CourseMarketplaceListing).where(
+                CourseMarketplaceListing.course_id == course_id,
+                CourseMarketplaceListing.is_listed.is_(True),
+            )
+        )
+        listing = listing_res.scalar_one_or_none()
+        if listing is None:
+            raise ValueError("course_not_found")
+
+        course_res = await self._db.execute(
+            select(Course).where(Course.id == course_id, Course.status == "published")
+        )
+        course = course_res.scalar_one_or_none()
+        if course is None:
+            raise ValueError("course_not_found")
+
+        uid = uuid.UUID(user_id)
+
+        existing_res = await self._db.execute(
+            select(UserCourseEnrollment).where(
+                UserCourseEnrollment.user_id == uid,
+                UserCourseEnrollment.course_id == course_id,
+                UserCourseEnrollment.status == "active",
+            )
+        )
+        if existing_res.scalar_one_or_none():
+            raise ValueError("already_enrolled")
+
+        if listing.price_credits > 0:
+            balance_res = await self._db.execute(
+                select(UserCreditBalance).where(UserCreditBalance.user_id == uid)
+            )
+            balance_row = balance_res.scalar_one_or_none()
+            current_balance = balance_row.balance if balance_row else 0
+
+            if current_balance < listing.price_credits:
+                raise ValueError("insufficient_credits")
+
+            if balance_row is None:
+                balance_row = UserCreditBalance(user_id=uid, balance=0)
+                self._db.add(balance_row)
+
+            balance_row.balance = current_balance - listing.price_credits
+
+            self._db.add(
+                CreditTransaction(
+                    user_id=uid,
+                    amount=-listing.price_credits,
+                    transaction_type="purchase",
+                    reference_id=listing.id,
+                    description=f"Purchase: {course.title_en}",
+                )
+            )
+
+            if course.created_by:
+                expert_balance_res = await self._db.execute(
+                    select(UserCreditBalance).where(UserCreditBalance.user_id == course.created_by)
+                )
+                expert_balance = expert_balance_res.scalar_one_or_none()
+                if expert_balance is None:
+                    expert_balance = UserCreditBalance(user_id=course.created_by, balance=0)
+                    self._db.add(expert_balance)
+                expert_balance.balance = expert_balance.balance + listing.price_credits
+
+                self._db.add(
+                    CreditTransaction(
+                        user_id=course.created_by,
+                        amount=listing.price_credits,
+                        transaction_type="sale",
+                        reference_id=listing.id,
+                        description=f"Sale: {course.title_en}",
+                    )
+                )
+
+        enrollment = UserCourseEnrollment(
+            user_id=uid,
+            course_id=course_id,
+            status="active",
+            completion_pct=0.0,
+        )
+        self._db.add(enrollment)
+
+        modules_res = await self._db.execute(select(Module).where(Module.course_id == course_id))
+        for module in modules_res.scalars().all():
+            prog_res = await self._db.execute(
+                select(UserModuleProgress).where(
+                    UserModuleProgress.user_id == uid,
+                    UserModuleProgress.module_id == module.id,
+                )
+            )
+            if prog_res.scalar_one_or_none() is None:
+                self._db.add(
+                    UserModuleProgress(
+                        user_id=uid,
+                        module_id=module.id,
+                        status="locked",
+                        completion_pct=0.0,
+                        time_spent_minutes=0,
+                    )
+                )
+
+        await self._db.commit()
+        await self._db.refresh(enrollment)
+
+        logger.info(
+            "Marketplace purchase complete",
+            user_id=user_id,
+            course_id=str(course_id),
+            credits=listing.price_credits,
+        )
+
+        return {
+            "course_id": str(enrollment.course_id),
+            "user_id": str(enrollment.user_id),
+            "status": enrollment.status,
+            "enrolled_at": enrollment.enrolled_at.isoformat(),
+            "credits_spent": listing.price_credits,
+        }
+
+    # ------------------------------------------------------------------
+    # Reviews
+    # ------------------------------------------------------------------
+
+    async def create_review(
+        self,
+        course_id: uuid.UUID,
+        user_id: str,
+        rating: int,
+        comment: str | None,
+    ) -> dict[str, Any]:
+        listing_res = await self._db.execute(
+            select(CourseMarketplaceListing).where(CourseMarketplaceListing.course_id == course_id)
+        )
+        listing = listing_res.scalar_one_or_none()
+        if listing is None:
+            raise ValueError("listing_not_found")
+
+        uid = uuid.UUID(user_id)
+
+        enrollment_res = await self._db.execute(
+            select(UserCourseEnrollment).where(
+                UserCourseEnrollment.user_id == uid,
+                UserCourseEnrollment.course_id == course_id,
+                UserCourseEnrollment.status == "active",
+            )
+        )
+        if enrollment_res.scalar_one_or_none() is None:
+            raise ValueError("not_enrolled")
+
+        existing_res = await self._db.execute(
+            select(CourseReview).where(
+                CourseReview.listing_id == listing.id,
+                CourseReview.user_id == uid,
+            )
+        )
+        if existing_res.scalar_one_or_none():
+            raise ValueError("review_exists")
+
+        review = CourseReview(
+            listing_id=listing.id,
+            user_id=uid,
+            rating=rating,
+            comment=comment,
+        )
+        self._db.add(review)
+        await self._db.commit()
+        await self._db.refresh(review)
+
+        logger.info("Review created", user_id=user_id, course_id=str(course_id), rating=rating)
+
+        return {
+            "id": str(review.id),
+            "listing_id": str(review.listing_id),
+            "user_id": str(review.user_id),
+            "rating": review.rating,
+            "comment": review.comment,
+            "created_at": review.created_at.isoformat(),
+        }
+
+    async def list_reviews(
+        self,
+        course_id: uuid.UUID,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        listing_res = await self._db.execute(
+            select(CourseMarketplaceListing).where(CourseMarketplaceListing.course_id == course_id)
+        )
+        listing = listing_res.scalar_one_or_none()
+        if listing is None:
+            return {"total": 0, "items": []}
+
+        count_res = await self._db.execute(
+            select(func.count()).where(CourseReview.listing_id == listing.id)
+        )
+        total = count_res.scalar_one()
+
+        rows_res = await self._db.execute(
+            select(
+                CourseReview,
+                User.name.label("reviewer_name"),
+                User.avatar_url.label("reviewer_avatar"),
+            )
+            .join(User, User.id == CourseReview.user_id)
+            .where(CourseReview.listing_id == listing.id)
+            .order_by(CourseReview.created_at.desc())
+            .offset(offset)
+            .limit(limit)
+        )
+        items = [
+            {
+                "id": str(row.CourseReview.id),
+                "rating": row.CourseReview.rating,
+                "comment": row.CourseReview.comment,
+                "created_at": row.CourseReview.created_at.isoformat(),
+                "reviewer_name": row.reviewer_name,
+                "reviewer_avatar": row.reviewer_avatar,
+            }
+            for row in rows_res.all()
+        ]
+        return {"total": total, "items": items}
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _row_to_summary(
+        self,
+        row: Any,
+        enrolled_ids: set[str],
+    ) -> dict[str, Any]:
+        course, listing, expert_name, expert_avatar, avg_rating, review_count, enrollment_count = (
+            row
+        )
+        return {
+            "id": str(course.id),
+            "slug": course.slug,
+            "title_fr": course.title_fr,
+            "title_en": course.title_en,
+            "description_fr": course.description_fr,
+            "description_en": course.description_en,
+            "course_domain": list(course.course_domain or []),
+            "course_level": list(course.course_level or []),
+            "audience_type": list(course.audience_type or []),
+            "estimated_hours": course.estimated_hours,
+            "module_count": course.module_count,
+            "cover_image_url": course.cover_image_url,
+            "languages": course.languages,
+            "price_credits": listing.price_credits,
+            "avg_rating": float(avg_rating),
+            "review_count": int(review_count),
+            "enrollment_count": int(enrollment_count),
+            "expert_name": expert_name,
+            "expert_avatar": expert_avatar,
+            "is_enrolled": str(course.id) in enrolled_ids,
+        }

--- a/backend/migrations/versions/025_add_marketplace_tables.py
+++ b/backend/migrations/versions/025_add_marketplace_tables.py
@@ -1,0 +1,113 @@
+"""Add marketplace tables: listings, reviews, credits.
+
+Revision ID: 025_add_marketplace_tables
+Revises: 024_add_course_taxonomy
+Create Date: 2026-04-04
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "025_add_marketplace_tables"
+down_revision: str | None = "024_add_course_taxonomy"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "course_marketplace_listings",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("course_id", sa.UUID(), nullable=False),
+        sa.Column("price_credits", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("is_listed", sa.Boolean(), server_default="true", nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["course_id"], ["courses.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("course_id"),
+    )
+    op.create_index(
+        "ix_course_marketplace_listings_course_id",
+        "course_marketplace_listings",
+        ["course_id"],
+    )
+
+    op.create_table(
+        "course_reviews",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("listing_id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("rating", sa.Integer(), nullable=False),
+        sa.Column("comment", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["listing_id"], ["course_marketplace_listings.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "listing_id", name="uq_review_user_listing"),
+    )
+    op.create_index("ix_course_reviews_listing_id", "course_reviews", ["listing_id"])
+    op.create_index("ix_course_reviews_user_id", "course_reviews", ["user_id"])
+
+    op.create_table(
+        "user_credit_balances",
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("balance", sa.Integer(), server_default="0", nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id"),
+    )
+
+    op.create_table(
+        "credit_transactions",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("amount", sa.Integer(), nullable=False),
+        sa.Column("transaction_type", sa.String(50), nullable=False),
+        sa.Column("reference_id", sa.UUID(), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_credit_transactions_user_id", "credit_transactions", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_credit_transactions_user_id", table_name="credit_transactions")
+    op.drop_table("credit_transactions")
+    op.drop_table("user_credit_balances")
+    op.drop_index("ix_course_reviews_user_id", table_name="course_reviews")
+    op.drop_index("ix_course_reviews_listing_id", table_name="course_reviews")
+    op.drop_table("course_reviews")
+    op.drop_index(
+        "ix_course_marketplace_listings_course_id", table_name="course_marketplace_listings"
+    )
+    op.drop_table("course_marketplace_listings")


### PR DESCRIPTION
## Summary

Implements the full marketplace API layer as specified in #621.

## Changes

- **`backend/app/domain/models/marketplace.py`** — 4 new SQLAlchemy models:
  - `CourseMarketplaceListing` — links a course to the marketplace with a credit price
  - `CourseReview` — per-user rating + comment, unique constraint per (user, listing)
  - `UserCreditBalance` — running credit balance per user
  - `CreditTransaction` — audit trail for every debit/credit

- **`backend/migrations/versions/025_add_marketplace_tables.py`** — Alembic migration (up/down) for all 4 tables

- **`backend/app/domain/services/marketplace_service.py`** — `MarketplaceService` with:
  - `browse_courses()` — filtering, text search, multi-sort, pagination, auth-aware enrollment status
  - `get_course_detail()` — full detail with modules preview
  - `purchase_course()` — atomic credit deduction + expert crediting + auto-enroll + module progress init
  - `create_review()` — enrollment check, one-review-per-user enforcement
  - `list_reviews()` — paginated with reviewer name/avatar

- **`backend/app/api/v1/marketplace.py`** — FastAPI router at `/marketplace`:
  | Method | Path | Auth |
  |--------|------|------|
  | GET | /marketplace/courses | optional |
  | GET | /marketplace/courses/{slug} | optional |
  | POST | /marketplace/courses/{id}/purchase | required |
  | POST | /marketplace/courses/{id}/review | required |
  | GET | /marketplace/courses/{id}/reviews | public |

- **`backend/app/api/v1/router.py`** — registers the new marketplace router

## Test plan
- [ ] `GET /marketplace/courses` returns only published + listed courses
- [ ] Filtering by `course_domain`, `course_level`, `audience_type`, `search`, `price_min/max` works
- [ ] All 5 sort modes return expected order
- [ ] `POST /marketplace/courses/{id}/purchase` deducts buyer credits, credits expert, creates enrollment
- [ ] Purchase returns 402 when balance insufficient, 409 when already enrolled, 404 for unlisted
- [ ] `POST /marketplace/courses/{id}/review` returns 403 for non-enrolled, 409 for duplicate review
- [ ] `GET /marketplace/courses/{id}/reviews` returns paginated reviews with reviewer info
- [ ] Anonymous users can browse and view reviews; enrollment/purchase endpoints require auth
- [ ] `uv run ruff check .` — no errors
- [ ] Migration applies cleanly with `alembic upgrade head`

Closes #621

Generated with [Claude Code](https://claude.ai/code)