### PR TITLE
feat(rag): chunk-image linker for explicit and contextual references

### DIFF
--- a/backend/app/ai/rag/image_linker.py
+++ b/backend/app/ai/rag/image_linker.py
@@ -1,0 +1,179 @@
+"""Links SourceImage records to DocumentChunk records via the source_image_chunks junction table.
+
+Two link types:
+- explicit: chunk text contains a "Figure X.Y" reference matching the image's figure_number
+- contextual: image and chunk share the same page number (proximity)
+"""
+
+from __future__ import annotations
+
+import re
+
+import structlog
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.models.document_chunk import DocumentChunk
+from app.domain.models.source_image import SourceImage, SourceImageChunk
+
+logger = structlog.get_logger(__name__)
+
+_FIGURE_RE = re.compile(r"Figure\s+(\d+\.?\d*)", re.IGNORECASE)
+
+
+class ImageLinker:
+    """Links images to text chunks for a given source document."""
+
+    async def link_images_to_chunks(self, source: str, session: AsyncSession) -> int:
+        """Create explicit and contextual links between images and chunks.
+
+        Args:
+            source: The source identifier (e.g. "donaldson").
+            session: Async SQLAlchemy session.
+
+        Returns:
+            Total number of new junction rows inserted.
+        """
+        explicit_pairs = await self._build_explicit_pairs(source, session)
+        contextual_pairs = await self._build_contextual_pairs(source, session, explicit_pairs)
+
+        rows: list[SourceImageChunk] = []
+        for image_id, chunk_id in explicit_pairs:
+            rows.append(
+                SourceImageChunk(
+                    source_image_id=image_id,
+                    document_chunk_id=chunk_id,
+                    reference_type="explicit",
+                )
+            )
+        for image_id, chunk_id in contextual_pairs:
+            rows.append(
+                SourceImageChunk(
+                    source_image_id=image_id,
+                    document_chunk_id=chunk_id,
+                    reference_type="contextual",
+                )
+            )
+
+        if rows:
+            session.add_all(rows)
+            await session.flush()
+
+        logger.info(
+            "image_linker.linked",
+            source=source,
+            explicit=len(explicit_pairs),
+            contextual=len(contextual_pairs),
+            total=len(rows),
+        )
+        return len(rows)
+
+    async def clear_links_for_source(self, source: str, session: AsyncSession) -> int:
+        """Delete all junction rows for images belonging to the given source.
+
+        Args:
+            source: The source identifier.
+            session: Async SQLAlchemy session.
+
+        Returns:
+            Number of deleted rows.
+        """
+        image_ids_result = await session.execute(
+            select(SourceImage.id).where(SourceImage.source == source)
+        )
+        image_ids = [row[0] for row in image_ids_result.all()]
+
+        if not image_ids:
+            return 0
+
+        result = await session.execute(
+            delete(SourceImageChunk).where(SourceImageChunk.source_image_id.in_(image_ids))
+        )
+        await session.flush()
+        deleted = result.rowcount
+        logger.info("image_linker.cleared", source=source, deleted=deleted)
+        return deleted
+
+    async def _build_explicit_pairs(self, source: str, session: AsyncSession) -> set[tuple]:
+        """Scan chunk content for Figure references and match to images."""
+        chunks_result = await session.execute(
+            select(DocumentChunk.id, DocumentChunk.content).where(DocumentChunk.source == source)
+        )
+        chunks = chunks_result.all()
+
+        images_result = await session.execute(
+            select(SourceImage.id, SourceImage.figure_number).where(
+                SourceImage.source == source,
+                SourceImage.figure_number.isnot(None),
+            )
+        )
+        figure_map: dict[str, object] = {}
+        for image_id, figure_number in images_result.all():
+            if figure_number:
+                figure_map[figure_number.strip()] = image_id
+
+        existing_pairs = await self._get_existing_pairs(source, session)
+
+        pairs: set[tuple] = set()
+        for chunk_id, content in chunks:
+            for match in _FIGURE_RE.finditer(content):
+                figure_num = match.group(1).strip()
+                image_id = figure_map.get(figure_num)
+                if image_id is not None:
+                    pair = (image_id, chunk_id)
+                    if pair not in existing_pairs:
+                        pairs.add(pair)
+
+        return pairs
+
+    async def _build_contextual_pairs(
+        self,
+        source: str,
+        session: AsyncSession,
+        explicit_pairs: set[tuple],
+    ) -> set[tuple]:
+        """Find same-page image↔chunk pairs, skipping already-explicit ones."""
+        images_result = await session.execute(
+            select(SourceImage.id, SourceImage.page_number).where(SourceImage.source == source)
+        )
+        images = images_result.all()
+
+        chunks_result = await session.execute(
+            select(DocumentChunk.id, DocumentChunk.page).where(
+                DocumentChunk.source == source,
+                DocumentChunk.page.isnot(None),
+            )
+        )
+        page_to_chunks: dict[int, list] = {}
+        for chunk_id, page in chunks_result.all():
+            page_to_chunks.setdefault(page, []).append(chunk_id)
+
+        existing_pairs = await self._get_existing_pairs(source, session)
+        explicit_image_chunk = {(img_id, c_id) for img_id, c_id in explicit_pairs}
+
+        pairs: set[tuple] = set()
+        for image_id, page_number in images:
+            for chunk_id in page_to_chunks.get(page_number, []):
+                pair = (image_id, chunk_id)
+                if pair not in existing_pairs and pair not in explicit_image_chunk:
+                    pairs.add(pair)
+
+        return pairs
+
+    async def _get_existing_pairs(self, source: str, session: AsyncSession) -> set[tuple]:
+        """Return set of (source_image_id, document_chunk_id) pairs already in DB."""
+        image_ids_result = await session.execute(
+            select(SourceImage.id).where(SourceImage.source == source)
+        )
+        image_ids = [row[0] for row in image_ids_result.all()]
+
+        if not image_ids:
+            return set()
+
+        existing_result = await session.execute(
+            select(
+                SourceImageChunk.source_image_id,
+                SourceImageChunk.document_chunk_id,
+            ).where(SourceImageChunk.source_image_id.in_(image_ids))
+        )
+        return {(row[0], row[1]) for row in existing_result.all()}

