### PR TITLE
feat(service): CostTracker — wrap AI calls to track token usage and deduct credits

### DIFF
--- a/backend/app/ai/claude_service.py
+++ b/backend/app/ai/claude_service.py
@@ -1,8 +1,9 @@
 """Claude API service for content generation."""
 
 import json
+import uuid
 from collections.abc import AsyncGenerator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import anthropic
 import structlog
@@ -11,13 +12,21 @@ from anthropic.types import Message
 from app.domain.services.platform_settings_service import SettingsCache
 from app.infrastructure.config.settings import get_settings
 
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from app.domain.services.cost_tracker import CostTracker
+
 logger = structlog.get_logger()
 
 
 class ClaudeService:
     """Service for interacting with Claude API for content generation."""
 
-    def __init__(self):
+    def __init__(
+        self,
+        cost_tracker: "CostTracker | None" = None,
+    ):
         self.settings = get_settings()
         if not self.settings.anthropic_api_key:
             raise ValueError("ANTHROPIC_API_KEY is required")
@@ -30,6 +39,7 @@ class ClaudeService:
         _cache = SettingsCache.instance()
         self._max_tokens = _cache.get("ai-max-tokens-content", 64000)
         self._temperature = _cache.get("ai-temperature-content", 0.7)
+        self._cost_tracker = cost_tracker
 
     async def generate_lesson_content_stream(
         self,
@@ -66,6 +76,9 @@ class ClaudeService:
         self,
         system_prompt: str,
         user_message: str,
+        user_id: uuid.UUID | None = None,
+        context: str = "lesson",
+        session: "AsyncSession | None" = None,
     ) -> Message:
         """
         Generate lesson content using Claude API without streaming.
@@ -73,6 +86,9 @@ class ClaudeService:
         Args:
             system_prompt: System prompt for pedagogical context
             user_message: User message with RAG context and requirements
+            user_id: Optional learner UUID for cost tracking.
+            context: Call-site label used in usage logs.
+            session: DB session for usage logging and credit deduction.
 
         Returns:
             Message object from Claude API
@@ -85,6 +101,15 @@ class ClaudeService:
                 messages=[{"role": "user", "content": user_message}],
                 temperature=self._temperature,
             )
+
+            if self._cost_tracker is not None:
+                await self._cost_tracker.track_anthropic_call(
+                    response=response,
+                    user_id=user_id,
+                    context=context,
+                    session=session,
+                )
+
             return response
 
         except Exception as e:
@@ -96,6 +121,8 @@ class ClaudeService:
         system_prompt: str,
         user_message: str,
         content_type: str,
+        user_id: uuid.UUID | None = None,
+        session: "AsyncSession | None" = None,
     ) -> dict[str, Any]:
         """
         Generate structured content (non-streaming) and parse JSON response.
@@ -104,6 +131,8 @@ class ClaudeService:
             system_prompt: System prompt with JSON structure requirements
             user_message: User message with context
             content_type: Type of content being generated (lesson, quiz, etc.)
+            user_id: Optional learner UUID for cost tracking.
+            session: DB session for usage logging and credit deduction.
 
         Returns:
             Parsed JSON content as dictionary
@@ -116,6 +145,14 @@ class ClaudeService:
                 messages=[{"role": "user", "content": user_message}],
                 temperature=self._temperature,
             )
+
+            if self._cost_tracker is not None:
+                await self._cost_tracker.track_anthropic_call(
+                    response=response,
+                    user_id=user_id,
+                    context=content_type,
+                    session=session,
+                )
 
             if not response.content or len(response.content) == 0:
                 raise ValueError("Empty response from Claude API")

--- a/backend/app/ai/rag/embeddings.py
+++ b/backend/app/ai/rag/embeddings.py
@@ -1,10 +1,16 @@
 """Embeddings service for RAG pipeline using OpenAI text-embedding-3-small."""
 
 import asyncio
-from typing import Any
+import uuid
+from typing import TYPE_CHECKING, Any
 
 import structlog
 from openai import AsyncOpenAI
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from app.domain.services.cost_tracker import CostTracker
 
 logger = structlog.get_logger()
 
@@ -12,17 +18,32 @@ logger = structlog.get_logger()
 class EmbeddingService:
     """Service for generating embeddings using OpenAI's text-embedding-3-small model."""
 
