### PR TITLE
fix(rag): commit session after image-chunk linking

### DIFF
--- a/backend/app/ai/rag/pipeline.py
+++ b/backend/app/ai/rag/pipeline.py
@@ -253,6 +253,7 @@ class RAGPipeline:
         logger.info("Stored source images", source=source, count=stored_count)
 
         links = await linker.link_images_to_chunks(source, session)
+        await session.commit()
         logger.info("Linked images to chunks", source=source, links=links)
 
         return stored_count


### PR DESCRIPTION
The linker flush()ed 277 junction rows but the pipeline never committed them. One-line fix: add `await session.commit()` after linker runs.