### PR TITLE
fix(progress): filter modules by course_id in GET /progress/modules

### DIFF
--- a/backend/app/api/v1/progress.py
+++ b/backend/app/api/v1/progress.py
@@ -4,7 +4,7 @@ from typing import Annotated
 from uuid import UUID
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_db
@@ -136,17 +136,19 @@ async def get_module_progress(
 async def get_all_module_progress(
     current_user: Annotated[User, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
+    course_id: Annotated[UUID | None, Query(description="Filter modules by course ID")] = None,
 ) -> list[ModuleProgressResponse]:
     """
     Get current user's progress for all modules.
 
-    Returns ALL modules (including locked ones), ordered by module_number.
+    When course_id is provided, only modules belonging to that course are returned.
+    Without course_id, returns ALL modules (including locked ones), ordered by module_number.
     Locked modules with no progress record have status 'locked' and 0% completion.
     """
     try:
         user_id = UUID(str(current_user.id))
         service = ProgressService(db)
-        all_modules = await service.get_all_modules_with_progress(user_id)
+        all_modules = await service.get_all_modules_with_progress(user_id, course_id=course_id)
 
         return [
             ModuleProgressResponse(

--- a/backend/app/domain/services/progress_service.py
+++ b/backend/app/domain/services/progress_service.py
@@ -222,14 +222,20 @@ class ProgressService:
         )
         return list(result.scalars().all())
 
-    async def get_all_modules_with_progress(self, user_id: UUID) -> list[dict]:
+    async def get_all_modules_with_progress(
+        self, user_id: UUID, course_id: UUID | None = None
+    ) -> list[dict]:
         """
-        Return ALL modules with their real lock/unlock status for the user.
+        Return modules with their real lock/unlock status for the user.
 
+        When course_id is provided, only modules belonging to that course are returned.
         Modules without a progress record default to 'locked'.
         Returns data ordered by module_number.
         """
-        modules_result = await self.db.execute(select(Module).order_by(Module.module_number))
+        stmt = select(Module).order_by(Module.module_number)
+        if course_id is not None:
+            stmt = stmt.where(Module.course_id == course_id)
+        modules_result = await self.db.execute(stmt)
         modules = list(modules_result.scalars().all())
 
         progress_result = await self.db.execute(

--- a/backend/tests/test_progress_service.py
+++ b/backend/tests/test_progress_service.py
@@ -807,3 +807,142 @@ class TestUnlockNextModule:
             if isinstance(obj, UserModuleProgress) and obj.module_id != module_id
         ]
         assert len(new_progress_rows) == 0
+
+
+class TestGetAllModulesWithProgress:
+    async def test_returns_all_modules_when_no_course_id(self, progress_service, mock_db, user_id):
+        from app.domain.models.module import Module
+
+        course_id = uuid.uuid4()
+        module1 = Module(
+            id=uuid.uuid4(),
+            module_number=1,
+            level=1,
+            title_fr="M01 FR",
+            title_en="M01 EN",
+            estimated_hours=20,
+            course_id=course_id,
+        )
+        module2 = Module(
+            id=uuid.uuid4(),
+            module_number=2,
+            level=1,
+            title_fr="M02 FR",
+            title_en="M02 EN",
+            estimated_hours=25,
+            course_id=uuid.uuid4(),
+        )
+
+        call_count = 0
+        executed_stmts = []
+
+        async def mock_execute(stmt):
+            nonlocal call_count
+            call_count += 1
+            executed_stmts.append(stmt)
+            mock_result = MagicMock()
+            if call_count == 1:
+                mock_result.scalars.return_value.all.return_value = [module1, module2]
+            else:
+                mock_result.scalars.return_value.all.return_value = []
+            return mock_result
+
+        mock_db.execute = mock_execute
+
+        result = await progress_service.get_all_modules_with_progress(user_id)
+
+        assert len(result) == 2
+        assert result[0]["module_number"] == 1
+        assert result[1]["module_number"] == 2
+
+    async def test_filters_by_course_id_when_provided(self, progress_service, mock_db, user_id):
+        from app.domain.models.module import Module
+
+        target_course_id = uuid.uuid4()
+        module_in_course = Module(
+            id=uuid.uuid4(),
+            module_number=1,
+            level=1,
+            title_fr="M01 FR",
+            title_en="M01 EN",
+            estimated_hours=20,
+            course_id=target_course_id,
+        )
+
+        call_count = 0
+
+        async def mock_execute(stmt):
+            nonlocal call_count
+            call_count += 1
+            mock_result = MagicMock()
+            if call_count == 1:
+                mock_result.scalars.return_value.all.return_value = [module_in_course]
+            else:
+                mock_result.scalars.return_value.all.return_value = []
+            return mock_result
+
+        mock_db.execute = mock_execute
+
+        result = await progress_service.get_all_modules_with_progress(
+            user_id, course_id=target_course_id
+        )
+
+        assert len(result) == 1
+        assert result[0]["module_number"] == 1
+
+    async def test_defaults_status_to_locked_when_no_progress(
+        self, progress_service, mock_db, user_id
+    ):
+        from app.domain.models.module import Module
+
+        module = Module(
+            id=uuid.uuid4(),
+            module_number=1,
+            level=1,
+            title_fr="M01 FR",
+            title_en="M01 EN",
+            estimated_hours=20,
+        )
+
+        call_count = 0
+
+        async def mock_execute(stmt):
+            nonlocal call_count
+            call_count += 1
+            mock_result = MagicMock()
+            if call_count == 1:
+                mock_result.scalars.return_value.all.return_value = [module]
+            else:
+                mock_result.scalars.return_value.all.return_value = []
+            return mock_result
+
+        mock_db.execute = mock_execute
+
+        result = await progress_service.get_all_modules_with_progress(user_id)
+
+        assert len(result) == 1
+        assert result[0]["status"] == "locked"
+        assert result[0]["completion_pct"] == 0.0
+
+    async def test_returns_empty_list_when_course_has_no_modules(
+        self, progress_service, mock_db, user_id
+    ):
+        course_id = uuid.uuid4()
+
+        call_count = 0
+
+        async def mock_execute(stmt):
+            nonlocal call_count
+            call_count += 1
+            mock_result = MagicMock()
+            if call_count == 1:
+                mock_result.scalars.return_value.all.return_value = []
+            else:
+                mock_result.scalars.return_value.all.return_value = []
+            return mock_result
+
+        mock_db.execute = mock_execute
+
+        result = await progress_service.get_all_modules_with_progress(user_id, course_id=course_id)
+
+        assert result == []


### PR DESCRIPTION
## Summary

Fixes the bug where `/modules?course_id=<id>` returned ALL courses' modules instead of only those belonging to the specified course.

- `GET /progress/modules` now accepts an optional `course_id` query parameter (`UUID | None`)
- The `ProgressService.get_all_modules_with_progress()` method now accepts `course_id: UUID | None = None` and adds `WHERE modules.course_id = :course_id` to the SQLAlchemy query when provided
- Without `course_id` the endpoint is fully backward-compatible (returns all modules as before)

## Changes

- `backend/app/api/v1/progress.py` — add `course_id: Annotated[UUID | None, Query(...)] = None` param and pass it to service
- `backend/app/domain/services/progress_service.py` — build statement with optional `where(Module.course_id == course_id)` clause
- `backend/tests/test_progress_service.py` — add `TestGetAllModulesWithProgress` with 4 new tests

## Test plan

- [x] `pytest tests/test_progress_service.py` — 33 passed
- [x] `ruff check` — all checks passed
- [x] `ruff format` — no unexpected changes

Closes #720

Generated with [Claude Code](https://claude.ai/code)