-    def __init__(self, api_key: str, model: str = "text-embedding-3-small"):
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "text-embedding-3-small",
+        cost_tracker: "CostTracker | None" = None,
+    ):
         self.client = AsyncOpenAI(api_key=api_key)
         self.model = model
         self.dimensions = 1536  # text-embedding-3-small dimensions
+        self._cost_tracker = cost_tracker
 
-    async def generate_embedding(self, text: str) -> list[float]:
+    async def generate_embedding(
+        self,
+        text: str,
+        user_id: uuid.UUID | None = None,
+        context: str = "embedding",
+        session: "AsyncSession | None" = None,
+    ) -> list[float]:
         """
         Generate embedding for a single text.
 
         Args:
             text: Text to embed
+            user_id: Optional learner UUID for cost tracking.
+            context: Call-site label used in usage logs.
+            session: DB session for usage logging and credit deduction.
 
         Returns:
             List of float values representing the embedding vector
@@ -31,13 +52,28 @@ class EmbeddingService:
             response = await self.client.embeddings.create(
                 input=text, model=self.model, dimensions=self.dimensions
             )
+
+            if self._cost_tracker is not None:
+                await self._cost_tracker.track_embedding_call(
+                    response=response,
+                    user_id=user_id,
+                    context=context,
+                    session=session,
+                )
+
             return response.data[0].embedding
         except Exception as e:
             logger.error("Failed to generate embedding", text_length=len(text), error=str(e))
             raise
 
     async def generate_embeddings_batch(
-        self, texts: list[str], batch_size: int = 100, max_concurrent: int = 10
+        self,
+        texts: list[str],
+        batch_size: int = 100,
+        max_concurrent: int = 10,
+        user_id: uuid.UUID | None = None,
+        context: str = "embedding_batch",
+        session: "AsyncSession | None" = None,
     ) -> list[list[float]]:
         """
         Generate embeddings for multiple texts in batches with concurrency control.
@@ -46,6 +82,9 @@ class EmbeddingService:
             texts: List of texts to embed
             batch_size: Number of texts to embed in each API call
             max_concurrent: Maximum number of concurrent API calls
+            user_id: Optional learner UUID for cost tracking.
+            context: Call-site label used in usage logs.
+            session: DB session for usage logging and credit deduction.
 
         Returns:
             List of embedding vectors in the same order as input texts
@@ -65,6 +104,15 @@ class EmbeddingService:
                     response = await self.client.embeddings.create(
                         input=batch, model=self.model, dimensions=self.dimensions
                     )
