### PR TITLE
feat(expert): expert dashboard UI — learners, analytics, reviews

### DIFF
--- a/frontend/app/[locale]/expert/courses/[id]/analytics/page.tsx
+++ b/frontend/app/[locale]/expert/courses/[id]/analytics/page.tsx
@@ -1,0 +1,30 @@
+import { getTranslations } from "next-intl/server";
+import { AnalyticsCharts } from "@/components/expert/analytics-charts";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata() {
+  const t = await getTranslations("ExpertAnalytics");
+  return {
+    title: t("pageTitle"),
+  };
+}
+
+export default async function CourseAnalyticsPage({ params }: PageProps) {
+  const { id } = await params;
+  const t = await getTranslations("ExpertAnalytics");
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <div className="border-b bg-background p-4 shrink-0">
+        <h1 className="text-2xl font-bold">{t("pageTitle")}</h1>
+        <p className="text-muted-foreground mt-1">{t("pageDescription")}</p>
+      </div>
+      <div className="flex-1 overflow-y-auto p-4 md:p-6">
+        <AnalyticsCharts courseId={id} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/[locale]/expert/courses/[id]/learners/page.tsx
+++ b/frontend/app/[locale]/expert/courses/[id]/learners/page.tsx
@@ -1,0 +1,32 @@
+import { getTranslations } from "next-intl/server";
+import { getLocale } from "next-intl/server";
+import { LearnerTable } from "@/components/expert/learner-table";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata() {
+  const t = await getTranslations("ExpertLearners");
+  return {
+    title: t("pageTitle"),
+  };
+}
+
+export default async function CourseLearnerPage({ params }: PageProps) {
+  const { id } = await params;
+  const t = await getTranslations("ExpertLearners");
+  const locale = await getLocale();
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <div className="border-b bg-background p-4 shrink-0">
+        <h1 className="text-2xl font-bold">{t("pageTitle")}</h1>
+        <p className="text-muted-foreground mt-1">{t("pageDescription")}</p>
+      </div>
+      <div className="flex-1 overflow-y-auto p-4 md:p-6">
+        <LearnerTable courseId={id} locale={locale} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/[locale]/expert/courses/[id]/reviews/page.tsx
+++ b/frontend/app/[locale]/expert/courses/[id]/reviews/page.tsx
@@ -1,0 +1,32 @@
+import { getTranslations } from "next-intl/server";
+import { getLocale } from "next-intl/server";
+import { ReviewsList } from "@/components/expert/reviews-list";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata() {
+  const t = await getTranslations("ExpertReviews");
+  return {
+    title: t("pageTitle"),
+  };
+}
+
+export default async function CourseReviewsPage({ params }: PageProps) {
+  const { id } = await params;
+  const t = await getTranslations("ExpertReviews");
+  const locale = await getLocale();
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <div className="border-b bg-background p-4 shrink-0">
+        <h1 className="text-2xl font-bold">{t("pageTitle")}</h1>
+        <p className="text-muted-foreground mt-1">{t("pageDescription")}</p>
+      </div>
+      <div className="flex-1 overflow-y-auto p-4 md:p-6">
+        <ReviewsList courseId={id} locale={locale} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/[locale]/expert/dashboard/page.tsx
+++ b/frontend/app/[locale]/expert/dashboard/page.tsx
@@ -1,0 +1,26 @@
+import { getTranslations } from "next-intl/server";
+import { SummaryCards } from "@/components/expert/summary-cards";
+
+export async function generateMetadata() {
+  const t = await getTranslations("ExpertDashboard");
+  return {
+    title: t("pageTitle"),
+    description: t("pageDescription"),
+  };
+}
+
+export default async function ExpertDashboardPage() {
+  const t = await getTranslations("ExpertDashboard");
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <div className="border-b bg-background p-4 shrink-0">
+        <h1 className="text-2xl font-bold">{t("pageTitle")}</h1>
+        <p className="text-muted-foreground mt-1">{t("pageDescription")}</p>
+      </div>
+      <div className="flex-1 overflow-y-auto p-4 md:p-6">
+        <SummaryCards />
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/[locale]/expert/layout.tsx
+++ b/frontend/app/[locale]/expert/layout.tsx
@@ -1,0 +1,23 @@
+import { ExpertGuard } from "@/components/expert/expert-guard";
+import { ExpertNav } from "@/components/expert/expert-nav";
+import { BottomNav } from "@/components/layout/bottom-nav";
+import { Header } from "@/components/layout/header";
+import { Sidebar } from "@/components/layout/sidebar";
+
+export default function ExpertLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <ExpertGuard>
+      <div className="flex h-dvh flex-col md:flex-row">
+        <Sidebar />
+        <div className="flex flex-1 flex-col min-h-0">
+          <Header />
+          <ExpertNav />
+          <main className="flex flex-col flex-1 overflow-y-auto pb-16 pt-0 md:pb-0">
+            {children}
+          </main>
+        </div>
+        <BottomNav />
+      </div>
+    </ExpertGuard>
+  );
+}

--- a/frontend/components/expert/analytics-charts.tsx
+++ b/frontend/components/expert/analytics-charts.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useQuery } from "@tanstack/react-query";
+import { Loader2, AlertCircle, TrendingUp, CheckCircle, Users } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { apiFetch } from "@/lib/api";
+
+interface CourseAnalytics {
+  quiz_pass_rate: number;
+  average_quiz_score: number;
+  funnel: {
+    enrolled: number;
+    started: number;
+    half_complete: number;
+    completed: number;
+  };
+  time_spent_distribution: TimeSpentBucket[];
+}
+
+interface TimeSpentBucket {
+  label: string;
+  count: number;
+}
+
+function useAnalytics(courseId: string) {
+  return useQuery<CourseAnalytics>({
+    queryKey: ["expert", "courses", courseId, "analytics"],
+    queryFn: () => apiFetch<CourseAnalytics>(`/api/v1/expert/courses/${courseId}/analytics`),
+  });
+}
+
+interface BarProps {
+  value: number;
+  max: number;
+  label: string;
+  count: number;
+}
+
+function FunnelBar({ value, max, label, count }: BarProps) {
+  const pct = max > 0 ? (value / max) * 100 : 0;
+  return (
+    <div className="flex items-center gap-3">
+      <p className="text-xs text-muted-foreground w-20 shrink-0 text-right">{label}</p>
+      <div className="flex-1 h-6 rounded bg-muted relative overflow-hidden">
+        <div
+          className="absolute inset-y-0 left-0 bg-primary/80 rounded transition-all"
+          style={{ width: `${pct}%` }}
+          role="progressbar"
+          aria-valuenow={value}
+          aria-valuemax={max}
+          aria-label={label}
+        />
+      </div>
+      <span className="text-xs font-medium w-10 shrink-0">{count}</span>
+    </div>
+  );
+}
+
+function ScoreGauge({ value, label }: { value: number; label: string }) {
+  const clampedValue = Math.min(100, Math.max(0, value));
+  const circumference = 2 * Math.PI * 40;
+  const offset = circumference - (clampedValue / 100) * circumference;
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <div className="relative h-24 w-24">
+        <svg className="h-24 w-24 -rotate-90" viewBox="0 0 100 100" aria-hidden="true">
+          <circle cx="50" cy="50" r="40" fill="none" stroke="currentColor" strokeWidth="10" className="text-muted" />
+          <circle
+            cx="50"
+            cy="50"
+            r="40"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="10"
+            strokeDasharray={circumference}
+            strokeDashoffset={offset}
+            strokeLinecap="round"
+            className="text-primary transition-all duration-500"
+          />
+        </svg>
+        <div className="absolute inset-0 flex items-center justify-center">
+          <span className="text-xl font-bold">{Math.round(clampedValue)}%</span>
+        </div>
+      </div>
+      <p className="text-xs text-muted-foreground text-center">{label}</p>
+    </div>
+  );
+}
+
+interface AnalyticsChartsProps {
+  courseId: string;
+}
+
+export function AnalyticsCharts({ courseId }: AnalyticsChartsProps) {
+  const t = useTranslations("ExpertAnalytics");
+  const { data, isLoading, error, refetch } = useAnalytics(courseId);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" aria-label={t("loading")} />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 p-8 text-center">
+        <AlertCircle className="h-10 w-10 text-destructive" aria-hidden="true" />
+        <p className="text-sm text-muted-foreground">{t("errorLoading")}</p>
+        <Button variant="outline" onClick={() => refetch()}>
+          {t("retry")}
+        </Button>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const funnelMax = data.funnel.enrolled;
+
+  const funnelSteps = [
+    { label: t("funnel.enrolled"), count: data.funnel.enrolled },
+    { label: t("funnel.started"), count: data.funnel.started },
+    { label: t("funnel.halfComplete"), count: data.funnel.half_complete },
+    { label: t("funnel.completed"), count: data.funnel.completed },
+  ];
+
+  const maxBucketCount = data.time_spent_distribution.reduce(
+    (max, b) => Math.max(max, b.count),
+    0
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-2 gap-4">
+        <Card className="p-4 flex flex-col items-center gap-2">
+          <div className="rounded-md bg-green-100 p-2">
+            <CheckCircle className="h-5 w-5 text-green-700" aria-hidden="true" />
+          </div>
+          <ScoreGauge value={data.quiz_pass_rate} label={t("quizPassRate")} />
+        </Card>
+
+        <Card className="p-4 flex flex-col items-center gap-2">
+          <div className="rounded-md bg-blue-100 p-2">
+            <TrendingUp className="h-5 w-5 text-blue-700" aria-hidden="true" />
+          </div>
+          <ScoreGauge value={data.average_quiz_score} label={t("avgQuizScore")} />
+        </Card>
+      </div>
+
+      <Card className="p-4 space-y-4">
+        <div className="flex items-center gap-2">
+          <Users className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+          <h3 className="text-sm font-semibold">{t("completionFunnel")}</h3>
+        </div>
+        <div className="space-y-3">
+          {funnelSteps.map((step) => (
+            <FunnelBar
+              key={step.label}
+              label={step.label}
+              count={step.count}
+              value={step.count}
+              max={funnelMax}
+            />
+          ))}
+        </div>
+      </Card>
+
+      {data.time_spent_distribution.length > 0 && (
+        <Card className="p-4 space-y-4">
+          <h3 className="text-sm font-semibold">{t("timeSpentDistribution")}</h3>
+          <div className="flex items-end gap-2 h-32">
+            {data.time_spent_distribution.map((bucket) => {
+              const heightPct = maxBucketCount > 0 ? (bucket.count / maxBucketCount) * 100 : 0;
+              return (
+                <div
+                  key={bucket.label}
+                  className="flex flex-col items-center gap-1 flex-1 min-w-0"
+                  title={`${bucket.label}: ${bucket.count}`}
+                >
+                  <div className="w-full flex items-end justify-center h-24">
+                    <div
+                      className="w-full max-w-[28px] rounded-t bg-primary/70"
+                      style={{ height: `${heightPct}%` }}
+                      role="img"
+                      aria-label={`${bucket.label}: ${bucket.count}`}
+                    />
+                  </div>
+                  <span className="text-[10px] text-muted-foreground text-center truncate w-full">
+                    {bucket.label}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+          <p className="text-xs text-muted-foreground text-center">{t("timeSpentUnit")}</p>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/expert/expert-guard.tsx
+++ b/frontend/components/expert/expert-guard.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { startTransition, useEffect, useState } from "react";
+import { useRouter, usePathname } from "next/navigation";
+import { useLocale } from "next-intl";
+
+function parseJwtPayload(token: string): Record<string, unknown> | null {
+  try {
+    const base64Url = token.split(".")[1];
+    if (!base64Url) return null;
+    const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+    return JSON.parse(atob(base64));
+  } catch {
+    return null;
+  }
+}
+
+function getStoredToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem("access_token");
+}
+
+export function ExpertGuard({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const locale = useLocale();
+  const pathname = usePathname();
+  const [authorized, setAuthorized] = useState(false);
+
+  useEffect(() => {
+    const token = getStoredToken();
+    if (!token) {
+      router.replace(`/${locale}/dashboard`);
+      return;
+    }
+    const payload = parseJwtPayload(token);
+    const role = payload?.role as string | undefined;
+    if (role === "admin" || role === "expert") {
+      startTransition(() => setAuthorized(true));
+    } else {
+      router.replace(`/${locale}/dashboard`);
+    }
+  }, [locale, pathname, router]);
+
+  if (!authorized) return null;
+
+  return <>{children}</>;
+}

--- a/frontend/components/expert/expert-nav.tsx
+++ b/frontend/components/expert/expert-nav.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useTranslations, useLocale } from "next-intl";
+import { cn } from "@/lib/utils";
+
+export function ExpertNav() {
+  const t = useTranslations("Expert");
+  const locale = useLocale();
+  const pathname = usePathname();
+
+  const items = [
+    { href: `/${locale}/expert/dashboard`, label: t("nav.dashboard") },
+    { href: `/${locale}/expert/courses`, label: t("nav.courses") },
+  ];
+
+  return (
+    <nav
+      className="flex gap-1 border-b px-4 md:px-6 overflow-x-auto"
+      aria-label="Expert navigation"
+    >
+      {items.map((item) => {
+        const isActive = pathname.startsWith(item.href);
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={cn(
+              "shrink-0 border-b-2 px-3 py-3 text-sm font-medium transition-colors",
+              isActive
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            )}
+            aria-current={isActive ? "page" : undefined}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/components/expert/learner-table.tsx
+++ b/frontend/components/expert/learner-table.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Search,
+  ChevronLeft,
+  ChevronRight,
+  Loader2,
+  AlertCircle,
+  Users,
+} from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { apiFetch } from "@/lib/api";
+
+interface Learner {
+  id: string;
+  name: string;
+  email: string;
+  enrolled_at: string;
+  progress_pct: number;
+  last_active: string | null;
+}
+
+interface LearnersResponse {
+  learners: Learner[];
+  total: number;
+  page: number;
+  page_size: number;
+}
+
+function useCourseLearners(courseId: string, page: number, search: string) {
+  return useQuery<LearnersResponse>({
+    queryKey: ["expert", "courses", courseId, "learners", page, search],
+    queryFn: () => {
+      const params = new URLSearchParams({ page: String(page), page_size: "20" });
+      if (search) params.set("search", search);
+      return apiFetch<LearnersResponse>(
+        `/api/v1/expert/courses/${courseId}/learners?${params.toString()}`
+      );
+    },
+  });
+}
+
+function formatDate(dateStr: string | null, locale: string): string {
+  if (!dateStr) return "—";
+  return new Date(dateStr).toLocaleDateString(locale === "fr" ? "fr-FR" : "en-US", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+interface LearnerTableProps {
+  courseId: string;
+  locale: string;
+}
+
+export function LearnerTable({ courseId, locale }: LearnerTableProps) {
+  const t = useTranslations("ExpertLearners");
+  const [page, setPage] = useState(1);
+  const [searchInput, setSearchInput] = useState("");
+  const [search, setSearch] = useState("");
+
+  const { data, isLoading, error, refetch } = useCourseLearners(courseId, page, search);
+
+  const totalPages = data ? Math.ceil(data.total / data.page_size) : 1;
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    setSearch(searchInput);
+    setPage(1);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" aria-label={t("loading")} />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 p-8 text-center">
+        <AlertCircle className="h-10 w-10 text-destructive" aria-hidden="true" />
+        <p className="text-sm text-muted-foreground">{t("errorLoading")}</p>
+        <Button variant="outline" onClick={() => refetch()}>
+          {t("retry")}
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <form onSubmit={handleSearch} className="flex gap-2">
+        <div className="relative flex-1">
+          <Search
+            className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <Input
+            placeholder={t("searchPlaceholder")}
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            className="pl-9 min-h-11"
+            aria-label={t("searchPlaceholder")}
+          />
+        </div>
+        <Button type="submit" variant="outline" className="min-h-11">
+          {t("search")}
+        </Button>
+      </form>
+
+      {!data?.learners || data.learners.length === 0 ? (
+        <div className="py-12 text-center">
+          <Users className="h-12 w-12 text-muted-foreground mx-auto mb-4" aria-hidden="true" />
+          <p className="font-medium text-muted-foreground">{t("noLearners")}</p>
+        </div>
+      ) : (
+        <>
+          <p className="text-sm text-muted-foreground">
+            {t("learnerCount", { count: data.total })}
+          </p>
+
+          <div className="hidden md:block overflow-x-auto rounded-lg border">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-muted/50 border-b">
+                  <th className="text-left px-4 py-3 font-medium">{t("name")}</th>
+                  <th className="text-left px-4 py-3 font-medium">{t("email")}</th>
+                  <th className="text-left px-4 py-3 font-medium">{t("enrolledDate")}</th>
+                  <th className="text-left px-4 py-3 font-medium">{t("progress")}</th>
+                  <th className="text-left px-4 py-3 font-medium">{t("lastActive")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.learners.map((learner) => (
+                  <tr key={learner.id} className="border-b last:border-0 hover:bg-muted/30 transition-colors">
+                    <td className="px-4 py-3 font-medium">{learner.name}</td>
+                    <td className="px-4 py-3 text-muted-foreground">{learner.email}</td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {formatDate(learner.enrolled_at, locale)}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        <div className="flex-1 h-1.5 rounded-full bg-muted max-w-[80px]">
+                          <div
+                            className="h-1.5 rounded-full bg-primary"
+                            style={{ width: `${learner.progress_pct}%` }}
+                          />
+                        </div>
+                        <span className="text-xs text-muted-foreground shrink-0">
+                          {Math.round(learner.progress_pct)}%
+                        </span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {formatDate(learner.last_active, locale)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="flex flex-col gap-3 md:hidden">
+            {data.learners.map((learner) => (
+              <Card key={learner.id} className="p-4">
+                <div className="flex flex-col gap-1">
+                  <p className="font-medium text-sm">{learner.name}</p>
+                  <p className="text-xs text-muted-foreground">{learner.email}</p>
+                  <div className="flex items-center gap-3 mt-2 flex-wrap text-xs text-muted-foreground">
+                    <span>{t("enrolledDate")}: {formatDate(learner.enrolled_at, locale)}</span>
+                    <span>{t("lastActive")}: {formatDate(learner.last_active, locale)}</span>
+                  </div>
+                  <div className="flex items-center gap-2 mt-2">
+                    <div className="flex-1 h-1.5 rounded-full bg-muted">
+                      <div
+                        className="h-1.5 rounded-full bg-primary"
+                        style={{ width: `${learner.progress_pct}%` }}
+                      />
+                    </div>
+                    <span className="text-xs text-muted-foreground shrink-0">
+                      {Math.round(learner.progress_pct)}%
+                    </span>
+                  </div>
+                </div>
+              </Card>
+            ))}
+          </div>
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between gap-3">
+              <Button
+                variant="outline"
+                size="sm"
+                className="min-h-11 gap-1"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page === 1}
+                aria-label={t("previousPage")}
+              >
+                <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+                {t("previous")}
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                {t("pageOf", { page, total: totalPages })}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                className="min-h-11 gap-1"
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page === totalPages}
+                aria-label={t("nextPage")}
+              >
+                {t("next")}
+                <ChevronRight className="h-4 w-4" aria-hidden="true" />
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/expert/reviews-list.tsx
+++ b/frontend/components/expert/reviews-list.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { useQuery } from "@tanstack/react-query";
+import { ChevronLeft, ChevronRight, Loader2, AlertCircle, MessageSquare } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { StarRating } from "@/components/marketplace/star-rating";
+import { apiFetch } from "@/lib/api";
+
+interface Review {
+  id: string;
+  rating: number;
+  comment: string | null;
+  user_name: string;
+  created_at: string;
+}
+
+interface ReviewsResponse {
+  average_rating: number;
+  total_reviews: number;
+  reviews: Review[];
+  page: number;
+  page_size: number;
+}
+
+function useCourseReviews(courseId: string, page: number) {
+  return useQuery<ReviewsResponse>({
+    queryKey: ["expert", "courses", courseId, "reviews", page],
+    queryFn: () =>
+      apiFetch<ReviewsResponse>(
+        `/api/v1/expert/courses/${courseId}/reviews?page=${page}&page_size=10`
+      ),
+  });
+}
+
+function formatDate(dateStr: string, locale: string): string {
+  return new Date(dateStr).toLocaleDateString(locale === "fr" ? "fr-FR" : "en-US", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+interface ReviewsListProps {
+  courseId: string;
+  locale: string;
+}
+
+export function ReviewsList({ courseId, locale }: ReviewsListProps) {
+  const t = useTranslations("ExpertReviews");
+  const [page, setPage] = useState(1);
+
+  const { data, isLoading, error, refetch } = useCourseReviews(courseId, page);
+
+  const totalPages = data ? Math.ceil(data.total_reviews / data.page_size) : 1;
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" aria-label={t("loading")} />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 p-8 text-center">
+        <AlertCircle className="h-10 w-10 text-destructive" aria-hidden="true" />
+        <p className="text-sm text-muted-foreground">{t("errorLoading")}</p>
+        <Button variant="outline" onClick={() => refetch()}>
+          {t("retry")}
+        </Button>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="space-y-6">
+      {data.total_reviews > 0 && (
+        <Card className="p-4 flex items-center gap-4">
+          <div className="text-center">
+            <p className="text-4xl font-bold">{data.average_rating.toFixed(1)}</p>
+            <StarRating rating={data.average_rating} size="md" className="mt-1" />
+            <p className="text-xs text-muted-foreground mt-1">
+              {t("totalReviews", { count: data.total_reviews })}
+            </p>
+          </div>
+        </Card>
+      )}
+
+      {!data.reviews || data.reviews.length === 0 ? (
+        <div className="py-12 text-center">
+          <MessageSquare className="h-12 w-12 text-muted-foreground mx-auto mb-4" aria-hidden="true" />
+          <p className="font-medium text-muted-foreground">{t("noReviews")}</p>
+        </div>
+      ) : (
+        <>
+          <div className="flex flex-col gap-3">
+            {data.reviews.map((review) => (
+              <Card key={review.id} className="p-4">
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-center justify-between gap-2 flex-wrap">
+                    <div className="flex items-center gap-2">
+                      <p className="font-medium text-sm">{review.user_name}</p>
+                      <StarRating rating={review.rating} size="sm" />
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      {formatDate(review.created_at, locale)}
+                    </p>
+                  </div>
+                  {review.comment && (
+                    <p className="text-sm text-muted-foreground">{review.comment}</p>
+                  )}
+                </div>
+              </Card>
+            ))}
+          </div>
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between gap-3">
+              <Button
+                variant="outline"
+                size="sm"
+                className="min-h-11 gap-1"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page === 1}
+                aria-label={t("previousPage")}
+              >
+                <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+                {t("previous")}
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                {t("pageOf", { page, total: totalPages })}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                className="min-h-11 gap-1"
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page === totalPages}
+                aria-label={t("nextPage")}
+              >
+                {t("next")}
+                <ChevronRight className="h-4 w-4" aria-hidden="true" />
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/expert/summary-cards.tsx
+++ b/frontend/components/expert/summary-cards.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useTranslations, useLocale } from "next-intl";
+import { useQuery } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { BookOpen, Users, TrendingUp, Coins, Loader2, AlertCircle, ChevronRight } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { apiFetch } from "@/lib/api";
+
+interface ExpertDashboardSummary {
+  total_courses: number;
+  active_learners: number;
+  monthly_revenue: number;
+  credit_balance: number;
+  courses: ExpertCourseSummary[];
+}
+
+interface ExpertCourseSummary {
+  id: string;
+  title_fr: string;
+  title_en: string;
+  learner_count: number;
+  completion_rate: number;
+}
+
+function useExpertDashboard() {
+  return useQuery<ExpertDashboardSummary>({
+    queryKey: ["expert", "dashboard"],
+    queryFn: () => apiFetch<ExpertDashboardSummary>("/api/v1/expert/dashboard"),
+  });
+}
+
+export function SummaryCards() {
+  const t = useTranslations("ExpertDashboard");
+  const locale = useLocale();
+  const router = useRouter();
+
+  const { data, isLoading, error, refetch } = useExpertDashboard();
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" aria-label={t("loading")} />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 p-8 text-center">
+        <AlertCircle className="h-10 w-10 text-destructive" aria-hidden="true" />
+        <p className="text-sm text-muted-foreground">{t("errorLoading")}</p>
+        <Button variant="outline" onClick={() => refetch()}>
+          {t("retry")}
+        </Button>
+      </div>
+    );
+  }
+
+  const stats = [
+    {
+      icon: BookOpen,
+      label: t("totalCourses"),
+      value: data?.total_courses ?? 0,
+    },
+    {
+      icon: Users,
+      label: t("activeLearners"),
+      value: data?.active_learners ?? 0,
+    },
+    {
+      icon: TrendingUp,
+      label: t("monthlyRevenue"),
+      value: `${(data?.monthly_revenue ?? 0).toLocaleString()} FCFA`,
+    },
+    {
+      icon: Coins,
+      label: t("creditBalance"),
+      value: data?.credit_balance ?? 0,
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        {stats.map((stat) => {
+          const Icon = stat.icon;
+          return (
+            <Card key={stat.label} className="p-4">
+              <div className="flex items-start gap-3">
+                <div className="rounded-md bg-primary/10 p-2 shrink-0">
+                  <Icon className="h-5 w-5 text-primary" aria-hidden="true" />
+                </div>
+                <div className="min-w-0">
+                  <p className="text-xs text-muted-foreground truncate">{stat.label}</p>
+                  <p className="text-xl font-bold mt-0.5">{stat.value}</p>
+                </div>
+              </div>
+            </Card>
+          );
+        })}
+      </div>
+
+      {data?.courses && data.courses.length > 0 && (
+        <div>
+          <h2 className="text-base font-semibold mb-3">{t("myCourses")}</h2>
+          <div className="flex flex-col gap-2">
+            {data.courses.map((course) => {
+              const title = locale === "fr" ? course.title_fr : course.title_en;
+              return (
+                <Card key={course.id} className="p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <p className="font-medium text-sm truncate">{title}</p>
+                      <div className="flex items-center gap-3 mt-1 flex-wrap">
+                        <span className="text-xs text-muted-foreground">
+                          {t("learnerCount", { count: course.learner_count })}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {t("completionRate", { rate: Math.round(course.completion_rate) })}
+                        </span>
+                      </div>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="shrink-0 min-h-11 min-w-11 p-2"
+                      onClick={() => router.push(`/${locale}/expert/courses/${course.id}/learners`)}
+                      aria-label={t("viewCourse")}
+                    >
+                      <ChevronRight className="h-4 w-4" aria-hidden="true" />
+                    </Button>
+                  </div>
+                </Card>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {(!data?.courses || data.courses.length === 0) && !isLoading && (
+        <div className="py-12 text-center">
+          <BookOpen className="h-12 w-12 text-muted-foreground mx-auto mb-4" aria-hidden="true" />
+          <p className="font-medium text-muted-foreground">{t("noCourses")}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/marketplace/star-rating.tsx
+++ b/frontend/components/marketplace/star-rating.tsx
@@ -1,0 +1,68 @@
+import { Star } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface StarRatingProps {
+  rating: number;
+  maxStars?: number;
+  size?: "sm" | "md" | "lg";
+  showValue?: boolean;
+  className?: string;
+}
+
+const sizeMap = {
+  sm: "h-3.5 w-3.5",
+  md: "h-4 w-4",
+  lg: "h-5 w-5",
+};
+
+export function StarRating({
+  rating,
+  maxStars = 5,
+  size = "md",
+  showValue = false,
+  className,
+}: StarRatingProps) {
+  const clampedRating = Math.min(maxStars, Math.max(0, rating));
+  const fullStars = Math.floor(clampedRating);
+  const hasHalf = clampedRating - fullStars >= 0.5;
+  const starClass = sizeMap[size];
+
+  return (
+    <span
+      className={cn("inline-flex items-center gap-0.5", className)}
+      role="img"
+      aria-label={`${clampedRating.toFixed(1)} / ${maxStars}`}
+    >
+      {Array.from({ length: maxStars }).map((_, i) => {
+        const filled = i < fullStars;
+        const half = !filled && hasHalf && i === fullStars;
+        return (
+          <span key={i} className="relative inline-block">
+            <Star
+              className={cn(starClass, "text-muted-foreground/30")}
+              fill="currentColor"
+              aria-hidden="true"
+            />
+            {(filled || half) && (
+              <span
+                className="absolute inset-0 overflow-hidden"
+                style={{ width: half ? "50%" : "100%" }}
+                aria-hidden="true"
+              >
+                <Star
+                  className={cn(starClass, "text-amber-500")}
+                  fill="currentColor"
+                />
+              </span>
+            )}
+          </span>
+        );
+      })}
+      {showValue && (
+        <span className="ml-1 text-xs font-medium text-muted-foreground">
+          {clampedRating.toFixed(1)}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1124,5 +1124,80 @@
     "bloomLevel": "Bloom level",
     "estimatedHours": "Duration (h)",
     "moduleNumber": "Module number"
+  },
+  "Expert": {
+    "nav": {
+      "dashboard": "Dashboard",
+      "courses": "My Courses"
+    }
+  },
+  "ExpertDashboard": {
+    "pageTitle": "Expert Dashboard",
+    "pageDescription": "Overview of your courses and learners",
+    "loading": "Loading dashboard...",
+    "errorLoading": "Failed to load dashboard data.",
+    "retry": "Retry",
+    "totalCourses": "Total Courses",
+    "activeLearners": "Active Learners",
+    "monthlyRevenue": "Monthly Revenue",
+    "creditBalance": "Credit Balance",
+    "myCourses": "My Courses",
+    "noCourses": "No courses yet",
+    "learnerCount": "{count, plural, one {# learner} other {# learners}}",
+    "completionRate": "{rate}% completed",
+    "viewCourse": "View course"
+  },
+  "ExpertLearners": {
+    "pageTitle": "Course Learners",
+    "pageDescription": "Learners enrolled in this course",
+    "loading": "Loading learners...",
+    "errorLoading": "Failed to load learners.",
+    "retry": "Retry",
+    "searchPlaceholder": "Search by name or email...",
+    "search": "Search",
+    "learnerCount": "{count, plural, one {# learner} other {# learners}}",
+    "noLearners": "No learners enrolled yet",
+    "name": "Name",
+    "email": "Email",
+    "enrolledDate": "Enrolled",
+    "progress": "Progress",
+    "lastActive": "Last Active",
+    "previousPage": "Previous page",
+    "nextPage": "Next page",
+    "previous": "Previous",
+    "next": "Next",
+    "pageOf": "Page {page} of {total}"
+  },
+  "ExpertAnalytics": {
+    "pageTitle": "Course Analytics",
+    "pageDescription": "Performance metrics for this course",
+    "loading": "Loading analytics...",
+    "errorLoading": "Failed to load analytics.",
+    "retry": "Retry",
+    "quizPassRate": "Quiz Pass Rate",
+    "avgQuizScore": "Avg. Quiz Score",
+    "completionFunnel": "Completion Funnel",
+    "funnel": {
+      "enrolled": "Enrolled",
+      "started": "Started",
+      "halfComplete": "50% Done",
+      "completed": "Completed"
+    },
+    "timeSpentDistribution": "Time Spent Distribution",
+    "timeSpentUnit": "Number of learners per time bracket"
+  },
+  "ExpertReviews": {
+    "pageTitle": "Course Reviews",
+    "pageDescription": "Learner reviews and ratings",
+    "loading": "Loading reviews...",
+    "errorLoading": "Failed to load reviews.",
+    "retry": "Retry",
+    "totalReviews": "{count, plural, one {# review} other {# reviews}}",
+    "noReviews": "No reviews yet",
+    "previousPage": "Previous page",
+    "nextPage": "Next page",
+    "previous": "Previous",
+    "next": "Next",
+    "pageOf": "Page {page} of {total}"
   }
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1124,5 +1124,80 @@
     "bloomLevel": "Niveau Bloom",
     "estimatedHours": "Durée (h)",
     "moduleNumber": "Numéro de module"
+  },
+  "Expert": {
+    "nav": {
+      "dashboard": "Tableau de bord",
+      "courses": "Mes formations"
+    }
+  },
+  "ExpertDashboard": {
+    "pageTitle": "Tableau de bord expert",
+    "pageDescription": "Vue d'ensemble de vos formations et apprenants",
+    "loading": "Chargement du tableau de bord...",
+    "errorLoading": "Erreur lors du chargement des données.",
+    "retry": "Réessayer",
+    "totalCourses": "Formations totales",
+    "activeLearners": "Apprenants actifs",
+    "monthlyRevenue": "Revenus mensuels",
+    "creditBalance": "Solde de crédits",
+    "myCourses": "Mes formations",
+    "noCourses": "Aucune formation pour l'instant",
+    "learnerCount": "{count, plural, one {# apprenant} other {# apprenants}}",
+    "completionRate": "{rate}% complété",
+    "viewCourse": "Voir la formation"
+  },
+  "ExpertLearners": {
+    "pageTitle": "Apprenants de la formation",
+    "pageDescription": "Apprenants inscrits à cette formation",
+    "loading": "Chargement des apprenants...",
+    "errorLoading": "Erreur lors du chargement des apprenants.",
+    "retry": "Réessayer",
+    "searchPlaceholder": "Rechercher par nom ou e-mail...",
+    "search": "Rechercher",
+    "learnerCount": "{count, plural, one {# apprenant} other {# apprenants}}",
+    "noLearners": "Aucun apprenant inscrit pour l'instant",
+    "name": "Nom",
+    "email": "Email",
+    "enrolledDate": "Inscrit le",
+    "progress": "Progression",
+    "lastActive": "Dernière activité",
+    "previousPage": "Page précédente",
+    "nextPage": "Page suivante",
+    "previous": "Précédent",
+    "next": "Suivant",
+    "pageOf": "Page {page} sur {total}"
+  },
+  "ExpertAnalytics": {
+    "pageTitle": "Analytiques de la formation",
+    "pageDescription": "Indicateurs de performance de cette formation",
+    "loading": "Chargement des analytiques...",
+    "errorLoading": "Erreur lors du chargement des analytiques.",
+    "retry": "Réessayer",
+    "quizPassRate": "Taux de réussite aux quiz",
+    "avgQuizScore": "Score moyen aux quiz",
+    "completionFunnel": "Entonnoir de complétion",
+    "funnel": {
+      "enrolled": "Inscrits",
+      "started": "Commencé",
+      "halfComplete": "50% terminé",
+      "completed": "Complété"
+    },
+    "timeSpentDistribution": "Distribution du temps passé",
+    "timeSpentUnit": "Nombre d'apprenants par tranche de temps"
+  },
+  "ExpertReviews": {
+    "pageTitle": "Avis sur la formation",
+    "pageDescription": "Avis et notes des apprenants",
+    "loading": "Chargement des avis...",
+    "errorLoading": "Erreur lors du chargement des avis.",
+    "retry": "Réessayer",
+    "totalReviews": "{count, plural, one {# avis} other {# avis}}",
+    "noReviews": "Aucun avis pour l'instant",
+    "previousPage": "Page précédente",
+    "nextPage": "Page suivante",
+    "previous": "Précédent",
+    "next": "Suivant",
+    "pageOf": "Page {page} sur {total}"
   }
 }


### PR DESCRIPTION
## Summary
- Add expert dashboard with summary cards (total courses, active learners, monthly revenue, credit balance)
- Add course learners table with pagination and search
- Add course analytics charts (quiz pass rate gauge, completion funnel, time-spent bar chart)
- Add course reviews list with average star rating and pagination
- Add `StarRating` reusable component in `frontend/components/marketplace/`

## Changes
- `frontend/app/[locale]/expert/layout.tsx` — Expert layout with ExpertGuard + ExpertNav
- `frontend/components/expert/expert-guard.tsx` — JWT-based role guard (expert/admin only)
- `frontend/components/expert/expert-nav.tsx` — Expert section navigation
- `frontend/components/expert/summary-cards.tsx` — Dashboard overview cards + course quick-links
- `frontend/components/expert/learner-table.tsx` — Paginated, searchable learner table
- `frontend/components/expert/analytics-charts.tsx` — SVG gauges + funnel + bar chart (no heavy deps)
- `frontend/components/expert/reviews-list.tsx` — Paginated reviews with star display
- `frontend/components/marketplace/star-rating.tsx` — Reusable star rating with half-star support
- `frontend/app/[locale]/expert/dashboard/page.tsx`
- `frontend/app/[locale]/expert/courses/[id]/learners/page.tsx`
- `frontend/app/[locale]/expert/courses/[id]/analytics/page.tsx`
- `frontend/app/[locale]/expert/courses/[id]/reviews/page.tsx`
- `frontend/messages/en.json` and `frontend/messages/fr.json` — Expert* i18n keys

## Test plan
- [ ] Backend tests pass
- [ ] Frontend lint passes (`npm run lint` — 0 errors)
- [ ] Manually verify expert dashboard on mobile viewport (320px)
- [ ] Verify bilingual toggle works (FR/EN)
- [ ] Verify guard redirects non-expert users to `/dashboard`

Closes #631

Generated with [Claude Code](https://claude.ai/code)