### PR TITLE
fix(deploy): add MinIO env vars to docker-compose.prod.yml

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -40,6 +40,11 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       SENTRY_DSN: ${SENTRY_DSN}
+      MINIO_ENDPOINT: ${MINIO_ENDPOINT:-http://minio:9000}
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
+      MINIO_PUBLIC_URL: ${MINIO_PUBLIC_URL:-http://minio:9000}
+      MINIO_BUCKET_MEDIA: ${MINIO_BUCKET_MEDIA:-santepublique-media}
     volumes:
       - ./resources:/app/resources
       - uploads:/app/uploads
@@ -48,6 +53,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      minio:
+        condition: service_started
     networks:
       - etutor-data
       - proxy
@@ -105,6 +112,11 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       SENTRY_DSN: ${SENTRY_DSN}
+      MINIO_ENDPOINT: ${MINIO_ENDPOINT:-http://minio:9000}
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
+      MINIO_PUBLIC_URL: ${MINIO_PUBLIC_URL:-http://minio:9000}
+      MINIO_BUCKET_MEDIA: ${MINIO_BUCKET_MEDIA:-santepublique-media}
     volumes:
       - ./resources:/app/resources
       - uploads:/app/uploads
@@ -115,6 +127,21 @@ services:
         condition: service_healthy
       backend:
         condition: service_healthy
+      minio:
+        condition: service_started
+    networks:
+      - etutor-data
+    restart: unless-stopped
+
+  minio:
+    image: minio/minio:latest
+    container_name: etutor-minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ACCESS_KEY:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_SECRET_KEY:-minioadmin123}
+    volumes:
+      - minio_data:/data
     networks:
       - etutor-data
     restart: unless-stopped
@@ -123,6 +150,7 @@ volumes:
   pgdata:
   redisdata:
   uploads:
+  minio_data:
 
 networks:
   etutor-data:


### PR DESCRIPTION
## Summary
- Add `MINIO_ENDPOINT`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`, `MINIO_PUBLIC_URL`, `MINIO_BUCKET_MEDIA` environment variables to `backend` and `celery-worker` services so MinIO settings are properly interpolated from the `.env` file
- Add MinIO service definition (`minio/minio:latest`) joined to the `etutor-data` network
- Add `minio_data` named volume for persistent object storage
- Add `minio: service_started` dependency to `backend` and `celery-worker`

## Changes
- `docker-compose.prod.yml` — 28 lines added

## Test plan
- [ ] Deploy stack with `docker compose -f docker-compose.prod.yml up -d` and verify MinIO container starts
- [ ] Confirm backend and celery-worker containers receive correct MINIO_* env vars via `docker inspect`
- [ ] Verify file uploads resolve to `http://minio:9000` inside the Docker network

Closes #807

Generated with [Claude Code](https://claude.ai/code)