### PR TITLE
fix(admin): hide Generate structure button for published courses

### DIFF
--- a/frontend/components/admin/courses-client.tsx
+++ b/frontend/components/admin/courses-client.tsx
@@ -494,21 +494,23 @@ function CourseRow({
         </button>
 
         <div className="flex items-center gap-2 shrink-0">
-          <Button
-            variant="outline"
-            size="sm"
-            className="gap-1.5 min-h-11 hidden sm:flex"
-            onClick={() => onGenerateStructure(course)}
-            disabled={isGenerating}
-            aria-label={t('generateStructure')}
-          >
-            {isGenerating ? (
-              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-            ) : (
-              <Sparkles className="h-4 w-4" aria-hidden="true" />
-            )}
-            <span className="hidden md:inline">{t('generateStructure')}</span>
-          </Button>
+          {course.status !== 'published' && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-1.5 min-h-11 hidden sm:flex"
+              onClick={() => onGenerateStructure(course)}
+              disabled={isGenerating}
+              aria-label={t('generateStructure')}
+            >
+              {isGenerating ? (
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+              ) : (
+                <Sparkles className="h-4 w-4" aria-hidden="true" />
+              )}
+              <span className="hidden md:inline">{t('generateStructure')}</span>
+            </Button>
+          )}
 
           <DropdownMenu>
             <DropdownMenuTrigger
@@ -528,14 +530,16 @@ function CourseRow({
                 <BookOpen className="mr-2 h-4 w-4" />
                 {t('editCourse')}
               </DropdownMenuItem>
-              <DropdownMenuItem
-                className="sm:hidden"
-                onClick={() => onGenerateStructure(course)}
-                disabled={isGenerating}
-              >
-                <Sparkles className="mr-2 h-4 w-4" />
-                {t('generateStructure')}
-              </DropdownMenuItem>
+              {course.status !== 'published' && (
+                <DropdownMenuItem
+                  className="sm:hidden"
+                  onClick={() => onGenerateStructure(course)}
+                  disabled={isGenerating}
+                >
+                  <Sparkles className="mr-2 h-4 w-4" />
+                  {t('generateStructure')}
+                </DropdownMenuItem>
+              )}
               {course.status !== 'published' && (
                 <DropdownMenuItem onClick={() => onPublish(course)}>
                   <Globe className="mr-2 h-4 w-4" />

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -979,6 +979,7 @@
     "estimatedHours": "{hours} h estimated",
     "moduleCount": "{count, plural, one {# module} other {# modules}}",
     "generateStructure": "Generate structure",
+    "generateStructureDisabled": "Archive first to regenerate structure",
     "generateError": "Generation failed. Please try again.",
     "publish": "Publish",
     "archive": "Archive",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -979,6 +979,7 @@
     "estimatedHours": "{hours} h estimées",
     "moduleCount": "{count, plural, one {# module} other {# modules}}",
     "generateStructure": "Générer la structure",
+    "generateStructureDisabled": "Archiver d'abord pour régénérer la structure",
     "generateError": "La génération a échoué. Veuillez réessayer.",
     "publish": "Publier",
     "archive": "Archiver",


### PR DESCRIPTION
## Summary

Published courses were showing the "Generate structure" button, which could allow admins to accidentally regenerate the syllabus on a live course — breaking enrolled learners' progress.

## Changes

- `frontend/components/admin/courses-client.tsx` — `CourseRow` component: wrapped both the desktop "Generate structure" `<Button>` and the mobile `<DropdownMenuItem>` in `{course.status !== 'published' && (...)}` guards
- `frontend/messages/en.json` — added `generateStructureDisabled` key: "Archive first to regenerate structure"
- `frontend/messages/fr.json` — added `generateStructureDisabled` key: "Archiver d'abord pour régénérer la structure"

## Behaviour after fix

| Status | Generate structure button |
|--------|--------------------------|
| draft | ✅ Visible |
| published | ❌ Hidden |
| archived | ✅ Visible |

## Test plan
- [ ] Backend tests pass
- [ ] Frontend lint passes (0 errors)
- [ ] On admin courses page, published courses no longer show "Generate structure" button
- [ ] Draft and archived courses still show "Generate structure" button
- [ ] Manually verified on mobile viewport (dropdown item also hidden)

Closes #695

Generated with [Claude Code](https://claude.ai/code)