### PR TITLE
feat(ui): expert revenue & credits pages

### DIFF
--- a/frontend/app/[locale]/expert/courses/page.tsx
+++ b/frontend/app/[locale]/expert/courses/page.tsx
@@ -1,0 +1,11 @@
+import { getTranslations } from "next-intl/server";
+
+export default async function ExpertCoursesPage() {
+  const t = await getTranslations("ExpertNav");
+
+  return (
+    <div className="p-4 md:p-6">
+      <h1 className="text-2xl font-semibold">{t("courses")}</h1>
+    </div>
+  );
+}

--- a/frontend/app/[locale]/expert/credits/page.tsx
+++ b/frontend/app/[locale]/expert/credits/page.tsx
@@ -1,0 +1,16 @@
+import { getTranslations } from "next-intl/server";
+import { CreditsClient } from "@/components/expert/credits-client";
+
+export default async function ExpertCreditsPage() {
+  const t = await getTranslations("ExpertCredits");
+
+  return (
+    <div className="p-4 md:p-6">
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold">{t("title")}</h1>
+        <p className="mt-1 text-muted-foreground">{t("subtitle")}</p>
+      </div>
+      <CreditsClient />
+    </div>
+  );
+}

--- a/frontend/app/[locale]/expert/layout.tsx
+++ b/frontend/app/[locale]/expert/layout.tsx
@@ -1,0 +1,23 @@
+import { ExpertGuard } from "@/components/expert/expert-guard";
+import { ExpertNav } from "@/components/expert/expert-nav";
+import { BottomNav } from "@/components/layout/bottom-nav";
+import { Header } from "@/components/layout/header";
+import { Sidebar } from "@/components/layout/sidebar";
+
+export default function ExpertLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <ExpertGuard>
+      <div className="flex h-dvh flex-col md:flex-row">
+        <Sidebar />
+        <div className="flex flex-1 flex-col min-h-0">
+          <Header />
+          <ExpertNav />
+          <main className="flex flex-col flex-1 overflow-y-auto pb-16 pt-0 md:pb-0">
+            {children}
+          </main>
+        </div>
+        <BottomNav />
+      </div>
+    </ExpertGuard>
+  );
+}

--- a/frontend/app/[locale]/expert/page.tsx
+++ b/frontend/app/[locale]/expert/page.tsx
@@ -1,0 +1,10 @@
+import { redirect } from "next/navigation";
+
+export default async function ExpertPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  redirect(`/${locale}/expert/revenue`);
+}

--- a/frontend/app/[locale]/expert/revenue/page.tsx
+++ b/frontend/app/[locale]/expert/revenue/page.tsx
@@ -1,0 +1,16 @@
+import { getTranslations } from "next-intl/server";
+import { RevenueClient } from "@/components/expert/revenue-client";
+
+export default async function ExpertRevenuePage() {
+  const t = await getTranslations("ExpertRevenue");
+
+  return (
+    <div className="p-4 md:p-6">
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold">{t("title")}</h1>
+        <p className="mt-1 text-muted-foreground">{t("subtitle")}</p>
+      </div>
+      <RevenueClient />
+    </div>
+  );
+}

