### PR TITLE
fix(lint): remove duplicate SettingsCache import in lesson.py

### DIFF
--- a/backend/app/ai/prompts/lesson.py
+++ b/backend/app/ai/prompts/lesson.py
@@ -5,8 +5,6 @@ from uuid import UUID
 
 from app.domain.services.platform_settings_service import SettingsCache
 
-from app.domain.services.platform_settings_service import SettingsCache
-
 # Mapping of country codes to French names for contextualization
 COUNTRY_NAMES_FR = {
     "SN": "Sénégal",


### PR DESCRIPTION
Remove duplicate import on line 8 of `backend/app/ai/prompts/lesson.py`.

Closes #790