### PR TITLE
feat(rag): retriever image lookup + source images API endpoints

### DIFF
--- a/backend/app/ai/rag/retriever.py
+++ b/backend/app/ai/rag/retriever.py
@@ -3,6 +3,7 @@
 import re
 from dataclasses import dataclass
 from typing import Any
+from uuid import UUID
 
 import structlog
 from sqlalchemy import select, text
@@ -10,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.ai.rag.embeddings import EmbeddingService
 from app.domain.models.document_chunk import DocumentChunk
+from app.domain.models.source_image import SourceImage, SourceImageChunk
 from app.domain.services.platform_settings_service import SettingsCache
 
 logger = structlog.get_logger()
@@ -269,6 +271,188 @@ class SemanticRetriever:
                     filters["source"] = named_keys
 
         return await self.search(query=query, top_k=top_k, filters=filters, session=session)
+
+    async def get_linked_images(
+        self,
+        chunk_ids: list[UUID],
+        session: AsyncSession,
+        max_per_chunk: int = 3,
+        max_total: int = 5,
+    ) -> dict[UUID, list[dict]]:
+        """
+        Fetch source images linked to given document chunk IDs.
+
+        Args:
+            chunk_ids: List of document chunk UUIDs
+            session: Database session
+            max_per_chunk: Maximum images returned per chunk
+            max_total: Maximum total images across all chunks
+
+        Returns:
+            Mapping {chunk_id: [image_meta_dict, ...]}
+        """
+        if not chunk_ids:
+            return {}
+
+        result: dict[UUID, list[dict]] = {cid: [] for cid in chunk_ids}
+        total_collected = 0
+
+        rows = await session.execute(
+            select(SourceImageChunk, SourceImage)
+            .join(SourceImage, SourceImageChunk.source_image_id == SourceImage.id)
+            .where(SourceImageChunk.document_chunk_id.in_(chunk_ids))
+            .order_by(
+                SourceImageChunk.document_chunk_id,
+                (SourceImageChunk.reference_type != "explicit"),
+            )
+        )
+        pairs = rows.all()
+
+        for sic, img in pairs:
+            if total_collected >= max_total:
+                break
+            cid = sic.document_chunk_id
+            if len(result[cid]) >= max_per_chunk:
+                continue
+            result[cid].append(img.to_meta_dict())
+            total_collected += 1
+
+        logger.info(
+            "Linked images fetched",
+            chunk_count=len(chunk_ids),
+            total_images=total_collected,
+        )
+        return result
+
+    async def search_source_images(
+        self,
+        query: str,
+        top_k: int = 5,
+        source: str | None = None,
+        rag_collection_id: str | None = None,
+        min_similarity: float = 0.3,
+        session: AsyncSession | None = None,
+    ) -> list[dict]:
+        """
+        Semantic search directly on source_images.embedding.
+
+        Args:
+            query: Search query text
+            top_k: Number of results to return
+            source: Optional filter by source book name
+            rag_collection_id: Optional filter by RAG collection ID
+            min_similarity: Minimum cosine similarity threshold
+            session: Database session
+
+        Returns:
+            List of image metadata dicts (no binary data)
+        """
+        if not query.strip():
+            return []
+
+        query_embedding = await self.embedding_service.generate_embedding(query)
+
+        session_provided = session is not None
+        if not session_provided:
+            from app.infrastructure.persistence.database import async_session_factory
+
+            async with async_session_factory() as session:
+                return await self._search_source_images(
+                    query_embedding, top_k, source, rag_collection_id, min_similarity, session
+                )
+        return await self._search_source_images(
+            query_embedding, top_k, source, rag_collection_id, min_similarity, session
+        )
+
+    async def _search_source_images(
+        self,
+        query_embedding: list[float],
+        top_k: int,
+        source: str | None,
+        rag_collection_id: str | None,
+        min_similarity: float,
+        session: AsyncSession,
+    ) -> list[dict]:
+        """Execute cosine similarity search on source_images table."""
+        embedding_literal = "[" + ",".join(str(x) for x in query_embedding) + "]"
+        vec_expr = f"embedding::vector <=> '{embedding_literal}'::vector"
+
+        where_clauses = ["embedding IS NOT NULL"]
+        params: dict[str, Any] = {}
+
+        if source is not None:
+            where_clauses.append("source = :source")
+            params["source"] = source
+
+        if rag_collection_id is not None:
+            where_clauses.append("rag_collection_id = :rag_collection_id")
+            params["rag_collection_id"] = rag_collection_id
+
+        where_sql = " AND ".join(where_clauses)
+
+        query_str = f"""
+        SELECT * FROM (
+            SELECT
+                id, source, rag_collection_id, figure_number, caption, attribution,
+                image_type, page_number, chapter, section, surrounding_text,
+                storage_key, storage_url, format, width, height, file_size_bytes,
+                original_format, alt_text_fr, alt_text_en, semantic_tags, created_at,
+                1 - ({vec_expr}) as similarity
+            FROM source_images
+            WHERE {where_sql}
+        ) sub
+        WHERE similarity >= :min_similarity
+        ORDER BY similarity DESC
+        LIMIT :limit
+        """
+
+        params["min_similarity"] = min_similarity
+        params["limit"] = top_k
+
+        try:
+            query_obj = text(query_str).bindparams(**params)
+            result = await session.execute(query_obj)
+            rows = result.fetchall()
+        except Exception as e:
+            logger.error("Source image semantic search failed", error=str(e))
+            raise
+
+        image_dicts = []
+        for row in rows:
+            img = SourceImage(
+                id=row.id,
+                source=row.source,
+                rag_collection_id=row.rag_collection_id,
+                figure_number=row.figure_number,
+                caption=row.caption,
+                attribution=row.attribution,
+                image_type=row.image_type,
+                page_number=row.page_number,
+                chapter=row.chapter,
+                section=row.section,
+                surrounding_text=row.surrounding_text,
+                storage_key=row.storage_key,
+                storage_url=row.storage_url,
+                format=row.format,
+                width=row.width,
+                height=row.height,
+                file_size_bytes=row.file_size_bytes,
+                original_format=row.original_format,
+                alt_text_fr=row.alt_text_fr,
+                alt_text_en=row.alt_text_en,
+                semantic_tags=row.semantic_tags,
+                created_at=row.created_at,
+            )
+            meta = img.to_meta_dict()
+            meta["similarity"] = float(row.similarity)
+            image_dicts.append(meta)
+
+        logger.info(
+            "Source image semantic search completed",
+            results=len(image_dicts),
+            top_similarity=image_dicts[0]["similarity"] if image_dicts else 0,
+        )
+        return image_dicts
 
     async def verify_search_functionality(
         self, session: AsyncSession | None = None

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -15,6 +15,7 @@ from app.api.v1.module_media import router as module_media_router
 from app.api.v1.placement import router as placement_router
 from app.api.v1.progress import router as progress_router
 from app.api.v1.quiz import router as quiz_router
+from app.api.v1.source_images import router as source_images_router
 from app.api.v1.tutor import router as tutor_router
 from app.api.v1.users import router as users_router
 
@@ -36,3 +37,4 @@ api_v1_router.include_router(admin_courses_router)
 api_v1_router.include_router(admin_taxonomy_router)
 api_v1_router.include_router(courses_router)
 api_v1_router.include_router(module_media_router)
+api_v1_router.include_router(source_images_router)

--- a/backend/app/api/v1/schemas/source_images.py
+++ b/backend/app/api/v1/schemas/source_images.py
@@ -1,0 +1,29 @@
+"""Pydantic V2 schemas for source image API endpoints."""
+
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class SourceImageMetadataResponse(BaseModel):
+    id: UUID
+    source: str
+    rag_collection_id: str | None = None
+    figure_number: str | None = None
+    caption: str | None = None
+    attribution: str | None = None
+    image_type: str
+    page_number: int
+    chapter: str | None = None
+    width: int | None = None
+    height: int | None = None
+    storage_url: str | None = None
+    alt_text_fr: str | None = None
+    alt_text_en: str | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class SourceImageListResponse(BaseModel):
+    items: list[SourceImageMetadataResponse] = Field(..., description="Source images")
+    total: int = Field(..., description="Total count")

--- a/backend/app/api/v1/source_images.py
+++ b/backend/app/api/v1/source_images.py
@@ -1,0 +1,92 @@
+"""Source image API endpoints — serve metadata and binary data from RAG-indexed PDFs."""
+
+import uuid
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import RedirectResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_db
+from app.api.deps_local_auth import AuthenticatedUser, get_current_user, require_role
+from app.api.v1.schemas.source_images import SourceImageListResponse, SourceImageMetadataResponse
+from app.domain.models.source_image import SourceImage
+from app.domain.models.user import UserRole
+
+logger = structlog.get_logger(__name__)
+router = APIRouter(prefix="/source-images", tags=["Source Images"])
+
+
+@router.get(
+    "/by-source/{source}",
+    response_model=SourceImageListResponse,
+)
+async def list_images_by_source(
+    source: str,
+    page: int = Query(1, ge=1),
+    limit: int = Query(20, ge=1, le=100),
+    _current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    db: AsyncSession = Depends(get_db),
+) -> SourceImageListResponse:
+    """List all source images for a given book/collection (admin only, paginated)."""
+    offset = (page - 1) * limit
+
+    count_result = await db.execute(select(SourceImage).where(SourceImage.source == source))
+    all_items = count_result.scalars().all()
+    total = len(all_items)
+
+    result = await db.execute(
+        select(SourceImage)
+        .where(SourceImage.source == source)
+        .order_by(SourceImage.page_number)
+        .offset(offset)
+        .limit(limit)
+    )
+    images = result.scalars().all()
+
+    return SourceImageListResponse(
+        items=[SourceImageMetadataResponse.model_validate(img) for img in images],
+        total=total,
+    )
+
+
+@router.get(
+    "/{image_id}",
+    response_model=SourceImageMetadataResponse,
+)
+async def get_image_metadata(
+    image_id: uuid.UUID,
+    _current_user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> SourceImageMetadataResponse:
+    """Return metadata JSON for a source image (auth required)."""
+    result = await db.execute(select(SourceImage).where(SourceImage.id == image_id))
+    img = result.scalar_one_or_none()
+    if img is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Image not found")
+    return SourceImageMetadataResponse.model_validate(img)
+
+
+@router.get("/{image_id}/data")
+async def get_image_data(
+    image_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+) -> RedirectResponse:
+    """Serve image binary — redirects to MinIO/storage URL with long-lived cache headers."""
+    result = await db.execute(select(SourceImage).where(SourceImage.id == image_id))
+    img = result.scalar_one_or_none()
+    if img is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Image not found")
+
+    if not img.storage_url:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Image binary not available"
+        )
+
+    logger.info("Source image data redirect", image_id=str(image_id))
+    return RedirectResponse(
+        url=img.storage_url,
+        status_code=status.HTTP_301_MOVED_PERMANENTLY,
+        headers={"Cache-Control": "public, max-age=31536000, immutable"},
+    )

--- a/backend/tests/test_retriever_image_lookup.py
+++ b/backend/tests/test_retriever_image_lookup.py
@@ -1,0 +1,172 @@
+"""Tests for SemanticRetriever.get_linked_images and search_source_images."""
+
+import uuid
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.ai.rag.retriever import SemanticRetriever
+
+
+@pytest.fixture
+def mock_embedding_service():
+    svc = AsyncMock()
+    svc.generate_embedding = AsyncMock(return_value=[0.1] * 1536)
+    return svc
+
+
+@pytest.fixture
+def retriever(mock_embedding_service):
+    return SemanticRetriever(mock_embedding_service)
+
+
+def _make_image(image_id=None, source="donaldson"):
+    from app.domain.models.source_image import SourceImage
+
+    img = SourceImage(
+        id=image_id or uuid.uuid4(),
+        source=source,
+        rag_collection_id=None,
+        figure_number="Fig 1.1",
+        caption="Test caption",
+        attribution=None,
+        image_type="diagram",
+        page_number=10,
+        chapter="1",
+        section=None,
+        surrounding_text=None,
+        storage_key="img/test.webp",
+        storage_url="https://cdn.example.com/img/test.webp",
+        format="webp",
+        width=800,
+        height=600,
+        file_size_bytes=12345,
+        original_format=None,
+        alt_text_fr="Diagramme de test",
+        alt_text_en="Test diagram",
+        semantic_tags=None,
+        created_at=datetime(2025, 1, 1),
+    )
+    return img
+
+
+def _make_chunk_pair(chunk_id, image, ref_type="contextual"):
+    from app.domain.models.source_image import SourceImageChunk
+
+    sic = MagicMock(spec=SourceImageChunk)
+    sic.document_chunk_id = chunk_id
+    sic.source_image_id = image.id
+    sic.reference_type = ref_type
+    return (sic, image)
+
+
+class TestGetLinkedImages:
+    async def test_empty_chunk_ids_returns_empty(self, retriever):
+        session = AsyncMock()
+        result = await retriever.get_linked_images([], session)
+        assert result == {}
+
+    async def test_returns_images_for_chunks(self, retriever):
+        chunk_id = uuid.uuid4()
+        img = _make_image()
+        pair = _make_chunk_pair(chunk_id, img, ref_type="explicit")
+
+        mock_result = MagicMock()
+        mock_result.all.return_value = [pair]
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        result = await retriever.get_linked_images([chunk_id], session)
+
+        assert chunk_id in result
+        assert len(result[chunk_id]) == 1
+        assert result[chunk_id][0]["id"] == str(img.id)
+
+    async def test_respects_max_per_chunk(self, retriever):
+        chunk_id = uuid.uuid4()
+        images = [_make_image() for _ in range(5)]
+        pairs = [_make_chunk_pair(chunk_id, img) for img in images]
+
+        mock_result = MagicMock()
+        mock_result.all.return_value = pairs
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        result = await retriever.get_linked_images([chunk_id], session, max_per_chunk=2)
+        assert len(result[chunk_id]) <= 2
+
+    async def test_respects_max_total(self, retriever):
+        chunk_ids = [uuid.uuid4() for _ in range(3)]
+        pairs = []
+        for cid in chunk_ids:
+            for _ in range(3):
+                pairs.append(_make_chunk_pair(cid, _make_image()))
+
+        mock_result = MagicMock()
+        mock_result.all.return_value = pairs
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        result = await retriever.get_linked_images(chunk_ids, session, max_total=4)
+        total = sum(len(v) for v in result.values())
+        assert total <= 4
+
+    async def test_unknown_chunk_ids_get_empty_lists(self, retriever):
+        chunk_id = uuid.uuid4()
+        other_chunk_id = uuid.uuid4()
+
+        mock_result = MagicMock()
+        mock_result.all.return_value = []
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        result = await retriever.get_linked_images([chunk_id, other_chunk_id], session)
+        assert result[chunk_id] == []
+        assert result[other_chunk_id] == []
+
+
+class TestSearchSourceImages:
+    async def test_empty_query_returns_empty(self, retriever):
+        session = AsyncMock()
+        result = await retriever.search_source_images("   ", session=session)
+        assert result == []
+
+    async def test_returns_metadata_dicts(self, retriever):
+        img = _make_image()
+        row = MagicMock()
+        row.id = img.id
+        row.source = img.source
+        row.rag_collection_id = img.rag_collection_id
+        row.figure_number = img.figure_number
+        row.caption = img.caption
+        row.attribution = img.attribution
+        row.image_type = img.image_type
+        row.page_number = img.page_number
+        row.chapter = img.chapter
+        row.section = img.section
+        row.surrounding_text = img.surrounding_text
+        row.storage_key = img.storage_key
+        row.storage_url = img.storage_url
+        row.format = img.format
+        row.width = img.width
+        row.height = img.height
+        row.file_size_bytes = img.file_size_bytes
+        row.original_format = img.original_format
+        row.alt_text_fr = img.alt_text_fr
+        row.alt_text_en = img.alt_text_en
+        row.semantic_tags = img.semantic_tags
+        row.created_at = img.created_at
+        row.similarity = 0.85
+
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [row]
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        result = await retriever.search_source_images("epidemiology diagram", session=session)
+
+        assert len(result) == 1
+        assert result[0]["id"] == str(img.id)
+        assert result[0]["similarity"] == pytest.approx(0.85)
+        assert "storage_url" in result[0]


### PR DESCRIPTION
## Summary
- Add `SemanticRetriever.get_linked_images`: queries `source_image_chunks` JOIN `source_images` for given chunk IDs; prioritises `explicit` over `contextual` refs; limits to 3 images/chunk and 5 total
- Add `SemanticRetriever.search_source_images`: cosine similarity search on `source_images.embedding` with optional source/collection filter
- Create `schemas/source_images.py`: `SourceImageMetadataResponse` + `SourceImageListResponse` (Pydantic V2)
- Create `api/v1/source_images.py`: 3 endpoints (data redirect, metadata, admin list)
- Register router; 7 passing unit tests

## Changes
- `backend/app/ai/rag/retriever.py` — `get_linked_images`, `search_source_images`, `_search_source_images`
- `backend/app/api/v1/schemas/source_images.py` — new file
- `backend/app/api/v1/source_images.py` — new file (3 endpoints)
- `backend/app/api/v1/router.py` — register `source_images_router`
- `backend/tests/test_retriever_image_lookup.py` — 7 unit tests

## Test plan
- [x] `ruff check --fix` + `ruff format` — all clean
- [x] 7 unit tests pass (`pytest tests/test_retriever_image_lookup.py`)
- [ ] Integration tests against real DB (requires Docker Compose)

Closes #740

Generated with [Claude Code](https://claude.ai/code)