### PR TITLE
fix(admin): fix migration 031 — JSONB cast syntax and missing columns (#829)

### DIFF
--- a/backend/migrations/versions/031_add_course_preassessment.py
+++ b/backend/migrations/versions/031_add_course_preassessment.py
@@ -703,6 +703,10 @@ def upgrade() -> None:
         sa.Column("generated_by", sa.String(10), nullable=False, server_default="manual"),
         sa.Column("generated_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("validated", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("question_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("sources_cited", JSONB, nullable=False, server_default="[]"),
+        sa.Column("generation_task_id", sa.String(255), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
@@ -757,8 +761,9 @@ def upgrade() -> None:
                 "INSERT INTO course_preassessments "
                 "(id, course_id, language, questions, answer_key, question_levels, domains, "
                 "generated_by, validated, created_at) "
-                "VALUES (:id, :course_id, :language, :questions::jsonb, :answer_key::jsonb, "
-                ":question_levels::jsonb, :domains::jsonb, :generated_by, false, now())"
+                "VALUES (:id, :course_id, :language, CAST(:questions AS jsonb), "
+                "CAST(:answer_key AS jsonb), CAST(:question_levels AS jsonb), "
+                "CAST(:domains AS jsonb), :generated_by, false, now())"
             ),
             {
                 "id": preassessment_id_fr,
@@ -778,8 +783,9 @@ def upgrade() -> None:
                 "INSERT INTO course_preassessments "
                 "(id, course_id, language, questions, answer_key, question_levels, domains, "
                 "generated_by, validated, created_at) "
-                "VALUES (:id, :course_id, :language, :questions::jsonb, :answer_key::jsonb, "
-                ":question_levels::jsonb, :domains::jsonb, :generated_by, false, now())"
+                "VALUES (:id, :course_id, :language, CAST(:questions AS jsonb), "
+                "CAST(:answer_key AS jsonb), CAST(:question_levels AS jsonb), "
+                "CAST(:domains AS jsonb), :generated_by, false, now())"
             ),
             {
                 "id": preassessment_id_en,


### PR DESCRIPTION
## Summary

Fixes the broken `031_add_course_preassessment` migration that caused \"Generation failed\" on the pre-assessment endpoint.

## Root cause

Two bugs in `backend/migrations/versions/031_add_course_preassessment.py`:

1. **asyncpg-incompatible JSONB cast syntax** — `:param::jsonb` uses PostgreSQL `::` cast notation which asyncpg does not support with named bind parameters. Fixed by replacing with `CAST(:param AS jsonb)`.
2. **Missing columns in CREATE TABLE** — The migration omitted `question_count`, `sources_cited`, `generation_task_id`, and `notes` columns which are defined on the `CoursePreAssessment` SQLAlchemy model, causing runtime errors when the ORM tried to insert/query those columns.

## Changes

- `backend/migrations/versions/031_add_course_preassessment.py`
  - Replaced `:questions::jsonb` → `CAST(:questions AS jsonb)` (and same for `answer_key`, `question_levels`, `domains`) in both FR and EN seed INSERT statements
  - Added `question_count INTEGER NOT NULL DEFAULT 0`, `sources_cited JSONB NOT NULL DEFAULT '[]'`, `generation_task_id VARCHAR(255)`, `notes TEXT` columns to `CREATE TABLE course_preassessments`

## Test plan

- [ ] Run `alembic upgrade head` — migration completes without errors
- [ ] Verify `course_preassessments` table exists with all expected columns
- [ ] Click \"Generate Pre-Assessment\" on a course — generation succeeds
- [ ] Backend tests pass

Closes #829

Generated with [Claude Code](https://claude.ai/code)