### PR TITLE
fix(rag): filter quiz/lesson RAG by course rag_collection_id, not hardcoded sources

### DIFF
--- a/backend/app/ai/rag/retriever.py
+++ b/backend/app/ai/rag/retriever.py
@@ -1,5 +1,6 @@
 """Semantic retrieval service for the RAG pipeline."""
 
+import re
 from dataclasses import dataclass
 from typing import Any
 
@@ -248,7 +249,24 @@ class SemanticRetriever:
         if books_sources:
             source_list = list(books_sources.keys())
             if source_list:
-                filters["source"] = source_list
+                # Detect whether keys are rag_collection_id UUIDs (new-style courses)
+                # or named textbook sources like "donaldson" (legacy public health course).
+                # UUID pattern: 8-4-4-4-12 hex chars separated by hyphens.
+                _uuid_pattern = re.compile(
+                    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                    re.IGNORECASE,
+                )
+                uuid_keys = [k for k in source_list if _uuid_pattern.match(k)]
+                named_keys = [k for k in source_list if not _uuid_pattern.match(k)]
+
+                if uuid_keys and not named_keys:
+                    # New-style course: every key is a rag_collection_id; search only
+                    # within those collections by matching the source column.
+                    filters["source"] = uuid_keys
+                elif named_keys:
+                    # Legacy public-health course (donaldson / triola / scutchfield)
+                    # or a mix — use the named keys as source filters.
+                    filters["source"] = named_keys
 
         return await self.search(query=query, top_k=top_k, filters=filters, session=session)
 

--- a/backend/app/domain/services/quiz_service.py
+++ b/backend/app/domain/services/quiz_service.py
@@ -12,6 +12,7 @@ from app.ai.claude_service import ClaudeService
 from app.ai.rag.retriever import SemanticRetriever
 from app.api.v1.schemas.quiz import QuizContent, QuizResponse
 from app.domain.models.content import GeneratedContent
+from app.domain.models.module import Module
 from app.domain.services.platform_settings_service import SettingsCache
 
 logger = structlog.get_logger()
