### PR TITLE
fix(deploy): replace SCP with ghcr.io registry pulls

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
 
+env:
+  REGISTRY: ghcr.io
+  BACKEND_IMAGE: ghcr.io/benidrissa/etutor-digital-ph/backend
+  FRONTEND_IMAGE: ghcr.io/benidrissa/etutor-digital-ph/frontend
+
 jobs:
   test:
     name: Lint & Test
@@ -61,60 +66,87 @@ jobs:
         env:
           NEXT_PUBLIC_API_URL: https://api.elearning.portfolio2.kimbetien.com
 
-  build-and-deploy:
-    name: Build & Deploy
+  build-and-push:
+    name: Build & Push (${{ matrix.service }})
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - service: backend
+            context: ./backend
+            image: ghcr.io/benidrissa/etutor-digital-ph/backend
+          - service: frontend
+            context: ./frontend
+            image: ghcr.io/benidrissa/etutor-digital-ph/frontend
     steps:
       - uses: actions/checkout@v6
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build backend image
-        uses: docker/build-push-action@v6
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
         with:
-          context: ./backend
-          load: true
-          tags: etutor-backend:latest
-          cache-from: type=gha,scope=backend
-          cache-to: type=gha,scope=backend,mode=max
+          images: ${{ matrix.image }}
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest
 
-      - name: Build frontend image
+      - name: Build and push backend
+        if: matrix.service == 'backend'
         uses: docker/build-push-action@v6
         with:
-          context: ./frontend
-          load: true
-          tags: etutor-frontend:latest
+          context: ${{ matrix.context }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ matrix.image }}:buildcache
+          cache-to: type=registry,ref=${{ matrix.image }}:buildcache,mode=max
+
+      - name: Build and push frontend
+        if: matrix.service == 'frontend'
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ matrix.image }}:buildcache
+          cache-to: type=registry,ref=${{ matrix.image }}:buildcache,mode=max
           build-args: |
             NEXT_PUBLIC_API_URL=https://api.elearning.portfolio2.kimbetien.com
             NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
             SENTRY_ORG=${{ secrets.SENTRY_ORG }}
             SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
-          cache-from: type=gha,scope=frontend
-          cache-to: type=gha,scope=frontend,mode=max
 
-      - name: Save images and transfer to server
+  deploy:
+    name: Deploy to Server
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Rsync compose file
         env:
           DEPLOY_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
         run: |
-          # Save images to tar
-          docker save etutor-backend:latest etutor-frontend:latest | gzip > images.tar.gz
-
-          # Setup SSH
           mkdir -p ~/.ssh
           echo "$DEPLOY_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H 167.86.115.58 >> ~/.ssh/known_hosts
-
-          # Transfer images
-          scp -i ~/.ssh/deploy_key images.tar.gz deploy@167.86.115.58:~/etutor/images.tar.gz
-
-      - name: Rsync compose and config
-        env:
-          DEPLOY_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
-        run: |
           rsync -avz -e "ssh -i ~/.ssh/deploy_key" \
             docker-compose.prod.yml \
             deploy@167.86.115.58:~/etutor/docker-compose.yml
@@ -139,10 +171,6 @@ jobs:
             set -e
             cd ~/etutor
 
-            # Load pre-built images (no docker pull needed)
-            docker load < images.tar.gz
-            rm -f images.tar.gz
-
             # Write .env
             cat > .env << EOF
             POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
@@ -154,7 +182,10 @@ jobs:
             NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST}
             EOF
 
-            # Deploy
+            # Pull new images (only changed layers transferred)
+            docker compose pull backend frontend
+
+            # Restart services
             docker compose up -d
 
             # Run database migrations then restart backend to pick up schema changes
@@ -170,5 +201,5 @@ jobs:
             sleep 15
             docker compose ps
 
-            # Cleanup
+            # Cleanup old images
             docker image prune -f

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,15 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+*.egg-info/
+data/
+scripts/
+.env
+.env.*
+.git/
+.github/

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -30,7 +30,7 @@ services:
       retries: 5
 
   backend:
-    image: etutor-backend:latest
+    image: ghcr.io/benidrissa/etutor-digital-ph/backend:latest
     container_name: etutor-backend
     environment:
       DATABASE_URL: postgresql+asyncpg://postgres:${POSTGRES_PASSWORD}@postgres:5432/santepublique_aof
@@ -73,7 +73,7 @@ services:
       retries: 3
 
   frontend:
-    image: etutor-frontend:latest
+    image: ghcr.io/benidrissa/etutor-digital-ph/frontend:latest
     container_name: etutor-frontend
     environment:
       HOSTNAME: "0.0.0.0"
@@ -101,7 +101,7 @@ services:
       retries: 3
 
   celery-worker:
-    image: etutor-backend:latest
+    image: ghcr.io/benidrissa/etutor-digital-ph/backend:latest
     container_name: etutor-celery-worker
     command: uv run celery -A app.tasks.celery_app worker --loglevel=info
     environment:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,12 @@
+node_modules/
+.next/
+out/
+.turbo/
+coverage/
+test-results/
+playwright-report/
+.env
+.env.*
+*.md
+.git/
+.github/


### PR DESCRIPTION
## Summary
- **Replace SCP image transfer (1.5GB+) with ghcr.io container registry** — only changed layers are pulled (~5-50MB for code-only changes)
- **Parallel matrix builds** — backend and frontend build+push simultaneously
- **Add `.dockerignore`** for both services to prevent bloated build contexts
- **SHA tagging** — every deploy tagged with commit SHA for rollback capability

## What changed
| File | Change |
|------|--------|
| `.github/workflows/deploy.yml` | Rewritten: login to ghcr.io, matrix build+push, `docker compose pull` on server |
| `docker-compose.prod.yml` | Image refs → `ghcr.io/benidrissa/etutor-digital-ph/{backend,frontend}:latest` |
| `backend/.dockerignore` | New — excludes .venv, __pycache__, test artifacts |
| `frontend/.dockerignore` | New — excludes node_modules, .next, test reports |

## Prerequisites
Server must be authenticated to ghcr.io (already done):
```bash
echo "PAT" | docker login ghcr.io -u Benidrissa --password-stdin
```

## Test plan
- [ ] Verify GH Actions builds and pushes both images to ghcr.io
- [ ] Verify server can `docker compose pull` the new images
- [ ] Verify `docker compose ps` shows all services healthy after deploy
- [ ] Verify rollback works: `docker compose pull` with a specific SHA tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)