### PR TITLE
feat(ai): inject source image references into lesson generation prompts

### DIFF
--- a/backend/app/ai/prompts/lesson.py
+++ b/backend/app/ai/prompts/lesson.py
@@ -227,6 +227,13 @@ EXIGENCES CRITIQUES :
 - {criteria_examples}
 - Respecte les particularités culturelles et économiques du contexte
 
+FIGURES DE RÉFÉRENCE :
+Certains extraits contiennent des annotations [FIGURE DISPONIBLE: ...] avec un marqueur {{{{source_image:UUID}}}}.
+- Tu PEUX utiliser ce marqueur dans ton texte pour référencer une figure quand elle illustre directement un concept expliqué
+- Place le marqueur immédiatement après la phrase qui décrit le concept illustré par la figure
+- N'utilise au maximum 3 marqueurs {{{{source_image:UUID}}}} dans ta réponse
+- N'invente PAS de marqueurs — utilise uniquement les UUIDs fournis dans les annotations
+
 RÉPONSE ATTENDUE : Contenu de leçon directement utilisable, sans métadiscours."""
 
     else:  # English
@@ -296,14 +303,34 @@ CRITICAL REQUIREMENTS:
 - {criteria_examples}
 - Respect cultural and economic particularities of the context
 
+REFERENCE FIGURES:
+Some extracts contain [FIGURE AVAILABLE: ...] annotations with a {{{{source_image:UUID}}}} marker.
+- You MAY use this marker in your text to reference a figure when it directly illustrates a concept being explained
+- Place the marker immediately after the sentence describing the concept the figure illustrates
+- Use at most 3 {{{{source_image:UUID}}}} markers in your response
+- Do NOT invent markers — only use UUIDs provided in the annotations
+
 EXPECTED RESPONSE: Directly usable lesson content, without meta-discourse."""
 
 
 def format_rag_context_for_lesson(
-    chunks: list, query: str, module_title: str, unit_id: str, language: Literal["fr", "en"]
+    chunks: list,
+    query: str,
+    module_title: str,
+    unit_id: str,
+    language: Literal["fr", "en"],
+    linked_images: dict | None = None,
 ) -> str:
-    """Format RAG chunks into context for lesson generation."""
+    """Format RAG chunks into context for lesson generation.
 
+    Args:
+        chunks: RAG search result chunks
+        query: Lesson generation query
+        module_title: Module title
+        unit_id: Unit identifier
+        language: Target language ('fr' or 'en')
+        linked_images: Optional mapping {chunk_id: [image_meta_dict, ...]} from get_linked_images
+    """
     if language == "fr":
         context_intro = f"""DEMANDE : Génère une leçon pour le module "{module_title}",
 unité {unit_id}, sur le sujet : "{query}"
@@ -325,16 +352,17 @@ REFERENCE DOCUMENTS:
     # Format chunks
     formatted_chunks = []
     sources = set()
+    total_image_annotations = 0
 
     for i, chunk in enumerate(chunks, 1):
         if hasattr(chunk, "chunk"):
-            # SearchResult object
+            chunk_id = str(chunk.chunk.id) if chunk.chunk.id else None
             content = chunk.chunk.content
             source = chunk.chunk.source
             chapter = getattr(chunk.chunk, "chapter", None)
             page = getattr(chunk.chunk, "page", None)
         else:
-            # Direct chunk object
+            chunk_id = str(chunk.id) if getattr(chunk, "id", None) else None
             content = chunk.content
             source = chunk.source
             chapter = getattr(chunk, "chapter", None)
@@ -347,7 +375,37 @@ REFERENCE DOCUMENTS:
         if page:
             source_ref += f", p.{page}"
 
-        formatted_chunks.append(f"[Extrait {i} - {source_ref}]\n{content}\n")
+        chunk_text = f"[Extrait {i} - {source_ref}]\n{content}\n"
+
+        # Append image annotations for this chunk (cap at 5 total across all chunks)
+        if linked_images and chunk_id and total_image_annotations < 5:
+            from uuid import UUID as _UUID
+
+            try:
+                lookup_key = _UUID(chunk_id)
+            except ValueError:
+                lookup_key = None
+
+            images_for_chunk = []
+            if lookup_key is not None and lookup_key in linked_images:
+                images_for_chunk = linked_images[lookup_key]
+            elif chunk_id in linked_images:
+                images_for_chunk = linked_images[chunk_id]  # type: ignore[assignment]
+
+            for img in images_for_chunk:
+                if total_image_annotations >= 5:
+                    break
+                img_id = img.get("id", "")
+                figure = img.get("figure_number") or ""
+                caption = img.get("caption") or ""
+                img_type = img.get("image_type", "image")
+                label = f'Figure {figure} — "{caption}"' if figure else f'"{caption}"'
+                chunk_text += (
+                    f"[FIGURE DISPONIBLE: {label} ({img_type}) — {{{{source_image:{img_id}}}}}]\n"
+                )
+                total_image_annotations += 1
+
+        formatted_chunks.append(chunk_text)
         sources.add(source_ref)
 
     # Build full context

--- a/backend/app/api/v1/schemas/content.py
+++ b/backend/app/api/v1/schemas/content.py
@@ -29,6 +29,20 @@ class LessonGenerationRequest(BaseModel):
     }
 
 
+class SourceImageRef(BaseModel):
+    """Reference to a source image used in a generated lesson."""
+
+    id: str = Field(..., description="Source image UUID")
+    figure_number: str | None = Field(None, description="Figure number e.g. '1.3'")
+    caption: str | None = Field(None, description="Image caption from source book")
+    image_type: str = Field(
+        ..., description="Image type: diagram, photo, chart, formula, icon, unknown"
+    )
+    storage_url: str | None = Field(None, description="CDN URL for the image")
+    alt_text_fr: str | None = Field(None, description="French alt text")
+    alt_text_en: str | None = Field(None, description="English alt text")
+
+
 class LessonContent(BaseModel):
     """Structured lesson content."""
 
@@ -53,6 +67,10 @@ class LessonResponse(BaseModel):
     content: LessonContent = Field(..., description="Structured lesson content")
     generated_at: str = Field(..., description="Generation timestamp (ISO format)")
     cached: bool = Field(default=False, description="Whether content was retrieved from cache")
+    source_image_refs: list[SourceImageRef] = Field(
+        default_factory=list,
+        description="Source images referenced in the generated lesson",
+    )
 
     model_config = {
         "json_schema_extra": {

--- a/backend/app/domain/services/lesson_service.py
+++ b/backend/app/domain/services/lesson_service.py
@@ -23,6 +23,7 @@ from app.api.v1.schemas.content import (
     CaseStudyResponse,
     LessonContent,
     LessonResponse,
+    SourceImageRef,
     StreamingEvent,
 )
 from app.domain.models.content import GeneratedContent
@@ -182,6 +183,18 @@ class LessonGenerationService:
 
             yield StreamingEvent(event="chunk", data="Documents trouvés, génération en cours...")
 
+            # Fetch images linked to retrieved chunks
+            chunk_ids = [
+                chunk.chunk.id if hasattr(chunk, "chunk") else chunk.id for chunk in rag_chunks
+            ]
+            try:
+                linked_images = await self.semantic_retriever.get_linked_images(
+                    chunk_ids, session, max_total=5
+                )
+            except Exception as exc:
+                logger.warning("Failed to fetch linked images, continuing without", error=str(exc))
+                linked_images = {}
+
             # Generate lesson using Claude API with streaming
             course: Course | None = module.course
             system_prompt = get_lesson_system_prompt(
@@ -204,6 +217,7 @@ class LessonGenerationService:
                 module.title_fr if language == "fr" else module.title_en,
                 unit_id,
                 language,
+                linked_images=linked_images,
             )
 
             # Stream content generation
@@ -217,6 +231,12 @@ class LessonGenerationService:
             # Parse and structure the generated content
             lesson_content = await self._parse_lesson_content(accumulated_content, rag_chunks)
 
+            # Post-process: extract {{source_image:UUID}} markers from generated text
+            all_images: list[dict] = []
+            for imgs in linked_images.values():
+                all_images.extend(imgs)
+            source_image_refs = self._extract_source_image_refs(accumulated_content, all_images)
+
             # Create response object
             lesson_response = LessonResponse(
                 module_id=module_id,
@@ -227,6 +247,7 @@ class LessonGenerationService:
                 content=lesson_content,
                 generated_at=datetime.utcnow().isoformat(),
                 cached=False,
+                source_image_refs=source_image_refs,
             )
 
             # Cache the result
@@ -305,6 +326,18 @@ class LessonGenerationService:
         if not rag_chunks:
             raise ValueError(f"No relevant content found for module {module.id}, unit {unit_id}")
 
+        # Fetch images linked to retrieved chunks
+        chunk_ids = [
+            chunk.chunk.id if hasattr(chunk, "chunk") else chunk.id for chunk in rag_chunks
+        ]
+        try:
+            linked_images = await self.semantic_retriever.get_linked_images(
+                chunk_ids, session, max_total=5
+            )
+        except Exception as exc:
+            logger.warning("Failed to fetch linked images, continuing without", error=str(exc))
+            linked_images = {}
+
         # Generate content with Claude
         course: Course | None = module.course
         system_prompt = get_lesson_system_prompt(
@@ -327,6 +360,7 @@ class LessonGenerationService:
             module.title_fr if language == "fr" else module.title_en,
             unit_id,
             language,
+            linked_images=linked_images,
         )
 
         # Get non-streaming response for structured parsing
@@ -344,6 +378,12 @@ class LessonGenerationService:
         # Parse structured content
         lesson_content = await self._parse_lesson_content(content_text, rag_chunks)
 
+        # Post-process: extract {{source_image:UUID}} markers from generated text
+        all_images: list[dict] = []
+        for imgs in linked_images.values():
+            all_images.extend(imgs)
+        source_image_refs = self._extract_source_image_refs(content_text, all_images)
+
         return LessonResponse(
             module_id=module.id,
             unit_id=unit_id,
@@ -353,6 +393,7 @@ class LessonGenerationService:
             content=lesson_content,
             generated_at=datetime.utcnow().isoformat(),
             cached=False,
+            source_image_refs=source_image_refs,
         )
 
     async def _build_lesson_query(
@@ -435,6 +476,41 @@ class LessonGenerationService:
             key_points=["Point clé 1", "Point clé 2", "Point clé 3"],  # Would be parsed
             sources_cited=sources_cited,
         )
+
+    @staticmethod
+    def _extract_source_image_refs(
+        content_text: str, available_images: list[dict]
+    ) -> list[SourceImageRef]:
+        """Extract {{source_image:UUID}} markers from generated text and resolve to SourceImageRef.
+
+        Args:
+            content_text: Generated lesson text possibly containing {{source_image:UUID}} markers
+            available_images: List of image metadata dicts from get_linked_images
+
+        Returns:
+            Deduplicated list of SourceImageRef objects for images referenced in the text
+        """
+        pattern = re.compile(r"\{\{source_image:([0-9a-f-]{36})\}\}", re.IGNORECASE)
+        found_ids = list(dict.fromkeys(m.group(1) for m in pattern.finditer(content_text)))
+
+        image_lookup = {img["id"]: img for img in available_images if "id" in img}
+
+        refs: list[SourceImageRef] = []
+        for img_id in found_ids:
+            meta = image_lookup.get(img_id)
+            if meta:
+                refs.append(
+                    SourceImageRef(
+                        id=meta["id"],
+                        figure_number=meta.get("figure_number"),
+                        caption=meta.get("caption"),
+                        image_type=meta.get("image_type", "unknown"),
+                        storage_url=meta.get("storage_url"),
+                        alt_text_fr=meta.get("alt_text_fr"),
+                        alt_text_en=meta.get("alt_text_en"),
+                    )
+                )
+        return refs
 
     async def _cache_lesson_content(
         self, lesson_response: LessonResponse, session: AsyncSession

--- a/backend/tests/test_source_image_injection.py
+++ b/backend/tests/test_source_image_injection.py
@@ -1,0 +1,263 @@
+"""Tests for source image injection into lesson generation prompts."""
+
+import uuid
+from unittest.mock import MagicMock
+
+from app.ai.prompts.lesson import format_rag_context_for_lesson, get_lesson_system_prompt
+from app.api.v1.schemas.content import LessonContent, LessonResponse, SourceImageRef
+from app.domain.services.lesson_service import LessonGenerationService
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_chunk(chunk_id=None, source="donaldson", chapter="3", page=45, content="Test content."):
+    chunk = MagicMock()
+    chunk.id = chunk_id or uuid.uuid4()
+    chunk.content = content
+    chunk.source = source
+    chunk.chapter = chapter
+    chunk.page = page
+    return chunk
+
+
+def _make_search_result(chunk_id=None, **kwargs):
+    sr = MagicMock()
+    sr.chunk = _make_chunk(chunk_id=chunk_id, **kwargs)
+    return sr
+
+
+def _make_image_meta(
+    image_id=None, figure_number="1.3", caption="Test figure", image_type="diagram"
+):
+    return {
+        "id": str(image_id or uuid.uuid4()),
+        "figure_number": figure_number,
+        "caption": caption,
+        "image_type": image_type,
+        "storage_url": "https://cdn.example.com/img/test.webp",
+        "alt_text_fr": "Diagramme de test",
+        "alt_text_en": "Test diagram",
+    }
+
+
+# ---------------------------------------------------------------------------
+# SourceImageRef schema tests
+# ---------------------------------------------------------------------------
+
+
+class TestSourceImageRefSchema:
+    def test_minimal_fields(self):
+        ref = SourceImageRef(id="abc-123", image_type="diagram")
+        assert ref.id == "abc-123"
+        assert ref.image_type == "diagram"
+        assert ref.figure_number is None
+        assert ref.caption is None
+        assert ref.storage_url is None
+
+    def test_all_fields(self):
+        ref = SourceImageRef(
+            id="abc-123",
+            figure_number="1.3",
+            caption="Steps in the Marketing Process",
+            image_type="diagram",
+            storage_url="https://cdn.example.com/img.webp",
+            alt_text_fr="Diagramme",
+            alt_text_en="Diagram",
+        )
+        assert ref.figure_number == "1.3"
+        assert ref.caption == "Steps in the Marketing Process"
+        assert ref.storage_url == "https://cdn.example.com/img.webp"
+
+
+def _make_lesson_content(**overrides):
+    defaults = dict(
+        introduction="intro",
+        concepts=["concept"],
+        aof_example="example",
+        synthesis="synthesis",
+        key_points=["point"],
+        sources_cited=["src"],
+    )
+    defaults.update(overrides)
+    return LessonContent(**defaults)
+
+
+class TestLessonResponseSourceImageRefs:
+    def test_default_empty_list(self):
+        resp = LessonResponse(
+            module_id=uuid.uuid4(),
+            unit_id="M01-U01",
+            language="fr",
+            level=1,
+            country_context="SN",
+            content=_make_lesson_content(),
+            generated_at="2026-01-01T00:00:00",
+        )
+        assert resp.source_image_refs == []
+
+    def test_accepts_source_image_refs(self):
+        ref = SourceImageRef(id="abc", image_type="diagram")
+        resp = LessonResponse(
+            module_id=uuid.uuid4(),
+            unit_id="M01-U01",
+            language="fr",
+            level=1,
+            country_context="SN",
+            content=_make_lesson_content(),
+            generated_at="2026-01-01T00:00:00",
+            source_image_refs=[ref],
+        )
+        assert len(resp.source_image_refs) == 1
+        assert resp.source_image_refs[0].id == "abc"
+
+
+# ---------------------------------------------------------------------------
+# format_rag_context_for_lesson tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatRagContextWithImages:
+    def test_no_linked_images_works_as_before(self):
+        chunk = _make_search_result()
+        result = format_rag_context_for_lesson([chunk], "epidemiology", "Module 1", "M01-U01", "fr")
+        assert "DEMANDE" in result
+        assert "DOCUMENTS DE RÉFÉRENCE" in result
+        assert "FIGURE DISPONIBLE" not in result
+
+    def test_no_linked_images_en(self):
+        chunk = _make_search_result()
+        result = format_rag_context_for_lesson([chunk], "epidemiology", "Module 1", "M01-U01", "en")
+        assert "REQUEST" in result
+        assert "FIGURE AVAILABLE" not in result
+
+    def test_image_annotation_appended_when_linked(self):
+        chunk_id = uuid.uuid4()
+        chunk = _make_search_result(chunk_id=chunk_id)
+        img = _make_image_meta(figure_number="1.3", caption="Test figure")
+        linked_images = {chunk_id: [img]}
+
+        result = format_rag_context_for_lesson(
+            [chunk], "epidemiology", "Module 1", "M01-U01", "fr", linked_images=linked_images
+        )
+        assert "FIGURE DISPONIBLE" in result
+        assert img["id"] in result
+        assert "{{source_image:" in result
+
+    def test_caps_at_5_total_annotations(self):
+        chunk_ids = [uuid.uuid4() for _ in range(3)]
+        chunks = [_make_search_result(chunk_id=cid) for cid in chunk_ids]
+        linked_images = {cid: [_make_image_meta() for _ in range(3)] for cid in chunk_ids}
+
+        result = format_rag_context_for_lesson(
+            chunks, "query", "Module", "M01-U01", "fr", linked_images=linked_images
+        )
+        count = result.count("{{source_image:")
+        assert count <= 5
+
+    def test_no_annotations_for_unknown_chunk(self):
+        chunk = _make_search_result()
+        other_id = uuid.uuid4()
+        linked_images = {other_id: [_make_image_meta()]}
+
+        result = format_rag_context_for_lesson(
+            [chunk], "query", "Module", "M01-U01", "fr", linked_images=linked_images
+        )
+        assert "FIGURE DISPONIBLE" not in result
+
+    def test_empty_linked_images_dict(self):
+        chunk = _make_search_result()
+        result = format_rag_context_for_lesson(
+            [chunk], "query", "Module", "M01-U01", "fr", linked_images={}
+        )
+        assert "FIGURE DISPONIBLE" not in result
+
+
+# ---------------------------------------------------------------------------
+# get_lesson_system_prompt tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetLessonSystemPromptImages:
+    def test_fr_prompt_contains_source_image_syntax(self):
+        prompt = get_lesson_system_prompt("fr", "SN", 1, "remember")
+        assert "source_image" in prompt
+        assert "FIGURES DE RÉFÉRENCE" in prompt
+
+    def test_en_prompt_contains_source_image_syntax(self):
+        prompt = get_lesson_system_prompt("en", "SN", 1, "remember")
+        assert "source_image" in prompt
+        assert "REFERENCE FIGURES" in prompt
+
+    def test_fr_prompt_max_3_markers_instruction(self):
+        prompt = get_lesson_system_prompt("fr", "SN", 2, "apply")
+        assert "3" in prompt
+
+    def test_en_prompt_max_3_markers_instruction(self):
+        prompt = get_lesson_system_prompt("en", "GH", 2, "apply")
+        assert "3" in prompt
+
+
+# ---------------------------------------------------------------------------
+# _extract_source_image_refs tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSourceImageRefs:
+    def test_no_markers_returns_empty(self):
+        refs = LessonGenerationService._extract_source_image_refs("No markers here.", [])
+        assert refs == []
+
+    def test_extracts_single_marker(self):
+        img_id = str(uuid.uuid4())
+        img = _make_image_meta(image_id=uuid.UUID(img_id))
+        text = f"See diagram {{{{source_image:{img_id}}}}} for details."
+        refs = LessonGenerationService._extract_source_image_refs(text, [img])
+        assert len(refs) == 1
+        assert refs[0].id == img_id
+
+    def test_extracts_multiple_markers(self):
+        ids = [str(uuid.uuid4()) for _ in range(3)]
+        images = [_make_image_meta(image_id=uuid.UUID(i)) for i in ids]
+        text = " ".join(f"{{{{source_image:{i}}}}}" for i in ids)
+        refs = LessonGenerationService._extract_source_image_refs(text, images)
+        assert len(refs) == 3
+
+    def test_deduplicates_repeated_marker(self):
+        img_id = str(uuid.uuid4())
+        img = _make_image_meta(image_id=uuid.UUID(img_id))
+        text = f"{{{{source_image:{img_id}}}}} and again {{{{source_image:{img_id}}}}}"
+        refs = LessonGenerationService._extract_source_image_refs(text, [img])
+        assert len(refs) == 1
+
+    def test_unknown_uuid_not_included(self):
+        unknown_id = str(uuid.uuid4())
+        text = f"{{{{source_image:{unknown_id}}}}}"
+        refs = LessonGenerationService._extract_source_image_refs(text, [])
+        assert refs == []
+
+    def test_ref_fields_populated_correctly(self):
+        img_id = str(uuid.uuid4())
+        img = {
+            "id": img_id,
+            "figure_number": "2.1",
+            "caption": "Epidemiological triangle",
+            "image_type": "diagram",
+            "storage_url": "https://cdn.example.com/img.webp",
+            "alt_text_fr": "Triangle épidémiologique",
+            "alt_text_en": "Epidemiological triangle",
+        }
+        text = f"{{{{source_image:{img_id}}}}}"
+        refs = LessonGenerationService._extract_source_image_refs(text, [img])
+        assert refs[0].figure_number == "2.1"
+        assert refs[0].caption == "Epidemiological triangle"
+        assert refs[0].image_type == "diagram"
+        assert refs[0].storage_url == "https://cdn.example.com/img.webp"
+        assert refs[0].alt_text_fr == "Triangle épidémiologique"
+
+    def test_empty_available_images_returns_empty(self):
+        img_id = str(uuid.uuid4())
+        text = f"{{{{source_image:{img_id}}}}}"
+        refs = LessonGenerationService._extract_source_image_refs(text, [])
+        assert refs == []


### PR DESCRIPTION
## Summary

- Add `SourceImageRef` Pydantic schema and `source_image_refs` field to `LessonResponse`
- Update `format_rag_context_for_lesson()` to accept optional `linked_images` parameter and append `[FIGURE DISPONIBLE: ...]` annotations (capped at 5 total per context)
- Add `{{source_image:UUID}}` instruction block to system prompt (both FR and EN, max 3 per lesson)
- Update `_generate_lesson_content()` and streaming equivalent to call `get_linked_images()` after RAG retrieval and pass results to prompt formatter
- Add `_extract_source_image_refs()` static method to post-process Claude's output and resolve marker UUIDs to full `SourceImageRef` objects

## Changes

- `backend/app/api/v1/schemas/content.py` — `SourceImageRef` model + `source_image_refs` on `LessonResponse`
- `backend/app/ai/prompts/lesson.py` — image annotations in `format_rag_context_for_lesson()`, `{{source_image:UUID}}` instructions in system prompt (FR + EN)
- `backend/app/domain/services/lesson_service.py` — linked image retrieval, prompt injection, `_extract_source_image_refs()` post-processing
- `backend/tests/test_source_image_injection.py` — 21 unit tests

## Test plan

- [x] 21 unit tests passing (`pytest tests/test_source_image_injection.py`)
- [x] `ruff check` + `ruff format` clean
- [x] Backward compatible: lessons without source images return `source_image_refs: []`
- [x] `get_linked_images()` failures handled gracefully (warning log, continues without images)

Closes #741

Generated with [Claude Code](https://claude.ai/code)