### PR TITLE
fix(flashcards): convert module_id UUID to str before startswith check

### DIFF
--- a/backend/app/api/v1/flashcards.py
+++ b/backend/app/api/v1/flashcards.py
@@ -547,7 +547,7 @@ async def get_upcoming_reviews(
                 today_due_count += len(flashcards)
 
             # Get module info from content
-            module_name = content.module_id or "General Review"
+            module_name = str(content.module_id) if content.module_id else "General Review"
             # Simplify module names for display
             if module_name.startswith("M"):
                 # Extract module number and create display name


### PR DESCRIPTION
## Summary

The `/api/v1/flashcards/upcoming` endpoint was returning 500 because `content.module_id` is an `asyncpg.pgproto.pgproto.UUID` object (not a Python string), and calling `.startswith("M")` on it raises `AttributeError`.

## Changes

- `backend/app/api/v1/flashcards.py`: Changed `module_name = content.module_id or "General Review"` to `module_name = str(content.module_id) if content.module_id else "General Review"` — explicitly converts the asyncpg UUID to a string before the `startswith` call.

## Test plan

- [ ] Backend lint passes (`ruff check`)
- [ ] `GET /api/v1/flashcards/upcoming` returns 200 (not 500) after login

Closes #675

Generated with [Claude Code](https://claude.ai/code)