### PR TITLE
fix(breadcrumb): show module title instead of UUID in lesson page

### DIFF
--- a/frontend/app/[locale]/(app)/modules/[moduleId]/lessons/[unitId]/page.tsx
+++ b/frontend/app/[locale]/(app)/modules/[moduleId]/lessons/[unitId]/page.tsx
@@ -3,7 +3,7 @@ import { getLocale } from 'next-intl/server';
 import { Link } from '@/i18n/routing';
 import { ChevronLeft } from 'lucide-react';
 
-import { getModuleUnits } from '@/lib/api';
+import { API_BASE, ModuleUnitsResponse } from '@/lib/api';
 import { LessonViewer } from '@/components/learning/lesson-viewer';
 import { CaseStudyViewer } from '@/components/learning/case-study-viewer';
 
@@ -11,13 +11,26 @@ interface LessonPageProps {
   params: Promise<{ moduleId: string; unitId: string }>;
 }
 
+async function fetchModuleData(moduleId: string): Promise<ModuleUnitsResponse | null> {
+  try {
+    const res = await fetch(`${API_BASE}/api/v1/content/modules/${moduleId}/units`, {
+      next: { revalidate: 300 },
+    });
+    if (!res.ok) return null;
+    return res.json();
+  } catch {
+    return null;
+  }
+}
+
 export default async function LessonPage({ params }: LessonPageProps) {
   const { moduleId, unitId } = await params;
   const locale = await getLocale();
   const t = await getTranslations('LessonPage');
+  const tNav = await getTranslations('Navigation');
 
   const language = locale as 'fr' | 'en';
-  const moduleData = await getModuleUnits(moduleId).catch(() => null);
+  const moduleData = await fetchModuleData(moduleId);
   const unit = moduleData?.units?.find(u => u.unit_number === unitId || u.id === unitId);
   const moduleTitle = language === 'fr' ? (moduleData?.title_fr || moduleId) : (moduleData?.title_en || moduleId);
   const unitTitle = language === 'fr' ? (unit?.title_fr || unitId) : (unit?.title_en || unitId);
@@ -29,6 +42,13 @@ export default async function LessonPage({ params }: LessonPageProps) {
       {/* Breadcrumb */}
       <div className="container mx-auto max-w-4xl px-4 py-4 border-b">
         <div className="flex items-center gap-2 text-sm text-gray-600">
+          <Link
+            href="/dashboard"
+            className="hover:text-gray-900 transition-colors"
+          >
+            {tNav('dashboard')}
+          </Link>
+          <span>/</span>
           <Link
             href="/modules"
             className="hover:text-gray-900 transition-colors"
@@ -83,7 +103,7 @@ export async function generateMetadata({ params }: LessonPageProps) {
   const t = await getTranslations('LessonPage.metadata');
 
   const language = locale as 'fr' | 'en';
-  const moduleData = await getModuleUnits(moduleId).catch(() => null);
+  const moduleData = await fetchModuleData(moduleId);
   const unit = moduleData?.units?.find(u => u.unit_number === unitId || u.id === unitId);
   const unitTitle = language === 'fr' ? (unit?.title_fr || unitId) : (unit?.title_en || unitId);
   const modTitle = language === 'fr' ? (moduleData?.title_fr || moduleId) : (moduleData?.title_en || moduleId);


### PR DESCRIPTION
## Summary

- Root cause: `getModuleUnits()` uses plain `fetch` without Next.js caching. On transient backend errors, `.catch(() => null)` returns null and `moduleTitle` falls back to the raw `moduleId` UUID.
- Added `fetchModuleData()` helper using Next.js extended `fetch` with `next: { revalidate: 300 }` — module data is cached for 5 minutes, preventing UUID fallback on brief API blips.
- Added Dashboard link at the start of the breadcrumb using `Navigation.dashboard` i18n key.
- `generateMetadata()` also uses the same cached helper.

## Changes

- `frontend/app/[locale]/(app)/modules/[moduleId]/lessons/[unitId]/page.tsx` — added `fetchModuleData()` with caching, added Dashboard breadcrumb link

## Breadcrumb before/after

- Before: `Modules > f76a2c3d-5fd1-4cf3-ac53-bf18924b1c39 > M01-U01`
- After: `Dashboard > Modules > Foundations of Public Health > M01-U01`

## Test plan

- [ ] Backend tests pass
- [ ] Frontend lint passes (0 errors confirmed)
- [ ] Navigate to `/modules/{moduleId}/lessons/{unitId}` — breadcrumb shows module title, not UUID
- [ ] Breadcrumb includes Dashboard link
- [ ] Verified on mobile viewport (320px)

Closes #711

Generated with [Claude Code](https://claude.ai/code)