### PR TITLE
fix(lesson): scan key_points in cached lesson source_image_refs extraction

### DIFF
--- a/backend/app/domain/services/lesson_service.py
+++ b/backend/app/domain/services/lesson_service.py
@@ -297,8 +297,12 @@ class LessonGenerationService:
                 str(content_dict.get(f, "") or "")
                 for f in ("introduction", "aof_example", "synthesis")
             )
-            for concept in content_dict.get("concepts", []):
-                all_text_fields += " " + str(concept or "")
+            for field in ("concepts", "key_points"):
+                for item in content_dict.get(field, []):
+                    if isinstance(item, dict):
+                        all_text_fields += " " + " ".join(str(v or "") for v in item.values())
+                    else:
+                        all_text_fields += " " + str(item or "")
 
             existing_ids = {ref.id for ref in source_image_refs}
             if re.search(r"\{\{source_image:[0-9a-f-]{36}\}\}", all_text_fields, re.IGNORECASE):
@@ -522,6 +526,12 @@ class LessonGenerationService:
         pattern = re.compile(r"\{\{source_image:([0-9a-f-]{36})\}\}", re.IGNORECASE)
         found_ids = list(dict.fromkeys(pattern.findall(content_text)))
 
+        logger.debug(
+            "_extract_source_image_refs: scanned content",
+            content_length=len(content_text),
+            found_ids=found_ids,
+        )
+
         if not found_ids:
             return []
 
@@ -534,12 +544,22 @@ class LessonGenerationService:
 
         missing_ids = [img_id for img_id in found_ids if img_id not in all_images]
         if missing_ids and session is not None:
+            logger.debug(
+                "_extract_source_image_refs: DB fallback for missing image IDs",
+                missing_ids=missing_ids,
+            )
             try:
                 missing_uuids = [uuid.UUID(img_id) for img_id in missing_ids]
                 db_result = await session.execute(
                     select(SourceImage).where(SourceImage.id.in_(missing_uuids))
                 )
-                for db_img in db_result.scalars().all():
+                db_rows = db_result.scalars().all()
+                logger.debug(
+                    "_extract_source_image_refs: DB fallback returned rows",
+                    row_count=len(db_rows),
+                    returned_ids=[str(r.id) for r in db_rows],
+                )
+                for db_img in db_rows:
                     img_id = str(db_img.id)
                     all_images[img_id] = db_img.to_meta_dict()
             except Exception as exc:
@@ -548,6 +568,11 @@ class LessonGenerationService:
                     missing_ids=missing_ids,
                     error=str(exc),
                 )
+        elif missing_ids and session is None:
+            logger.warning(
+                "_extract_source_image_refs: session is None, cannot resolve missing image IDs",
+                missing_ids=missing_ids,
+            )
 
         refs = []
         for img_id in found_ids:

--- a/backend/tests/test_lesson_query_builder.py
+++ b/backend/tests/test_lesson_query_builder.py
@@ -289,3 +289,171 @@ class TestGetCachedLesson:
 
         assert result is not None
         assert result.module_id == sample_module_id
