### PR TITLE
feat(mobile-nav): add course catalog to mobile bottom nav (#673)

### DIFF
--- a/frontend/app/[locale]/(app)/dashboard/dashboard-client.tsx
+++ b/frontend/app/[locale]/(app)/dashboard/dashboard-client.tsx
@@ -65,10 +65,18 @@ export function DashboardClient() {
 
   if (enrollments.length === 1) {
     return (
-      <ModuleMap
-        courseId={enrollments[0].id}
-        onModuleClick={handleModuleClick}
-      />
+      <div className="space-y-4">
+        <ModuleMap
+          courseId={enrollments[0].id}
+          onModuleClick={handleModuleClick}
+        />
+        <button
+          className="w-full text-center text-teal-600 text-sm font-medium underline-offset-2 hover:underline min-h-11 rounded-lg border border-dashed border-teal-200 py-3 hover:bg-teal-50 transition-colors"
+          onClick={() => router.push('/courses')}
+        >
+          {t('browseMoreCourses')}
+        </button>
+      </div>
     );
   }
 
@@ -117,6 +125,12 @@ export function DashboardClient() {
           </div>
         );
       })}
+      <button
+        className="w-full text-center text-teal-600 text-sm font-medium underline-offset-2 hover:underline min-h-11 rounded-lg border border-dashed border-teal-200 py-3 hover:bg-teal-50 transition-colors"
+        onClick={() => router.push('/courses')}
+      >
+        {t('browseMoreCourses')}
+      </button>
     </div>
   );
 }

