### PR TITLE
fix(rag): extract number from Figure X.Y before building linker map

### DIFF
--- a/backend/app/ai/rag/image_linker.py
+++ b/backend/app/ai/rag/image_linker.py
@@ -118,7 +118,11 @@ class ImageLinker:
         figure_map: dict[str, object] = {}
         for image_id, figure_number in images_result.all():
             if figure_number:
-                figure_map[_normalize_figure_number(figure_number)] = image_id
+                # Extract just the number from "Figure 1.2" -> "1.2"
+                num_match = _FIGURE_RE.search(figure_number)
+                raw = num_match.group(1) if num_match else figure_number
+                key = _normalize_figure_number(raw)
+                figure_map[key] = image_id
 
         existing_pairs = await self._get_existing_pairs(source, session)
 


### PR DESCRIPTION
## Root cause
`source_images.figure_number` stores `"Figure 1.2"` but the regex `_FIGURE_RE` extracts just `"1.2"` from chunk text. The `figure_map` used the full string as key, so `figure_map.get("1.2")` never matched `figure_map["Figure 1.2"]`.

## Fix
Extract the number from the stored `figure_number` using the same regex before inserting into the map.

Closes #804