### PR TITLE
fix(rag): image linker returns 0 links despite matching sources

### DIFF
--- a/backend/app/ai/rag/image_linker.py
+++ b/backend/app/ai/rag/image_linker.py
@@ -2,7 +2,8 @@
 
 Two link types:
 - explicit: chunk text contains a "Figure X.Y" reference matching the image's figure_number
-- contextual: image and chunk share the same page number (proximity)
+- contextual: image and chunk share the same page number (proximity), with chapter fallback
+  for chunks whose `page` column is NULL
 """
 
 from __future__ import annotations
@@ -18,7 +19,14 @@ from app.domain.models.source_image import SourceImage, SourceImageChunk
 
 logger = structlog.get_logger(__name__)
 
-_FIGURE_RE = re.compile(r"Figure\s+(\d+\.?\d*)", re.IGNORECASE)
+_FIGURE_RE = re.compile(r"(?:Figure|Fig\.?)\s+(\d+[\.\-]?\d*)", re.IGNORECASE)
+
+_PAGE_ADJACENCY = 1
+
+
+def _normalize_figure_number(raw: str) -> str:
+    """Normalise figure numbers so that '1-3' and '1.3' compare equal."""
+    return raw.strip().replace("-", ".")
 
 
 class ImageLinker:
@@ -110,14 +118,14 @@ class ImageLinker:
         figure_map: dict[str, object] = {}
         for image_id, figure_number in images_result.all():
             if figure_number:
-                figure_map[figure_number.strip()] = image_id
+                figure_map[_normalize_figure_number(figure_number)] = image_id
 
         existing_pairs = await self._get_existing_pairs(source, session)
 
         pairs: set[tuple] = set()
         for chunk_id, content in chunks:
             for match in _FIGURE_RE.finditer(content):
-                figure_num = match.group(1).strip()
+                figure_num = _normalize_figure_number(match.group(1))
                 image_id = figure_map.get(figure_num)
                 if image_id is not None:
                     pair = (image_id, chunk_id)
@@ -132,28 +140,51 @@ class ImageLinker:
         session: AsyncSession,
         explicit_pairs: set[tuple],
     ) -> set[tuple]:
-        """Find same-page image↔chunk pairs, skipping already-explicit ones."""
+        """Find same-page image↔chunk pairs, skipping already-explicit ones.
+
+        When a chunk's ``page`` is NULL, fall back to chapter-based matching so
+        that the entire chapter's chunks are considered contextually linked to
+        images whose ``chapter`` matches.  Page adjacency (±1) is applied when
+        page information is available on both sides.
+        """
         images_result = await session.execute(
-            select(SourceImage.id, SourceImage.page_number).where(SourceImage.source == source)
+            select(SourceImage.id, SourceImage.page_number, SourceImage.chapter).where(
+                SourceImage.source == source
+            )
         )
         images = images_result.all()
 
-        chunks_result = await session.execute(
-            select(DocumentChunk.id, DocumentChunk.page).where(
+        chunks_with_page_result = await session.execute(
+            select(DocumentChunk.id, DocumentChunk.page, DocumentChunk.chapter).where(
                 DocumentChunk.source == source,
-                DocumentChunk.page.isnot(None),
             )
         )
+        chunks_all = chunks_with_page_result.all()
+
         page_to_chunks: dict[int, list] = {}
-        for chunk_id, page in chunks_result.all():
-            page_to_chunks.setdefault(page, []).append(chunk_id)
+        chapter_to_chunks: dict[str, list] = {}
+        null_page_chunks: list = []
+
+        for chunk_id, page, chapter in chunks_all:
+            if page is not None:
+                for p in range(page - _PAGE_ADJACENCY, page + _PAGE_ADJACENCY + 1):
+                    page_to_chunks.setdefault(p, []).append(chunk_id)
+            else:
+                null_page_chunks.append((chunk_id, chapter))
+                if chapter:
+                    chapter_to_chunks.setdefault(chapter, []).append(chunk_id)
 
         existing_pairs = await self._get_existing_pairs(source, session)
         explicit_image_chunk = {(img_id, c_id) for img_id, c_id in explicit_pairs}
 
         pairs: set[tuple] = set()
-        for image_id, page_number in images:
-            for chunk_id in page_to_chunks.get(page_number, []):
+        for image_id, page_number, image_chapter in images:
+            candidate_chunk_ids: list = list(page_to_chunks.get(page_number, []))
+
+            if not candidate_chunk_ids and image_chapter:
+                candidate_chunk_ids = list(chapter_to_chunks.get(image_chapter, []))
+
+            for chunk_id in candidate_chunk_ids:
                 pair = (image_id, chunk_id)
                 if pair not in existing_pairs and pair not in explicit_image_chunk:
                     pairs.add(pair)

--- a/backend/tests/test_image_linker.py
+++ b/backend/tests/test_image_linker.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from app.ai.rag.image_linker import _FIGURE_RE, ImageLinker
+from app.ai.rag.image_linker import _FIGURE_RE, ImageLinker, _normalize_figure_number
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -58,6 +58,37 @@ class TestFigureRegex:
         matches = _FIGURE_RE.findall("See Figure 1.1 and Figure 1.2.")
         assert matches == ["1.1", "1.2"]
 
+    def test_matches_fig_abbreviation(self):
+        matches = _FIGURE_RE.findall("See Fig. 3.2 above.")
+        assert matches == ["3.2"]
+
+    def test_matches_fig_without_dot(self):
+        matches = _FIGURE_RE.findall("See Fig 4.1 for the chart.")
+        assert matches == ["4.1"]
+
+    def test_matches_dash_figure_number(self):
+        matches = _FIGURE_RE.findall("See Figure 1-3 for details.")
+        assert matches == ["1-3"]
+
+
+# ---------------------------------------------------------------------------
+# Normalisation helper
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeFigureNumber:
+    def test_dot_unchanged(self):
+        assert _normalize_figure_number("1.3") == "1.3"
+
+    def test_dash_converted_to_dot(self):
+        assert _normalize_figure_number("1-3") == "1.3"
+
+    def test_strips_whitespace(self):
+        assert _normalize_figure_number("  2.5  ") == "2.5"
+
+    def test_integer_unchanged(self):
+        assert _normalize_figure_number("5") == "5"
+
 
 # ---------------------------------------------------------------------------
 # link_images_to_chunks — explicit linkage
@@ -76,8 +107,8 @@ class TestExplicitLinkage:
             _make_execute_result([(chunk_id, "See Figure 1.3 for the diagram.")]),
             _make_execute_result([(img_id, "1.3")]),
             _make_execute_result([]),
-            _make_execute_result([(img_id, 5)]),
-            _make_execute_result([(chunk_id, 5)]),
+            _make_execute_result([(img_id, 5, "chapter_1")]),
+            _make_execute_result([(chunk_id, 5, "chapter_1")]),
             _make_execute_result([]),
         ]
 
@@ -92,6 +123,53 @@ class TestExplicitLinkage:
         assert explicit_rows[0].document_chunk_id == chunk_id
 
     @pytest.mark.asyncio
+    async def test_explicit_link_dash_figure_number(self):
+        """DB stores '1-3', text says 'Figure 1.3' — must still match after normalisation."""
+        linker = ImageLinker()
+        session = _mock_session()
+        img_id = _uuid()
+        chunk_id = _uuid()
+
+        session.execute.side_effect = [
+            _make_execute_result([(chunk_id, "See Figure 1.3 for the diagram.")]),
+            _make_execute_result([(img_id, "1-3")]),
+            _make_execute_result([]),
+            _make_execute_result([(img_id, 5, None)]),
+            _make_execute_result([(chunk_id, 5, None)]),
+            _make_execute_result([]),
+        ]
+
+        count = await linker.link_images_to_chunks("donaldson", session)
+
+        assert count >= 1
+        added = session.add_all.call_args[0][0]
+        explicit_rows = [r for r in added if r.reference_type == "explicit"]
+        assert len(explicit_rows) == 1
+
+    @pytest.mark.asyncio
+    async def test_explicit_link_fig_abbreviation(self):
+        """'Fig. 2.1' in chunk text should match image with figure_number '2.1'."""
+        linker = ImageLinker()
+        session = _mock_session()
+        img_id = _uuid()
+        chunk_id = _uuid()
+
+        session.execute.side_effect = [
+            _make_execute_result([(chunk_id, "As shown in Fig. 2.1, the data reveals...")]),
+            _make_execute_result([(img_id, "2.1")]),
+            _make_execute_result([]),
+            _make_execute_result([(img_id, 10, None)]),
+            _make_execute_result([(chunk_id, 10, None)]),
+            _make_execute_result([]),
+        ]
+
+        await linker.link_images_to_chunks("donaldson", session)
+
+        added = session.add_all.call_args[0][0]
+        explicit_rows = [r for r in added if r.reference_type == "explicit"]
+        assert len(explicit_rows) == 1
+
+    @pytest.mark.asyncio
     async def test_no_explicit_link_when_figure_not_in_text(self):
         linker = ImageLinker()
         session = _mock_session()
@@ -102,7 +180,7 @@ class TestExplicitLinkage:
             _make_execute_result([(chunk_id, "No figures mentioned here.")]),
             _make_execute_result([(img_id, "1.3")]),
             _make_execute_result([]),
-            _make_execute_result([(img_id, 3)]),
+            _make_execute_result([(img_id, 3, None)]),
             _make_execute_result([]),
             _make_execute_result([]),
         ]
@@ -142,8 +220,8 @@ class TestExplicitLinkage:
             _make_execute_result([(img_id, "1.3")]),
             _make_execute_result([(img_id,)]),
             _make_execute_result([(img_id, chunk_id)]),
-            _make_execute_result([(img_id, 5)]),
-            _make_execute_result([(chunk_id, 5)]),
+            _make_execute_result([(img_id, 5, None)]),
+            _make_execute_result([(chunk_id, 5, None)]),
             _make_execute_result([(img_id,)]),
             _make_execute_result([(img_id, chunk_id)]),
         ]
@@ -170,8 +248,8 @@ class TestContextualLinkage:
             _make_execute_result([(chunk_id, "No figures here.")]),
             _make_execute_result([]),
             _make_execute_result([]),
-            _make_execute_result([(img_id, 7)]),
-            _make_execute_result([(chunk_id, 7)]),
+            _make_execute_result([(img_id, 7, None)]),
+            _make_execute_result([(chunk_id, 7, None)]),
             _make_execute_result([]),
         ]
 
@@ -185,6 +263,75 @@ class TestContextualLinkage:
         assert contextual_rows[0].document_chunk_id == chunk_id
 
     @pytest.mark.asyncio
+    async def test_contextual_link_adjacent_page(self):
+        """Chunk on page N-1 should be contextually linked to image on page N."""
+        linker = ImageLinker()
+        session = _mock_session()
+        img_id = _uuid()
+        chunk_id = _uuid()
+
+        session.execute.side_effect = [
+            _make_execute_result([(chunk_id, "Text on page 6.")]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+            _make_execute_result([(img_id, 7, None)]),
+            _make_execute_result([(chunk_id, 6, None)]),
+            _make_execute_result([]),
+        ]
+
+        count = await linker.link_images_to_chunks("donaldson", session)
+
+        assert count == 1
+        added = session.add_all.call_args[0][0]
+        contextual_rows = [r for r in added if r.reference_type == "contextual"]
+        assert len(contextual_rows) == 1
+
+    @pytest.mark.asyncio
+    async def test_contextual_link_chapter_fallback_when_page_null(self):
+        """Chunks with NULL page should be linked via chapter matching."""
+        linker = ImageLinker()
+        session = _mock_session()
+        img_id = _uuid()
+        chunk_id = _uuid()
+
+        session.execute.side_effect = [
+            _make_execute_result([(chunk_id, "No figures mentioned here.")]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+            _make_execute_result([(img_id, 5, "chapter_2")]),
+            _make_execute_result([(chunk_id, None, "chapter_2")]),
+            _make_execute_result([]),
+        ]
+
+        count = await linker.link_images_to_chunks("donaldson", session)
+
+        assert count == 1
+        added = session.add_all.call_args[0][0]
+        contextual_rows = [r for r in added if r.reference_type == "contextual"]
+        assert len(contextual_rows) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_contextual_link_when_page_null_and_no_chapter(self):
+        """Chunks with NULL page and NULL chapter produce no contextual links."""
+        linker = ImageLinker()
+        session = _mock_session()
+        img_id = _uuid()
+        chunk_id = _uuid()
+
+        session.execute.side_effect = [
+            _make_execute_result([(chunk_id, "No figures mentioned here.")]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+            _make_execute_result([(img_id, 5, None)]),
+            _make_execute_result([(chunk_id, None, None)]),
+            _make_execute_result([]),
+        ]
+
+        count = await linker.link_images_to_chunks("donaldson", session)
+
+        assert count == 0
+
+    @pytest.mark.asyncio
     async def test_contextual_link_skipped_when_explicit_exists(self):
         linker = ImageLinker()
         session = _mock_session()
@@ -195,8 +342,8 @@ class TestContextualLinkage:
             _make_execute_result([(chunk_id, "See Figure 2.0 here.")]),
             _make_execute_result([(img_id, "2.0")]),
             _make_execute_result([]),
-            _make_execute_result([(img_id, 10)]),
-            _make_execute_result([(chunk_id, 10)]),
+            _make_execute_result([(img_id, 10, None)]),
+            _make_execute_result([(chunk_id, 10, None)]),
             _make_execute_result([]),
         ]
 
@@ -220,8 +367,8 @@ class TestContextualLinkage:
             _make_execute_result([(chunk_id, "Text on page 3.")]),
             _make_execute_result([]),
             _make_execute_result([]),
-            _make_execute_result([(img_id, 8)]),
-            _make_execute_result([(chunk_id, 3)]),
+            _make_execute_result([(img_id, 8, None)]),
+            _make_execute_result([(chunk_id, 3, None)]),
             _make_execute_result([]),
         ]
 
@@ -240,8 +387,8 @@ class TestContextualLinkage:
             _make_execute_result([(chunk_id, "Text on page 5.")]),
             _make_execute_result([]),
             _make_execute_result([]),
-            _make_execute_result([(img_id, 5)]),
-            _make_execute_result([(chunk_id, 5)]),
+            _make_execute_result([(img_id, 5, None)]),
+            _make_execute_result([(chunk_id, 5, None)]),
             _make_execute_result([(img_id,)]),
             _make_execute_result([(img_id, chunk_id)]),
         ]
@@ -327,8 +474,8 @@ class TestEdgeCases:
             _make_execute_result([(chunk_id, "See Figure 1.1 and Figure 2.2.")]),
             _make_execute_result([(img1_id, "1.1"), (img2_id, "2.2")]),
             _make_execute_result([]),
-            _make_execute_result([(img1_id, 4), (img2_id, 9)]),
-            _make_execute_result([(chunk_id, 4)]),
+            _make_execute_result([(img1_id, 4, None), (img2_id, 9, None)]),
+            _make_execute_result([(chunk_id, 4, None)]),
             _make_execute_result([]),
         ]
 
@@ -384,8 +531,8 @@ class TestEdgeCases:
             _make_execute_result([(chunk_id, "Figure 3.0 here.")]),
             _make_execute_result([(img_id, "3.0")]),
             _make_execute_result([]),
-            _make_execute_result([(img_id, 2)]),
-            _make_execute_result([(chunk_id, 99)]),
+            _make_execute_result([(img_id, 2, None)]),
+            _make_execute_result([(chunk_id, 99, None)]),
             _make_execute_result([]),
         ]
 


### PR DESCRIPTION
## Summary

- Expand `_FIGURE_RE` regex to match `Fig.` / `Fig` abbreviations and dash-separated figure numbers (e.g. `Fig. 1-3`)
- Normalise figure numbers on both sides of the comparison (`-` → `.`) so `"1-3"` in the DB matches `"Figure 1.3"` in chunk text
- Remove the `.isnot(None)` filter that silently excluded all chunks with `NULL` page from contextual linking
- Add ±1 page adjacency window: image on page N links chunks on pages N−1, N, N+1
- Add chapter-based fallback for chunks whose `page` column is NULL — link by `chapter` name instead

## Changes

- `backend/app/ai/rag/image_linker.py` — all fixes above + new `_normalize_figure_number()` helper, `_PAGE_ADJACENCY` constant
- `backend/tests/test_image_linker.py` — updated existing mocks (3-tuple rows) + 8 new tests for dash numbers, `Fig.` abbreviation, adjacent pages, NULL-page chapter fallback

## Test plan

- [x] `uv run pytest tests/test_image_linker.py` — 33 passed, 0 failed
- [x] `uv run ruff check` — no issues
- [ ] Manually re-run `link_images_to_chunks("Principles Marketing", session)` and verify rows appear in `source_image_chunks`

Closes #804

Generated with [Claude Code](https://claude.ai/code)