+
+
+class TestGetCachedLessonSourceImageRefs:
+    """Tests that source_image_refs are extracted from all content fields in cached lessons."""
+
+    def _make_session_with_cached(self, content: dict, module_id: uuid.UUID) -> AsyncMock:
+        session = AsyncMock(spec=AsyncSession)
+        cached = GeneratedContent(
+            id=uuid.uuid4(),
+            module_id=module_id,
+            content_type="lesson",
+            language="fr",
+            level=1,
+            content=content,
+            sources_cited=["Source 1"],
+            country_context="SN",
+            generated_at=datetime(2026, 1, 1, 0, 0, 0),
+            validated=False,
+        )
+        mock_result = MagicMock()
+        mock_scalars = MagicMock()
+        mock_scalars.first.return_value = cached
+        mock_result.scalars.return_value = mock_scalars
+        session.execute = AsyncMock(return_value=mock_result)
+        return session
+
+    @pytest.mark.asyncio
+    async def test_image_marker_in_concepts_list_is_found(self, lesson_service, sample_module_id):
+        img_id = str(uuid.uuid4())
+        mock_db_img = MagicMock()
+        mock_db_img.id = uuid.UUID(img_id)
+        mock_db_img.to_meta_dict.return_value = {
+            "id": img_id,
+            "figure_number": "1.10",
+            "caption": "Diagram",
+            "image_type": "diagram",
+            "storage_url": "https://cdn.example.com/img.webp",
+            "alt_text_fr": None,
+            "alt_text_en": None,
+            "attribution": None,
+        }
+
+        content = {
+            "unit_id": "M01-U01",
+            "introduction": "Introduction text",
+            "concepts": [f"Concept with marker {{{{source_image:{img_id}}}}}"],
+            "aof_example": "Example",
+            "synthesis": "Synthesis",
+            "key_points": ["Point 1"],
+            "sources_cited": ["Source 1"],
+            "source_image_refs": [],
+        }
+
+        session = AsyncMock(spec=AsyncSession)
+        cached = GeneratedContent(
+            id=uuid.uuid4(),
+            module_id=sample_module_id,
+            content_type="lesson",
+            language="fr",
+            level=1,
+            content=content,
+            sources_cited=["Source 1"],
+            country_context="SN",
+            generated_at=datetime(2026, 1, 1, 0, 0, 0),
+            validated=False,
+        )
+
+        mock_first_result = MagicMock()
+        mock_scalars_first = MagicMock()
+        mock_scalars_first.first.return_value = cached
+        mock_first_result.scalars.return_value = mock_scalars_first
+
+        mock_db_result = MagicMock()
+        mock_db_scalars = MagicMock()
+        mock_db_scalars.all.return_value = [mock_db_img]
+        mock_db_result.scalars.return_value = mock_db_scalars
+
+        session.execute = AsyncMock(side_effect=[mock_first_result, mock_db_result])
+
+        result = await lesson_service._get_cached_lesson(
+            sample_module_id, "M01-U01", "fr", "SN", 1, session
+        )
+
+        assert result is not None
+        assert len(result.source_image_refs) == 1
+        assert result.source_image_refs[0].id == img_id
+
+    @pytest.mark.asyncio
+    async def test_image_marker_in_key_points_list_is_found(self, lesson_service, sample_module_id):
+        img_id = str(uuid.uuid4())
+        mock_db_img = MagicMock()
+        mock_db_img.id = uuid.UUID(img_id)
+        mock_db_img.to_meta_dict.return_value = {
+            "id": img_id,
+            "figure_number": "2.1",
+            "caption": "Key point figure",
+            "image_type": "chart",
+            "storage_url": "https://cdn.example.com/chart.webp",
+            "alt_text_fr": None,
+            "alt_text_en": None,
+            "attribution": None,
+        }
+
+        content = {
+            "unit_id": "M01-U01",
+            "introduction": "Introduction text",
+            "concepts": ["Normal concept"],
+            "aof_example": "Example",
+            "synthesis": "Synthesis",
+            "key_points": ["Normal point", f"Point with {{{{source_image:{img_id}}}}}"],
+            "sources_cited": ["Source 1"],
+            "source_image_refs": [],
+        }
+
+        session = AsyncMock(spec=AsyncSession)
+        cached = GeneratedContent(
+            id=uuid.uuid4(),
+            module_id=sample_module_id,
+            content_type="lesson",
+            language="fr",
+            level=1,
+            content=content,
+            sources_cited=["Source 1"],
+            country_context="SN",
+            generated_at=datetime(2026, 1, 1, 0, 0, 0),
+            validated=False,
+        )
+
+        mock_first_result = MagicMock()
+        mock_scalars_first = MagicMock()
+        mock_scalars_first.first.return_value = cached
+        mock_first_result.scalars.return_value = mock_scalars_first
+
+        mock_db_result = MagicMock()
+        mock_db_scalars = MagicMock()
+        mock_db_scalars.all.return_value = [mock_db_img]
+        mock_db_result.scalars.return_value = mock_db_scalars
+
+        session.execute = AsyncMock(side_effect=[mock_first_result, mock_db_result])
+
+        result = await lesson_service._get_cached_lesson(
+            sample_module_id, "M01-U01", "fr", "SN", 1, session
+        )
+
+        assert result is not None
+        assert len(result.source_image_refs) == 1
+        assert result.source_image_refs[0].id == img_id
+
+    @pytest.mark.asyncio
+    async def test_extract_source_image_refs_handles_dict_text_directly(self, lesson_service):
+        img_id = str(uuid.uuid4())
+        img_meta = {
+            "id": img_id,
+            "figure_number": "3.5",
+            "caption": "Concept dict figure",
+            "image_type": "diagram",
+            "storage_url": None,
+            "alt_text_fr": None,
+            "alt_text_en": None,
+            "attribution": None,
+        }
+        text = f"title Concept A body Body with {{{{source_image:{img_id}}}}}"
+        linked = {uuid.uuid4(): [img_meta]}
+
+        result = await LessonGenerationService._extract_source_image_refs(text, linked)
+
+        assert len(result) == 1
+        assert result[0].id == img_id


### PR DESCRIPTION
## Summary

- `source_image_refs` was returning `[]` for cached lessons even when `{{source_image:UUID}}` markers existed in content — because `key_points` was never scanned
- Dict items in list fields now handled defensively (values flattened to text)
- Added debug/warning logging to `_extract_source_image_refs` for easier diagnosis

## Changes

- `backend/app/domain/services/lesson_service.py`
  - `_get_cached_lesson`: extend `all_text_fields` to also iterate `key_points` list items (was only scanning `concepts`); handle dict items by flattening `.values()`
  - `_extract_source_image_refs`: add `debug` log for `found_ids`; add `debug` log when DB fallback is attempted (with `missing_ids` and returned row count); add `warning` log when `session is None` and IDs cannot be resolved
- `backend/tests/test_lesson_query_builder.py`: 3 new tests in `TestGetCachedLessonSourceImageRefs` covering markers in concepts list, key_points list, and dict-flattened text via `_extract_source_image_refs` directly

## Test plan
- [x] `tests/test_lesson_query_builder.py` — 19 passed
- [x] ruff check + format — no issues

Closes #828

Generated with [Claude Code](https://claude.ai/code)