@@ -215,12 +216,17 @@ class QuizService:
             QuizContent with generated questions and metadata
         """
         try:
-            # Retrieve relevant content chunks using RAG
-            search_query = f"module {module_id} unit {unit_id} public health epidemiology concepts"
+            module: Module | None = None
+            if session is not None:
+                module_result = await session.execute(select(Module).where(Module.id == module_id))
+                module = module_result.scalar_one_or_none()
+
+            search_query = self._build_quiz_search_query(module, unit_id, language)
             search_results = await self.semantic_retriever.search_for_module(
                 query=search_query,
                 user_level=level,
                 user_language=language,
+                books_sources=module.books_sources if module else None,
                 top_k=SettingsCache.instance().get("ai-rag-default-top-k", 8),
                 session=session,
             )
@@ -255,6 +261,25 @@ class QuizService:
         except Exception as e:
             logger.error("Quiz content generation failed", error=str(e))
             raise
+
+    def _build_quiz_search_query(
+        self,
+        module: "Module | None",
+        unit_id: str,
+        language: str,
+    ) -> str:
+        """Build a context-aware RAG search query from module/unit metadata."""
+        if module is None:
+            return f"unit {unit_id}"
+
+        title = module.title_fr if language == "fr" else module.title_en
+        description = module.description_fr if language == "fr" else module.description_en
+        parts = [title]
+        if unit_id:
+            parts.append(unit_id)
+        if description:
+            parts.append(description[:200])
+        return " ".join(parts)
 
     def _build_quiz_prompt(
         self,

--- a/backend/tests/test_quiz_service.py
+++ b/backend/tests/test_quiz_service.py
@@ -359,3 +359,112 @@ class TestBuildQuizPrompt:
         assert "CRITICAL" in system_prompt
         assert "JSON" in system_prompt
         assert "title" in system_prompt
+
+
+class TestBuildQuizSearchQuery:
+    def test_returns_unit_id_when_module_is_none(self, quiz_service):
+        result = quiz_service._build_quiz_search_query(None, "M01-U04", "fr")
+        assert result == "unit M01-U04"
+
+    def test_uses_module_title_fr(self, quiz_service):
+        module = MagicMock()
+        module.title_fr = "Fondements de la santé publique"
+        module.title_en = "Foundations of Public Health"
+        module.description_fr = None
+        module.description_en = None
+        result = quiz_service._build_quiz_search_query(module, "M01-U01", "fr")
+        assert "Fondements de la santé publique" in result
+        assert "M01-U01" in result
+
+    def test_uses_module_title_en(self, quiz_service):
+        module = MagicMock()
+        module.title_fr = "Audit Interne"
+        module.title_en = "Internal Audit"
+        module.description_fr = None
+        module.description_en = None
+        result = quiz_service._build_quiz_search_query(module, "M01-U01", "en")
+        assert "Internal Audit" in result
+
+    def test_includes_description_up_to_200_chars(self, quiz_service):
+        module = MagicMock()
+        module.title_fr = "Module"
+        module.title_en = "Module"
+        module.description_fr = "A" * 300
+        module.description_en = "A" * 300
+        result = quiz_service._build_quiz_search_query(module, "M01-U01", "fr")
+        assert "A" * 200 in result
+        assert "A" * 201 not in result
+
+    def test_does_not_include_public_health_hardcode(self, quiz_service):
+        module = MagicMock()
+        module.title_fr = "Audit Interne GIAS 2024"
+        module.title_en = "Internal Audit GIAS 2024"
+        module.description_fr = None
+        module.description_en = None
+        result = quiz_service._build_quiz_search_query(module, "M01-U01", "fr")
+        assert "public health epidemiology" not in result.lower()
+
+
+class TestGenerateQuizContentPassesBooksSources:
+    async def test_passes_books_sources_to_retriever(
+        self, quiz_service, mock_retriever, mock_claude_service
+    ):
+        module_id = uuid.uuid4()
+        mock_session = AsyncMock()
+        mock_module = MagicMock()
+        mock_module.id = module_id
+        mock_module.title_fr = "Audit Interne GIAS 2024"
+        mock_module.title_en = "Internal Audit GIAS 2024"
+        mock_module.description_fr = None
+        mock_module.description_en = None
+        rag_collection_id = "a1b2c3d4-1234-5678-abcd-ef0123456789"
+        mock_module.books_sources = {rag_collection_id: []}
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none = MagicMock(return_value=mock_module)
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        await quiz_service._generate_quiz_content(
+            module_id=module_id,
+            unit_id="M01-U01",
+            language="fr",
+            country="senegal",
+            level=1,
+            num_questions=5,
+            session=mock_session,
+        )
+
+        call_kwargs = mock_retriever.search_for_module.call_args
+        assert call_kwargs.kwargs["books_sources"] == {rag_collection_id: []}
+
+    async def test_search_query_uses_module_title_not_hardcode(
+        self, quiz_service, mock_retriever, mock_claude_service
+    ):
+        module_id = uuid.uuid4()
+        mock_session = AsyncMock()
+        mock_module = MagicMock()
+        mock_module.id = module_id
+        mock_module.title_fr = "Définition et Mission de l'Audit Interne"
+        mock_module.title_en = "Definition and Mission of Internal Audit"
+        mock_module.description_fr = None
+        mock_module.description_en = None
+        mock_module.books_sources = None
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none = MagicMock(return_value=mock_module)
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        await quiz_service._generate_quiz_content(
+            module_id=module_id,
+            unit_id="M01-U01",
+            language="en",
+            country="senegal",
+            level=1,
+            num_questions=5,
+            session=mock_session,
+        )
+
+        call_kwargs = mock_retriever.search_for_module.call_args
+        actual_query = call_kwargs.kwargs["query"]
+        assert "Internal Audit" in actual_query
+        assert "public health epidemiology" not in actual_query.lower()

--- a/backend/tests/test_retriever_source_filter.py
+++ b/backend/tests/test_retriever_source_filter.py
@@ -1,0 +1,98 @@
+"""Tests for SemanticRetriever.search_for_module source-filtering logic."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.ai.rag.retriever import SemanticRetriever
+
+
+@pytest.fixture
+def mock_embedding_service():
+    svc = AsyncMock()
+    svc.generate_embedding = AsyncMock(return_value=[0.1] * 1536)
+    return svc
+
+
+@pytest.fixture
+def retriever(mock_embedding_service):
+    return SemanticRetriever(mock_embedding_service)
+
+
+class TestSearchForModuleSourceFiltering:
+    async def test_uuid_keys_added_as_source_filter(self, retriever):
+        rag_id = "a1b2c3d4-1234-5678-abcd-ef0123456789"
+        books_sources = {rag_id: []}
+
+        with patch.object(retriever, "search", new=AsyncMock(return_value=[])) as mock_search:
+            await retriever.search_for_module(
+                query="internal audit definition",
+                user_level=1,
+                user_language="fr",
+                books_sources=books_sources,
+            )
+            filters_used = mock_search.call_args.kwargs["filters"]
+            assert "source" in filters_used
+            assert filters_used["source"] == [rag_id]
+
+    async def test_named_keys_added_as_source_filter(self, retriever):
+        books_sources = {"donaldson": ["ch1", "ch2"], "triola": []}
+
+        with patch.object(retriever, "search", new=AsyncMock(return_value=[])) as mock_search:
+            await retriever.search_for_module(
+                query="epidemiology",
+                user_level=2,
+                user_language="en",
+                books_sources=books_sources,
+            )
+            filters_used = mock_search.call_args.kwargs["filters"]
+            assert "source" in filters_used
+            assert set(filters_used["source"]) == {"donaldson", "triola"}
+
+    async def test_no_source_filter_when_books_sources_none(self, retriever):
+        with patch.object(retriever, "search", new=AsyncMock(return_value=[])) as mock_search:
+            await retriever.search_for_module(
+                query="health data",
+                user_level=1,
+                user_language="fr",
+                books_sources=None,
+            )
+            filters_used = mock_search.call_args.kwargs["filters"]
+            assert "source" not in filters_used
+
+    async def test_no_source_filter_when_books_sources_empty(self, retriever):
+        with patch.object(retriever, "search", new=AsyncMock(return_value=[])) as mock_search:
+            await retriever.search_for_module(
+                query="health data",
+                user_level=1,
+                user_language="fr",
+                books_sources={},
+            )
+            filters_used = mock_search.call_args.kwargs["filters"]
+            assert "source" not in filters_used
+
+    async def test_mixed_keys_uses_only_named_sources(self, retriever):
+        rag_id = "a1b2c3d4-1234-5678-abcd-ef0123456789"
+        books_sources = {"donaldson": [], rag_id: []}
+
+        with patch.object(retriever, "search", new=AsyncMock(return_value=[])) as mock_search:
+            await retriever.search_for_module(
+                query="public health",
+                user_level=1,
+                user_language="fr",
+                books_sources=books_sources,
+            )
+            filters_used = mock_search.call_args.kwargs["filters"]
+            assert "source" in filters_used
+            assert filters_used["source"] == ["donaldson"]
+
+    async def test_level_filter_always_present(self, retriever):
+        with patch.object(retriever, "search", new=AsyncMock(return_value=[])) as mock_search:
+            await retriever.search_for_module(
+                query="biostatistics",
+                user_level=3,
+                user_language="en",
+                books_sources=None,
+            )
+            filters_used = mock_search.call_args.kwargs["filters"]
+            assert filters_used["level"] == {"$lte": 3}


