### PR TITLE
fix(syllabus): use selectinload for units to fix async lazy-load 500 crash

### DIFF
--- a/backend/app/domain/services/syllabus_agent_service.py
+++ b/backend/app/domain/services/syllabus_agent_service.py
@@ -20,6 +20,7 @@ import structlog
 from anthropic import AsyncAnthropic
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.ai.prompts.syllabus_agent import get_syllabus_agent_system_prompt, get_tool_definitions
 from app.ai.rag.embeddings import EmbeddingService
@@ -424,13 +425,15 @@ class SyllabusAgentService:
 
     async def get_modules_list(self, session: AsyncSession) -> list[dict]:
         """Return module list for the admin syllabus view."""
-        result = await session.execute(select(Module).order_by(Module.module_number))
+        result = await session.execute(
+            select(Module).options(selectinload(Module.units)).order_by(Module.module_number)
+        )
         modules = result.scalars().all()
         out = []
         for m in modules:
             books = m.books_sources or {}
             sources = books.get("source_references", [])
-            unit_count = len([u for u in (m.units if hasattr(m, "units") else [])])
+            unit_count = len(m.units)
             out.append(
                 {
                     "id": str(m.id),


### PR DESCRIPTION
## Summary
- Fixes 500 Internal Server Error on `GET /api/v1/admin/syllabus`
- Root cause: `get_modules_list` accessed `m.units` (lazy-loaded SQLAlchemy relationship) in async context, which is forbidden in SQLAlchemy 2.0 async mode and raises `MissingGreenlet`
- The `hasattr(m, "units")` guard was ineffective because the attribute descriptor exists on the ORM class, but accessing the collection triggers lazy loading

## Changes
- `backend/app/domain/services/syllabus_agent_service.py`: added `selectinload(Module.units)` to the query in `get_modules_list`, and simplified `unit_count = len(m.units)` now that the collection is always eagerly loaded

## Test plan
- [x] `ruff check` passes on changed file
- [ ] Backend tests pass (`uv run pytest`)
- [ ] Admin can navigate to `/admin/syllabus` without 500 error
- [ ] Module list loads correctly with accurate `unit_count`

Closes #674

Generated with [Claude Code](https://claude.ai/code)