### PR TITLE
feat(rag): integrate image extraction into RAG pipeline and Celery task (#739)

### DIFF
--- a/backend/app/ai/rag/image_extractor.py
+++ b/backend/app/ai/rag/image_extractor.py
@@ -1,0 +1,454 @@
+"""PDF image extraction for RAG pipeline.
+
+Extracts images from reference PDFs using PyMuPDF with rich metadata:
+- Figure numbers and captions from surrounding text
+- Attribution/license information
+- Surrounding context text (~500 chars)
+- Image type classification (diagram, chart, photo, formula, icon, unknown)
+- WebP conversion via Pillow for optimal web delivery
+"""
+
+import io
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import pymupdf
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+MIN_WIDTH_PX = 100
+MIN_HEIGHT_PX = 100
+MIN_SIZE_BYTES = 5 * 1024
+WEBP_MAX_WIDTH = 1024
+WEBP_QUALITY = 87
+CAPTION_PROXIMITY_PT = 50
+SURROUNDING_CHAR_LIMIT = 500
+
+
+@dataclass
+class ExtractedImage:
+    """Represents an image extracted from a PDF with metadata."""
+
+    image_bytes: bytes
+    width: int
+    height: int
+    original_format: str
+    file_size_bytes: int
+    page_number: int
+    figure_number: str | None
+    caption: str | None
+    attribution: str | None
+    image_type: str
+    surrounding_text: str
+    chapter: str | None
+    section: str | None
+
+
+BOOKS = {
+    "donaldson": {
+        "filename_pattern": "Donaldson",
+        "figure_patterns": [r"Figure\s+(\d+\.?\d*)", r"Fig\.?\s+(\d+\.?\d*)"],
+        "exhibit_patterns": [],
+    },
+    "scutchfield": {
+        "filename_pattern": "Scutchfield",
+        "figure_patterns": [r"Figure\s+(\d+\.?\d*)", r"Fig\.?\s+(\d+\.?\d*)"],
+        "exhibit_patterns": [r"Exhibit\s+(\d+\.?\d*)"],
+    },
+    "triola": {
+        "filename_pattern": "Triola",
+        "figure_patterns": [r"Figure\s+(\d+\.?\d*)", r"Fig\.?\s+(\d+\.?\d*)"],
+        "exhibit_patterns": [r"Table\s+(\d+[\-\.]?\d*)", r"Chart\s+(\d+\.?\d*)"],
+    },
+}
+
+_ATTRIBUTION_PATTERNS = [
+    r"(?i)(credit\s*[:=]\s*[^\n]+)",
+    r"(?i)(attribution\s*[:=]\s*[^\n]+)",
+    r"(?i)(CC\s+BY[^\n]*)",
+    r"(?i)(license\s*[:=]\s*[^\n]+)",
+    r"(?i)(source\s*[:=]\s*[^\n]+)",
+    r"(?i)(©\s*[^\n]+)",
+]
+
+
+def _build_figure_patterns(book_config: dict) -> list[re.Pattern]:
+    all_patterns = book_config.get("figure_patterns", []) + book_config.get("exhibit_patterns", [])
+    if not all_patterns:
+        all_patterns = [r"Figure\s+(\d+\.?\d*)", r"Fig\.?\s+(\d+\.?\d*)"]
+    return [re.compile(p, re.IGNORECASE) for p in all_patterns]
+
+
+class PDFImageExtractor:
+    """Extract images from reference PDFs with rich metadata for RAG integration."""
+
+    def __init__(self, resources_path: Path):
+        self.resources_path = Path(resources_path)
+        if not self.resources_path.exists():
+            raise ValueError(f"Resources path does not exist: {resources_path}")
+
+    def identify_book(self, filename: str) -> str | None:
+        filename_lower = filename.lower()
+        for book_id, config in BOOKS.items():
+            if config["filename_pattern"].lower() in filename_lower:
+                return book_id
+        return None
+
+    def extract_images_from_pdf(self, pdf_path: Path, source: str) -> list[ExtractedImage]:
+        """Extract all qualifying images from a PDF with metadata.
+
+        Args:
+            pdf_path: Path to the PDF file.
+            source: Source book identifier (e.g. "donaldson").
+
+        Returns:
+            List of ExtractedImage objects; empty list if no images found.
+        """
+        if not pdf_path.exists():
+            raise FileNotFoundError(f"PDF file not found: {pdf_path}")
+
+        book_config = BOOKS.get(source, BOOKS["donaldson"])
+        figure_patterns = _build_figure_patterns(book_config)
+
+        results: list[ExtractedImage] = []
+        doc = pymupdf.open(pdf_path)
+
+        try:
+            for page_idx in range(doc.page_count):
+                page = doc.load_page(page_idx)
+                page_number = page_idx + 1
+                xrefs = page.get_images(full=True)
+
+                if not xrefs:
+                    extracted = self._try_rasterize_figure(doc, page, page_number, figure_patterns)
+                    if extracted:
+                        results.append(extracted)
+                    continue
+
+                for xref_info in xrefs:
+                    xref = xref_info[0]
+                    try:
+                        raw = doc.extract_image(xref)
+                    except Exception as exc:
+                        logger.warning(
+                            "Failed to extract image xref",
+                            page=page_number,
+                            xref=xref,
+                            error=str(exc),
+                        )
+                        continue
+
+                    if not raw:
+                        continue
+
+                    img_bytes: bytes = raw["image"]
+                    original_format: str = raw.get("ext", "png").lower()
+                    orig_width: int = raw.get("width", 0)
+                    orig_height: int = raw.get("height", 0)
+                    orig_size: int = len(img_bytes)
+
+                    if (
+                        orig_width < MIN_WIDTH_PX
+                        or orig_height < MIN_HEIGHT_PX
+                        or orig_size < MIN_SIZE_BYTES
+                    ):
+                        continue
+
+                    image_bbox = self._get_image_bbox(page, xref)
+                    metadata = self._extract_figure_metadata(page, image_bbox, figure_patterns)
+                    surrounding_text = self._extract_surrounding_text(
+                        page, image_bbox, SURROUNDING_CHAR_LIMIT
+                    )
+                    image_type = self._classify_image_type(
+                        metadata.get("caption"), orig_width, orig_height
+                    )
+
+                    try:
+                        webp_bytes, final_width, final_height = self._convert_to_webp(
+                            img_bytes, original_format, max_width=WEBP_MAX_WIDTH
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "WebP conversion failed, using original",
+                            page=page_number,
+                            error=str(exc),
+                        )
+                        webp_bytes = img_bytes
+                        final_width = orig_width
+                        final_height = orig_height
+
+                    results.append(
+                        ExtractedImage(
+                            image_bytes=webp_bytes,
+                            width=final_width,
+                            height=final_height,
+                            original_format=original_format,
+                            file_size_bytes=len(webp_bytes),
+                            page_number=page_number,
+                            figure_number=metadata.get("figure_number"),
+                            caption=metadata.get("caption"),
+                            attribution=metadata.get("attribution"),
+                            image_type=image_type,
+                            surrounding_text=surrounding_text,
+                            chapter=metadata.get("chapter"),
+                            section=metadata.get("section"),
+                        )
+                    )
+
+        finally:
+            doc.close()
+
+        logger.info(
+            "Image extraction complete",
+            source=source,
+            pdf=str(pdf_path),
+            count=len(results),
+        )
+        return results
+
+    def _get_image_bbox(self, page: pymupdf.Page, xref: int) -> pymupdf.Rect:
+        """Return the bounding box of an image on a page by its xref."""
+        for img_info in page.get_image_info(xrefs=True):
+            if img_info.get("xref") == xref:
+                bbox = img_info.get("bbox")
+                if bbox:
+                    return pymupdf.Rect(bbox)
+        return page.rect
+
+    def _extract_figure_metadata(
+        self,
+        page: pymupdf.Page,
+        image_bbox: pymupdf.Rect,
+        figure_patterns: list[re.Pattern],
+    ) -> dict:
+        """Extract figure number, caption, and attribution from text near image bbox."""
+        page_dict = page.get_text("dict")
+        blocks = page_dict.get("blocks", [])
+
+        text_blocks: list[tuple[float, str]] = []
+        for block in blocks:
+            if block.get("type") != 0:
+                continue
+            block_bbox = pymupdf.Rect(block["bbox"])
+            block_text = " ".join(
+                span["text"] for line in block.get("lines", []) for span in line.get("spans", [])
+            ).strip()
+            if not block_text:
+                continue
+            vertical_dist = min(
+                abs(block_bbox.y0 - image_bbox.y1),
+                abs(block_bbox.y1 - image_bbox.y0),
+            )
+            text_blocks.append((vertical_dist, block_text))
+
+        nearby: list[str] = [
+            text
+            for dist, text in sorted(text_blocks, key=lambda x: x[0])
+            if dist <= CAPTION_PROXIMITY_PT
+        ]
+
+        figure_number: str | None = None
+        caption: str | None = None
+        attribution: str | None = None
+        chapter: str | None = None
+        section: str | None = None
+
+        combined_nearby = " ".join(nearby)
+
+        for pattern in figure_patterns:
+            m = pattern.search(combined_nearby)
+            if m:
+                figure_number = m.group(0).strip()
+                caption_start = m.end()
+                rest = combined_nearby[caption_start:].strip()
+                if rest:
+                    caption = rest[:300].strip()
+                break
+
+        for attr_pattern in _ATTRIBUTION_PATTERNS:
+            m = re.search(attr_pattern, combined_nearby)
+            if m:
+                attribution = m.group(1).strip()
+                break
+
+        ch_match = re.search(r"(?i)chapter\s+(\d+)[:\s–-]*([^\n]{0,80})", combined_nearby)
+        if ch_match:
+            chapter = ch_match.group(0).strip()
+
+        return {
+            "figure_number": figure_number,
+            "caption": caption,
+            "attribution": attribution,
+            "chapter": chapter,
+            "section": section,
+        }
+
+    def _classify_image_type(self, caption: str | None, width: int, height: int) -> str:
+        """Classify image type based on caption keywords and dimensions."""
+        if caption:
+            caption_lower = caption.lower()
+            if any(
+                kw in caption_lower
+                for kw in ("diagram", "flowchart", "model", "framework", "process", "pathway")
+            ):
+                return "diagram"
+            if any(kw in caption_lower for kw in ("chart", "graph", "table", "plot")):
+                return "chart"
+            if any(kw in caption_lower for kw in ("formula", "equation")):
+                return "formula"
+
+        if width < 150 or height < 150:
+            return "icon"
+
+        if width > 400 and height > 300:
+            return "photo"
+
+        return "unknown"
+
+    def _convert_to_webp(
+        self,
+        image_bytes: bytes,
+        original_format: str,
+        max_width: int = WEBP_MAX_WIDTH,
+    ) -> tuple[bytes, int, int]:
+        """Convert image bytes to WebP, capping width at max_width."""
+        from PIL import Image
+
+        img = Image.open(io.BytesIO(image_bytes))
+        if img.mode not in ("RGB", "RGBA"):
+            img = img.convert("RGB")
+        elif img.mode == "RGBA":
+            background = Image.new("RGB", img.size, (255, 255, 255))
+            background.paste(img, mask=img.split()[3])
+            img = background
+
+        if img.width > max_width:
+            ratio = max_width / img.width
+            new_height = max(1, int(img.height * ratio))
+            img = img.resize((max_width, new_height), Image.LANCZOS)
+
+        buf = io.BytesIO()
+        img.save(buf, format="WEBP", quality=WEBP_QUALITY)
+        return buf.getvalue(), img.width, img.height
+
+    def _extract_surrounding_text(
+        self,
+        page: pymupdf.Page,
+        image_bbox: pymupdf.Rect,
+        char_limit: int = SURROUNDING_CHAR_LIMIT,
+    ) -> str:
+        """Extract up to char_limit chars of text surrounding the image bbox."""
+        full_text = page.get_text()
+        if not full_text:
+            return ""
+
+        half = char_limit // 2
+
+        page_dict = page.get_text("dict")
+        blocks = page_dict.get("blocks", [])
+
+        before_texts: list[str] = []
+        after_texts: list[str] = []
+
+        for block in blocks:
+            if block.get("type") != 0:
+                continue
+            block_bbox = pymupdf.Rect(block["bbox"])
+            block_text = " ".join(
+                span["text"] for line in block.get("lines", []) for span in line.get("spans", [])
+            ).strip()
+            if not block_text:
+                continue
+
+            if block_bbox.y1 <= image_bbox.y0:
+                before_texts.append(block_text)
+            elif block_bbox.y0 >= image_bbox.y1:
+                after_texts.append(block_text)
+
+        before = " ".join(before_texts)[-half:]
+        after = " ".join(after_texts)[:half]
+        return (before + " " + after).strip()[:char_limit]
+
+    def _try_rasterize_figure(
+        self,
+        doc: pymupdf.Document,
+        page: pymupdf.Page,
+        page_number: int,
+        figure_patterns: list[re.Pattern],
+    ) -> ExtractedImage | None:
+        """Rasterize a page region when a figure reference exists but no image xref found."""
+        page_text = page.get_text()
+        for pattern in figure_patterns:
+            m = pattern.search(page_text)
+            if not m:
+                continue
+
+            figure_number = m.group(0).strip()
+            try:
+                pixmap = page.get_pixmap(dpi=150)
+                png_bytes = pixmap.tobytes("png")
+            except Exception as exc:
+                logger.warning("Rasterization failed", page=page_number, error=str(exc))
+                return None
+
+            if len(png_bytes) < MIN_SIZE_BYTES:
+                return None
+
+            try:
+                webp_bytes, w, h = self._convert_to_webp(png_bytes, "png", max_width=WEBP_MAX_WIDTH)
+            except Exception:
+                webp_bytes = png_bytes
+                w = pixmap.width
+                h = pixmap.height
+
+            image_bbox = page.rect
+            metadata = self._extract_figure_metadata(page, image_bbox, figure_patterns)
+            surrounding_text = self._extract_surrounding_text(
+                page, image_bbox, SURROUNDING_CHAR_LIMIT
+            )
+            image_type = self._classify_image_type(metadata.get("caption"), w, h)
+
+            return ExtractedImage(
+                image_bytes=webp_bytes,
+                width=w,
+                height=h,
+                original_format="png",
+                file_size_bytes=len(webp_bytes),
+                page_number=page_number,
+                figure_number=figure_number,
+                caption=metadata.get("caption"),
+                attribution=metadata.get("attribution"),
+                image_type=image_type,
+                surrounding_text=surrounding_text,
+                chapter=metadata.get("chapter"),
+                section=metadata.get("section"),
+            )
+
+        return None
+
+    def extract_all_pdfs(self) -> dict[str, list[ExtractedImage]]:
+        """Extract images from all recognized PDFs in resources_path."""
+        results: dict[str, list[ExtractedImage]] = {}
+        pdf_files = list(self.resources_path.glob("*.pdf"))
+
+        if not pdf_files:
+            logger.warning("No PDF files found", path=str(self.resources_path))
+            return results
+
+        for pdf_path in pdf_files:
+            source = self.identify_book(pdf_path.name)
+            if source is None:
+                logger.warning("Could not identify book", filename=pdf_path.name)
+                continue
+
+            images = self.extract_images_from_pdf(pdf_path, source)
+            results[source] = images
+            logger.info(
+                "Extracted images from book",
+                source=source,
+                count=len(images),
+            )
+
+        return results

--- a/backend/app/ai/rag/pipeline.py
+++ b/backend/app/ai/rag/pipeline.py
@@ -10,8 +10,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.ai.rag.chunker import TextChunker, detect_language, extract_text_from_pdf
 from app.ai.rag.embeddings import EmbeddingService
+from app.ai.rag.image_extractor import PDFImageExtractor
+from app.ai.rag.image_linker import ImageLinker
 from app.domain.models.document_chunk import DocumentChunk
+from app.domain.models.source_image import SourceImage
 from app.infrastructure.persistence.database import async_session_factory
+from app.infrastructure.storage.s3 import S3StorageService
 
 logger = structlog.get_logger()
 
@@ -139,6 +143,165 @@ class RAGPipeline:
         logger.info("Stored chunks in database", stored_count=stored_count)
 
         return stored_count
+
+    async def process_pdf_images(
+        self,
+        pdf_path: str | Path,
+        source: str,
+        rag_collection_id: str | None = None,
+        session: AsyncSession | None = None,
+    ) -> int:
+        """Extract images from a PDF, upload to MinIO, store metadata, and link to chunks.
+
+        Args:
+            pdf_path: Path to the PDF file.
+            source: Source identifier (e.g., "donaldson").
+            rag_collection_id: Optional RAG collection identifier.
+            session: Database session (will create one if not provided).
+
+        Returns:
+            Number of images processed and stored.
+        """
+        pdf_path = Path(pdf_path)
+        if not pdf_path.exists():
+            raise FileNotFoundError(f"PDF file not found: {pdf_path}")
+
+        session_provided = session is not None
+        if not session_provided:
+            async with async_session_factory() as session:
+                return await self._process_images(pdf_path, source, rag_collection_id, session)
+        else:
+            return await self._process_images(pdf_path, source, rag_collection_id, session)
+
+    async def _process_images(
+        self,
+        pdf_path: Path,
+        source: str,
+        rag_collection_id: str | None,
+        session: AsyncSession,
+    ) -> int:
+        """Internal: extract, upload, store, and link images."""
+        images = PDFImageExtractor.extract_images_from_pdf(str(pdf_path), source)
+
+        if not images:
+            logger.info("No images extracted from PDF", pdf_path=str(pdf_path), source=source)
+            return 0
+
+        storage = S3StorageService()
+        linker = ImageLinker()
+        stored_count = 0
+
+        for idx, img in enumerate(images):
+            figure_label = img.figure_number or str(idx)
+            safe_label = figure_label.replace(" ", "_").replace(".", "_")
+            key = f"source-images/{source}/{img.page_number}_{safe_label}.webp"
+
+            try:
+                storage_url = await storage.upload_bytes(
+                    key=key,
+                    data=img.image_bytes,
+                    content_type="image/webp",
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to upload image to MinIO, skipping",
+                    key=key,
+                    source=source,
+                    error=str(exc),
+                )
+                continue
+
+            caption_text = " ".join(filter(None, [img.caption, img.surrounding_text]))
+            embedding: list[float] | None = None
+            if caption_text.strip():
+                try:
+                    embedding = await self.embedding_service.generate_embedding(caption_text)
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to generate caption embedding, storing without embedding",
+                        source=source,
+                        error=str(exc),
+                    )
+
+            db_image = SourceImage(
+                id=uuid4(),
+                source=source,
+                rag_collection_id=rag_collection_id,
+                figure_number=img.figure_number,
+                caption=img.caption,
+                attribution=img.attribution,
+                image_type=img.image_type,
+                page_number=img.page_number,
+                chapter=img.chapter,
+                section=img.section,
+                surrounding_text=img.surrounding_text,
+                storage_key=key,
+                storage_url=storage_url,
+                format="webp",
+                width=img.width,
+                height=img.height,
+                file_size_bytes=img.file_size_bytes,
+                original_format=img.original_format,
+                embedding=embedding,
+            )
+
+            session.add(db_image)
+            stored_count += 1
+
+        await session.commit()
+        logger.info("Stored source images", source=source, count=stored_count)
+
+        links = await linker.link_images_to_chunks(source, session)
+        logger.info("Linked images to chunks", source=source, links=links)
+
+        return stored_count
+
+    async def clear_source_images(self, source: str, session: AsyncSession | None = None) -> int:
+        """Delete all source images for a given source from DB and MinIO.
+
+        Args:
+            source: Source identifier to clear.
+            session: Database session.
+
+        Returns:
+            Number of images removed.
+        """
+        session_provided = session is not None
+        if not session_provided:
+            async with async_session_factory() as session:
+                return await self._delete_source_images(source, session)
+        else:
+            return await self._delete_source_images(source, session)
+
+    async def _delete_source_images(self, source: str, session: AsyncSession) -> int:
+        """Delete source images from DB and MinIO."""
+        result = await session.execute(select(SourceImage).where(SourceImage.source == source))
+        images = result.scalars().all()
+
+        if not images:
+            logger.info("No source images to delete", source=source)
+            return 0
+
+        storage = S3StorageService()
+
+        for image in images:
+            if image.storage_key:
+                try:
+                    await storage.delete_object(image.storage_key)
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to delete MinIO object",
+                        key=image.storage_key,
+                        source=source,
+                        error=str(exc),
+                    )
+
+        await session.execute(delete(SourceImage).where(SourceImage.source == source))
+        await session.commit()
+        deleted_count = len(images)
+
+        logger.info("Cleared source images", source=source, count=deleted_count)
+        return deleted_count
 
     async def process_resources_directory(
         self, resources_dir: str | Path, source_mappings: dict[str, str] | None = None

--- a/backend/app/tasks/rag_indexation.py
+++ b/backend/app/tasks/rag_indexation.py
@@ -126,6 +126,7 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
         pipeline = RAGPipeline(embedding_service)
 
         total_chunks = 0
+        total_images = 0
         for i, pdf_path in enumerate(pdf_files):
             extract_progress = 5 + int((i / len(pdf_files)) * 30)
             self.update_state(
@@ -171,7 +172,6 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
                 },
             )
 