### PR DESCRIPTION
## Summary

- **Bug**: Quiz/lesson content for new courses (e.g. Internal Audit GIAS 2024) was sourced from the old Public Health course chunks (donaldson/triola/scutchfield) instead of the new course's uploaded PDFs.
- Fixes the two independent root causes.

## Changes

### `backend/app/domain/services/quiz_service.py`
- Load the `Module` record before performing RAG search (was skipped entirely)
- Build the search query from `module.title` + `unit_id` + `description` instead of the hardcoded string `"module {id} unit {id} public health epidemiology concepts"`
- Pass `module.books_sources` to `semantic_retriever.search_for_module` (was always `None`)
- New helper `_build_quiz_search_query(module, unit_id, language)`

### `backend/app/ai/rag/retriever.py`
- `search_for_module`: detect whether `books_sources` keys are UUID-format `rag_collection_id` strings (new-style courses) vs. named textbook sources like `"donaldson"` (legacy public-health course)
- UUID keys → filter `document_chunks.source` by those collection IDs (prevents cross-course bleed)
- Named keys → existing behaviour (filter by named source)
- Mixed keys → use only the named keys (safe fallback)

### `backend/tests/test_quiz_service.py`
- `TestBuildQuizSearchQuery`: verifies query uses module title, not hardcoded PH string
- `TestGenerateQuizContentPassesBooksSources`: verifies `books_sources` is forwarded to retriever

### `backend/tests/test_retriever_source_filter.py` _(new)_
- Full coverage of UUID-key vs named-key detection in `search_for_module`

## Test plan
- [x] `ruff check` and `ruff format` pass on all changed files
- [x] Logic verified with inline Python assertions
- [ ] Backend integration tests pass (requires DB — run with `uv run pytest`)
- [ ] Manually test quiz generation for new Internal Audit course

Closes #715

Generated with [Claude Code](https://claude.ai/code)