### PR TITLE
feat(tutor): scope AI tutor answers to enrolled courses + per-thread course filter

### DIFF
--- a/backend/app/ai/prompts/tutor.py
+++ b/backend/app/ai/prompts/tutor.py
@@ -18,6 +18,7 @@ class TutorContext:
     previous_session_context: str | None = None  # Compacted context from prior session
     progress_snapshot: str | None = None  # Short learner progress summary
     tutor_mode: str = "socratic"  # "socratic" (guided questions) or "explanatory" (direct answers)
+    course_filter_names: list[str] | None = None  # Display names of courses in scope
 
 
 def get_socratic_system_prompt(context: TutorContext, rag_chunks: list[dict[str, Any]]) -> str:
@@ -49,6 +50,7 @@ def get_socratic_system_prompt(context: TutorContext, rag_chunks: list[dict[str,
     sources_context = _format_sources_context(rag_chunks)
 
     pedagogical_section = _get_pedagogical_rules(context.tutor_mode)
+    course_scope_section = _format_course_scope_section(context.course_filter_names)
 
     prompt = f"""Tu es un tuteur IA spécialisé en santé publique pour l'Afrique de l'Ouest.
 {_get_mode_intro(context.tutor_mode)}
@@ -59,7 +61,7 @@ def get_socratic_system_prompt(context: TutorContext, rag_chunks: list[dict[str,
 - Pays: {country_context}
 - Module actuel: {context.module_id or "Non spécifié"}
 - Mode: {"Socratique (guidage par questions)" if context.tutor_mode == "socratic" else "Explicatif (réponses directes)"}
-{_format_progress_section(context.progress_snapshot)}{_format_memory_section(context.learner_memory)}{_format_previous_session_section(context.previous_session_context)}
+{_format_progress_section(context.progress_snapshot)}{_format_memory_section(context.learner_memory)}{_format_previous_session_section(context.previous_session_context)}{course_scope_section}
 
 {pedagogical_section}
 
@@ -153,6 +155,20 @@ une fois qu'on aura exploré cette idée ensemble ?"
 Réponds maintenant dans cette approche socratique stricte."""
 
     return prompt
+
+
+def _format_course_scope_section(course_filter_names: list[str] | None) -> str:
+    """Format course scope restriction as a section for the system prompt."""
+    if not course_filter_names:
+        return ""
+    course_list = ", ".join(course_filter_names)
+    return f"""
+
+## PÉRIMÈTRE DE RÉPONSE
+L'apprenant a limité cette conversation aux cours suivants: {course_list}
+- Réponds UNIQUEMENT avec du contenu pertinent à ces cours
+- Si la question sort du périmètre, indique poliment que le sujet sera couvert dans un autre cours
+- Cite uniquement les sources pertinentes aux cours sélectionnés"""
 
 
 def _format_memory_section(learner_memory: str | None) -> str:

--- a/backend/app/api/v1/schemas/tutor.py
+++ b/backend/app/api/v1/schemas/tutor.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class FileUploadResponse(BaseModel):
@@ -44,6 +44,18 @@ class TutorChatRequest(BaseModel):
         description="Tutor mode: socratic (guided questions) or explanatory (direct answers)",
     )
     file_ids: list[str] = Field(default_factory=list, description="Uploaded file IDs to attach")
+    course_filter: list[UUID] | None = Field(
+        None,
+        max_length=2,
+        description="Optional list of course IDs (max 2) to scope RAG search for this conversation",
+    )
+
+    @field_validator("course_filter")
+    @classmethod
+    def validate_course_filter_max(cls, v: list[UUID] | None) -> list[UUID] | None:
+        if v is not None and len(v) > 2:
+            raise ValueError("course_filter accepts at most 2 course IDs")
+        return v
 
 
 class TutorChatResponse(BaseModel):
@@ -71,6 +83,9 @@ class ConversationSummary(BaseModel):
     has_context: bool = Field(
         False, description="Whether this conversation has prior compacted context"
     )
+    course_filter: list[UUID] | None = Field(
+        None, description="Course IDs this conversation is scoped to"
+    )
 
 
 class TutorConversationListResponse(BaseModel):
@@ -87,6 +102,9 @@ class TutorConversationResponse(BaseModel):
     module_id: UUID | None = Field(None, description="Associated module ID")
     messages: list[TutorMessage] = Field(..., description="All messages in conversation")
     created_at: datetime = Field(..., description="Conversation creation timestamp")
+    course_filter: list[UUID] | None = Field(
+        None, description="Course IDs this conversation is scoped to"
+    )
 
 
 class TutorStatsResponse(BaseModel):

--- a/backend/app/api/v1/tutor.py
+++ b/backend/app/api/v1/tutor.py
@@ -158,6 +158,7 @@ async def chat_with_tutor(
                 conversation_id=request.conversation_id,
                 tutor_mode=request.tutor_mode,
                 file_content_blocks=file_content_blocks,
+                course_filter=request.course_filter,
             ):
                 yield f"data: {json.dumps(chunk)}\n\n"
 

--- a/backend/app/domain/models/conversation.py
+++ b/backend/app/domain/models/conversation.py
@@ -26,6 +26,7 @@ class TutorConversation(Base):
     compacted_context: Mapped[str | None] = mapped_column(Text, nullable=True)
     compacted_at: Mapped[datetime | None] = mapped_column(nullable=True)
     message_count: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
+    course_filter: Mapped[list | None] = mapped_column(JSON, nullable=True)
 
     user: Mapped[User] = relationship(back_populates="tutor_conversations")
     module: Mapped[Module] = relationship(back_populates="tutor_conversations")

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -22,6 +22,7 @@ from app.ai.prompts.tutor import (
 from app.ai.rag.embeddings import EmbeddingService
 from app.ai.rag.retriever import SemanticRetriever
 from app.domain.models.conversation import TutorConversation
+from app.domain.models.course import Course, UserCourseEnrollment
 from app.domain.models.module import Module
 from app.domain.models.user import User
 from app.domain.services.learner_memory_service import LearnerMemoryService
@@ -214,6 +215,7 @@ class TutorService:
         conversation_id: uuid.UUID | None = None,
         tutor_mode: str = "socratic",
         file_content_blocks: list[dict[str, Any]] | None = None,
+        course_filter: list[uuid.UUID] | None = None,
     ) -> AsyncGenerator[dict[str, Any], None]:
         """
         Send a message to the AI tutor and stream the response using agentic tool_use.
@@ -257,8 +259,14 @@ class TutorService:
         try:
             is_new_conversation = conversation_id is None
             conversation = await self._get_or_create_conversation(
-                user_id, module_id, conversation_id, session
+                user_id, module_id, conversation_id, session, course_filter=course_filter
             )
+
+            effective_course_filter = conversation.course_filter
+            if not effective_course_filter:
+                effective_course_filter = await self._get_default_course_filter(
+                    user_id, session
+                )
 
             session_ctx = await self.session_manager.build_session_context(
                 user=user,
@@ -281,6 +289,10 @@ class TutorService:
                 "data": {"conversation_id": str(conversation.id)},
             }
 
+            course_names = await self._get_course_names(
+                effective_course_filter or [], session
+            ) if effective_course_filter else []
+
             context = TutorContext(
                 user_level=user.current_level,
                 user_language=user.preferred_language,
@@ -292,6 +304,7 @@ class TutorService:
                 learner_memory=session_ctx.learner_memory,
                 previous_session_context=session_ctx.previous_compact,
                 progress_snapshot=session_ctx.progress_snapshot,
+                course_filter_names=course_names,
             )
 
             system_prompt = get_socratic_system_prompt(context, [])
@@ -317,6 +330,7 @@ class TutorService:
                 user_id=user_id,
                 user_level=user.current_level,
                 user_language=user.preferred_language,
+                course_filter=effective_course_filter,
             )
 
             tool_call_count = 0
@@ -532,6 +546,7 @@ class TutorService:
             "module_id": conversation.module_id,
             "messages": conversation.messages,
             "created_at": conversation.created_at,
+            "course_filter": conversation.course_filter,
         }
 
     async def list_conversations(
@@ -584,6 +599,7 @@ class TutorService:
                     "last_message_at": last_message_at,
                     "preview": preview,
                     "has_context": bool(conv.compacted_context),
+                    "course_filter": conv.course_filter,
                 }
             )
 
@@ -700,6 +716,7 @@ class TutorService:
         module_id: uuid.UUID | None,
         conversation_id: uuid.UUID | None,
         session: AsyncSession,
+        course_filter: list[uuid.UUID] | None = None,
     ) -> TutorConversation:
         """Get existing conversation or create a new one."""
         if isinstance(user_id, str):
@@ -713,19 +730,57 @@ class TutorService:
             result = await session.execute(query)
             conversation = result.scalar_one_or_none()
             if conversation:
+                if course_filter and not conversation.course_filter:
+                    conversation.course_filter = [str(c) for c in course_filter]
+                    session.add(conversation)
+                    await session.flush()
                 return conversation
 
+        course_filter_stored = [str(c) for c in course_filter] if course_filter else None
         conversation = TutorConversation(
             id=uuid.uuid4(),
             user_id=user_id,
             module_id=module_id,
             messages=[],
             created_at=datetime.utcnow(),
+            course_filter=course_filter_stored,
         )
         session.add(conversation)
         await session.flush()
 
         return conversation
+
+    async def _get_default_course_filter(
+        self,
+        user_id: uuid.UUID,
+        session: AsyncSession,
+    ) -> list[str] | None:
+        """Return the learner's most recently enrolled course ID as default filter."""
+        result = await session.execute(
+            select(UserCourseEnrollment)
+            .where(UserCourseEnrollment.user_id == user_id)
+            .order_by(UserCourseEnrollment.enrolled_at.desc())
+            .limit(1)
+        )
+        enrollment = result.scalar_one_or_none()
+        if enrollment:
+            return [str(enrollment.course_id)]
+        return None
+
+    async def _get_course_names(
+        self,
+        course_ids: list[str | uuid.UUID],
+        session: AsyncSession,
+    ) -> list[str]:
+        """Fetch display names for the given course IDs."""
+        if not course_ids:
+            return []
+        uuids = [uuid.UUID(str(c)) for c in course_ids]
+        result = await session.execute(
+            select(Course).where(Course.id.in_(uuids))
+        )
+        courses = result.scalars().all()
+        return [c.title_fr for c in courses]
 
     async def _retrieve_relevant_context(
         self, query: str, user: User, module_id: uuid.UUID | None, session: AsyncSession

--- a/backend/app/domain/services/tutor_tools.py
+++ b/backend/app/domain/services/tutor_tools.py
@@ -152,6 +152,7 @@ class TutorToolExecutor:
         user_level: int,
         user_language: str,
         learner_memory_service: LearnerMemoryService | None = None,
+        course_filter: list[uuid.UUID] | None = None,
     ):
         self.retriever = retriever
         self.anthropic = anthropic_client
@@ -159,6 +160,7 @@ class TutorToolExecutor:
         self.user_level = user_level
         self.user_language = user_language
         self.learner_memory_service = learner_memory_service or LearnerMemoryService()
+        self.course_filter = course_filter
 
     async def execute(
         self,
@@ -224,6 +226,11 @@ class TutorToolExecutor:
             except (ValueError, TypeError):
                 pass
 
+        if not books_sources and self.course_filter:
+            books_sources = await self._get_books_sources_for_courses(
+                self.course_filter, session
+            )
+
         results = await self.retriever.search_for_module(
             query=query,
             user_level=self.user_level,
@@ -232,6 +239,16 @@ class TutorToolExecutor:
             top_k=5,
             session=session,
         )
+
+        if not results and books_sources:
+            results = await self.retriever.search_for_module(
+                query=query,
+                user_level=self.user_level,
+                user_language=self.user_language,
+                books_sources=None,
+                top_k=5,
+                session=session,
+            )
 
         chunks = []
         for result in results:
@@ -252,6 +269,26 @@ class TutorToolExecutor:
             user_id=str(self.user_id),
         )
         return json.dumps({"query": query, "results": chunks, "count": len(chunks)})
+
+    async def _get_books_sources_for_courses(
+        self,
+        course_ids: list[uuid.UUID],
+        session: AsyncSession,
+    ) -> dict[str, list[str]] | None:
+        """Aggregate books_sources from all modules belonging to the given courses."""
+        from sqlalchemy import select as sa_select
+
+        result = await session.execute(
+            sa_select(Module).where(Module.course_id.in_(course_ids))
+        )
+        modules = result.scalars().all()
+        merged: dict[str, list[str]] = {}
+        for module in modules:
+            if module.books_sources:
+                for key, val in module.books_sources.items():
+                    if key not in merged:
+                        merged[key] = val
+        return merged if merged else None
 
     async def _get_learner_progress(self, tool_input: dict[str, Any], session: AsyncSession) -> str:
         """Execute get_learner_progress tool."""

--- a/backend/migrations/versions/029_add_course_filter_to_tutor_conversations.py
+++ b/backend/migrations/versions/029_add_course_filter_to_tutor_conversations.py
@@ -1,0 +1,27 @@
+"""add course_filter to tutor_conversations
+
+Revision ID: 029
+Revises: 028
+Create Date: 2026-04-04
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSON
+
+revision = "029"
+down_revision = "028"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tutor_conversations",
+        sa.Column("course_filter", JSON, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("tutor_conversations", "course_filter")

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -2,8 +2,9 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { useTranslations } from 'next-intl';
-import { X, MoreVertical, Trash2, Menu, HelpCircle, BookOpen } from 'lucide-react';
+import { X, MoreVertical, Trash2, Menu, HelpCircle, BookOpen, Filter } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -37,6 +38,7 @@ import {
   invalidateConversationsCache,
   deleteConversation as apiDeleteConversation,
 } from '@/lib/tutor-api';
+import { getMyEnrollments, type CourseWithEnrollment } from '@/lib/api';
 
 interface ChatPanelProps {
   isOpen: boolean;
@@ -77,6 +79,9 @@ export function ChatPanel({
     }
     return 'socratic';
   });
+  const [enrolledCourses, setEnrolledCourses] = useState<CourseWithEnrollment[]>([]);
+  const [selectedCourseIds, setSelectedCourseIds] = useState<string[]>([]);
+  const [showCourseSelector, setShowCourseSelector] = useState(false);
   const scrollAreaRef = useRef<HTMLDivElement>(null);
 
   const isLimitReached = currentUsage >= maxDailyUsage;
@@ -91,6 +96,14 @@ export function ChatPanel({
   useEffect(() => {
     localStorage.setItem('tutorMode', tutorMode);
   }, [tutorMode]);
+
+  useEffect(() => {
+    getMyEnrollments()
+      .then((courses) => {
+        setEnrolledCourses(courses);
+      })
+      .catch(() => {});
+  }, []);
 
   useEffect(() => {
     fetchTutorStats()
@@ -197,6 +210,7 @@ export function ChatPanel({
           module_id: moduleId ?? null,
           tutor_mode: tutorMode,
           file_ids: attachedFiles.map((f) => f.fileId),
+          course_filter: selectedCourseIds.length > 0 ? selectedCourseIds : null,
         }),
       });
 
@@ -313,6 +327,16 @@ export function ChatPanel({
     }
   };
 
+  const toggleCourseSelection = (courseId: string) => {
+    setSelectedCourseIds((prev) => {
+      if (prev.includes(courseId)) {
+        return prev.filter((id) => id !== courseId);
+      }
+      if (prev.length >= 2) return prev;
+      return [...prev, courseId];
+    });
+  };
+
   const handleClearHistory = async () => {
     if (activeConversationId) {
       try {
@@ -395,6 +419,71 @@ export function ChatPanel({
             </Button>
           </div>
         </div>
+
+        {/* Course Filter Bar */}
+        {enrolledCourses.length > 0 && (
+          <div className="px-3 py-1.5 border-b bg-background shrink-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1.5 text-xs text-muted-foreground px-2"
+                onClick={() => setShowCourseSelector(!showCourseSelector)}
+                aria-label={t('courseFilter.ariaLabel')}
+              >
+                <Filter className="h-3 w-3" />
+                {t('courseFilter.label')}
+              </Button>
+              {selectedCourseIds.length === 0 ? (
+                <span className="text-xs text-muted-foreground">{t('courseFilter.placeholder')}</span>
+              ) : (
+                selectedCourseIds.map((id) => {
+                  const course = enrolledCourses.find((c) => c.id === id);
+                  return course ? (
+                    <Badge
+                      key={id}
+                      variant="secondary"
+                      className="text-xs cursor-pointer h-6"
+                      onClick={() => toggleCourseSelection(id)}
+                    >
+                      {course.title_fr}
+                      <X className="h-3 w-3 ml-1" />
+                    </Badge>
+                  ) : null;
+                })
+              )}
+            </div>
+            {showCourseSelector && (
+              <div className="mt-1.5 flex flex-col gap-1">
+                {enrolledCourses.map((course) => {
+                  const selected = selectedCourseIds.includes(course.id);
+                  const maxReached = selectedCourseIds.length >= 2 && !selected;
+                  return (
+                    <button
+                      key={course.id}
+                      type="button"
+                      disabled={maxReached}
+                      onClick={() => toggleCourseSelection(course.id)}
+                      className={cn(
+                        'flex items-center gap-2 text-left text-xs px-2 py-1.5 rounded-md transition-colors min-h-[44px]',
+                        selected
+                          ? 'bg-primary/10 text-primary font-medium'
+                          : 'hover:bg-muted text-foreground',
+                        maxReached && 'opacity-40 cursor-not-allowed'
+                      )}
+                    >
+                      <span className="flex-1">{course.title_fr}</span>
+                      {selected && <span className="text-primary">✓</span>}
+                    </button>
+                  );
+                })}
+                {selectedCourseIds.length >= 2 && (
+                  <p className="text-xs text-muted-foreground px-2">{t('courseFilter.maxReached')}</p>
+                )}
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Usage Counter */}
         <UsageCounter

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -361,6 +361,15 @@
     "modeExplanatory": "Explanatory Mode",
     "modeSocraticTooltip": "Guided questions",
     "modeExplanatoryTooltip": "Direct answers",
+    "courseFilter": {
+      "label": "Course scope",
+      "placeholder": "All enrolled courses",
+      "selectCourses": "Select courses (max 2)",
+      "maxReached": "Maximum 2 courses",
+      "noEnrollments": "No enrolled courses",
+      "outsideScope": "This content is from a course you are not enrolled in.",
+      "ariaLabel": "Filter tutor answers by course"
+    },
     "fileUpload": {
       "attach": "Attach a file",
       "attachAriaLabel": "Attach a file",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -361,6 +361,15 @@
     "modeExplanatory": "Mode Explicatif",
     "modeSocraticTooltip": "Guidage par questions",
     "modeExplanatoryTooltip": "Réponses directes",
+    "courseFilter": {
+      "label": "Périmètre de cours",
+      "placeholder": "Tous les cours inscrits",
+      "selectCourses": "Sélectionner des cours (max 2)",
+      "maxReached": "Maximum 2 cours",
+      "noEnrollments": "Aucun cours inscrit",
+      "outsideScope": "Ce contenu provient d'un cours auquel vous n'êtes pas inscrit.",
+      "ariaLabel": "Filtrer les réponses du tuteur par cours"
+    },
     "fileUpload": {
       "attach": "Joindre un fichier",
       "attachAriaLabel": "Joindre un fichier",


### PR DESCRIPTION
## Summary

- Scopes the AI tutor's RAG search to courses the learner is enrolled in
- Adds a per-thread course filter (max 2 courses) persisted on the conversation
- Adapts the system prompt with a PÉRIMÈTRE DE RÉPONSE section when filter is active
- Adds a course selector UI in the chat header (mobile-first, 44px touch targets)

## Changes

- `backend/app/api/v1/schemas/tutor.py` — `course_filter` field (max 2 UUIDs) + validator
- `backend/app/domain/models/conversation.py` — `course_filter` JSON column
- `backend/migrations/versions/029_add_course_filter_to_tutor_conversations.py` — Alembic migration
- `backend/app/domain/services/tutor_service.py` — auto-scope to enrolled courses, persist filter, fallback logic, fetch course names
- `backend/app/domain/services/tutor_tools.py` — aggregate `books_sources` from enrolled course modules, fallback to full RAG
- `backend/app/api/v1/tutor.py` — pass `course_filter` to service
- `backend/app/ai/prompts/tutor.py` — `TutorContext.course_filter_names` + `_format_course_scope_section()`
- `frontend/components/chat/chat-panel.tsx` — course selector dropdown with chip badges
- `frontend/messages/en.json` & `fr.json` — `ChatTutor.courseFilter` i18n strings

## Test plan

- [ ] Backend tests pass (`uv run pytest`)
- [ ] Frontend lint passes (`npm run lint`)
- [ ] RAG scoped to enrolled modules when `course_filter` set
- [ ] Validation rejects `course_filter` with >2 entries (422 response)
- [ ] Filter persists across messages in same conversation
- [ ] System prompt includes PÉRIMÈTRE DE RÉPONSE when filter is active
- [ ] Default auto-scope uses most recent enrollment when no filter provided
- [ ] Fallback to full RAG when no chunks found within enrolled courses
- [ ] Course selector renders with ≤2 selectable chips on mobile (320px)

Closes #476

Generated with [Claude Code](https://claude.ai/code)