-            # Use PDF filename (without extension) as readable source for citations
             source_name = pdf_path.stem.replace("_", " ")
             chunks = await pipeline.process_pdf_document(
                 pdf_path=str(pdf_path),
@@ -179,7 +179,7 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
             )
             total_chunks += chunks
 
-            store_progress = 35 + int(((i + 1) / len(pdf_files)) * 55)
+            store_progress = 35 + int(((i + 1) / len(pdf_files)) * 45)
             self.update_state(
                 state="STORING",
                 meta={
@@ -194,17 +194,65 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
                 },
             )
 
+            img_progress = store_progress + int((1 / len(pdf_files)) * 8)
+            self.update_state(
+                state="EXTRACTING_IMAGES",
+                meta={
+                    "step": "extracting_images",
+                    "step_label": f"Extraction des illustrations: {pdf_path.name}",
+                    "progress": img_progress,
+                    "files_total": len(pdf_files),
+                    "files_processed": i + 1,
+                    "current_file": pdf_path.name,
+                    "chunks_processed": total_chunks,
+                    "estimated_seconds_remaining": _remaining(img_progress),
+                },
+            )
+
+            image_count = 0
+            try:
+                image_count = await pipeline.process_pdf_images(
+                    pdf_path=str(pdf_path),
+                    source=source_name,
+                    rag_collection_id=rag_collection_id,
+                )
+                total_images += image_count
+            except Exception as img_exc:
+                logger.warning(
+                    "Image extraction failed for PDF (non-blocking)",
+                    file=pdf_path.name,
+                    course_id=course_id,
+                    error=str(img_exc),
+                )
+
+            link_progress = img_progress + int((1 / len(pdf_files)) * 7)
+            self.update_state(
+                state="LINKING_IMAGES",
+                meta={
+                    "step": "linking_images",
+                    "step_label": f"Liaison images-texte: {image_count} liens créés",
+                    "progress": link_progress,
+                    "files_total": len(pdf_files),
+                    "files_processed": i + 1,
+                    "current_file": pdf_path.name,
+                    "chunks_processed": total_chunks,
+                    "images_processed": total_images,
+                    "estimated_seconds_remaining": _remaining(link_progress),
+                },
+            )
+
             logger.info(
                 "PDF indexed",
                 file=pdf_path.name,
                 chunks=chunks,
+                images=image_count,
                 course_id=course_id,
             )
 
