### PR TITLE
feat(courses): complete multi-course lesson pipeline

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -16,8 +16,10 @@ from app.api.deps_local_auth import AuthenticatedUser, require_role
 from app.domain.models.course import Course, UserCourseEnrollment
 from app.domain.models.document_chunk import DocumentChunk
 from app.domain.models.module import Module
+from app.domain.models.module_unit import ModuleUnit
 from app.domain.models.taxonomy import TaxonomyCategory
 from app.domain.models.user import UserRole
+from app.tasks.content_generation import generate_lesson_task
 from app.tasks.rag_indexation import UPLOAD_DIR, index_course_resources
 from app.tasks.syllabus_generation import generate_course_syllabus
 
@@ -576,3 +578,81 @@ async def delete_course_resource(
         filename=safe_name,
         admin_id=current_user.id,
     )
+
+
+# ---------------------------------------------------------------------------
+# Content Pre-generation
+# ---------------------------------------------------------------------------
+
+
+class GenerateContentRequest(BaseModel):
+    language: str = "fr"
+    country: str = "SN"
+    level: int = 1
+
+
+@router.post("/{course_id}/modules/{module_id}/generate-content")
+async def admin_generate_module_content(
+    course_id: uuid.UUID,
+    module_id: uuid.UUID,
+    request: GenerateContentRequest,
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    db=Depends(get_db_session),
+) -> dict:
+    """Trigger lesson content generation for all units in a module. Admin only.
+
+    Allows admins to pre-generate and verify lesson quality before learners access it.
+    Returns task IDs that can be polled for status.
+    """
+    course_result = await db.execute(select(Course).where(Course.id == course_id))
+    course = course_result.scalar_one_or_none()
+    if not course:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
+
+    module_result = await db.execute(
+        select(Module).where(Module.id == module_id, Module.course_id == course_id)
+    )
+    module = module_result.scalar_one_or_none()
+    if not module:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Module not found in this course"
+        )
+
+    units_result = await db.execute(
+        select(ModuleUnit).where(ModuleUnit.module_id == module_id).order_by(ModuleUnit.order_index)
+    )
+    units = units_result.scalars().all()
+
+    if not units:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Module has no units. Generate the syllabus first.",
+        )
+
+    dispatched = []
+    for unit in units:
+        unit_id = f"M{module.module_number:02d}-U{unit.order_index + 1:02d}"
+        task = generate_lesson_task.delay(
+            str(module_id),
+            unit_id,
+            request.language,
+            request.country,
+            request.level,
+        )
+        dispatched.append({"unit_id": unit_id, "task_id": task.id})
+
+    logger.info(
+        "Admin triggered content generation for module",
+        course_id=str(course_id),
+        module_id=str(module_id),
+        units_count=len(dispatched),
+        admin_id=current_user.id,
+    )
+
+    return {
+        "course_id": str(course_id),
+        "module_id": str(module_id),
+        "module_number": module.module_number,
+        "units_dispatched": len(dispatched),
+        "tasks": dispatched,
+    }

--- a/backend/app/api/v1/courses.py
+++ b/backend/app/api/v1/courses.py
@@ -251,11 +251,12 @@ async def enroll_in_course(
             )
         )
         if prog_result.scalar_one_or_none() is None:
+            module_status = "in_progress" if module.module_number == 1 else "locked"
             db.add(
                 UserModuleProgress(
                     user_id=uuid.UUID(current_user.id),
                     module_id=module.id,
-                    status="locked",
+                    status=module_status,
                     completion_pct=0.0,
                     time_spent_minutes=0,
                 )

--- a/backend/app/domain/models/course.py
+++ b/backend/app/domain/models/course.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from sqlalchemy import DateTime, Enum, ForeignKey, String, Text, func
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.domain.models.base import Base
@@ -35,6 +36,7 @@ class Course(Base):
     )
     rag_collection_id: Mapped[str | None] = mapped_column(String)
     indexation_task_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    syllabus_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     published_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 

--- a/backend/app/tasks/syllabus_generation.py
+++ b/backend/app/tasks/syllabus_generation.py
@@ -54,6 +54,7 @@ def generate_course_syllabus(self, course_id: str, estimated_hours: int) -> dict
 
         from app.domain.models.course import Course
         from app.domain.models.module import Module