--- a/frontend/components/expert/cost-breakdown.tsx
+++ b/frontend/components/expert/cost-breakdown.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+interface CourseGenerationCost {
+  courseId: string;
+  courseTitle: string;
+  totalCostUsd: number;
+  apiCalls: number;
+  lastUsedAt: string | null;
+}
+
+interface CostBreakdownProps {
+  courses: CourseGenerationCost[];
+  loading?: boolean;
+  error?: boolean;
+}
+
+export function CostBreakdown({ courses, loading, error }: CostBreakdownProps) {
+  const t = useTranslations("ExpertCredits.breakdown");
+
+  if (loading) {
+    return (
+      <p className="py-4 text-sm text-muted-foreground">{t("loading")}</p>
+    );
+  }
+
+  if (error) {
+    return (
+      <p className="py-4 text-sm text-destructive">{t("error")}</p>
+    );
+  }
+
+  if (courses.length === 0) {
+    return (
+      <p className="py-4 text-sm text-muted-foreground">{t("noCourses")}</p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left text-muted-foreground">
+            <th className="py-2 pr-4 font-medium">{t("course")}</th>
+            <th className="py-2 pr-4 font-medium text-right">{t("calls")}</th>
+            <th className="py-2 pr-4 font-medium text-right">{t("totalCost")}</th>
+            <th className="py-2 font-medium">{t("lastUsed")}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {courses.map((item) => (
+            <tr key={item.courseId} className="border-b last:border-0">
+              <td className="py-2.5 pr-4 font-medium">{item.courseTitle}</td>
+              <td className="py-2.5 pr-4 text-right tabular-nums">{item.apiCalls}</td>
+              <td className="py-2.5 pr-4 text-right tabular-nums">
+                ${item.totalCostUsd.toFixed(4)}
+              </td>
+              <td className="py-2.5 text-muted-foreground">
+                {item.lastUsedAt
+                  ? new Date(item.lastUsedAt).toLocaleDateString()
+                  : "—"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/components/expert/credits-client.tsx
+++ b/frontend/components/expert/credits-client.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslations, useLocale } from "next-intl";
+import Link from "next/link";
+import { CostBreakdown } from "@/components/expert/cost-breakdown";
+
+const OPERATION_KEYS = [
+  "lesson_generation",
+  "quiz_generation",
+  "case_study_generation",
+  "flashcard_generation",
+  "tutor_chat",
+] as const;
+
+interface CourseGenerationCost {
+  courseId: string;
+  courseTitle: string;
+  totalCostUsd: number;
+  apiCalls: number;
+  lastUsedAt: string | null;
+}
+
+interface UsageLogEntry {
+  id: string;
+  createdAt: string;
+  courseTitle: string;
+  operation: string;
+  tokensIn: number;
+  tokensOut: number;
+  costUsd: number;
+}
+
+interface CreditsData {
+  balance: number;
+  courses: CourseGenerationCost[];
+  usageLogs: UsageLogEntry[];
+}
+
+function getStoredToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem("access_token");
+}
+
+export function CreditsClient() {
+  const t = useTranslations("ExpertCredits");
+  const locale = useLocale();
+  const [data, setData] = useState<CreditsData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const token = getStoredToken();
+        const res = await fetch("/api/v1/expert/credits", {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        });
+        if (!res.ok) throw new Error("fetch failed");
+        const json = (await res.json()) as CreditsData;
+        setData(json);
+      } catch {
+        setError(true);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  if (loading) {
+    return <p className="py-8 text-center text-sm text-muted-foreground">{t("loading")}</p>;
+  }
+
+  if (error || !data) {
+    return <p className="py-8 text-center text-sm text-destructive">{t("error")}</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border bg-card p-4">
+        <p className="text-sm text-muted-foreground">{t("balance.title")}</p>
+        <p className="mt-1 text-3xl font-bold tabular-nums">
+          {t("balance.credits", { count: data.balance })}
+        </p>
+        <div className="mt-3">
+          <Link
+            href={`/${locale}/billing/purchase`}
+            className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            {t("balance.purchase")}
+          </Link>
+        </div>
+      </div>
+
+      <div className="rounded-lg border bg-card p-4">
+        <h2 className="mb-4 text-sm font-semibold">{t("breakdown.title")}</h2>
+        <CostBreakdown courses={data.courses} />
+      </div>
+
+      <div className="rounded-lg border bg-card p-4">
+        <h2 className="mb-4 text-sm font-semibold">{t("history.title")}</h2>
+        {data.usageLogs.length === 0 ? (
+          <p className="py-4 text-sm text-muted-foreground">{t("history.noHistory")}</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left text-muted-foreground">
+                  <th className="py-2 pr-4 font-medium">{t("history.date")}</th>
+                  <th className="py-2 pr-4 font-medium">{t("history.course")}</th>
+                  <th className="py-2 pr-4 font-medium">{t("history.operation")}</th>
+                  <th className="py-2 pr-4 font-medium text-right">{t("history.tokensIn")}</th>
+                  <th className="py-2 pr-4 font-medium text-right">{t("history.tokensOut")}</th>
+                  <th className="py-2 font-medium text-right">{t("history.cost")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.usageLogs.map((log) => (
+                  <tr key={log.id} className="border-b last:border-0">
+                    <td className="py-2.5 pr-4 text-muted-foreground">
+                      {new Date(log.createdAt).toLocaleDateString()}
+                    </td>
+                    <td className="py-2.5 pr-4 max-w-[10rem] truncate">{log.courseTitle}</td>
+                    <td className="py-2.5 pr-4 text-muted-foreground">
+                      {(OPERATION_KEYS as ReadonlyArray<string>).includes(log.operation)
+                        ? t(`operations.${log.operation as typeof OPERATION_KEYS[number]}`)
+                        : log.operation}
+                    </td>
+                    <td className="py-2.5 pr-4 text-right tabular-nums">{log.tokensIn.toLocaleString()}</td>
+                    <td className="py-2.5 pr-4 text-right tabular-nums">{log.tokensOut.toLocaleString()}</td>
+                    <td className="py-2.5 text-right tabular-nums">${log.costUsd.toFixed(4)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/expert/expert-guard.tsx
+++ b/frontend/components/expert/expert-guard.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { startTransition, useEffect, useState } from "react";
+import { useRouter, usePathname } from "next/navigation";
+import { useLocale } from "next-intl";
+
+function parseJwtPayload(token: string): Record<string, unknown> | null {
+  try {
+    const base64Url = token.split(".")[1];
+    if (!base64Url) return null;
+    const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+    return JSON.parse(atob(base64));
+  } catch {
+    return null;
+  }
+}
+
+function getStoredToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem("access_token");
+}
+
+export function ExpertGuard({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const locale = useLocale();
+  const pathname = usePathname();
+  const [authorized, setAuthorized] = useState(false);
+
+  useEffect(() => {
+    const token = getStoredToken();
+    if (!token) {
+      router.replace(`/${locale}/dashboard`);
+      return;
+    }
+    const payload = parseJwtPayload(token);
+    const role = payload?.role as string | undefined;
+    if (role === "admin" || role === "expert") {
+      startTransition(() => setAuthorized(true));
+    } else {
+      router.replace(`/${locale}/dashboard`);
+    }
+  }, [locale, pathname, router]);
+
+  if (!authorized) return null;
+
+  return <>{children}</>;
+}

--- a/frontend/components/expert/expert-nav.tsx
+++ b/frontend/components/expert/expert-nav.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useTranslations, useLocale } from "next-intl";
+import { cn } from "@/lib/utils";
+
+export function ExpertNav() {
+  const t = useTranslations("ExpertNav");
+  const locale = useLocale();
+  const pathname = usePathname();
+
+  const items = [
+    { href: `/${locale}/expert/revenue`, label: t("revenue") },
+    { href: `/${locale}/expert/credits`, label: t("credits") },
+    { href: `/${locale}/expert/courses`, label: t("courses") },
+  ];
+
+  return (
+    <nav className="flex gap-1 border-b px-4 md:px-6 overflow-x-auto" aria-label="Expert navigation">
+      {items.map((item) => {
+        const isActive = pathname.startsWith(item.href);
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={cn(
+              "shrink-0 border-b-2 px-3 py-3 text-sm font-medium transition-colors",
+              isActive
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            )}
+            aria-current={isActive ? "page" : undefined}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/components/expert/revenue-chart.tsx
+++ b/frontend/components/expert/revenue-chart.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+interface MonthlyRevenue {
+  month: string;
+  gross: number;
+  commission: number;
+  net: number;
+}
+
+interface RevenueChartProps {
+  data: MonthlyRevenue[];
+}
+
+export function RevenueChart({ data }: RevenueChartProps) {
+  const t = useTranslations("ExpertRevenue.chart");
+
+  if (data.length === 0) {
+    return (
+      <div className="flex h-48 items-center justify-center text-sm text-muted-foreground">
+        {t("noData")}
+      </div>
+    );
+  }
+
+  const maxValue = Math.max(...data.map((d) => d.gross), 1);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-4 text-xs text-muted-foreground">
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-2.5 w-2.5 rounded-sm bg-primary" />
+          {t("gross")}
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-2.5 w-2.5 rounded-sm bg-amber-500" />
+          {t("commission")}
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-2.5 w-2.5 rounded-sm bg-emerald-500" />
+          {t("net")}
+        </span>
+      </div>
+      <div
+        className="flex items-end gap-1 overflow-x-auto pb-2"
+        role="img"
+        aria-label={t("title")}
+      >
+        {data.map((item) => {
+          const grossPct = (item.gross / maxValue) * 100;
+          const commissionPct = (item.commission / maxValue) * 100;
+          const netPct = (item.net / maxValue) * 100;
+          return (
+            <div key={item.month} className="flex min-w-[2.5rem] flex-1 flex-col items-center gap-1">
+              <div className="flex w-full items-end justify-center gap-0.5" style={{ height: "120px" }}>
+                <div
+                  className="w-2.5 rounded-t bg-primary transition-all"
+                  style={{ height: `${grossPct}%` }}
+                  title={`${t("gross")}: ${item.gross.toFixed(2)}`}
+                />
+                <div
+                  className="w-2.5 rounded-t bg-amber-500 transition-all"
+                  style={{ height: `${commissionPct}%` }}
+                  title={`${t("commission")}: ${item.commission.toFixed(2)}`}
+                />
+                <div
+                  className="w-2.5 rounded-t bg-emerald-500 transition-all"
+                  style={{ height: `${netPct}%` }}
+                  title={`${t("net")}: ${item.net.toFixed(2)}`}
+                />
+              </div>
+              <span className="text-[10px] text-muted-foreground">{item.month}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/expert/revenue-client.tsx
+++ b/frontend/components/expert/revenue-client.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { RevenueChart } from "@/components/expert/revenue-chart";
+
+interface MonthlyRevenue {
+  month: string;
+  gross: number;
+  commission: number;
+  net: number;
+}
+
+interface Transaction {
+  id: string;
+  date: string;
+  description: string;
+  gross: number;
+  commission: number;
+  net: number;
+}
+
+interface RevenueSummary {
+  totalEarned: number;
+  totalCommission: number;
+  netEarnings: number;
+  monthly: MonthlyRevenue[];
+  transactions: Transaction[];
+}
+
+function getStoredToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem("access_token");
+}
+
+export function RevenueClient() {
+  const t = useTranslations("ExpertRevenue");
+  const [summary, setSummary] = useState<RevenueSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const token = getStoredToken();
+        const res = await fetch("/api/v1/expert/revenue", {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        });
+        if (!res.ok) throw new Error("fetch failed");
+        const data = (await res.json()) as RevenueSummary;
+        setSummary(data);
+      } catch {
+        setError(true);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  if (loading) {
+    return <p className="py-8 text-center text-sm text-muted-foreground">{t("loading")}</p>;
+  }
+
+  if (error || !summary) {
+    return <p className="py-8 text-center text-sm text-destructive">{t("error")}</p>;
+  }
+
+  const summaryItems = [
+    { label: t("summaryCards.totalEarned"), value: summary.totalEarned },
+    { label: t("summaryCards.totalCommission"), value: summary.totalCommission },
+    { label: t("summaryCards.netEarnings"), value: summary.netEarnings },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        {summaryItems.map((item) => (
+          <div key={item.label} className="rounded-lg border bg-card p-4">
+            <p className="text-sm text-muted-foreground">{item.label}</p>
+            <p className="mt-1 text-2xl font-semibold tabular-nums">
+              ${item.value.toFixed(2)}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <div className="rounded-lg border bg-card p-4">
+        <h2 className="mb-4 text-sm font-semibold">{t("chart.title")}</h2>
+        <RevenueChart data={summary.monthly} />
+      </div>
+
+      <div className="rounded-lg border bg-card p-4">
+        <div className="mb-4 flex items-center justify-between gap-2">
+          <h2 className="text-sm font-semibold">{t("transactions.title")}</h2>
+          <button
+            disabled
+            className="rounded border px-3 py-1.5 text-xs text-muted-foreground opacity-50"
+          >
+            {t("export")}
+          </button>
+        </div>
+        {summary.transactions.length === 0 ? (
+          <p className="py-4 text-sm text-muted-foreground">
+            {t("transactions.noTransactions")}
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left text-muted-foreground">
+                  <th className="py-2 pr-4 font-medium">{t("transactions.date")}</th>
+                  <th className="py-2 pr-4 font-medium">{t("transactions.description")}</th>
+                  <th className="py-2 pr-4 font-medium text-right">{t("transactions.gross")}</th>
+                  <th className="py-2 pr-4 font-medium text-right">{t("transactions.commission")}</th>
+                  <th className="py-2 font-medium text-right">{t("transactions.net")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {summary.transactions.map((tx) => (
+                  <tr key={tx.id} className="border-b last:border-0">
+                    <td className="py-2.5 pr-4 text-muted-foreground">
+                      {new Date(tx.date).toLocaleDateString()}
+                    </td>
+                    <td className="py-2.5 pr-4">{tx.description}</td>
+                    <td className="py-2.5 pr-4 text-right tabular-nums">
+                      ${tx.gross.toFixed(2)}
+                    </td>
+                    <td className="py-2.5 pr-4 text-right tabular-nums text-amber-600">
+                      -${tx.commission.toFixed(2)}
+                    </td>
+                    <td className="py-2.5 text-right tabular-nums text-emerald-600">
+                      ${tx.net.toFixed(2)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1124,5 +1124,81 @@
     "bloomLevel": "Bloom level",
     "estimatedHours": "Duration (h)",
     "moduleNumber": "Module number"
+  },
+  "ExpertNav": {
+    "dashboard": "Dashboard",
+    "revenue": "Revenue",
+    "credits": "AI Credits",
+    "courses": "My Courses"
+  },
+  "ExpertRevenue": {
+    "title": "Revenue",
+    "subtitle": "Track your earnings and commissions",
+    "summaryCards": {
+      "totalEarned": "Total Earned",
+      "totalCommission": "Commissions",
+      "netEarnings": "Net Earnings"
+    },
+    "chart": {
+      "title": "Revenue — last 12 months",
+      "gross": "Gross",
+      "commission": "Commission",
+      "net": "Net",
+      "noData": "No revenue data available"
+    },
+    "transactions": {
+      "title": "Transactions",
+      "date": "Date",
+      "description": "Description",
+      "gross": "Gross",
+      "commission": "Commission",
+      "net": "Net",
+      "noTransactions": "No transactions",
+      "loading": "Loading transactions...",
+      "error": "Unable to load transactions."
+    },
+    "export": "Export (coming soon)",
+    "loading": "Loading revenue...",
+    "error": "Unable to load revenue data."
+  },
+  "ExpertCredits": {
+    "title": "AI Credits",
+    "subtitle": "Manage your content generation credits",
+    "balance": {
+      "title": "Current Balance",
+      "credits": "{count} credits",
+      "purchase": "Purchase Credits"
+    },
+    "breakdown": {
+      "title": "Generation Cost by Course",
+      "course": "Course",
+      "totalCost": "Total Cost",
+      "calls": "API Calls",
+      "lastUsed": "Last Used",
+      "noCourses": "No courses with generation costs",
+      "loading": "Loading costs...",
+      "error": "Unable to load generation costs."
+    },
+    "history": {
+      "title": "Usage History",
+      "date": "Date",
+      "course": "Course",
+      "operation": "Operation",
+      "tokensIn": "Input tokens",
+      "tokensOut": "Output tokens",
+      "cost": "Cost (USD)",
+      "noHistory": "No usage history",
+      "loading": "Loading history...",
+      "error": "Unable to load history."
+    },
+    "operations": {
+      "lesson_generation": "Lesson generation",
+      "quiz_generation": "Quiz generation",
+      "case_study_generation": "Case study generation",
+      "flashcard_generation": "Flashcard generation",
+      "tutor_chat": "Tutor chat"
+    },
+    "loading": "Loading credits...",
+    "error": "Unable to load credits data."
   }
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1124,5 +1124,81 @@
     "bloomLevel": "Niveau Bloom",
     "estimatedHours": "Durée (h)",
     "moduleNumber": "Numéro de module"
+  },
+  "ExpertNav": {
+    "dashboard": "Tableau de bord",
+    "revenue": "Revenus",
+    "credits": "Crédits IA",
+    "courses": "Mes cours"
+  },
+  "ExpertRevenue": {
+    "title": "Revenus",
+    "subtitle": "Suivi de vos gains et commissions",
+    "summaryCards": {
+      "totalEarned": "Total brut",
+      "totalCommission": "Commissions",
+      "netEarnings": "Revenus nets"
+    },
+    "chart": {
+      "title": "Revenus des 12 derniers mois",
+      "gross": "Brut",
+      "commission": "Commission",
+      "net": "Net",
+      "noData": "Aucune donnée de revenus disponible"
+    },
+    "transactions": {
+      "title": "Transactions",
+      "date": "Date",
+      "description": "Description",
+      "gross": "Montant brut",
+      "commission": "Commission",
+      "net": "Net",
+      "noTransactions": "Aucune transaction",
+      "loading": "Chargement des transactions...",
+      "error": "Impossible de charger les transactions."
+    },
+    "export": "Exporter (bientôt disponible)",
+    "loading": "Chargement des revenus...",
+    "error": "Impossible de charger les données de revenus."
+  },
+  "ExpertCredits": {
+    "title": "Crédits IA",
+    "subtitle": "Gérez vos crédits de génération de contenu",
+    "balance": {
+      "title": "Solde actuel",
+      "credits": "{count} crédits",
+      "purchase": "Acheter des crédits"
+    },
+    "breakdown": {
+      "title": "Coût de génération par cours",
+      "course": "Cours",
+      "totalCost": "Coût total",
+      "calls": "Appels API",
+      "lastUsed": "Dernière utilisation",
+      "noCourses": "Aucun cours avec des coûts de génération",
+      "loading": "Chargement des coûts...",
+      "error": "Impossible de charger les coûts de génération."
+    },
+    "history": {
+      "title": "Historique des utilisations",
+      "date": "Date",
+      "course": "Cours",
+      "operation": "Opération",
+      "tokensIn": "Tokens entrée",
+      "tokensOut": "Tokens sortie",
+      "cost": "Coût (USD)",
+      "noHistory": "Aucun historique d'utilisation",
+      "loading": "Chargement de l'historique...",
+      "error": "Impossible de charger l'historique."
+    },
+    "operations": {
+      "lesson_generation": "Génération de leçon",
+      "quiz_generation": "Génération de quiz",
+      "case_study_generation": "Génération d'étude de cas",
+      "flashcard_generation": "Génération de flashcards",
+      "tutor_chat": "Chat tuteur"
+    },
+    "loading": "Chargement des crédits...",
+    "error": "Impossible de charger les données de crédits."
   }
 }


### PR DESCRIPTION
## Summary

- Add expert section layout at `/[locale]/expert/` with `ExpertGuard` (expert + admin roles), `ExpertNav` tab bar (Revenue, AI Credits, My Courses)
- Add `/expert/revenue` page: summary cards (total earned / commission / net), 12-month bar chart with gross/commission/net columns, transactions table with export placeholder
- Add `/expert/credits` page: current credit balance + purchase link, generation cost breakdown by course, full API usage log table (operation, tokens in/out, cost USD)
- Add `RevenueChart` — pure CSS/Tailwind bar chart, no extra library dependency
- Add `CostBreakdown` — reusable table component
- All text via next-intl (FR/EN) — new `ExpertNav`, `ExpertRevenue`, `ExpertCredits` namespaces added to both message files
- Lint passes (0 errors), TypeScript clean

## Changes

- `frontend/app/[locale]/expert/layout.tsx` — ExpertGuard + ExpertNav layout
- `frontend/app/[locale]/expert/page.tsx` — redirect to /revenue
- `frontend/app/[locale]/expert/revenue/page.tsx`
- `frontend/app/[locale]/expert/credits/page.tsx`
- `frontend/app/[locale]/expert/courses/page.tsx` — placeholder (linked from ExpertNav)
- `frontend/components/expert/expert-guard.tsx`
- `frontend/components/expert/expert-nav.tsx`
- `frontend/components/expert/revenue-chart.tsx`
- `frontend/components/expert/revenue-client.tsx`
- `frontend/components/expert/cost-breakdown.tsx`
- `frontend/components/expert/credits-client.tsx`
- `frontend/messages/fr.json` + `en.json` — ExpertNav, ExpertRevenue, ExpertCredits translations

## Test plan

- [ ] Backend tests pass
- [ ] Frontend lint/tests pass (`npm run lint` — 0 errors, `npx tsc --noEmit` clean)
- [ ] Manually verified on mobile viewport (320px)
- [ ] Revenue chart renders last 12 months with gross/commission/net bars
- [ ] Commission clearly separated from gross in chart legend and transactions table
- [ ] Credits page links to `/billing/purchase`

Closes #632

Generated with [Claude Code](https://claude.ai/code)