-        return total_chunks
+        return total_chunks, total_images
 
     try:
-        total_chunks = asyncio.run(_run_pipeline())
+        total_chunks, total_images = asyncio.run(_run_pipeline())
 
         self.update_state(
             state="COMPLETE",
@@ -213,6 +261,7 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
                 "step_label": "Indexation terminée",
                 "progress": 100,
                 "chunks_stored": total_chunks,
+                "images_stored": total_images,
                 "files_processed": len(pdf_files),
                 "files_total": len(pdf_files),
                 "estimated_seconds_remaining": 0,
@@ -222,6 +271,7 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
         return {
             "status": "complete",
             "chunks_stored": total_chunks,
+            "images_stored": total_images,
             "files_processed": len(pdf_files),
             "rag_collection_id": rag_collection_id,
         }

--- a/backend/tests/test_rag_pipeline_images.py
+++ b/backend/tests/test_rag_pipeline_images.py
@@ -1,0 +1,428 @@
+"""Unit tests for image extraction integration in RAGPipeline."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.ai.rag.image_extractor import ExtractedImage
+from app.ai.rag.image_linker import ImageLinker
+from app.ai.rag.pipeline import RAGPipeline
+
+
+def _make_extracted_image(**kwargs) -> ExtractedImage:
+    defaults = dict(
+        image_bytes=b"fake_webp_data",
+        width=300,
+        height=200,
+        original_format="png",
+        file_size_bytes=14,
+        page_number=1,
+        figure_number="Figure 1",
+        caption="Diagram of disease spread",
+        attribution=None,
+        image_type="diagram",
+        surrounding_text="surrounding text about disease",
+        chapter="Chapter 1",
+        section=None,
+    )
+    defaults.update(kwargs)
+    return ExtractedImage(**defaults)
+
+
+class TestRAGPipelineProcessPDFImages:
+    def setup_method(self):
+        self.embedding_service = AsyncMock()
+        self.embedding_service.generate_embedding = AsyncMock(return_value=[0.1] * 1536)
+        self.pipeline = RAGPipeline(self.embedding_service)
+        self.temp_dir = tempfile.mkdtemp()
+
+    def teardown_method(self):
+        import shutil
+
+        shutil.rmtree(self.temp_dir)
+
+    @pytest.mark.asyncio
+    async def test_raises_file_not_found_for_missing_pdf(self):
+        with pytest.raises(FileNotFoundError):
+            await self.pipeline.process_pdf_images(
+                pdf_path="/nonexistent/path.pdf",
+                source="donaldson",
+            )
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_no_images_extracted(self):
+        pdf_path = Path(self.temp_dir) / "test.pdf"
+        pdf_path.touch()
+
+        with patch(
+            "app.ai.rag.pipeline.PDFImageExtractor.extract_images_from_pdf",
+            return_value=[],
+        ):
+            count = await self.pipeline.process_pdf_images(
+                pdf_path=str(pdf_path),
+                source="donaldson",
+            )
+
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_uploads_images_and_stores_metadata(self):
+        pdf_path = Path(self.temp_dir) / "Donaldson_test.pdf"
+        pdf_path.touch()
+
+        fake_image = _make_extracted_image()
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=MagicMock())
+
+        with (
+            patch(
+                "app.ai.rag.pipeline.PDFImageExtractor.extract_images_from_pdf",
+                return_value=[fake_image],
+            ),
+            patch(
+                "app.ai.rag.pipeline.S3StorageService.upload_bytes",
+                new_callable=AsyncMock,
+                return_value="http://minio/bucket/source-images/donaldson/1_Figure_1.webp",
+            ),
+            patch.object(
+                ImageLinker, "link_images_to_chunks", new_callable=AsyncMock, return_value=1
+            ),
+        ):
+            count = await self.pipeline.process_pdf_images(
+                pdf_path=str(pdf_path),
+                source="donaldson",
+                session=mock_session,
+            )
+
+        assert count == 1
+        mock_session.add.assert_called_once()
+        mock_session.commit.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_storage_key_contains_source_and_page(self):
+        pdf_path = Path(self.temp_dir) / "test.pdf"
+        pdf_path.touch()
+
+        fake_image = _make_extracted_image(page_number=5, figure_number="Figure 3.2")
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=MagicMock())
+
+        captured_key = {}
+
+        async def capture_upload(key, data, content_type):
+            captured_key["key"] = key
+            return f"http://minio/{key}"
+
+        with (
+            patch(
+                "app.ai.rag.pipeline.PDFImageExtractor.extract_images_from_pdf",
+                return_value=[fake_image],
+            ),
+            patch(
+                "app.ai.rag.pipeline.S3StorageService.upload_bytes",
+                side_effect=capture_upload,
+            ),
+            patch.object(
+                ImageLinker, "link_images_to_chunks", new_callable=AsyncMock, return_value=0
+            ),
+        ):
+            await self.pipeline.process_pdf_images(
+                pdf_path=str(pdf_path),
+                source="donaldson",
+                session=mock_session,
+            )
+
+        assert "source-images/donaldson" in captured_key["key"]
+        assert "5_" in captured_key["key"]
+
+    @pytest.mark.asyncio
+    async def test_upload_failure_skips_image_gracefully(self):
+        pdf_path = Path(self.temp_dir) / "Donaldson_test.pdf"
+        pdf_path.touch()
+
+        fake_image = _make_extracted_image()
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+
+        with (
+            patch(
+                "app.ai.rag.pipeline.PDFImageExtractor.extract_images_from_pdf",
+                return_value=[fake_image],
+            ),
+            patch(
+                "app.ai.rag.pipeline.S3StorageService.upload_bytes",
+                new_callable=AsyncMock,
+                side_effect=ConnectionError("MinIO unreachable"),
+            ),
+            patch.object(
+                ImageLinker, "link_images_to_chunks", new_callable=AsyncMock, return_value=0
+            ),
+        ):
+            count = await self.pipeline.process_pdf_images(
+                pdf_path=str(pdf_path),
+                source="donaldson",
+                session=mock_session,
+            )
+
+        assert count == 0
+        mock_session.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_embedding_failure_stores_image_without_embedding(self):
+        pdf_path = Path(self.temp_dir) / "Donaldson_test.pdf"
+        pdf_path.touch()
+
+        fake_image = _make_extracted_image()
+        self.embedding_service.generate_embedding = AsyncMock(side_effect=Exception("OpenAI error"))
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=MagicMock())
+
+        with (
+            patch(
+                "app.ai.rag.pipeline.PDFImageExtractor.extract_images_from_pdf",
+                return_value=[fake_image],
+            ),
+            patch(
+                "app.ai.rag.pipeline.S3StorageService.upload_bytes",
+                new_callable=AsyncMock,
+                return_value="http://minio/bucket/key.webp",
+            ),
+            patch.object(
+                ImageLinker, "link_images_to_chunks", new_callable=AsyncMock, return_value=0
+            ),
+        ):
+            count = await self.pipeline.process_pdf_images(
+                pdf_path=str(pdf_path),
+                source="donaldson",
+                session=mock_session,
+            )
+
+        assert count == 1
+        added_image = mock_session.add.call_args[0][0]
+        assert added_image.embedding is None
+
+    @pytest.mark.asyncio
+    async def test_links_images_to_chunks_after_storing(self):
+        pdf_path = Path(self.temp_dir) / "test.pdf"
+        pdf_path.touch()
+
+        fake_image = _make_extracted_image()
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=MagicMock())
+
+        mock_linker = AsyncMock()
+        mock_linker.link_images_to_chunks = AsyncMock(return_value=3)
+
+        with (
+            patch(
+                "app.ai.rag.pipeline.PDFImageExtractor.extract_images_from_pdf",
+                return_value=[fake_image],
+            ),
+            patch(
+                "app.ai.rag.pipeline.S3StorageService.upload_bytes",
+                new_callable=AsyncMock,
+                return_value="http://minio/key.webp",
+            ),
+            patch("app.ai.rag.pipeline.ImageLinker", return_value=mock_linker),
+        ):
+            count = await self.pipeline.process_pdf_images(
+                pdf_path=str(pdf_path),
+                source="donaldson",
+                session=mock_session,
+            )
+
+        assert count == 1
+        mock_linker.link_images_to_chunks.assert_called_once_with("donaldson", mock_session)
+
+    @pytest.mark.asyncio
+    async def test_multiple_images_all_stored(self):
+        pdf_path = Path(self.temp_dir) / "test.pdf"
+        pdf_path.touch()
+
+        images = [
+            _make_extracted_image(page_number=1, figure_number="Figure 1"),
+            _make_extracted_image(page_number=2, figure_number="Figure 2"),
+            _make_extracted_image(page_number=3, figure_number=None),
+        ]
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=MagicMock())
+
+        with (
+            patch(
+                "app.ai.rag.pipeline.PDFImageExtractor.extract_images_from_pdf",
+                return_value=images,
+            ),
+            patch(
+                "app.ai.rag.pipeline.S3StorageService.upload_bytes",
+                new_callable=AsyncMock,
+                return_value="http://minio/key.webp",
+            ),
+            patch.object(
+                ImageLinker, "link_images_to_chunks", new_callable=AsyncMock, return_value=2
+            ),
+        ):
+            count = await self.pipeline.process_pdf_images(
+                pdf_path=str(pdf_path),
+                source="donaldson",
+                session=mock_session,
+            )
+
+        assert count == 3
+        assert mock_session.add.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_rag_collection_id_stored_in_db_record(self):
+        pdf_path = Path(self.temp_dir) / "test.pdf"
+        pdf_path.touch()
+
+        fake_image = _make_extracted_image()
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=MagicMock())
+
+        with (
+            patch(
+                "app.ai.rag.pipeline.PDFImageExtractor.extract_images_from_pdf",
+                return_value=[fake_image],
+            ),
+            patch(
+                "app.ai.rag.pipeline.S3StorageService.upload_bytes",
+                new_callable=AsyncMock,
+                return_value="http://minio/key.webp",
+            ),
+            patch.object(
+                ImageLinker, "link_images_to_chunks", new_callable=AsyncMock, return_value=0
+            ),
+        ):
+            await self.pipeline.process_pdf_images(
+                pdf_path=str(pdf_path),
+                source="donaldson",
+                rag_collection_id="rag-col-123",
+                session=mock_session,
+            )
+
+        added_image = mock_session.add.call_args[0][0]
+        assert added_image.rag_collection_id == "rag-col-123"
+
+
+class TestRAGPipelineClearSourceImages:
+    def setup_method(self):
+        self.embedding_service = AsyncMock()
+        self.pipeline = RAGPipeline(self.embedding_service)
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_no_images(self):
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        count = await self.pipeline.clear_source_images("donaldson", session=mock_session)
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_deletes_from_db_and_minio(self):
+        from app.domain.models.source_image import SourceImage
+
+        mock_img = MagicMock(spec=SourceImage)
+        mock_img.storage_key = "source-images/donaldson/1_Figure_1.webp"
+
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [mock_img]
+        mock_session.execute = AsyncMock(return_value=mock_result)
+        mock_session.commit = AsyncMock()
+
+        with patch(
+            "app.ai.rag.pipeline.S3StorageService.delete_object",
+            new_callable=AsyncMock,
+        ) as mock_delete:
+            count = await self.pipeline.clear_source_images("donaldson", session=mock_session)
+
+        assert count == 1
+        mock_delete.assert_called_once_with(mock_img.storage_key)
+        mock_session.commit.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_minio_failure_does_not_block_db_delete(self):
+        from app.domain.models.source_image import SourceImage
+
+        mock_img = MagicMock(spec=SourceImage)
+        mock_img.storage_key = "source-images/donaldson/1_Figure_1.webp"
+
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [mock_img]
+        mock_session.execute = AsyncMock(return_value=mock_result)
+        mock_session.commit = AsyncMock()
+
+        with patch(
+            "app.ai.rag.pipeline.S3StorageService.delete_object",
+            new_callable=AsyncMock,
+            side_effect=ConnectionError("MinIO unreachable"),
+        ):
+            count = await self.pipeline.clear_source_images("donaldson", session=mock_session)
+
+        assert count == 1
+        mock_session.commit.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_image_without_storage_key_does_not_call_minio(self):
+        from app.domain.models.source_image import SourceImage
+
+        mock_img = MagicMock(spec=SourceImage)
+        mock_img.storage_key = None
+
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [mock_img]
+        mock_session.execute = AsyncMock(return_value=mock_result)
+        mock_session.commit = AsyncMock()
+
+        with patch(
+            "app.ai.rag.pipeline.S3StorageService.delete_object",
+            new_callable=AsyncMock,
+        ) as mock_delete:
+            count = await self.pipeline.clear_source_images("donaldson", session=mock_session)
+
+        assert count == 1
+        mock_delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_deletes_multiple_images_all_from_minio(self):
+        from app.domain.models.source_image import SourceImage
+
+        mock_imgs = []
+        for i in range(3):
+            m = MagicMock(spec=SourceImage)
+            m.storage_key = f"source-images/donaldson/{i}_Figure.webp"
+            mock_imgs.append(m)
+
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = mock_imgs
+        mock_session.execute = AsyncMock(return_value=mock_result)
+        mock_session.commit = AsyncMock()
+
+        with patch(
+            "app.ai.rag.pipeline.S3StorageService.delete_object",
+            new_callable=AsyncMock,
+        ) as mock_delete:
+            count = await self.pipeline.clear_source_images("donaldson", session=mock_session)
+
+        assert count == 3
+        assert mock_delete.call_count == 3


### PR DESCRIPTION
## Summary

- Wire `PDFImageExtractor` into `RAGPipeline.process_pdf_images()`: extracts images, uploads WebP to MinIO, generates caption embeddings, persists `SourceImage` records, and links to chunks via `ImageLinker`
- Add `RAGPipeline.clear_source_images()`: deletes DB records + MinIO objects (MinIO failures are non-blocking)
- Update Celery `index_course_resources` task with `EXTRACTING_IMAGES` and `LINKING_IMAGES` progress states; image extraction failure never blocks text indexation
- Include `image_extractor.py` (from #737) which was not yet merged into dev

## Changes

| File | Action |
|------|--------|
| `backend/app/ai/rag/image_extractor.py` | **New** — PDF image extraction engine with PyMuPDF (from #737) |
| `backend/app/ai/rag/pipeline.py` | **Modified** — `process_pdf_images()`, `clear_source_images()` |
| `backend/app/tasks/rag_indexation.py` | **Modified** — `EXTRACTING_IMAGES` / `LINKING_IMAGES` progress states |
| `backend/tests/test_rag_pipeline_images.py` | **New** — 14 unit tests |

## Test plan

- [x] 14 new unit tests pass (`pytest tests/test_rag_pipeline_images.py`)
- [x] Ruff lint: all checks passed ✓
- [x] Ruff format applied ✓
- [ ] Manually verify on staging with actual PDFs

## Acceptance criteria

- [x] `process_pdf_images` extracts, uploads to MinIO, stores metadata, and links to chunks
- [x] Celery task shows image extraction progress (`EXTRACTING_IMAGES`, `LINKING_IMAGES`)
- [x] Image extraction failure doesn't block text indexation (graceful degradation)
- [x] `clear_source_images` cleans up both DB and MinIO

Closes #739

🤖 Generated with [Claude Code](https://claude.ai/code)