+        from app.domain.models.module_unit import ModuleUnit
         from app.domain.services.course_agent_service import CourseAgentService
         from app.infrastructure.config.settings import settings
 
@@ -100,6 +101,7 @@ def generate_course_syllabus(self, course_id: str, estimated_hours: int) -> dict
             await session.execute(delete(Module).where(Module.course_id == uuid.UUID(course_id)))
             await session.flush()
 
+            rag_collection_id = course.rag_collection_id
             saved_modules = []
             for i, m in enumerate(module_dicts):
                 module = Module(
@@ -113,18 +115,36 @@ def generate_course_syllabus(self, course_id: str, estimated_hours: int) -> dict
                     estimated_hours=m.get("estimated_hours", 20),
                     bloom_level=m.get("bloom_level"),
                     course_id=uuid.UUID(course_id),
+                    books_sources={rag_collection_id: []} if rag_collection_id else None,
                 )
                 session.add(module)
+                await session.flush()
+
+                for j, u in enumerate(m.get("units", [])):
+                    unit = ModuleUnit(
+                        id=uuid.uuid4(),
+                        module_id=module.id,
+                        unit_number=str(j + 1),
+                        title_fr=u.get("title_fr", f"Unité {j + 1}"),
+                        title_en=u.get("title_en", f"Unit {j + 1}"),
+                        description_fr=u.get("description_fr"),
+                        description_en=u.get("description_en"),
+                        order_index=j,
+                    )
+                    session.add(unit)
+
                 saved_modules.append(
                     {
                         "id": str(module.id),
                         "module_number": module.module_number,
                         "title_fr": module.title_fr,
                         "title_en": module.title_en,
+                        "units_count": len(m.get("units", [])),
                     }
                 )
 
             course.module_count = len(module_dicts)
+            course.syllabus_json = module_dicts
             await session.commit()
 
             logger.info(

--- a/backend/migrations/versions/029_add_syllabus_json_to_courses.py
+++ b/backend/migrations/versions/029_add_syllabus_json_to_courses.py
@@ -1,0 +1,27 @@
+"""add syllabus_json to courses
+
+Revision ID: 029
+Revises: 028
+Create Date: 2026-04-04
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "029"
+down_revision = "028"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "courses",
+        sa.Column("syllabus_json", JSONB, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("courses", "syllabus_json")


### PR DESCRIPTION
## Summary

- **Save units**: `syllabus_generation.py` now loops `m.get("units", [])` after each module and creates `ModuleUnit` records
- **Set RAG sources**: Each new module gets `books_sources = {course.rag_collection_id: []}` so RAG retrieval searches the correct document chunks
- **Store syllabus JSON**: Full AI response saved to `courses.syllabus_json` (new JSONB column) for use by lesson generator
- **Auto-unlock M1**: Enrollment handler sets module 1 to `in_progress` instead of `locked` so learners can start immediately
- **Admin pre-generate**: New `POST /admin/courses/{course_id}/modules/{module_id}/generate-content` endpoint dispatches `generate_lesson_task` for all units in a module

## Changes

- `backend/app/tasks/syllabus_generation.py` — save `ModuleUnit` records, set `books_sources`, store `syllabus_json`
- `backend/app/domain/models/course.py` — add `syllabus_json: Mapped[dict | None]` JSONB column
- `backend/migrations/versions/029_add_syllabus_json_to_courses.py` — migration to add `syllabus_json` to courses table
- `backend/app/api/v1/courses.py` — auto-unlock module 1 on enrollment
- `backend/app/api/v1/admin_courses.py` — new `POST /{course_id}/modules/{module_id}/generate-content` admin endpoint

## Test plan

- [x] Backend tests pass (`pytest` — all tests green)
- [x] `ruff check` passes with no issues
- [ ] E2E: create course → upload PDF → generate syllabus → verify units created → verify books_sources set → index → publish → enroll → confirm M1 is `in_progress` → start lesson
- [ ] Admin: call `POST /admin/courses/{id}/modules/{mod_id}/generate-content` and verify Celery tasks dispatched

Closes #706

Generated with [Claude Code](https://claude.ai/code)