### PR TITLE
feat(ai): tutor source image tool + DALL-E fallback optimization

### DIFF
--- a/backend/app/ai/prompts/tutor.py
+++ b/backend/app/ai/prompts/tutor.py
@@ -70,7 +70,15 @@ def get_socratic_system_prompt(context: TutorContext, rag_chunks: list[dict[str,
 
 ## OUTILS DISPONIBLES (tool_use)
 
-Tu as accès à 5 outils que tu peux appeler de manière autonome:
+Tu as accès à 6 outils que tu peux appeler de manière autonome:
+
+### `search_source_images(query, image_type?)`
+Utilise cet outil quand:
+- L'apprenant demande à voir une figure, un diagramme ou une illustration spécifique
+- Un visuel aiderait à expliquer un concept (anatomie, épidémiologie, flux de données, etc.)
+- Tu veux enrichir une explication avec une illustration des manuels de référence
+- Résultats: retourne des métadonnées + un marqueur `{{{{source_image:UUID}}}}` à inclure dans ta réponse
+- **Important:** Intègre le marqueur `{{{{source_image:UUID}}}}` directement dans ton texte pour afficher la figure
 
 ### `search_knowledge_base(query, module_id?)`
 Utilise cet outil CHAQUE FOIS que tu dois:
@@ -78,6 +86,7 @@ Utilise cet outil CHAQUE FOIS que tu dois:
 - Trouver des informations précises sur un sujet de santé publique
 - Appuyer ta guidance Socratique sur des références bibliographiques
 - Répondre à des questions nécessitant des données factuelles
+- Les résultats incluent aussi `available_figures` — des figures liées aux chunks trouvés
 
 ### `get_learner_progress(user_id)`
 Utilise cet outil quand tu dois:
@@ -106,6 +115,20 @@ Utilise cet outil quand tu détectes un pattern récurrent:
 - L'apprenant préfère une approche plus directe ou plus Socratique
 
 **IMPORTANT:** Tu peux enchaîner jusqu'à 3 appels d'outils par message. Utilise les outils intelligemment selon le contexte — ne les appelle pas tous systématiquement.
+
+## RÉFÉRENCES D'IMAGES ({{{{source_image:UUID}}}})
+
+Lorsqu'un outil retourne un marqueur `{{{{source_image:UUID}}}}`, tu peux l'inclure directement dans ta réponse pour afficher la figure correspondante du manuel de référence.
+
+**Format d'utilisation:**
+- Dans le texte: "Observe la Figure 3.2 {{{{source_image:abc123-...}}}} qui illustre le cycle de transmission."
+- Après une explication: "Voici le diagramme correspondant: {{{{source_image:abc123-...}}}}"
+
+**Quand utiliser:**
+- Quand `search_source_images` retourne des figures pertinentes
+- Quand `search_knowledge_base` retourne des `available_figures` liées au contenu
+- N'invente JAMAIS un UUID — utilise uniquement les références retournées par les outils
+- Si aucune figure n'est disponible, continue sans marqueur d'image
 
 ## INSTRUCTIONS SPÉCIALES
 

--- a/backend/app/domain/services/image_service.py
+++ b/backend/app/domain/services/image_service.py
@@ -11,6 +11,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.domain.models.generated_image import GeneratedImage
+from app.domain.models.source_image import SourceImage, SourceImageChunk
 from app.infrastructure.config.settings import settings
 
 logger = structlog.get_logger(__name__)
@@ -77,6 +78,31 @@ class ImageGenerationService:
                     "Reused existing image",
                     reused_from=str(reusable.id),
                     lesson_id=str(lesson_id),
+                )
+                return image_record
+
+            source_img = await self._find_source_image(lesson_id, session)
+            if source_img is not None:
+                image_record.status = "ready"
+                image_record.image_url = (
+                    source_img.storage_url or f"/api/v1/source-images/{source_img.id}/data"
+                )
+                image_record.alt_text_fr = source_img.alt_text_fr or (
+                    f"Figure {source_img.figure_number}" if source_img.figure_number else concept
+                )
+                image_record.alt_text_en = source_img.alt_text_en or (
+                    f"Figure {source_img.figure_number}" if source_img.figure_number else concept
+                )
+                image_record.width = source_img.width or 512
+                image_record.format = source_img.format or "webp"
+                image_record.file_size_bytes = source_img.file_size_bytes
+                image_record.generated_at = datetime.utcnow()
+                await session.commit()
+                logger.info(
+                    "Skipping DALL-E — source image found: Figure %s",
+                    source_img.figure_number or str(source_img.id),
+                    lesson_id=str(lesson_id),
+                    source_image_id=str(source_img.id),
                 )
                 return image_record
 
@@ -156,6 +182,38 @@ class ImageGenerationService:
 
         text = message.content[0].text if message.content else ""
         return _parse_concept_response(text)
+
+    async def _find_source_image(
+        self, lesson_id: uuid.UUID, session: AsyncSession
+    ) -> SourceImage | None:
+        """Check if any source images are explicitly linked to the lesson's document chunks.
+
+        Returns the first SourceImage with image_type in ('diagram', 'chart', 'photo')
+        that is explicitly linked to a document chunk via the lesson's generated content.
+        """
+        from app.domain.models.content import GeneratedContent
+
+        lesson = await session.get(GeneratedContent, lesson_id)
+        if lesson is None or not lesson.sources_cited:
+            return None
+
+        sources = [
+            s.get("source") for s in lesson.sources_cited if isinstance(s, dict) and s.get("source")
+        ]
+        if not sources:
+            return None
+
+        result = await session.execute(
+            select(SourceImage)
+            .join(SourceImageChunk, SourceImageChunk.source_image_id == SourceImage.id)
+            .where(
+                SourceImage.source.in_(sources),
+                SourceImage.image_type.in_(["diagram", "chart", "photo"]),
+                SourceImageChunk.reference_type == "explicit",
+            )
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
 
     async def _find_reusable_image(
         self, tags: list[str], session: AsyncSession

--- a/backend/app/domain/services/tutor_tools.py
+++ b/backend/app/domain/services/tutor_tools.py
@@ -22,6 +22,29 @@ logger = structlog.get_logger()
 
 TOOL_DEFINITIONS: list[ToolParam] = [
     {
+        "name": "search_source_images",
+        "description": (
+            "Search for diagrams, charts, and illustrations from reference textbooks. "
+            "Use when the learner asks about a specific figure or when a visual would help explain a concept. "
+            "Returns matching images with metadata and {{source_image:UUID}} references you can embed in responses."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "What the image should illustrate.",
+                },
+                "image_type": {
+                    "type": "string",
+                    "enum": ["diagram", "photo", "chart", "any"],
+                    "description": "Type of image to search for. Defaults to 'any'.",
+                },
+            },
+            "required": ["query"],
+        },
+    },
+    {
         "name": "search_knowledge_base",
         "description": (
             "Search the knowledge base (reference textbooks on public health) for relevant information. "
@@ -196,6 +219,8 @@ class TutorToolExecutor:
                 return await self._search_flashcards(tool_input, session)
             elif tool_name == "save_learner_preference":
                 return await self._save_learner_preference(tool_input, session)
+            elif tool_name == "search_source_images":
+                return await self._search_source_images(tool_input, session)
             else:
                 logger.warning("Unknown tool called", tool_name=tool_name)
                 return json.dumps({"error": f"Unknown tool: {tool_name}"})
@@ -235,6 +260,7 @@ class TutorToolExecutor:
         )
 
         chunks = []
+        chunk_ids = []
         for result in results:
             chunks.append(
                 {
@@ -245,14 +271,48 @@ class TutorToolExecutor:
                     "similarity": round(result.similarity_score, 3),
                 }
             )
+            if result.chunk.id is not None:
+                chunk_ids.append(result.chunk.id)
+
+        available_figures: list[dict[str, Any]] = []
+        if chunk_ids:
+            try:
+                linked = await self.retriever.get_linked_images(chunk_ids, session)
+                seen: set[str] = set()
+                for img_list in linked.values():
+                    for img in img_list:
+                        img_id = str(img.get("id", ""))
+                        if img_id and img_id not in seen:
+                            seen.add(img_id)
+                            available_figures.append(
+                                {
+                                    "figure_number": img.get("figure_number"),
+                                    "caption": img.get("caption"),
+                                    "image_type": img.get("image_type"),
+                                    "ref": f"{{{{source_image:{img_id}}}}}",
+                                }
+                            )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to fetch linked images for search_knowledge_base",
+                    error=str(exc),
+                )
 
         logger.info(
             "search_knowledge_base tool completed",
             query=query,
             results_count=len(chunks),
+            figures_count=len(available_figures),
             user_id=str(self.user_id),
         )
-        return json.dumps({"query": query, "results": chunks, "count": len(chunks)})
+        return json.dumps(
+            {
+                "query": query,
+                "results": chunks,
+                "count": len(chunks),
+                "available_figures": available_figures,
+            }
+        )
 
     async def _get_learner_progress(self, tool_input: dict[str, Any], session: AsyncSession) -> str:
         """Execute get_learner_progress tool."""
@@ -498,6 +558,45 @@ Respond ONLY with valid JSON in this exact format:
             user_id=str(self.user_id),
         )
         return json.dumps({"concept": concept, "flashcards": matching, "count": len(matching)})
+
+    async def _search_source_images(self, tool_input: dict[str, Any], session: AsyncSession) -> str:
+        """Execute search_source_images tool."""
+        query = tool_input["query"]
+        image_type_filter = tool_input.get("image_type", "any")
+
+        raw_results = await self.retriever.search_source_images(
+            query=query,
+            top_k=3,
+            session=session,
+        )
+
+        figures = []
+        for img in raw_results:
+            img_type = img.get("image_type", "unknown")
+            if image_type_filter != "any" and img_type != image_type_filter:
+                continue
+            img_id = str(img.get("id", ""))
+            figures.append(
+                {
+                    "figure_number": img.get("figure_number"),
+                    "caption": img.get("caption"),
+                    "image_type": img_type,
+                    "source": img.get("source"),
+                    "chapter": img.get("chapter"),
+                    "page_number": img.get("page_number"),
+                    "similarity": round(float(img.get("similarity", 0)), 3),
+                    "ref": f"{{{{source_image:{img_id}}}}}",
+                }
+            )
+
+        logger.info(
+            "search_source_images tool completed",
+            query=query,
+            image_type=image_type_filter,
+            results_count=len(figures),
+            user_id=str(self.user_id),
+        )
+        return json.dumps({"query": query, "figures": figures, "count": len(figures)})
 
     async def _save_learner_preference(
         self, tool_input: dict[str, Any], session: AsyncSession

--- a/backend/tests/test_image_generation.py
+++ b/backend/tests/test_image_generation.py
@@ -145,6 +145,7 @@ class TestImageGenerationService:
         session.flush = AsyncMock()
         session.commit = AsyncMock()
         session.add = MagicMock()
+        session.get = AsyncMock(return_value=None)
         return session
 
     @pytest.fixture

--- a/backend/tests/test_tutor_source_image.py
+++ b/backend/tests/test_tutor_source_image.py
@@ -1,0 +1,648 @@
+"""Tests for tutor source image tool and DALL-E fallback optimization (issue #743)."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.ai.rag.retriever import SemanticRetriever
+from app.domain.models.generated_image import GeneratedImage
+from app.domain.models.source_image import SourceImage
+from app.domain.services.image_service import ImageGenerationService
+from app.domain.services.tutor_tools import TOOL_DEFINITIONS, TutorToolExecutor
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_source_image(
+    image_type: str = "diagram",
+    figure_number: str = "3.2",
+    caption: str = "Disease transmission cycle",
+    storage_url: str = "https://cdn.example.com/fig3.2.webp",
+) -> SourceImage:
+    img_id = uuid.uuid4()
+    return SourceImage(
+        id=img_id,
+        source="donaldson",
+        figure_number=figure_number,
+        caption=caption,
+        image_type=image_type,
+        page_number=42,
+        chapter="3",
+        storage_url=storage_url,
+        format="webp",
+        width=512,
+        height=400,
+    )
+
+
+def _make_generated_image(tags: list[str], status: str = "ready") -> GeneratedImage:
+    img_id = uuid.uuid4()
+    return GeneratedImage(
+        id=img_id,
+        status=status,
+        semantic_tags=tags,
+        image_url=f"/api/v1/images/{img_id}/data",
+        image_data=b"fake-webp-data",
+        alt_text_fr="Image FR",
+        alt_text_en="Image EN",
+        width=512,
+        format="webp",
+        file_size_bytes=14,
+        reuse_count=0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TOOL_DEFINITIONS — search_source_images is registered
+# ---------------------------------------------------------------------------
+
+
+def test_tool_definitions_include_search_source_images():
+    names = {t["name"] for t in TOOL_DEFINITIONS}
+    assert "search_source_images" in names
+
+
+def test_search_source_images_tool_has_required_fields():
+    tool = next(t for t in TOOL_DEFINITIONS if t["name"] == "search_source_images")
+    assert "query" in tool["input_schema"]["required"]
+    props = tool["input_schema"]["properties"]
+    assert "query" in props
+    assert "image_type" in props
+    enum_vals = props["image_type"]["enum"]
+    assert set(enum_vals) == {"diagram", "photo", "chart", "any"}
+
+
+def test_tool_count_increased_to_six():
+    assert len(TOOL_DEFINITIONS) == 6
+
+
+# ---------------------------------------------------------------------------
+# TutorToolExecutor._search_source_images
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_retriever():
+    retriever = AsyncMock(spec=SemanticRetriever)
+    retriever.search_for_module = AsyncMock(return_value=[])
+    retriever.search_source_images = AsyncMock(return_value=[])
+    retriever.get_linked_images = AsyncMock(return_value={})
+    return retriever
+
+
+@pytest.fixture
+def tool_executor(mock_retriever):
+    user_id = uuid.uuid4()
+    return TutorToolExecutor(
+        retriever=mock_retriever,
+        anthropic_client=MagicMock(),
+        user_id=user_id,
+        user_level=2,
+        user_language="fr",
+    )
+
+
+async def test_search_source_images_returns_figures(tool_executor, mock_retriever):
+    img_id = str(uuid.uuid4())
+    mock_retriever.search_source_images = AsyncMock(
+        return_value=[
+            {
+                "id": img_id,
+                "figure_number": "3.2",
+                "caption": "Disease transmission cycle",
+                "image_type": "diagram",
+                "source": "donaldson",
+                "chapter": "3",
+                "page_number": 42,
+                "similarity": 0.87,
+            }
+        ]
+    )
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    result_str = await tool_executor._search_source_images({"query": "transmission"}, mock_session)
+    result = json.loads(result_str)
+
+    assert result["query"] == "transmission"
+    assert result["count"] == 1
+    fig = result["figures"][0]
+    assert fig["figure_number"] == "3.2"
+    assert fig["caption"] == "Disease transmission cycle"
+    assert fig["image_type"] == "diagram"
+    assert f"{{{{source_image:{img_id}}}}}" in fig["ref"]
+
+
+async def test_search_source_images_empty_query_returns_empty(tool_executor, mock_retriever):
+    mock_retriever.search_source_images = AsyncMock(return_value=[])
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    result_str = await tool_executor._search_source_images(
+        {"query": "unknown concept xyz"}, mock_session
+    )
+    result = json.loads(result_str)
+
+    assert result["count"] == 0
+    assert result["figures"] == []
+
+
+async def test_search_source_images_filters_by_image_type(tool_executor, mock_retriever):
+    img_id = str(uuid.uuid4())
+    mock_retriever.search_source_images = AsyncMock(
+        return_value=[
+            {
+                "id": img_id,
+                "figure_number": "1.1",
+                "caption": "Epidemiology photo",
+                "image_type": "photo",
+                "source": "donaldson",
+                "chapter": "1",
+                "page_number": 10,
+                "similarity": 0.75,
+            }
+        ]
+    )
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    result_str = await tool_executor._search_source_images(
+        {"query": "surveillance", "image_type": "diagram"}, mock_session
+    )
+    result = json.loads(result_str)
+
+    assert result["count"] == 0, "Photo should be filtered out when diagram requested"
+
+
+async def test_search_source_images_any_type_returns_all(tool_executor, mock_retriever):
+    img_id1 = str(uuid.uuid4())
+    img_id2 = str(uuid.uuid4())
+    mock_retriever.search_source_images = AsyncMock(
+        return_value=[
+            {
+                "id": img_id1,
+                "figure_number": "1.1",
+                "caption": "Photo",
+                "image_type": "photo",
+                "source": "donaldson",
+                "chapter": "1",
+                "page_number": 10,
+                "similarity": 0.8,
+            },
+            {
+                "id": img_id2,
+                "figure_number": "2.1",
+                "caption": "Diagram",
+                "image_type": "diagram",
+                "source": "donaldson",
+                "chapter": "2",
+                "page_number": 20,
+                "similarity": 0.75,
+            },
+        ]
+    )
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    result_str = await tool_executor._search_source_images(
+        {"query": "health", "image_type": "any"}, mock_session
+    )
+    result = json.loads(result_str)
+
+    assert result["count"] == 2
+
+
+async def test_search_source_images_ref_format(tool_executor, mock_retriever):
+    img_id = str(uuid.uuid4())
+    mock_retriever.search_source_images = AsyncMock(
+        return_value=[
+            {
+                "id": img_id,
+                "figure_number": "5.3",
+                "caption": "Chart",
+                "image_type": "chart",
+                "source": "triola",
+                "chapter": "5",
+                "page_number": 100,
+                "similarity": 0.9,
+            }
+        ]
+    )
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    result_str = await tool_executor._search_source_images({"query": "statistics"}, mock_session)
+    result = json.loads(result_str)
+
+    fig = result["figures"][0]
+    assert fig["ref"] == f"{{{{source_image:{img_id}}}}}"
+
+
+async def test_execute_dispatches_search_source_images(tool_executor, mock_retriever):
+    mock_retriever.search_source_images = AsyncMock(return_value=[])
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    result_str = await tool_executor.execute(
+        "search_source_images", {"query": "diagram"}, mock_session
+    )
+    result = json.loads(result_str)
+
+    mock_retriever.search_source_images.assert_called_once()
+    assert "figures" in result
+
+
+# ---------------------------------------------------------------------------
+# search_knowledge_base — available_figures in result
+# ---------------------------------------------------------------------------
+
+
+async def test_search_knowledge_base_includes_available_figures(tool_executor, mock_retriever):
+    chunk_id = uuid.uuid4()
+    img_id = str(uuid.uuid4())
+
+    mock_chunk = MagicMock()
+    mock_chunk.content = "Public health surveillance..."
+    mock_chunk.source = "donaldson"
+    mock_chunk.chapter = "4"
+    mock_chunk.page = 89
+    mock_chunk.id = chunk_id
+
+    mock_result = MagicMock()
+    mock_result.chunk = mock_chunk
+    mock_result.similarity_score = 0.85
+
+    mock_retriever.search_for_module = AsyncMock(return_value=[mock_result])
+    mock_retriever.get_linked_images = AsyncMock(
+        return_value={
+            chunk_id: [
+                {
+                    "id": img_id,
+                    "figure_number": "4.1",
+                    "caption": "Surveillance network diagram",
+                    "image_type": "diagram",
+                }
+            ]
+        }
+    )
+
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_session.get = AsyncMock(return_value=None)
+
+    result_str = await tool_executor._search_knowledge_base({"query": "surveillance"}, mock_session)
+    result = json.loads(result_str)
+
+    assert "available_figures" in result
+    assert len(result["available_figures"]) == 1
+    fig = result["available_figures"][0]
+    assert fig["figure_number"] == "4.1"
+    assert fig["caption"] == "Surveillance network diagram"
+    assert f"{{{{source_image:{img_id}}}}}" in fig["ref"]
+
+
+async def test_search_knowledge_base_no_figures_when_none_linked(tool_executor, mock_retriever):
+    chunk_id = uuid.uuid4()
+
+    mock_chunk = MagicMock()
+    mock_chunk.content = "Epidemiology basics..."
+    mock_chunk.source = "donaldson"
+    mock_chunk.chapter = "1"
+    mock_chunk.page = 5
+    mock_chunk.id = chunk_id
+
+    mock_result = MagicMock()
+    mock_result.chunk = mock_chunk
+    mock_result.similarity_score = 0.72
+
+    mock_retriever.search_for_module = AsyncMock(return_value=[mock_result])
+    mock_retriever.get_linked_images = AsyncMock(return_value={chunk_id: []})
+
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_session.get = AsyncMock(return_value=None)
+
+    result_str = await tool_executor._search_knowledge_base({"query": "epidemiology"}, mock_session)
+    result = json.loads(result_str)
+
+    assert result["available_figures"] == []
+
+
+async def test_search_knowledge_base_deduplicates_figures(tool_executor, mock_retriever):
+    chunk_id1 = uuid.uuid4()
+    chunk_id2 = uuid.uuid4()
+    img_id = str(uuid.uuid4())
+
+    def make_chunk_result(chunk_id):
+        mock_chunk = MagicMock()
+        mock_chunk.content = "Content..."
+        mock_chunk.source = "donaldson"
+        mock_chunk.chapter = "4"
+        mock_chunk.page = 89
+        mock_chunk.id = chunk_id
+        r = MagicMock()
+        r.chunk = mock_chunk
+        r.similarity_score = 0.8
+        return r
+
+    mock_retriever.search_for_module = AsyncMock(
+        return_value=[make_chunk_result(chunk_id1), make_chunk_result(chunk_id2)]
+    )
+    mock_retriever.get_linked_images = AsyncMock(
+        return_value={
+            chunk_id1: [
+                {"id": img_id, "figure_number": "4.1", "caption": "Fig", "image_type": "diagram"}
+            ],
+            chunk_id2: [
+                {"id": img_id, "figure_number": "4.1", "caption": "Fig", "image_type": "diagram"}
+            ],
+        }
+    )
+
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_session.get = AsyncMock(return_value=None)
+
+    result_str = await tool_executor._search_knowledge_base({"query": "test"}, mock_session)
+    result = json.loads(result_str)
+
+    assert len(result["available_figures"]) == 1, "Same image should not appear twice"
+
+
+# ---------------------------------------------------------------------------
+# ImageGenerationService._find_source_image & DALL-E fallback
+# ---------------------------------------------------------------------------
+
+
+class TestFindSourceImage:
+    @pytest.fixture
+    def service(self):
+        return ImageGenerationService()
+
+    @pytest.fixture
+    def mock_session(self):
+        session = AsyncMock()
+        session.flush = AsyncMock()
+        session.commit = AsyncMock()
+        session.add = MagicMock()
+        session.get = AsyncMock(return_value=None)
+        return session
+
+    async def test_returns_none_when_lesson_not_found(self, service, mock_session):
+        mock_session.get = AsyncMock(return_value=None)
+        result = await service._find_source_image(uuid.uuid4(), mock_session)
+        assert result is None
+
+    async def test_returns_none_when_no_sources_cited(self, service, mock_session):
+        from app.domain.models.content import GeneratedContent
+
+        lesson = MagicMock(spec=GeneratedContent)
+        lesson.sources_cited = None
+        mock_session.get = AsyncMock(return_value=lesson)
+
+        result = await service._find_source_image(uuid.uuid4(), mock_session)
+        assert result is None
+
+    async def test_returns_none_when_sources_cited_empty(self, service, mock_session):
+        from app.domain.models.content import GeneratedContent
+
+        lesson = MagicMock(spec=GeneratedContent)
+        lesson.sources_cited = []
+        mock_session.get = AsyncMock(return_value=lesson)
+
+        result = await service._find_source_image(uuid.uuid4(), mock_session)
+        assert result is None
+
+    async def test_returns_source_image_when_explicit_link_exists(self, service, mock_session):
+        from app.domain.models.content import GeneratedContent
+
+        lesson = MagicMock(spec=GeneratedContent)
+        lesson.sources_cited = [{"source": "donaldson", "chapter": "3", "page": 42}]
+        mock_session.get = AsyncMock(return_value=lesson)
+
+        source_img = _make_source_image(image_type="diagram")
+        mock_execute_result = MagicMock()
+        mock_execute_result.scalar_one_or_none = MagicMock(return_value=source_img)
+        mock_session.execute = AsyncMock(return_value=mock_execute_result)
+
+        result = await service._find_source_image(uuid.uuid4(), mock_session)
+        assert result is source_img
+
+    async def test_returns_none_when_no_explicit_source_image(self, service, mock_session):
+        from app.domain.models.content import GeneratedContent
+
+        lesson = MagicMock(spec=GeneratedContent)
+        lesson.sources_cited = [{"source": "triola", "chapter": "1", "page": 5}]
+        mock_session.get = AsyncMock(return_value=lesson)
+
+        mock_execute_result = MagicMock()
+        mock_execute_result.scalar_one_or_none = MagicMock(return_value=None)
+        mock_session.execute = AsyncMock(return_value=mock_execute_result)
+
+        result = await service._find_source_image(uuid.uuid4(), mock_session)
+        assert result is None
+
+
+class TestDallEFallbackOptimization:
+    @pytest.fixture
+    def service(self):
+        return ImageGenerationService()
+
+    @pytest.fixture
+    def mock_session(self):
+        session = AsyncMock()
+        session.flush = AsyncMock()
+        session.commit = AsyncMock()
+        session.add = MagicMock()
+        session.get = AsyncMock(return_value=None)
+        return session
+
+    @pytest.fixture
+    def mock_claude_response(self):
+        msg = MagicMock()
+        content_block = MagicMock()
+        content_block.text = (
+            "CONCEPT: surveillance\n"
+            "PROMPT: Disease surveillance network in West Africa\n"
+            'TAGS: ["surveillance", "epidemiology", "aof"]'
+        )
+        msg.content = [content_block]
+        return msg
+
+    async def test_dalle_skipped_when_source_image_found(
+        self, service, mock_session, mock_claude_response
+    ):
+        """When an explicit source image exists, DALL-E must NOT be called."""
+        from app.domain.models.content import GeneratedContent
+
+        source_img = _make_source_image(image_type="diagram", figure_number="3.2")
+
+        lesson = MagicMock(spec=GeneratedContent)
+        lesson.sources_cited = [{"source": "donaldson", "chapter": "3", "page": 42}]
+        mock_session.get = AsyncMock(return_value=lesson)
+
+        reuse_result = MagicMock()
+        reuse_result.scalars.return_value.all.return_value = []
+
+        source_result = MagicMock()
+        source_result.scalar_one_or_none = MagicMock(return_value=source_img)
+
+        mock_session.execute = AsyncMock(side_effect=[reuse_result, source_result])
+
+        with __import__("unittest.mock", fromlist=["patch"]).patch(
+            "anthropic.AsyncAnthropic"
+        ) as mock_anthropic_cls:
+            mock_client = AsyncMock()
+            mock_anthropic_cls.return_value = mock_client
+            mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
+
+            with __import__("unittest.mock", fromlist=["patch"]).patch(
+                "openai.AsyncOpenAI"
+            ) as mock_openai_cls:
+                result = await service.generate_for_lesson(
+                    lesson_id=uuid.uuid4(),
+                    module_id=uuid.uuid4(),
+                    unit_id="u01",
+                    lesson_content="Lesson about disease surveillance in West Africa.",
+                    session=mock_session,
+                )
+
+                mock_openai_cls.assert_not_called()
+
+        assert result.status == "ready"
+        assert source_img.storage_url in (result.image_url or "")
+
+    async def test_dalle_called_when_no_source_image(
+        self, service, mock_session, mock_claude_response
+    ):
+        """When no source image found, DALL-E should proceed normally."""
+        from unittest.mock import patch
+
+        mock_session.get = AsyncMock(return_value=None)
+
+        reuse_result = MagicMock()
+        reuse_result.scalars.return_value.all.return_value = []
+
+        alt_text_msg = MagicMock()
+        alt_text_msg.content = [MagicMock(text="FR: Illustration\nEN: Illustration")]
+
+        dalle_response = MagicMock()
+        dalle_response.data = [MagicMock(url="https://example.com/img.png")]
+
+        mock_session.execute = AsyncMock(return_value=reuse_result)
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
+            mock_client = AsyncMock()
+            mock_anthropic_cls.return_value = mock_client
+            mock_client.messages.create = AsyncMock(
+                side_effect=[mock_claude_response, alt_text_msg]
+            )
+
+            with patch("openai.AsyncOpenAI") as mock_openai_cls:
+                mock_openai = AsyncMock()
+                mock_openai_cls.return_value = mock_openai
+                mock_openai.images.generate = AsyncMock(return_value=dalle_response)
+
+                with patch("httpx.AsyncClient") as mock_http_cls:
+                    mock_http = AsyncMock()
+                    mock_http_cls.return_value.__aenter__ = AsyncMock(return_value=mock_http)
+                    mock_http_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+                    mock_http.get = AsyncMock(
+                        return_value=MagicMock(
+                            content=b"FAKE_PNG_DATA", raise_for_status=MagicMock()
+                        )
+                    )
+
+                    result = await service.generate_for_lesson(
+                        lesson_id=uuid.uuid4(),
+                        module_id=uuid.uuid4(),
+                        unit_id="u01",
+                        lesson_content="Lesson about cholera outbreak.",
+                        session=mock_session,
+                    )
+
+            mock_openai.images.generate.assert_called_once()
+
+        assert result.status == "ready"
+
+    async def test_source_image_url_used_when_available(
+        self, service, mock_session, mock_claude_response
+    ):
+        """Source image's storage_url must be used as image_url."""
+        from app.domain.models.content import GeneratedContent
+
+        source_img = _make_source_image(
+            image_type="chart",
+            storage_url="https://cdn.example.com/figures/fig1.webp",
+        )
+
+        lesson = MagicMock(spec=GeneratedContent)
+        lesson.sources_cited = [{"source": "triola", "chapter": "5", "page": 90}]
+        mock_session.get = AsyncMock(return_value=lesson)
+
+        reuse_result = MagicMock()
+        reuse_result.scalars.return_value.all.return_value = []
+
+        source_result = MagicMock()
+        source_result.scalar_one_or_none = MagicMock(return_value=source_img)
+
+        mock_session.execute = AsyncMock(side_effect=[reuse_result, source_result])
+
+        with __import__("unittest.mock", fromlist=["patch"]).patch(
+            "anthropic.AsyncAnthropic"
+        ) as mock_anthropic_cls:
+            mock_client = AsyncMock()
+            mock_anthropic_cls.return_value = mock_client
+            mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
+
+            with __import__("unittest.mock", fromlist=["patch"]).patch("openai.AsyncOpenAI"):
+                result = await service.generate_for_lesson(
+                    lesson_id=uuid.uuid4(),
+                    module_id=uuid.uuid4(),
+                    unit_id="u01",
+                    lesson_content="Statistics lesson with charts.",
+                    session=mock_session,
+                )
+
+        assert result.image_url == "https://cdn.example.com/figures/fig1.webp"
+        assert result.format == "webp"
+
+
+# ---------------------------------------------------------------------------
+# Tutor system prompt — source_image instructions
+# ---------------------------------------------------------------------------
+
+
+def test_tutor_prompt_mentions_search_source_images():
+    from app.ai.prompts.tutor import TutorContext, get_socratic_system_prompt
+
+    context = TutorContext(
+        user_level=2,
+        user_language="fr",
+        user_country="SN",
+    )
+    prompt = get_socratic_system_prompt(context, [])
+    assert "search_source_images" in prompt
+
+
+def test_tutor_prompt_explains_source_image_marker():
+    from app.ai.prompts.tutor import TutorContext, get_socratic_system_prompt
+
+    context = TutorContext(
+        user_level=2,
+        user_language="fr",
+        user_country="SN",
+    )
+    prompt = get_socratic_system_prompt(context, [])
+    assert "source_image" in prompt
+    assert "UUID" in prompt
+
+
+def test_tutor_prompt_warns_against_inventing_uuid():
+    from app.ai.prompts.tutor import TutorContext, get_socratic_system_prompt
+
+    context = TutorContext(
+        user_level=2,
+        user_language="fr",
+        user_country="SN",
+    )
+    prompt = get_socratic_system_prompt(context, [])
+    assert "N'invente JAMAIS" in prompt or "Never invent" in prompt.lower() or "JAMAIS" in prompt

--- a/backend/tests/test_tutor_tools.py
+++ b/backend/tests/test_tutor_tools.py
@@ -71,6 +71,8 @@ def sample_conversation(sample_user):
 def mock_retriever():
     retriever = AsyncMock(spec=SemanticRetriever)
     retriever.search_for_module = AsyncMock(return_value=[])
+    retriever.get_linked_images = AsyncMock(return_value={})
+    retriever.search_source_images = AsyncMock(return_value=[])
     return retriever
 
 
@@ -120,12 +122,13 @@ def tutor_service(mock_retriever, mock_anthropic, mock_learner_memory_service):
 
 
 def test_tool_definitions_count():
-    assert len(TOOL_DEFINITIONS) == 5
+    assert len(TOOL_DEFINITIONS) == 6
 
 
 def test_tool_names():
     names = {t["name"] for t in TOOL_DEFINITIONS}
     assert names == {
+        "search_source_images",
         "search_knowledge_base",
         "get_learner_progress",
         "generate_mini_quiz",


### PR DESCRIPTION
## Summary

- Adds `search_source_images` tool to the AI tutor (new 6th tool) for finding diagrams/charts/illustrations from reference textbooks
- Enhances `search_knowledge_base` results to include `available_figures` metadata with `{{source_image:UUID}}` references for linked images
- Updates tutor system prompt with instructions for using `{{source_image:UUID}}` markers in responses
- Adds DALL-E fallback optimization: skips DALL-E generation when an explicit source image (diagram/chart/photo) already exists for the lesson's cited sources

## Changes

- `backend/app/domain/services/tutor_tools.py` — new `search_source_images` tool definition + handler; `search_knowledge_base` enhanced with `available_figures`
- `backend/app/ai/prompts/tutor.py` — updated system prompt with 6 tools and `{{source_image:UUID}}` marker instructions
- `backend/app/domain/services/image_service.py` — `_find_source_image` method + DALL-E skip logic in `generate_for_lesson`
- `backend/tests/test_tutor_source_image.py` — 23 new tests covering all new functionality
- `backend/tests/test_tutor_tools.py` — updated fixtures and tool count assertions
- `backend/tests/test_image_generation.py` — added `session.get` mock to prevent regression

## Test plan

- [x] 74 tests pass (23 new + 51 existing)
- [x] ruff check passes (no lint errors)
- [x] `search_source_images` tool returns figures with `{{source_image:UUID}}` refs
- [x] `search_knowledge_base` returns `available_figures` from linked chunks
- [x] DALL-E skipped when explicit source image found
- [x] DALL-E called normally when no source image
- [x] Tutor prompt references new tool and UUID marker format

Closes #743

Generated with [Claude Code](https://claude.ai/code)