### PR TITLE
fix(ai): make lesson/quiz/case-study prompts course-aware

### DIFF
--- a/backend/app/ai/prompts/case_study.py
+++ b/backend/app/ai/prompts/case_study.py
@@ -37,7 +37,12 @@ CASE_STUDY_TOPICS = {
 
 
 def get_case_study_system_prompt(
-    language: Literal["fr", "en"], country: str, level: int, bloom_level: str
+    language: Literal["fr", "en"],
+    country: str,
+    level: int,
+    bloom_level: str,
+    course_title: str | None = None,
+    course_description: str | None = None,
 ) -> str:
     """Generate system prompt for case study content generation."""
 
@@ -45,10 +50,35 @@ def get_case_study_system_prompt(
     country_name = country_names.get(country, country)
 
     if language == "fr":
-        return f"""Tu es un expert pédagogue en santé publique spécialisé en Afrique de l'Ouest.
-Tu génères des études de cas éducatives adaptatives pour des professionnels de santé au {country_name}.
+        if course_title:
+            expert_role = f"Tu es un expert pédagogue en {course_title} spécialisé pour le contexte d'Afrique de l'Ouest."
+            audience_line = f"Tu génères des études de cas éducatives adaptatives pour des professionnels au {country_name} dans le domaine : {course_title}."
+            mission_line = f"Créer une étude de cas structurée basée sur une situation réelle liée à {course_title} en AOF."
+            context_section = (
+                f"   - Présente la situation géographique, économique et organisationnelle\n"
+                f"   - Décrit le contexte institutionnel du pays concerné\n"
+                f"   - Fournit les indicateurs pertinents pour {course_title} avant l'événement"
+            )
+            data_sources = "   - Sources : organisations professionnelles, rapports institutionnels, données du secteur"
+            conclusion_line = f"   - Relie les conclusions aux pratiques de {course_title} en AOF"
+        else:
+            expert_role = (
+                "Tu es un expert pédagogue en santé publique spécialisé en Afrique de l'Ouest."
+            )
+            audience_line = f"Tu génères des études de cas éducatives adaptatives pour des professionnels de santé au {country_name}."
+            mission_line = "Créer une étude de cas structurée basée sur un événement de santé publique réel en AOF."
+            context_section = (
+                "   - Présente la situation géographique, économique et sanitaire\n"
+                "   - Décrit le système de santé du pays concerné\n"
+                "   - Fournit les indicateurs de santé pertinents avant l'événement"
+            )
+            data_sources = "   - Sources : DHIS2, OMS AFRO, MSF, ministère de la santé"
+            conclusion_line = "   - Relie les conclusions aux pratiques de santé publique en AOF"
 
-MISSION : Créer une étude de cas structurée basée sur un événement de santé publique réel en AOF.
+        return f"""{expert_role}
+{audience_line}
+
+MISSION : {mission_line}
 
 CONTEXTE UTILISATEUR :
 - Pays : {country_name}
@@ -59,15 +89,13 @@ CONTEXTE UTILISATEUR :
 STRUCTURE REQUISE pour l'étude de cas :
 
 1. **Contexte AOF** (2-3 paragraphes)
-   - Présente la situation géographique, économique et sanitaire
-   - Décrit le système de santé du pays concerné
-   - Fournit les indicateurs de santé pertinents avant l'événement
+{context_section}
 
 2. **Données réelles** (tableaux ou listes structurées)
-   - Données épidémiologiques : cas confirmés, décès, taux d'attaque
+   - Données quantitatives : chiffres clés, indicateurs mesurables
    - Données temporelles : chronologie de l'événement
-   - Données géographiques : distribution des cas
-   - Sources : DHIS2, OMS AFRO, MSF, ministère de la santé
+   - Données géographiques ou organisationnelles : distribution des faits
+{data_sources}
 
 3. **Questions guidées** (4-6 questions progressives)
    - Niveau débutant : questions d'identification et de description
@@ -79,7 +107,7 @@ STRUCTURE REQUISE pour l'étude de cas :
    - Répond à chaque question guidée avec une explication complète
    - Cite les références bibliographiques utilisées
    - Propose des leçons apprises et recommandations
-   - Relie les conclusions aux pratiques de santé publique en AOF
+{conclusion_line}
 
 EXIGENCES CRITIQUES :
 - Base-toi UNIQUEMENT sur les documents fournis - ne pas inventer d'informations
@@ -91,10 +119,37 @@ EXIGENCES CRITIQUES :
 RÉPONSE ATTENDUE : Étude de cas directement utilisable, structurée en 4 sections numérotées."""
 
     else:
-        return f"""You are a public health education expert specializing in West Africa.
-You generate adaptive educational case studies for health professionals in {country_name}.
+        if course_title:
+            expert_role = f"You are an expert educator in {course_title} specializing in the West African context."
+            audience_line = f"You generate adaptive educational case studies for professionals in {country_name} in the domain: {course_title}."
+            mission_line = f"Create a structured case study based on a real situation related to {course_title} in West Africa."
+            context_section = (
+                f"   - Present the geographic, economic and organizational situation\n"
+                f"   - Describe the institutional context of the country concerned\n"
+                f"   - Provide relevant indicators for {course_title} before the event"
+            )
+            data_sources = (
+                "   - Sources: professional organizations, institutional reports, sector data"
+            )
+            conclusion_line = f"   - Links conclusions to {course_title} practices in West Africa"
+        else:
+            expert_role = "You are a public health education expert specializing in West Africa."
+            audience_line = f"You generate adaptive educational case studies for health professionals in {country_name}."
+            mission_line = (
+                "Create a structured case study based on a real public health event in West Africa."
+            )
+            context_section = (
+                "   - Present the geographic, economic and health situation\n"
+                "   - Describe the health system of the country concerned\n"
+                "   - Provide relevant health indicators before the event"
+            )
+            data_sources = "   - Sources: DHIS2, WHO AFRO, MSF, Ministry of Health"
+            conclusion_line = "   - Links conclusions to public health practices in West Africa"
 
-MISSION: Create a structured case study based on a real public health event in West Africa.
+        return f"""{expert_role}
+{audience_line}
+
+MISSION: {mission_line}
 
 USER CONTEXT:
 - Country: {country_name}
@@ -105,15 +160,13 @@ USER CONTEXT:
 REQUIRED STRUCTURE for the case study:
 
 1. **AOF Context** (2-3 paragraphs)
-   - Present the geographic, economic and health situation
-   - Describe the health system of the country concerned
-   - Provide relevant health indicators before the event
+{context_section}
 
 2. **Real Data** (tables or structured lists)
-   - Epidemiological data: confirmed cases, deaths, attack rates
+   - Quantitative data: key figures, measurable indicators
    - Temporal data: event timeline
-   - Geographic data: case distribution
-   - Sources: DHIS2, WHO AFRO, MSF, Ministry of Health
+   - Geographic or organizational data: distribution of facts
+{data_sources}
 
 3. **Guided Questions** (4-6 progressive questions)
    - Beginner level: identification and description questions
@@ -125,16 +178,41 @@ REQUIRED STRUCTURE for the case study:
    - Answers each guided question with full explanation
    - Cites used bibliographic references
    - Proposes lessons learned and recommendations
-   - Links conclusions to public health practices in West Africa
+{conclusion_line}
 
 CRITICAL REQUIREMENTS:
 - Base content ONLY on provided documents - do not invent information
 - Cite sources in brackets [Donaldson Ch.3, p.45]
-- Use real or realistic data for AOF context
+- Use real or realistic data for West African context
 - Adapt question complexity to level {level}/4
 - Include at least one verifiable numeric data point
 
 EXPECTED RESPONSE: Directly usable case study, structured in 4 numbered sections."""
+
+
+def _get_case_study_topic(
+    module_id: str | None,
+    language: Literal["fr", "en"],
+    syllabus_json: dict | None = None,
+) -> str | None:
+    """Resolve case study topic from syllabus_json or fallback to CASE_STUDY_TOPICS."""
+    if syllabus_json:
+        case_study_topics = syllabus_json.get("case_study_topics") or syllabus_json.get(
+            "case_studies"
+        )
+        if isinstance(case_study_topics, list) and case_study_topics:
+            first = case_study_topics[0]
+            if isinstance(first, dict):
+                return first.get(language) or first.get("fr") or first.get("en") or str(first)
+            return str(first)
+        if isinstance(case_study_topics, dict):
+            return case_study_topics.get(language) or case_study_topics.get("fr")
+
+    module_key = module_id.upper() if module_id else None
+    if module_key and module_key in CASE_STUDY_TOPICS:
+        return CASE_STUDY_TOPICS[module_key][language]
+
+    return None
 
 
 def format_rag_context_for_case_study(
@@ -144,13 +222,11 @@ def format_rag_context_for_case_study(
     unit_id: str,
     language: Literal["fr", "en"],
     module_id: str | None = None,
+    syllabus_json: dict | None = None,
 ) -> str:
     """Format RAG chunks into context for case study generation."""
 
-    module_key = module_id.upper() if module_id else None
-    topic = None
-    if module_key and module_key in CASE_STUDY_TOPICS:
-        topic = CASE_STUDY_TOPICS[module_key][language]
+    topic = _get_case_study_topic(module_id, language, syllabus_json)
 
     if language == "fr":
         topic_line = f'Sujet recommandé : "{topic}"\n' if topic else ""

--- a/backend/app/ai/prompts/lesson.py
+++ b/backend/app/ai/prompts/lesson.py
@@ -41,7 +41,12 @@ COUNTRY_NAMES_EN = {
 
 
 def get_lesson_system_prompt(
-    language: Literal["fr", "en"], country: str, level: int, bloom_level: str
+    language: Literal["fr", "en"],
+    country: str,
+    level: int,
+    bloom_level: str,
+    course_title: str | None = None,
+    course_description: str | None = None,
 ) -> str:
     """Generate system prompt for lesson content generation."""
 
@@ -49,8 +54,39 @@ def get_lesson_system_prompt(
     country_name = country_names.get(country, country)
 
     if language == "fr":
-        return f"""Tu es un expert pédagogue en santé publique spécialisé en Afrique de l'Ouest.
-Tu génères du contenu éducatif adaptatif pour des professionnels de santé au {country_name}.
+        if course_title:
+            expert_role = f"Tu es un expert pédagogue en {course_title} spécialisé pour le contexte d'Afrique de l'Ouest."
+            audience_line = f"Tu génères du contenu éducatif adaptatif pour des professionnels au {country_name} dans le domaine : {course_title}."
+            intro_guidance = (
+                f"Présente le sujet dans le contexte de {course_title} en Afrique de l'Ouest"
+            )
+            if course_description:
+                intro_guidance += f" ({course_description[:150]})"
+            challenge_line = f"Lie le concept aux défis de {country_name} dans ce domaine"
+            data_line = (
+                "Intègre des données et exemples pertinents d'Afrique de l'Ouest pour ce domaine"
+            )
+            example_line = f"Utilise un cas pratique du {country_name} ou d'un pays voisin CEDEAO lié à {course_title}"
+            synthesis_line = f"Relie aux enjeux régionaux dans le domaine de {course_title}"
+            criteria_examples = (
+                f"Utilise des exemples et situations pertinents pour {course_title} en AOF"
+            )
+        else:
+            expert_role = (
+                "Tu es un expert pédagogue en santé publique spécialisé en Afrique de l'Ouest."
+            )
+            audience_line = f"Tu génères du contenu éducatif adaptatif pour des professionnels de santé au {country_name}."
+            intro_guidance = (
+                "Présente le sujet dans le contexte de la santé publique en Afrique de l'Ouest"
+            )
+            challenge_line = f"Lie le concept aux défis sanitaires du {country_name}"
+            data_line = "Intègre les données épidémiologiques d'Afrique de l'Ouest quand pertinent"
+            example_line = f"Utilise un cas pratique du {country_name} ou d'un pays voisin CEDEAO"
+            synthesis_line = "Relie aux enjeux de santé publique régionaux"
+            criteria_examples = "Utilise des exemples de maladies/situations communes en AOF"
+
+        return f"""{expert_role}
+{audience_line}
 
 MISSION : Créer une leçon structurée basée sur les documents de référence fournis.
 
@@ -63,21 +99,21 @@ CONTEXTE UTILISATEUR :
 STRUCTURE REQUISE pour chaque leçon :
 
 1. **Introduction** (2-3 phrases)
-   - Présente le sujet dans le contexte de la santé publique en Afrique de l'Ouest
-   - Lie le concept aux défis sanitaires du {country_name}
+   - {intro_guidance}
+   - {challenge_line}
 
 2. **Concepts clés** (3-4 paragraphes)
    - Explique les concepts principaux basés sur les documents
    - Adapte le niveau de complexité au niveau {level}/4
-   - Intègre les données épidémiologiques d'Afrique de l'Ouest quand pertinent
+   - {data_line}
 
 3. **Exemple concret AOF** (1-2 paragraphes)
-   - Utilise un cas pratique du {country_name} ou d'un pays voisin CEDEAO
+   - {example_line}
    - Montre l'application concrète des concepts
 
 4. **Synthèse** (1 paragraphe)
    - Résume les points essentiels
-   - Relie aux enjeux de santé publique régionaux
+   - {synthesis_line}
 
 5. **Points clés à retenir** (5 points maximum)
    - Liste numérotée des éléments essentiels
@@ -87,14 +123,39 @@ EXIGENCES CRITIQUES :
 - Base-toi UNIQUEMENT sur les documents fournis - ne pas inventer d'informations
 - Cite tes sources entre crochets [Donaldson Ch.3, p.45]
 - Adapte le vocabulaire technique au niveau de l'apprenant
-- Utilise des exemples de maladies/situations communes en AOF
+- {criteria_examples}
 - Respecte les particularités culturelles et économiques du contexte
 
 RÉPONSE ATTENDUE : Contenu de leçon directement utilisable, sans métadiscours."""
 
     else:  # English
-        return f"""You are a public health education expert specializing in West Africa.
-You generate adaptive educational content for health professionals in {country_name}.
+        if course_title:
+            expert_role = f"You are an expert educator in {course_title} specializing in the West African context."
+            audience_line = f"You generate adaptive educational content for professionals in {country_name} in the domain: {course_title}."
+            intro_guidance = f"Present the topic in the context of {course_title} in West Africa"
+            if course_description:
+                intro_guidance += f" ({course_description[:150]})"
+            challenge_line = f"Link the concept to challenges in {country_name} in this domain"
+            data_line = "Integrate relevant data and examples from West Africa for this domain"
+            example_line = f"Use a practical case from {country_name} or a neighboring ECOWAS country related to {course_title}"
+            synthesis_line = f"Connect to regional challenges in the domain of {course_title}"
+            criteria_examples = (
+                f"Use examples and situations relevant to {course_title} in West Africa"
+            )
+        else:
+            expert_role = "You are a public health education expert specializing in West Africa."
+            audience_line = f"You generate adaptive educational content for health professionals in {country_name}."
+            intro_guidance = "Present the topic in the context of West African public health"
+            challenge_line = f"Link the concept to health challenges in {country_name}"
+            data_line = "Integrate West African epidemiological data when relevant"
+            example_line = (
+                f"Use a practical case from {country_name} or a neighboring ECOWAS country"
+            )
+            synthesis_line = "Connect to regional public health issues"
+            criteria_examples = "Use examples of diseases/situations common in West Africa"
+
+        return f"""{expert_role}
+{audience_line}
 
 MISSION: Create a structured lesson based on the provided reference documents.
 
@@ -107,21 +168,21 @@ USER CONTEXT:
 REQUIRED STRUCTURE for each lesson:
 
 1. **Introduction** (2-3 sentences)
-   - Present the topic in the context of West African public health
-   - Link the concept to health challenges in {country_name}
+   - {intro_guidance}
+   - {challenge_line}
 
 2. **Key Concepts** (3-4 paragraphs)
    - Explain main concepts based on the documents
    - Adapt complexity level to level {level}/4
-   - Integrate West African epidemiological data when relevant
+   - {data_line}
 
 3. **Concrete AOF Example** (1-2 paragraphs)
-   - Use a practical case from {country_name} or a neighboring ECOWAS country
+   - {example_line}
    - Show concrete application of concepts
 
 4. **Synthesis** (1 paragraph)
    - Summarize essential points
-   - Connect to regional public health issues
+   - {synthesis_line}
 
 5. **Key Takeaways** (maximum 5 points)
    - Numbered list of essential elements
@@ -131,7 +192,7 @@ CRITICAL REQUIREMENTS:
 - Base content ONLY on provided documents - do not invent information
 - Cite sources in brackets [Donaldson Ch.3, p.45]
 - Adapt technical vocabulary to learner level
-- Use examples of diseases/situations common in AOF
+- {criteria_examples}
 - Respect cultural and economic particularities of the context
 
 EXPECTED RESPONSE: Directly usable lesson content, without meta-discourse."""

--- a/backend/app/ai/prompts/quiz.py
+++ b/backend/app/ai/prompts/quiz.py
@@ -1,8 +1,8 @@
 """Claude prompts for quiz generation."""
 
 QUIZ_GENERATION_PROMPT = """
-Tu es un expert en santé publique spécialisé dans la création de contenus pédagogiques
-pour l'Afrique de l'Ouest.
+Tu es un expert spécialisé dans la création de contenus pédagogiques pour l'Afrique de l'Ouest
+dans le domaine : {course_context}.
 
 Tu dois créer un quiz formatif de 10 questions à choix multiples (QCM) basé sur le contenu fourni.
 
@@ -15,9 +15,10 @@ Tu dois créer un quiz formatif de 10 questions à choix multiples (QCM) basé s
 5. **Sources**: Chaque question doit citer sa source (chapitre, page)
 
 ## Adaptation contextuelle:
+- **Domaine**: {course_context}
 - **Langue**: {language}
 - **Niveau**: Adapté au niveau utilisateur
-- **Contexte**: Inclure des exemples pertinents pour l'Afrique de l'Ouest quand approprié
+- **Contexte**: Inclure des exemples pertinents pour l'Afrique de l'Ouest dans le domaine {course_context}
 
 ## Types de questions à créer:
 - **Faciles (3)**: Définitions, concepts de base, mémorisation
@@ -50,11 +51,11 @@ Tu dois créer un quiz formatif de 10 questions à choix multiples (QCM) basé s
 
 ## Critères de qualité:
 
-1. **Précision scientifique**: Informations exactes et à jour
+1. **Précision**: Informations exactes et à jour pour {course_context}
 2. **Pertinence pédagogique**: Questions alignées sur les objectifs d'apprentissage
 3. **Clarté**: Formulation claire et non ambiguë
 4. **Diversité**: Variété dans les types de questions et concepts couverts
-5. **Contextualisation**: Exemples adaptés à l'Afrique de l'Ouest
+5. **Contextualisation**: Exemples adaptés à l'Afrique de l'Ouest dans le domaine {course_context}
 
 ## Distracteurs (mauvaises options):
 - Plausibles mais incorrects
@@ -69,7 +70,8 @@ Génère maintenant le quiz basé sur ce contenu:
 
 
 QUIZ_GENERATION_PROMPT_EN = """
-You are a public health expert specializing in creating educational content for West Africa.
+You are an expert specializing in creating educational content for West Africa
+in the domain: {course_context}.
 
 You must create a formative quiz with 10 multiple-choice questions (MCQ)
 based on the provided content.
@@ -83,9 +85,10 @@ based on the provided content.
 5. **Sources**: Each question must cite its source (chapter, page)
 
 ## Contextual adaptation:
+- **Domain**: {course_context}
 - **Language**: {language}
 - **Level**: Adapted to user level
-- **Context**: Include relevant examples for West Africa when appropriate
+- **Context**: Include relevant examples for West Africa when appropriate for {course_context}
 
 ## Types of questions to create:
 - **Easy (3)**: Definitions, basic concepts, memorization
@@ -118,11 +121,11 @@ based on the provided content.
 
 ## Quality criteria:
 
-1. **Scientific accuracy**: Exact and up-to-date information
+1. **Accuracy**: Exact and up-to-date information for {course_context}
 2. **Pedagogical relevance**: Questions aligned with learning objectives
 3. **Clarity**: Clear and unambiguous formulation
 4. **Diversity**: Variety in question types and concepts covered
-5. **Contextualization**: Examples adapted to West Africa
+5. **Contextualization**: Examples adapted to West Africa in the domain {course_context}
 
 ## Distractors (incorrect options):
 - Plausible but incorrect

--- a/backend/app/domain/services/lesson_service.py
+++ b/backend/app/domain/services/lesson_service.py
@@ -9,6 +9,7 @@ import structlog
 from sqlalchemy import and_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.ai.claude_service import ClaudeService
 from app.ai.prompts.case_study import (
@@ -25,6 +26,7 @@ from app.api.v1.schemas.content import (
     StreamingEvent,
 )
 from app.domain.models.content import GeneratedContent
+from app.domain.models.course import Course
 from app.domain.models.module import Module
 from app.domain.models.module_unit import ModuleUnit
 from app.domain.services.platform_settings_service import SettingsCache
@@ -82,8 +84,10 @@ class LessonGenerationService:
                 )
                 return cached_lesson
 
-        # Get module information
-        module_result = await session.execute(select(Module).where(Module.id == module_id))
+        # Get module information (eager-load course for prompt context)
+        module_result = await session.execute(
+            select(Module).where(Module.id == module_id).options(selectinload(Module.course))
+        )
         module = module_result.scalar_one_or_none()
 
         if not module:
@@ -141,8 +145,10 @@ class LessonGenerationService:
                 yield StreamingEvent(event="complete", data=cached_lesson.model_dump())
                 return
 
-            # Get module information
-            module_result = await session.execute(select(Module).where(Module.id == module_id))
+            # Get module information (eager-load course for prompt context)
+            module_result = await session.execute(
+                select(Module).where(Module.id == module_id).options(selectinload(Module.course))
+            )
             module = module_result.scalar_one_or_none()
 
             if not module:
@@ -177,7 +183,21 @@ class LessonGenerationService:
             yield StreamingEvent(event="chunk", data="Documents trouvés, génération en cours...")
 
             # Generate lesson using Claude API with streaming
-            system_prompt = get_lesson_system_prompt(language, country, level, module.bloom_level)
+            course: Course | None = module.course
+            system_prompt = get_lesson_system_prompt(
+                language,
+                country,
+                level,
+                module.bloom_level,
+                course_title=(
+                    (course.title_fr if language == "fr" else course.title_en) if course else None
+                ),
+                course_description=(
+                    (course.description_fr if language == "fr" else course.description_en)
+                    if course
+                    else None
+                ),
+            )
             user_message = format_rag_context_for_lesson(
                 rag_chunks,
                 query,
@@ -286,7 +306,21 @@ class LessonGenerationService:
             raise ValueError(f"No relevant content found for module {module.id}, unit {unit_id}")
 
         # Generate content with Claude
-        system_prompt = get_lesson_system_prompt(language, country, level, module.bloom_level)
+        course: Course | None = module.course
+        system_prompt = get_lesson_system_prompt(
+            language,
+            country,
+            level,
+            module.bloom_level,
+            course_title=(
+                (course.title_fr if language == "fr" else course.title_en) if course else None
+            ),
+            course_description=(
+                (course.description_fr if language == "fr" else course.description_en)
+                if course
+                else None
+            ),
+        )
         user_message = format_rag_context_for_lesson(
             rag_chunks,
             query,
@@ -520,7 +554,9 @@ class CaseStudyGenerationService:
                 )
                 return cached
 
-        module_result = await session.execute(select(Module).where(Module.id == module_id))
+        module_result = await session.execute(
+            select(Module).where(Module.id == module_id).options(selectinload(Module.course))
+        )
         module = module_result.scalar_one_or_none()
 
         if not module:
@@ -567,7 +603,9 @@ class CaseStudyGenerationService:
                 yield StreamingEvent(event="complete", data=cached.model_dump())
                 return
 
-            module_result = await session.execute(select(Module).where(Module.id == module_id))
+            module_result = await session.execute(
+                select(Module).where(Module.id == module_id).options(selectinload(Module.course))
+            )
             module = module_result.scalar_one_or_none()
 
             if not module:
@@ -600,8 +638,20 @@ class CaseStudyGenerationService:
             yield StreamingEvent(event="chunk", data="Documents trouvés, génération en cours...")
 
             module_key = f"M{module.module_number:02d}"
+            course: Course | None = module.course
             system_prompt = get_case_study_system_prompt(
-                language, country, level, module.bloom_level
+                language,
+                country,
+                level,
+                module.bloom_level,
+                course_title=(
+                    (course.title_fr if language == "fr" else course.title_en) if course else None
+                ),
+                course_description=(
+                    (course.description_fr if language == "fr" else course.description_en)
+                    if course
+                    else None
+                ),
             )
             user_message = format_rag_context_for_case_study(
                 rag_chunks,
@@ -610,6 +660,7 @@ class CaseStudyGenerationService:
                 unit_id,
                 language,
                 module_id=module_key,
+                syllabus_json=course.syllabus_json if course else None,
             )
 
             accumulated_content = ""
@@ -708,7 +759,21 @@ class CaseStudyGenerationService:
             raise ValueError(f"No relevant content found for module {module.id}, unit {unit_id}")
 
         module_key = f"M{module.module_number:02d}"
-        system_prompt = get_case_study_system_prompt(language, country, level, module.bloom_level)
+        course: Course | None = module.course
+        system_prompt = get_case_study_system_prompt(
+            language,
+            country,
+            level,
+            module.bloom_level,
+            course_title=(
+                (course.title_fr if language == "fr" else course.title_en) if course else None
+            ),
+            course_description=(
+                (course.description_fr if language == "fr" else course.description_en)
+                if course
+                else None
+            ),
+        )
         user_message = format_rag_context_for_case_study(
             rag_chunks,
             query,
@@ -716,6 +781,7 @@ class CaseStudyGenerationService:
             unit_id,
             language,
             module_id=module_key,
+            syllabus_json=course.syllabus_json if course else None,
         )
 
         response = await self.claude_service.generate_lesson_content(system_prompt, user_message)

--- a/backend/app/domain/services/quiz_service.py
+++ b/backend/app/domain/services/quiz_service.py
@@ -7,11 +7,13 @@ import structlog
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.ai.claude_service import ClaudeService
 from app.ai.rag.retriever import SemanticRetriever
 from app.api.v1.schemas.quiz import QuizContent, QuizResponse
 from app.domain.models.content import GeneratedContent
+from app.domain.models.course import Course
 from app.domain.models.module import Module
 from app.domain.services.platform_settings_service import SettingsCache
 
@@ -217,9 +219,16 @@ class QuizService:
         """
         try:
             module: Module | None = None
+            course: Course | None = None
             if session is not None:
-                module_result = await session.execute(select(Module).where(Module.id == module_id))
+                module_result = await session.execute(
+                    select(Module)
+                    .where(Module.id == module_id)
+                    .options(selectinload(Module.course))
+                )
                 module = module_result.scalar_one_or_none()
+                if module:
+                    course = module.course
 
             search_query = self._build_quiz_search_query(module, unit_id, language)
             search_results = await self.semantic_retriever.search_for_module(
@@ -247,6 +256,14 @@ class QuizService:
                 country=country,
                 level=level,
                 num_questions=num_questions,
+                course_title=(
+                    (course.title_fr if language == "fr" else course.title_en) if course else None
+                ),
+                course_description=(
+                    (course.description_fr if language == "fr" else course.description_en)
+                    if course
+                    else None
+                ),
             )
 
             response = await self.claude_service.generate_structured_content(
@@ -289,6 +306,8 @@ class QuizService:
         country: str,
         level: int,
         num_questions: int,
+        course_title: str | None = None,
+        course_description: str | None = None,
     ) -> tuple[str, str]:
         """Build the system and user prompts for Claude API to generate quiz questions."""
 
@@ -300,17 +319,41 @@ class QuizService:
             4: "expert (research, policy implications)",
         }
 
-        system_prompt = """You are an expert public health educator creating adaptive quiz content for West African health professionals.
+        domain = course_title or "public health"
 
-CRITICAL: You MUST respond with valid JSON ONLY. No preamble, no explanation, no markdown code fences. Your entire response must be a single JSON object starting with { and ending with }. The JSON must have exactly these top-level keys: "title", "description", "questions", "time_limit_minutes", "passing_score"."""
+        system_prompt = f"""You are an expert educator creating adaptive quiz content for West African professionals in {domain}.
 
-        user_message = f"""Create a multiple-choice quiz for public health professionals in West Africa.
+CRITICAL: You MUST respond with valid JSON ONLY. No preamble, no explanation, no markdown code fences. Your entire response must be a single JSON object starting with {{ and ending with }}. The JSON must have exactly these top-level keys: "title", "description", "questions", "time_limit_minutes", "passing_score"."""
+
+        audience = (
+            f"professionals in {domain} in {country}"
+            if course_title
+            else f"public health professionals in {country}"
+        )
+        context_note = (
+            f"Use examples relevant to {country} and West African context when possible, adapted to {domain}"
+            if course_title
+            else f"Use examples relevant to {country} and West African context when possible"
+        )
+        practical_note = (
+            f"Focus on practical applications for {domain} work"
+            if course_title
+            else "Focus on practical applications for public health work"
+        )
+        closing_note = (
+            f"Generate the quiz now, ensuring all questions are relevant to {domain} practice in West Africa."
+            if course_title
+            else "Generate the quiz now, ensuring all questions are relevant to public health practice in West Africa."
+        )
+
+        user_message = f"""Create a multiple-choice quiz for {audience}.
 
 CONTEXT MATERIAL:
 {context}
 
 QUIZ REQUIREMENTS:
-- Target audience: Public health professionals in {country}
+- Target audience: {audience.capitalize()}
+- Domain: {domain}
 - Language: {lang_instruction}
 - Level: {level_desc.get(level, "intermediate")}
 - Unit: {unit_id}
@@ -324,9 +367,9 @@ INSTRUCTIONS:
 3. Only ONE option should be correct
 4. Include clear explanations for why the correct answer is right
 5. Add source citations from the context material
-6. Use examples relevant to {country} and West African context when possible
+6. {context_note}
 7. Progress from easier to harder questions
-8. Focus on practical applications for public health work
+8. {practical_note}
 
 RESPONSE FORMAT (JSON):
 {{
@@ -352,7 +395,7 @@ RESPONSE FORMAT (JSON):
   "passing_score": {SettingsCache.instance().get("quiz-passing-score", 80.0)}
 }}
 
-Generate the quiz now, ensuring all questions are relevant to public health practice in West Africa."""
+{closing_note}"""
 
         return system_prompt, user_message
 


### PR DESCRIPTION
## Summary

Fixes #728 — AI system prompts were hardcoded to "public health" framing, causing health-related examples (nurses, epidemiology, vaccination) to appear in non-health courses like Internal Audit.

## Changes

- **`backend/app/ai/prompts/lesson.py`** — `get_lesson_system_prompt()` now accepts optional `course_title` and `course_description`; all role definitions, contextual examples, and domain references adapt dynamically to the course
- **`backend/app/ai/prompts/quiz.py`** — Added `{course_context}` placeholder to both FR/EN template strings (templates now properly parameterized)
- **`backend/app/ai/prompts/case_study.py`** — `get_case_study_system_prompt()` accepts `course_title`/`course_description`; new `_get_case_study_topic()` helper prefers `course.syllabus_json["case_study_topics"]` over hardcoded `CASE_STUDY_TOPICS` dict; `format_rag_context_for_case_study()` exposes `syllabus_json` param
- **`backend/app/domain/services/lesson_service.py`** — All module queries now eager-load `Module.course` via `selectinload`; course title/description passed to both lesson and case study prompt builders (streaming and non-streaming paths)
- **`backend/app/domain/services/quiz_service.py`** — Module query now eager-loads `Module.course`; `_build_quiz_prompt()` gains optional `course_title`/`course_description` params; system prompt and user message adapt to course domain

## Test plan

- [x] All 368 backend tests pass (`uv run pytest`)
- [x] Ruff lint passes (`uv run ruff check .`)
- [x] Ruff format passes (`uv run ruff format .`)
- [ ] Manual test: generate lesson for Internal Audit course — expect audit/governance examples, not health examples
- [ ] Manual test: generate lesson for public health course without course set — expect unchanged behavior (backward compatible)

Generated with [Claude Code](https://claude.ai/code)