--- a/frontend/components/layout/bottom-nav.tsx
+++ b/frontend/components/layout/bottom-nav.tsx
@@ -5,92 +5,208 @@ import { usePathname } from "next/navigation";
 import { useTranslations, useLocale } from "next-intl";
 import {
   Home,
-  BookOpen,
+  GraduationCap,
   CreditCard,
   Bot,
+  MoreHorizontal,
+  BookOpen,
+  User,
   Settings,
+  X,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useState, useEffect, useRef } from "react";
 
 export function BottomNav() {
   const t = useTranslations("Navigation");
   const pathname = usePathname();
   const locale = useLocale();
+  const [moreOpen, setMoreOpen] = useState(false);
+  const moreRef = useRef<HTMLDivElement>(null);
 
-  const navItems = [
+  useEffect(() => {
+    if (!moreOpen) return;
+    function handleOutside(e: MouseEvent) {
+      if (moreRef.current && !moreRef.current.contains(e.target as Node)) {
+        setMoreOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleOutside);
+    return () => document.removeEventListener("mousedown", handleOutside);
+  }, [moreOpen]);
+
+  const primaryItems = [
     {
       href: `/${locale}/dashboard`,
       label: t("dashboard"),
       icon: Home,
-      description: t("dashboardDescription")
+      description: t("dashboardDescription"),
     },
     {
-      href: `/${locale}/modules`,
-      label: t("modules"),
-      icon: BookOpen,
-      description: t("modulesDescription")
+      href: `/${locale}/courses`,
+      label: t("courses"),
+      icon: GraduationCap,
+      description: t("coursesDescription"),
     },
     {
       href: `/${locale}/flashcards`,
       label: t("flashcards"),
       icon: CreditCard,
-      description: t("flashcardsDescription")
+      description: t("flashcardsDescription"),
     },
     {
       href: `/${locale}/tutor`,
       label: t("tutor"),
       icon: Bot,
-      description: t("tutorDescription")
+      description: t("tutorDescription"),
+    },
+  ];
+
+  const moreItems = [
+    {
+      href: `/${locale}/modules`,
+      label: t("modules"),
+      icon: BookOpen,
+      description: t("modulesDescription"),
+    },
+    {
+      href: `/${locale}/profile`,
+      label: t("profile"),
+      icon: User,
+      description: t("profileDescription"),
     },
     {
       href: `/${locale}/settings`,
       label: t("settings"),
       icon: Settings,
-      description: t("settingsDescription")
+      description: t("settingsDescription"),
     },
   ];
 
+  const isMoreActive = moreItems.some((item) => pathname.includes(item.href));
+
   return (
-    <nav 
-      className="fixed bottom-0 left-0 right-0 z-50 border-t bg-card md:hidden"
-      role="navigation"
-      aria-label={t("mobileNavigation")}
-    >
-      <div className="flex items-center justify-around">
-        {navItems.map((item) => {
-          const Icon = item.icon;
-          const isActive = pathname.includes(item.href);
-          
-          return (
-            <Link
-              key={item.href}
-              href={item.href}
-              className={cn(
-                "flex min-h-11 min-w-11 flex-1 flex-col items-center justify-center py-2 text-xs transition-colors",
-                isActive
-                  ? "text-primary"
-                  : "text-muted-foreground hover:text-foreground"
-              )}
-              aria-label={item.description}
-              aria-current={isActive ? "page" : undefined}
+    <div ref={moreRef} className="fixed bottom-0 left-0 right-0 z-50 md:hidden">
+      {moreOpen && (
+        <div
+          className="border-t bg-card shadow-lg"
+          role="menu"
+          aria-label={t("moreMenuLabel")}
+        >
+          <div className="flex items-center justify-between border-b px-4 py-2">
+            <span className="text-sm font-medium text-foreground">
+              {t("more")}
+            </span>
+            <button
+              className="flex min-h-11 min-w-11 items-center justify-center rounded-md text-muted-foreground hover:text-foreground"
+              onClick={() => setMoreOpen(false)}
+              aria-label={t("closeMoreMenu")}
             >
-              <Icon 
+              <X className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </div>
+          <div className="grid grid-cols-3 gap-1 p-2">
+            {moreItems.map((item) => {
+              const Icon = item.icon;
+              const isActive = pathname.includes(item.href);
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  role="menuitem"
+                  onClick={() => setMoreOpen(false)}
+                  className={cn(
+                    "flex min-h-[56px] flex-col items-center justify-center gap-1 rounded-md px-2 py-3 text-xs transition-colors",
+                    isActive
+                      ? "bg-primary/10 text-primary"
+                      : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                  )}
+                  aria-label={item.description}
+                  aria-current={isActive ? "page" : undefined}
+                >
+                  <Icon className="h-5 w-5" aria-hidden="true" />
+                  <span className={cn("text-xs", isActive && "font-medium")}>
+                    {item.label}
+                  </span>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      <nav
+        className="border-t bg-card"
+        role="navigation"
+        aria-label={t("mobileNavigation")}
+      >
+        <div className="flex items-center justify-around">
+          {primaryItems.map((item) => {
+            const Icon = item.icon;
+            const isActive = pathname.includes(item.href);
+
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
                 className={cn(
-                  "h-5 w-5 mb-1",
-                  isActive && "text-primary"
-                )} 
-                aria-hidden="true"
-              />
-              <span className={cn(
+                  "flex min-h-11 min-w-11 flex-1 flex-col items-center justify-center py-2 text-xs transition-colors",
+                  isActive
+                    ? "text-primary"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+                aria-label={item.description}
+                aria-current={isActive ? "page" : undefined}
+              >
+                <Icon
+                  className={cn(
+                    "h-5 w-5 mb-1",
+                    isActive && "text-primary"
+                  )}
+                  aria-hidden="true"
+                />
+                <span
+                  className={cn(
+                    "text-xs",
+                    isActive && "text-primary font-medium"
+                  )}
+                >
+                  {item.label}
+                </span>
+              </Link>
+            );
+          })}
+
+          <button
+            className={cn(
+              "flex min-h-11 min-w-11 flex-1 flex-col items-center justify-center py-2 text-xs transition-colors",
+              (moreOpen || isMoreActive)
+                ? "text-primary"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+            onClick={() => setMoreOpen((prev) => !prev)}
+            aria-label={t("moreMenuLabel")}
+            aria-expanded={moreOpen}
+            aria-haspopup="menu"
+          >
+            <MoreHorizontal
+              className={cn(
+                "h-5 w-5 mb-1",
+                (moreOpen || isMoreActive) && "text-primary"
+              )}
+              aria-hidden="true"
+            />
+            <span
+              className={cn(
                 "text-xs",
-                isActive && "text-primary font-medium"
-              )}>
-                {item.label}
-              </span>
-            </Link>
-          );
-        })}
-      </div>
-    </nav>
+                (moreOpen || isMoreActive) && "text-primary font-medium"
+              )}
+            >
+              {t("more")}
+            </span>
+          </button>
+        </div>
+      </nav>
+    </div>
   );
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -39,7 +39,10 @@
     "logout": "Log out",
     "logoutDescription": "Sign out of your account",
     "admin": "Administration",
-    "adminDescription": "Access the administration panel"
+    "adminDescription": "Access the administration panel",
+    "more": "More",
+    "moreMenuLabel": "More navigation options",
+    "closeMoreMenu": "Close more menu"
   },
   "Auth": {
     "login": "Sign in",
@@ -178,7 +181,8 @@
     "justGettingStarted": "Just getting started",
     "loading": "Loading...",
     "noEnrollments": "You are not enrolled in any courses yet.",
-    "browseCourses": "Browse available courses"
+    "browseCourses": "Browse available courses",
+    "browseMoreCourses": "Browse more courses"
   },
   "ModuleCard": {
     "locked": "Locked",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -39,7 +39,10 @@
     "logout": "Déconnexion",
     "logoutDescription": "Se déconnecter de votre compte",
     "admin": "Administration",
-    "adminDescription": "Accéder au panneau d'administration"
+    "adminDescription": "Accéder au panneau d'administration",
+    "more": "Plus",
+    "moreMenuLabel": "Plus d'options de navigation",
+    "closeMoreMenu": "Fermer le menu Plus"
   },
   "Auth": {
     "login": "Se connecter",
@@ -178,7 +181,8 @@
     "justGettingStarted": "Tout juste commencé",
     "loading": "Chargement...",
     "noEnrollments": "Vous n'êtes inscrit à aucune formation pour l'instant.",
-    "browseCourses": "Parcourir les formations disponibles"
+    "browseCourses": "Parcourir les formations disponibles",
+    "browseMoreCourses": "Parcourir d'autres formations"
   },
   "ModuleCard": {
     "locked": "Verrouillé",


### PR DESCRIPTION
## Summary

- Mobile bottom nav now includes **Courses** (GraduationCap icon) as a primary tab
- New layout: **Dashboard → Courses → Flashcards → AI Tutor → More**
- **More** button opens an upward panel with Modules, Profile, and Settings
- Dashboard now **always** shows a "Browse more courses" link, even after enrollment

## Changes

- `frontend/components/layout/bottom-nav.tsx` — replaced Settings with Courses in the 5-item bar; added a "More" expandable panel (closes on outside click or item navigation) containing Modules, Profile, Settings
- `frontend/app/[locale]/(app)/dashboard/dashboard-client.tsx` — added "Browse more courses" button in both single-enrollment and multi-enrollment views
- `frontend/messages/en.json` + `frontend/messages/fr.json` — added i18n keys: `Navigation.more`, `Navigation.moreMenuLabel`, `Navigation.closeMoreMenu`, `Dashboard.browseMoreCourses`

## Test plan

- [ ] Mobile viewport: bottom nav shows Dashboard, Courses, Flashcards, AI Tutor, More
- [ ] Tapping "More" opens a panel with Modules, Profile, Settings
- [ ] Tapping an item in the More panel navigates and closes the panel
- [ ] Tapping outside the More panel closes it
- [ ] Dashboard shows "Browse more courses" link even when already enrolled
- [ ] Works in both FR and EN
- [ ] Touch targets ≥ 44×44px on all items
- [ ] Frontend lint passes (0 errors)

Closes #673

Generated with [Claude Code](https://claude.ai/code)