--- a/backend/tests/test_image_linker.py
+++ b/backend/tests/test_image_linker.py
@@ -1,0 +1,412 @@
+"""Unit tests for ImageLinker — explicit and contextual chunk↔image linkage."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.ai.rag.image_linker import _FIGURE_RE, ImageLinker
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _uuid():
+    return uuid.uuid4()
+
+
+def _mock_session():
+    session = AsyncMock()
+    session.add_all = MagicMock()
+    session.flush = AsyncMock()
+    return session
+
+
+def _make_execute_result(rows: list):
+    result = MagicMock()
+    result.all.return_value = rows
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Regex tests
+# ---------------------------------------------------------------------------
+
+
+class TestFigureRegex:
+    def test_matches_simple_figure(self):
+        matches = _FIGURE_RE.findall("See Figure 1.3 for details.")
+        assert matches == ["1.3"]
+
+    def test_matches_integer_figure(self):
+        matches = _FIGURE_RE.findall("Figure 5 shows the trend.")
+        assert matches == ["5"]
+
+    def test_case_insensitive(self):
+        matches = _FIGURE_RE.findall("figure 2.1 and FIGURE 3")
+        assert "2.1" in matches
+        assert "3" in matches
+
+    def test_no_match(self):
+        matches = _FIGURE_RE.findall("No figures here.")
+        assert matches == []
+
+    def test_multiple_figures(self):
+        matches = _FIGURE_RE.findall("See Figure 1.1 and Figure 1.2.")
+        assert matches == ["1.1", "1.2"]
+
+
+# ---------------------------------------------------------------------------
+# link_images_to_chunks — explicit linkage
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitLinkage:
+    @pytest.mark.asyncio
+    async def test_explicit_link_created_when_figure_matches(self):
+        linker = ImageLinker()
+        session = _mock_session()
+        img_id = _uuid()
+        chunk_id = _uuid()
+
+        session.execute.side_effect = [
+            _make_execute_result([(chunk_id, "See Figure 1.3 for the diagram.")]),
+            _make_execute_result([(img_id, "1.3")]),
+            _make_execute_result([]),
+            _make_execute_result([(img_id, 5)]),
+            _make_execute_result([(chunk_id, 5)]),
+            _make_execute_result([]),
+        ]
+
+        count = await linker.link_images_to_chunks("donaldson", session)
+
+        assert count >= 1
+        session.add_all.assert_called_once()
+        added = session.add_all.call_args[0][0]
+        explicit_rows = [r for r in added if r.reference_type == "explicit"]
+        assert len(explicit_rows) == 1
+        assert explicit_rows[0].source_image_id == img_id
+        assert explicit_rows[0].document_chunk_id == chunk_id
+
+    @pytest.mark.asyncio
+    async def test_no_explicit_link_when_figure_not_in_text(self):
+        linker = ImageLinker()
+        session = _mock_session()
+        img_id = _uuid()
+        chunk_id = _uuid()
+
+        session.execute.side_effect = [
+            _make_execute_result([(chunk_id, "No figures mentioned here.")]),
+            _make_execute_result([(img_id, "1.3")]),
+            _make_execute_result([]),
+            _make_execute_result([(img_id, 3)]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+        ]
+
+        count = await linker.link_images_to_chunks("donaldson", session)
+
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_no_explicit_link_when_no_matching_image(self):
+        linker = ImageLinker()
+        session = _mock_session()
+        chunk_id = _uuid()
+
+        session.execute.side_effect = [
+            _make_execute_result([(chunk_id, "Figure 9.9 details.")]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+        ]
+
+        count = await linker.link_images_to_chunks("donaldson", session)
+
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_duplicate_explicit_pair_skipped(self):
+        linker = ImageLinker()
+        session = _mock_session()
+        img_id = _uuid()
+        chunk_id = _uuid()
+
+        session.execute.side_effect = [
+            _make_execute_result([(chunk_id, "Figure 1.3 is important.")]),
+            _make_execute_result([(img_id, "1.3")]),
+            _make_execute_result([(img_id,)]),
+            _make_execute_result([(img_id, chunk_id)]),
+            _make_execute_result([(img_id, 5)]),
+            _make_execute_result([(chunk_id, 5)]),
+            _make_execute_result([(img_id,)]),
+            _make_execute_result([(img_id, chunk_id)]),
+        ]
+
+        count = await linker.link_images_to_chunks("donaldson", session)
+
+        assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# link_images_to_chunks — contextual linkage
+# ---------------------------------------------------------------------------
+
+
+class TestContextualLinkage:
+    @pytest.mark.asyncio
+    async def test_contextual_link_created_for_same_page(self):
+        linker = ImageLinker()
+        session = _mock_session()
+        img_id = _uuid()
+        chunk_id = _uuid()
+
+        session.execute.side_effect = [
+            _make_execute_result([(chunk_id, "No figures here.")]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+            _make_execute_result([(img_id, 7)]),
+            _make_execute_result([(chunk_id, 7)]),
+            _make_execute_result([]),
+        ]
+
+        count = await linker.link_images_to_chunks("donaldson", session)
+
+        assert count == 1
+        added = session.add_all.call_args[0][0]
+        contextual_rows = [r for r in added if r.reference_type == "contextual"]
+        assert len(contextual_rows) == 1
+        assert contextual_rows[0].source_image_id == img_id
+        assert contextual_rows[0].document_chunk_id == chunk_id
+
+    @pytest.mark.asyncio
+    async def test_contextual_link_skipped_when_explicit_exists(self):
+        linker = ImageLinker()
+        session = _mock_session()
+        img_id = _uuid()
+        chunk_id = _uuid()
+
+        session.execute.side_effect = [
+            _make_execute_result([(chunk_id, "See Figure 2.0 here.")]),
+            _make_execute_result([(img_id, "2.0")]),
+            _make_execute_result([]),
+            _make_execute_result([(img_id, 10)]),
+            _make_execute_result([(chunk_id, 10)]),
+            _make_execute_result([]),
+        ]
+
+        count = await linker.link_images_to_chunks("donaldson", session)
+
+        assert count == 1
+        added = session.add_all.call_args[0][0]
+        explicit_rows = [r for r in added if r.reference_type == "explicit"]
+        contextual_rows = [r for r in added if r.reference_type == "contextual"]
+        assert len(explicit_rows) == 1
+        assert len(contextual_rows) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_contextual_link_different_pages(self):
+        linker = ImageLinker()
+        session = _mock_session()
+        img_id = _uuid()
+        chunk_id = _uuid()
+
+        session.execute.side_effect = [
+            _make_execute_result([(chunk_id, "Text on page 3.")]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+            _make_execute_result([(img_id, 8)]),
+            _make_execute_result([(chunk_id, 3)]),
+            _make_execute_result([]),
+        ]
+
+        count = await linker.link_images_to_chunks("donaldson", session)
+
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_duplicate_contextual_pair_skipped(self):
+        linker = ImageLinker()
+        session = _mock_session()
+        img_id = _uuid()
+        chunk_id = _uuid()
+
+        session.execute.side_effect = [
+            _make_execute_result([(chunk_id, "Text on page 5.")]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+            _make_execute_result([(img_id, 5)]),
+            _make_execute_result([(chunk_id, 5)]),
+            _make_execute_result([(img_id,)]),
+            _make_execute_result([(img_id, chunk_id)]),
+        ]
+
+        count = await linker.link_images_to_chunks("donaldson", session)
+
+        assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# clear_links_for_source
+# ---------------------------------------------------------------------------
+
+
+class TestClearLinksForSource:
+    @pytest.mark.asyncio
+    async def test_clear_deletes_existing_rows(self):
+        linker = ImageLinker()
+        session = _mock_session()
+        img_id = _uuid()
+
+        delete_result = MagicMock()
+        delete_result.rowcount = 3
+
+        session.execute.side_effect = [
+            _make_execute_result([(img_id,)]),
+            delete_result,
+        ]
+
+        deleted = await linker.clear_links_for_source("donaldson", session)
+
+        assert deleted == 3
+        session.flush.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_clear_no_images_returns_zero(self):
+        linker = ImageLinker()
+        session = _mock_session()
+
+        session.execute.side_effect = [
+            _make_execute_result([]),
+        ]
+
+        deleted = await linker.clear_links_for_source("donaldson", session)
+
+        assert deleted == 0
+        session.flush.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_clear_only_affects_given_source(self):
+        linker = ImageLinker()
+        session = _mock_session()
+        img_id = _uuid()
+
+        delete_result = MagicMock()
+        delete_result.rowcount = 2
+
+        session.execute.side_effect = [
+            _make_execute_result([(img_id,)]),
+            delete_result,
+        ]
+
+        deleted = await linker.clear_links_for_source("triola", session)
+
+        assert deleted == 2
+
+
+# ---------------------------------------------------------------------------
+# Edge-cases and multiple images/chunks
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    @pytest.mark.asyncio
+    async def test_multiple_figures_in_single_chunk(self):
+        linker = ImageLinker()
+        session = _mock_session()
+        img1_id = _uuid()
+        img2_id = _uuid()
+        chunk_id = _uuid()
+
+        session.execute.side_effect = [
+            _make_execute_result([(chunk_id, "See Figure 1.1 and Figure 2.2.")]),
+            _make_execute_result([(img1_id, "1.1"), (img2_id, "2.2")]),
+            _make_execute_result([]),
+            _make_execute_result([(img1_id, 4), (img2_id, 9)]),
+            _make_execute_result([(chunk_id, 4)]),
+            _make_execute_result([]),
+        ]
+
+        count = await linker.link_images_to_chunks("donaldson", session)
+
+        assert count >= 2
+
+    @pytest.mark.asyncio
+    async def test_no_chunks_returns_zero(self):
+        linker = ImageLinker()
+        session = _mock_session()
+
+        session.execute.side_effect = [
+            _make_execute_result([]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+        ]
+
+        count = await linker.link_images_to_chunks("empty_source", session)
+
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_no_images_returns_zero(self):
+        linker = ImageLinker()
+        session = _mock_session()
+        chunk_id = _uuid()
+
+        session.execute.side_effect = [
+            _make_execute_result([(chunk_id, "Figure 1.1 mentioned here.")]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+        ]
+
+        count = await linker.link_images_to_chunks("donaldson", session)
+
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_flush_called_when_rows_added(self):
+        linker = ImageLinker()
+        session = _mock_session()
+        img_id = _uuid()
+        chunk_id = _uuid()
+
+        session.execute.side_effect = [
+            _make_execute_result([(chunk_id, "Figure 3.0 here.")]),
+            _make_execute_result([(img_id, "3.0")]),
+            _make_execute_result([]),
+            _make_execute_result([(img_id, 2)]),
+            _make_execute_result([(chunk_id, 99)]),
+            _make_execute_result([]),
+        ]
+
+        await linker.link_images_to_chunks("donaldson", session)
+
+        session.flush.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_flush_when_no_rows(self):
+        linker = ImageLinker()
+        session = _mock_session()
+
+        session.execute.side_effect = [
+            _make_execute_result([]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+        ]
+
+        await linker.link_images_to_chunks("empty_source", session)
+
+        session.flush.assert_not_called()


### PR DESCRIPTION
## Summary
- Add `ImageLinker` class in `backend/app/ai/rag/image_linker.py`
- Explicit linkage: regex scan for `Figure X.Y` in chunk content matched against `SourceImage.figure_number`
- Contextual linkage: same-page proximity between `SourceImage.page_number` and `DocumentChunk.page`
- Deduplication: skip pairs already present in `source_image_chunks` junction table
- Contextual skips pairs already covered by an explicit link
- Batch insert via `session.add_all` + flush
- `clear_links_for_source()` helper for re-indexation

## Changes
- `backend/app/ai/rag/image_linker.py` — `ImageLinker` with explicit + contextual linkage
- `backend/tests/test_image_linker.py` — 21 unit tests with AsyncMock sessions

## Test plan
- [x] Backend tests pass (21/21)
- [x] Ruff lint clean
- [ ] Manually verified on mobile viewport (N/A — backend only)

Closes #738

Generated with [Claude Code](https://claude.ai/code)