### PR TITLE
fix(placement): filter modules by course_id and add visible error feedback

### DIFF
--- a/backend/app/domain/services/placement_service.py
+++ b/backend/app/domain/services/placement_service.py
@@ -13,6 +13,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
+from ..models.course import Course
 from ..models.module import Module
 from ..models.progress import UserModuleProgress
 from ..repositories.protocols import UserRepositoryProtocol
@@ -174,7 +175,14 @@ class PlacementService:
         user.current_level = assigned_level
         await self.user_repo.update(user)
 
-        await self._unlock_modules_after_placement(user_id, assigned_level, db)
+        try:
+            await self._unlock_modules_after_placement(user_id, assigned_level, db)
+        except Exception:
+            logger.exception(
+                "Module unlock failed after placement; level still assigned",
+                user_id=str(user_id),
+                assigned_level=assigned_level,
+            )
 
         result = PlacementTestResult(
             assigned_level=assigned_level,
@@ -209,7 +217,22 @@ class PlacementService:
             assigned_level: Level assigned by placement test (1-4)
             db: Database session
         """
-        modules_result = await db.execute(select(Module).order_by(Module.module_number))
+        default_slug = SettingsCache.instance().get("default-course-slug", "sante-publique-aof")
+        course_result = await db.execute(select(Course).where(Course.slug == default_slug))
+        default_course = course_result.scalar_one_or_none()
+
+        modules_query = select(Module).order_by(Module.module_number)
+        if default_course is not None:
+            modules_query = modules_query.where(Module.course_id == default_course.id)
+        else:
+            logger.warning(
+                "Default course not found, skipping module unlock",
+                slug=default_slug,
+                user_id=str(user_id),
+            )
+            return
+
+        modules_result = await db.execute(modules_query)
         all_modules = list(modules_result.scalars().all())
 
         first_module_at_level: UUID | None = None

--- a/frontend/components/placement/placement-test-interface.tsx
+++ b/frontend/components/placement/placement-test-interface.tsx
@@ -45,6 +45,7 @@ export function PlacementTestInterface({ onComplete, locale }: PlacementTestInte
   const [timeLeft, setTimeLeft] = useState(20 * 60); // 20 minutes in seconds
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const [startTime] = useState(Date.now());
 
   // Load test questions
@@ -107,6 +108,7 @@ export function PlacementTestInterface({ onComplete, locale }: PlacementTestInte
     if (!testData) return;
 
     setIsSubmitting(true);
+    setSubmitError(null);
 
     try {
       const timeTaken = Math.floor((Date.now() - startTime) / 1000);
@@ -124,6 +126,10 @@ export function PlacementTestInterface({ onComplete, locale }: PlacementTestInte
       onComplete(result);
     } catch (error) {
       console.error('Failed to submit placement test:', error);
+      if (!autoSubmit) {
+        setSubmitError(t('error.failedToSubmit'));
+      }
+    } finally {
       setIsSubmitting(false);
     }
   };
@@ -236,6 +242,19 @@ export function PlacementTestInterface({ onComplete, locale }: PlacementTestInte
           </div>
         </CardContent>
       </Card>
+
+      {/* Submission error */}
+      {submitError && (
+        <div className="rounded-lg border border-destructive bg-destructive/10 p-4 text-sm text-destructive">
+          <p>{submitError}</p>
+          <button
+            onClick={() => setSubmitError(null)}
+            className="mt-2 underline underline-offset-2 hover:no-underline"
+          >
+            {t('error.retry')}
+          </button>
+        </div>
+      )}
 
       {/* Navigation */}
       <div className="flex justify-between">

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -546,7 +546,8 @@
     "error": {
       "failedToLoad": "Failed to load assessment. Please try again.",
       "failedToSubmit": "Failed to submit assessment. Please check your connection and try again.",
-      "timeExpired": "Time has expired. Your assessment has been automatically submitted."
+      "timeExpired": "Time has expired. Your assessment has been automatically submitted.",
+      "retry": "Dismiss and retry"
     }
   },
   "SummativeAssessment": {

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -546,7 +546,8 @@
     "error": {
       "failedToLoad": "Échec du chargement de l'évaluation. Veuillez réessayer.",
       "failedToSubmit": "Échec de la soumission de l'évaluation. Veuillez vérifier votre connexion et réessayer.",
-      "timeExpired": "Le temps a expiré. Votre évaluation a été soumise automatiquement."
+      "timeExpired": "Le temps a expiré. Votre évaluation a été soumise automatiquement.",
+      "retry": "Ignorer et réessayer"
     }
   },
   "SummativeAssessment": {


### PR DESCRIPTION
## Summary
- Backend `_unlock_modules_after_placement()` now queries only modules belonging to the default SantePublique AOF course (by slug `sante-publique-aof`), preventing constraint violations in multi-course mode
- Module unlock errors are caught and logged without aborting the overall submission, so the user's level is always assigned
- Frontend submission error is now shown as an inline visible message instead of a silent `console.error()`; `setIsSubmitting(false)` moved to `finally` so the button re-enables after any failure

## Changes
- `backend/app/domain/services/placement_service.py`: import `Course`, look up default course by slug, filter module query by `course_id`, wrap unlock in `try/except`
- `frontend/components/placement/placement-test-interface.tsx`: add `submitError` state, show inline error banner with dismiss/retry, `finally` block for `setIsSubmitting`
- `frontend/messages/en.json` + `fr.json`: add `PlacementTest.error.retry` translation key

## Test plan
- [x] Backend tests pass (29/29)
- [x] Frontend lint passes (0 errors)
- [ ] Manually verify placement test submission succeeds end-to-end
- [ ] Manually verify error banner appears on network failure with retry option

Closes #781

Generated with [Claude Code](https://claude.ai/code)