+
+                    if self._cost_tracker is not None:
+                        await self._cost_tracker.track_embedding_call(
+                            response=response,
+                            user_id=user_id,
+                            context=context,
+                            session=session,
+                        )
+
                     return [data.embedding for data in response.data]
                 except Exception as e:
                     logger.error(

--- a/backend/app/domain/services/cost_tracker.py
+++ b/backend/app/domain/services/cost_tracker.py
@@ -1,0 +1,320 @@
+"""CostTracker — wraps AI API calls to capture token usage, calculate credits, and log usage.
+
+Designed to be injected as an optional dependency so existing admin flows
+(that do not pass a user_id) are unaffected.
+
+Dependencies resolved at runtime (lazy imports) so this module can be imported
+even before #608/#609/#612 DB migrations are applied.  When those tables are
+not yet present the tracker logs the event but silently skips DB writes.
+"""
+
+from __future__ import annotations
+
+import math
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+import structlog
+
+from app.domain.services.platform_settings_service import SettingsCache
+
+if TYPE_CHECKING:
+    from anthropic.types import Message as AnthropicMessage
+    from openai.types import CreateEmbeddingResponse
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = structlog.get_logger(__name__)
+
+_CLAUDE_INPUT_USD_PER_1K = 0.003
+_CLAUDE_OUTPUT_USD_PER_1K = 0.015
+_EMBEDDING_USD_PER_1K = 0.00002
+
+
+@runtime_checkable
+class CreditServiceProtocol(Protocol):
+    """Minimal interface expected from CreditService (#612)."""
+
+    async def deduct(
+        self,
+        user_id: uuid.UUID,
+        amount: int,
+        reason: str,
+        session: AsyncSession,
+    ) -> None: ...
+
+
+class CostTracker:
+    """Wraps Claude/OpenAI API responses to track token usage and deduct credits.
+
+    Usage
+    -----
+    Inject via constructor of any AI service::
+
+        tracker = CostTracker(credit_service=credit_svc)
+        response = await client.messages.create(...)
+        await tracker.track_anthropic_call(response, user_id, "lesson", session)
+
+    The *credit_service* parameter is optional so that admin/RAG flows that
+    have no associated user continue to work without modification.
+    """
+
+    def __init__(
+        self,
+        credit_service: CreditServiceProtocol | None = None,
+    ) -> None:
+        self._credit_service = credit_service
+        self._cache = SettingsCache.instance()
+
+    def _rate_input(self) -> float:
+        return float(self._cache.get("credits-per-1k-input-tokens", 1.0))
+
+    def _rate_output(self) -> float:
+        return float(self._cache.get("credits-per-1k-output-tokens", 3.0))
+
+    def _rate_embedding(self) -> float:
+        return float(self._cache.get("credits-per-1k-embedding-tokens", 0.1))
+
+    def estimate_cost(
+        self,
+        input_tokens: int,
+        output_tokens: int,
+    ) -> dict[str, float]:
+        """Preview the credit cost before issuing an API call.
+
+        Args:
+            input_tokens: Estimated input token count.
+            output_tokens: Estimated output token count.
+
+        Returns:
+            Dict with ``credits`` (int ceiling) and ``cost_usd`` (float).
+        """
+        credits = self._calc_credits(
+            input_tokens, output_tokens, self._rate_input(), self._rate_output()
+        )
+        cost_usd = (input_tokens / 1000) * _CLAUDE_INPUT_USD_PER_1K + (
+            output_tokens / 1000
+        ) * _CLAUDE_OUTPUT_USD_PER_1K
+        return {"credits": credits, "cost_usd": round(cost_usd, 6)}
+
+    async def track_anthropic_call(
+        self,
+        response: AnthropicMessage,
+        user_id: uuid.UUID | None,
+        context: str,
+        session: AsyncSession | None = None,
+    ) -> dict[str, Any]:
+        """Extract usage from an Anthropic Message, log, and deduct credits.
+
+        Args:
+            response: The ``Message`` object returned by ``client.messages.create()``.
+            user_id: UUID of the learner. ``None`` for admin/system flows.
+            context: Human-readable call site label (e.g. ``"lesson"``, ``"quiz"``).
+            session: Async DB session.  Required for DB writes; if ``None`` only logs.
+
+        Returns:
+            Dict summarising ``input_tokens``, ``output_tokens``, ``credits``, ``cost_usd``.
+        """
+        usage = response.usage
+        input_tokens: int = getattr(usage, "input_tokens", 0)
+        output_tokens: int = getattr(usage, "output_tokens", 0)
+
+        credits = self._calc_credits(
+            input_tokens, output_tokens, self._rate_input(), self._rate_output()
+        )
+        cost_usd = (input_tokens / 1000) * _CLAUDE_INPUT_USD_PER_1K + (
+            output_tokens / 1000
+        ) * _CLAUDE_OUTPUT_USD_PER_1K
+
+        logger.info(
+            "cost_tracker.anthropic",
+            context=context,
+            user_id=str(user_id) if user_id else None,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            credits=credits,
+            cost_usd=round(cost_usd, 6),
+        )
+
+        if session is not None and user_id is not None:
+            await self._write_usage_log(
+                user_id=user_id,
+                api_provider="anthropic",
+                model=getattr(response, "model", "claude-sonnet-4-6"),
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                credits=credits,
+                cost_usd=cost_usd,
+                context=context,
+                session=session,
+            )
+            await self._deduct(user_id, credits, context, session)
+
+        return {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "credits": credits,
+            "cost_usd": round(cost_usd, 6),
+        }
+
+    async def track_embedding_call(
+        self,
+        response: CreateEmbeddingResponse,
+        user_id: uuid.UUID | None,
+        context: str,
+        session: AsyncSession | None = None,
+    ) -> dict[str, Any]:
+        """Extract usage from an OpenAI embedding response, log, and deduct credits.
+
+        Args:
+            response: The ``CreateEmbeddingResponse`` from ``client.embeddings.create()``.
+            user_id: UUID of the learner. ``None`` for RAG indexing flows.
+            context: Human-readable label (e.g. ``"rag_index"``, ``"query_embed"``).
+            session: Async DB session.
+
+        Returns:
+            Dict summarising ``total_tokens``, ``credits``, ``cost_usd``.
+        """
+        usage = getattr(response, "usage", None)
+        total_tokens: int = getattr(usage, "total_tokens", 0) if usage else 0
+
+        credits = self._calc_embedding_credits(total_tokens, self._rate_embedding())
+        cost_usd = (total_tokens / 1000) * _EMBEDDING_USD_PER_1K
+
+        logger.info(
+            "cost_tracker.embedding",
+            context=context,
+            user_id=str(user_id) if user_id else None,
+            total_tokens=total_tokens,
+            credits=credits,
+            cost_usd=round(cost_usd, 8),
+        )
+
+        if session is not None and user_id is not None:
+            model = (
+                getattr(getattr(response, "data", [None])[0], "object", "text-embedding-3-small")
+                if getattr(response, "data", None)
+                else "text-embedding-3-small"
+            )
+            await self._write_usage_log(
+                user_id=user_id,
+                api_provider="openai",
+                model=model,
+                input_tokens=total_tokens,
+                output_tokens=0,
+                credits=credits,
+                cost_usd=cost_usd,
+                context=context,
+                session=session,
+            )
+            await self._deduct(user_id, credits, context, session)
+
+        return {
+            "total_tokens": total_tokens,
+            "credits": credits,
+            "cost_usd": round(cost_usd, 8),
+        }
+
+    async def _write_usage_log(
+        self,
+        user_id: uuid.UUID,
+        api_provider: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        credits: int,
+        cost_usd: float,
+        context: str,
+        session: AsyncSession,
+    ) -> None:
+        """Persist an api_usage_logs row (table created by migration #609).
+
+        Silently skips if the table does not yet exist so the service can run
+        before the migration is applied.
+        """
+        try:
+            from sqlalchemy import text
+
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO api_usage_logs
+                        (id, user_id, api_provider, model,
+                         input_tokens, output_tokens, credits_deducted,
+                         cost_usd, context, created_at)
+                    VALUES
+                        (:id, :user_id, :api_provider, :model,
+                         :input_tokens, :output_tokens, :credits,
+                         :cost_usd, :context, :created_at)
+                    """
+                ),
+                {
+                    "id": str(uuid.uuid4()),
+                    "user_id": str(user_id),
+                    "api_provider": api_provider,
+                    "model": model,
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "credits": credits,
+                    "cost_usd": round(cost_usd, 8),
+                    "context": context,
+                    "created_at": datetime.now(UTC).isoformat(),
+                },
+            )
+            await session.flush()
+        except Exception as exc:
+            logger.warning(
+                "cost_tracker.usage_log_skipped",
+                reason=str(exc),
+                user_id=str(user_id),
+                context=context,
+            )
+
+    async def _deduct(
+        self,
+        user_id: uuid.UUID,
+        credits: int,
+        context: str,
+        session: AsyncSession,
+    ) -> None:
+        """Deduct credits via CreditService if injected, else log a warning."""
+        if credits <= 0:
+            return
+        if self._credit_service is None:
+            logger.warning(
+                "cost_tracker.no_credit_service",
+                user_id=str(user_id),
+                credits=credits,
+                context=context,
+            )
+            return
+        try:
+            await self._credit_service.deduct(
+                user_id=user_id,
+                amount=credits,
+                reason=f"ai_call:{context}",
+                session=session,
+            )
+        except Exception as exc:
+            logger.error(
+                "cost_tracker.deduct_failed",
+                user_id=str(user_id),
+                credits=credits,
+                context=context,
+                error=str(exc),
+            )
+
+    @staticmethod
+    def _calc_credits(
+        input_tokens: int,
+        output_tokens: int,
+        rate_in: float,
+        rate_out: float,
+    ) -> int:
+        raw = (input_tokens / 1000) * rate_in + (output_tokens / 1000) * rate_out
+        return math.ceil(raw)
+
+    @staticmethod
+    def _calc_embedding_credits(total_tokens: int, rate: float) -> int:
+        raw = (total_tokens / 1000) * rate
+        return math.ceil(raw)

--- a/backend/app/infrastructure/config/platform_defaults.py
+++ b/backend/app/infrastructure/config/platform_defaults.py
@@ -484,6 +484,34 @@ SETTING_DEFINITIONS: list[SettingDef] = [
         "Default tutor conversations returned.",
         {"min": 5, "max": 100},
     ),
+    # ── Credits & Cost Tracking ────────────────────────────
+    SettingDef(
+        "credits-per-1k-input-tokens",
+        "credits",
+        1.0,
+        "float",
+        "Credits per 1k input tokens (Claude)",
+        "Credit rate for Claude API input tokens.",
+        {"min": 0.0, "max": 1000.0},
+    ),
+    SettingDef(
+        "credits-per-1k-output-tokens",
+        "credits",
+        3.0,
+        "float",
+        "Credits per 1k output tokens (Claude)",
+        "Credit rate for Claude API output tokens.",
+        {"min": 0.0, "max": 1000.0},
+    ),
+    SettingDef(
+        "credits-per-1k-embedding-tokens",
+        "credits",
+        0.1,
+        "float",
+        "Credits per 1k embedding tokens (OpenAI)",
+        "Credit rate for OpenAI embedding tokens.",
+        {"min": 0.0, "max": 1000.0},
+    ),
 ]
 
 DEFAULTS_BY_KEY: dict[str, SettingDef] = {s.key: s for s in SETTING_DEFINITIONS}

--- a/backend/tests/test_cost_tracker.py
+++ b/backend/tests/test_cost_tracker.py
@@ -1,0 +1,251 @@
+"""Tests for CostTracker service."""
+
+import math
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.domain.services.cost_tracker import CostTracker
+
+
+@pytest.fixture
+def tracker():
+    return CostTracker()
+
+
+@pytest.fixture
+def tracker_with_credit_service():
+    credit_service = AsyncMock()
+    credit_service.deduct = AsyncMock()
+    return CostTracker(credit_service=credit_service), credit_service
+
+
+def _make_anthropic_response(
+    input_tokens: int, output_tokens: int, model: str = "claude-sonnet-4-6"
+) -> MagicMock:
+    response = MagicMock()
+    response.usage.input_tokens = input_tokens
+    response.usage.output_tokens = output_tokens
+    response.model = model
+    return response
+
+
+def _make_embedding_response(total_tokens: int) -> MagicMock:
+    response = MagicMock()
+    response.usage.total_tokens = total_tokens
+    response.data = [MagicMock(object="text-embedding-3-small")]
+    return response
+
+
+class TestEstimateCost:
+    def test_zero_tokens(self, tracker):
+        result = tracker.estimate_cost(0, 0)
+        assert result["credits"] == 0
+        assert result["cost_usd"] == 0.0
+
+    def test_1k_input_tokens_default_rates(self, tracker):
+        result = tracker.estimate_cost(1000, 0)
+        assert result["credits"] == math.ceil(1.0)
+        assert result["credits"] == 1
+
+    def test_1k_output_tokens_default_rates(self, tracker):
+        result = tracker.estimate_cost(0, 1000)
+        assert result["credits"] == math.ceil(3.0)
+        assert result["credits"] == 3
+
+    def test_mixed_tokens_rounds_up(self, tracker):
+        result = tracker.estimate_cost(500, 500)
+        expected = math.ceil((500 / 1000) * 1.0 + (500 / 1000) * 3.0)
+        assert result["credits"] == expected
+
+    def test_returns_cost_usd(self, tracker):
+        result = tracker.estimate_cost(1000, 1000)
+        assert result["cost_usd"] > 0.0
+
+    def test_small_token_count_rounds_up_to_1(self, tracker):
+        result = tracker.estimate_cost(1, 0)
+        assert result["credits"] == 1
+
+
+class TestCalcCredits:
+    def test_basic_calculation(self):
+        credits = CostTracker._calc_credits(1000, 1000, 1.0, 3.0)
+        assert credits == 4
+
+    def test_ceiling_applied(self):
+        credits = CostTracker._calc_credits(100, 0, 1.0, 3.0)
+        assert credits == math.ceil(0.1)
+        assert credits == 1
+
+    def test_zero_tokens(self):
+        assert CostTracker._calc_credits(0, 0, 1.0, 3.0) == 0
+
+    def test_custom_rates(self):
+        credits = CostTracker._calc_credits(2000, 1000, 2.0, 5.0)
+        assert credits == math.ceil(4.0 + 5.0)
+        assert credits == 9
+
+
+class TestCalcEmbeddingCredits:
+    def test_basic(self):
+        credits = CostTracker._calc_embedding_credits(1000, 0.1)
+        assert credits == 1
+
+    def test_rounding_up(self):
+        credits = CostTracker._calc_embedding_credits(100, 0.1)
+        assert credits == math.ceil(0.01)
+        assert credits == 1
+
+    def test_zero(self):
+        assert CostTracker._calc_embedding_credits(0, 0.1) == 0
+
+
+class TestTrackAnthropicCall:
+    @pytest.mark.asyncio
+    async def test_returns_usage_dict(self, tracker):
+        response = _make_anthropic_response(1000, 500)
+        result = await tracker.track_anthropic_call(response, None, "lesson")
+        assert result["input_tokens"] == 1000
+        assert result["output_tokens"] == 500
+        assert result["credits"] > 0
+        assert result["cost_usd"] > 0.0
+
+    @pytest.mark.asyncio
+    async def test_no_session_no_db_write(self, tracker):
+        response = _make_anthropic_response(1000, 500)
+        result = await tracker.track_anthropic_call(response, uuid.uuid4(), "lesson", session=None)
+        assert result["input_tokens"] == 1000
+
+    @pytest.mark.asyncio
+    async def test_no_user_id_no_deduct(self, tracker_with_credit_service):
+        tracker, credit_service = tracker_with_credit_service
+        response = _make_anthropic_response(1000, 500)
+        session = AsyncMock()
+        await tracker.track_anthropic_call(response, None, "lesson", session=session)
+        credit_service.deduct.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_with_user_id_and_session_deducts_credits(self, tracker_with_credit_service):
+        tracker, credit_service = tracker_with_credit_service
+        response = _make_anthropic_response(1000, 1000)
+        user_id = uuid.uuid4()
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        session.flush = AsyncMock()
+
+        with patch.object(tracker, "_write_usage_log", new_callable=AsyncMock):
+            await tracker.track_anthropic_call(response, user_id, "quiz", session=session)
+
+        credit_service.deduct.assert_called_once()
+        call_kwargs = credit_service.deduct.call_args.kwargs
+        assert call_kwargs["user_id"] == user_id
+        assert call_kwargs["amount"] > 0
+        assert "quiz" in call_kwargs["reason"]
+
+    @pytest.mark.asyncio
+    async def test_credit_calculation_matches_estimate(self, tracker):
+        input_tokens, output_tokens = 2000, 1000
+        response = _make_anthropic_response(input_tokens, output_tokens)
+        result = await tracker.track_anthropic_call(response, None, "lesson")
+        estimate = tracker.estimate_cost(input_tokens, output_tokens)
+        assert result["credits"] == estimate["credits"]
+
+    @pytest.mark.asyncio
+    async def test_missing_usage_attr_defaults_to_zero(self, tracker):
+        response = MagicMock()
+        response.usage.input_tokens = 0
+        response.usage.output_tokens = 0
+        response.model = "claude-sonnet-4-6"
+        result = await tracker.track_anthropic_call(response, None, "test")
+        assert result["input_tokens"] == 0
+        assert result["output_tokens"] == 0
+
+
+class TestTrackEmbeddingCall:
+    @pytest.mark.asyncio
+    async def test_returns_usage_dict(self, tracker):
+        response = _make_embedding_response(1000)
+        result = await tracker.track_embedding_call(response, None, "rag_index")
+        assert result["total_tokens"] == 1000
+        assert result["credits"] >= 1
+        assert result["cost_usd"] >= 0.0
+
+    @pytest.mark.asyncio
+    async def test_no_user_no_deduct(self, tracker_with_credit_service):
+        tracker, credit_service = tracker_with_credit_service
+        response = _make_embedding_response(500)
+        session = AsyncMock()
+        await tracker.track_embedding_call(response, None, "rag", session=session)
+        credit_service.deduct.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_with_user_deducts(self, tracker_with_credit_service):
+        tracker, credit_service = tracker_with_credit_service
+        response = _make_embedding_response(1000)
+        user_id = uuid.uuid4()
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        session.flush = AsyncMock()
+
+        with patch.object(tracker, "_write_usage_log", new_callable=AsyncMock):
+            await tracker.track_embedding_call(response, user_id, "query_embed", session=session)
+
+        credit_service.deduct.assert_called_once()
+        call_kwargs = credit_service.deduct.call_args.kwargs
+        assert call_kwargs["user_id"] == user_id
+
+    @pytest.mark.asyncio
+    async def test_zero_tokens(self, tracker):
+        response = _make_embedding_response(0)
+        result = await tracker.track_embedding_call(response, None, "test")
+        assert result["total_tokens"] == 0
+        assert result["credits"] == 0
+
+
+class TestDeductWithNoCreditService:
+    @pytest.mark.asyncio
+    async def test_logs_warning_without_raising(self, tracker):
+        with patch("app.domain.services.cost_tracker.logger") as mock_logger:
+            session = AsyncMock()
+            await tracker._deduct(uuid.uuid4(), 5, "lesson", session)
+            mock_logger.warning.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_zero_credits_skipped(self, tracker):
+        with patch("app.domain.services.cost_tracker.logger") as mock_logger:
+            session = AsyncMock()
+            await tracker._deduct(uuid.uuid4(), 0, "lesson", session)
+            mock_logger.warning.assert_not_called()
+
+
+class TestWriteUsageLogFailure:
+    @pytest.mark.asyncio
+    async def test_db_error_is_swallowed(self, tracker):
+        session = AsyncMock()
+        session.execute = AsyncMock(side_effect=Exception("table does not exist"))
+        session.flush = AsyncMock()
+
+        await tracker._write_usage_log(
+            user_id=uuid.uuid4(),
+            api_provider="anthropic",
+            model="claude-sonnet-4-6",
+            input_tokens=1000,
+            output_tokens=500,
+            credits=4,
+            cost_usd=0.009,
+            context="lesson",
+            session=session,
+        )
+
+
+class TestSettingsRateReading:
+    def test_default_rates_are_floats(self, tracker):
+        assert isinstance(tracker._rate_input(), float)
+        assert isinstance(tracker._rate_output(), float)
+        assert isinstance(tracker._rate_embedding(), float)
+
+    def test_default_rate_values(self, tracker):
+        assert tracker._rate_input() == 1.0
+        assert tracker._rate_output() == 3.0
+        assert tracker._rate_embedding() == 0.1


### PR DESCRIPTION
## Summary

Implements `CostTracker` service (closes #613) to wrap Claude/OpenAI API calls and capture token usage, calculate credit costs, log to `api_usage_logs`, and deduct credits from user balance.

## Changes

- **`backend/app/domain/services/cost_tracker.py`** _(new)_
  - `CostTracker.track_anthropic_call()` — extracts `usage.input_tokens` + `usage.output_tokens` from Anthropic `Message`, calculates credits (ceil), logs to `api_usage_logs`, calls `CreditService.deduct()`
  - `CostTracker.track_embedding_call()` — same for OpenAI `CreateEmbeddingResponse`
  - `CostTracker.estimate_cost()` — preview credit cost before generation
  - `CreditServiceProtocol` — `runtime_checkable` Protocol ready for #612
  - DB writes silently skipped if `api_usage_logs` table not yet migrated (#609)
  - No `CreditService` injected → warning logged, no exception (admin flows unaffected)

- **`backend/app/infrastructure/config/platform_defaults.py`** — adds 3 credit-rate settings (new `credits` category):
  - `credits-per-1k-input-tokens` (default 1.0)
  - `credits-per-1k-output-tokens` (default 3.0)
  - `credits-per-1k-embedding-tokens` (default 0.1)
  - All configurable at runtime via `PlatformSettingsService`

- **`backend/app/ai/claude_service.py`** — optional `cost_tracker` constructor param; `generate_lesson_content()` and `generate_structured_content()` accept `user_id`, `context`, `session` for tracking

- **`backend/app/ai/rag/embeddings.py`** — optional `cost_tracker` constructor param; `generate_embedding()` and `generate_embeddings_batch()` accept `user_id`, `context`, `session`

- **`backend/tests/test_cost_tracker.py`** _(new)_ — 28 unit tests covering all methods, edge cases, credit calculation, DB failure resilience

## Test plan

- [x] 28 unit tests pass (`pytest tests/test_cost_tracker.py`)
- [x] Ruff lint clean (`ruff check --fix && ruff format`)
- [x] Existing admin flows unaffected (`cost_tracker` is optional in all constructors)
- [x] Credit rates read from platform settings (configurable at runtime)
- [x] DB errors in usage log writing are silently caught (resilient before migration #609)

Closes #613
Parent: #606 | Depends on: #608, #609, #612

Generated with [Claude Code](https://claude.ai/code)