### PR TITLE
chore: rename app to Sira

### DIFF
--- a/.claude/skills/fastapi-service/SKILL.md
+++ b/.claude/skills/fastapi-service/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: fastapi-service
-description: Build and modify FastAPI backend for the SantePublique AOF learning platform. Use when creating endpoints, domain models, services, RAG pipelines, or Celery tasks. Enforces the 4-layer architecture (Backend → AI/RAG → External Data), async SQLAlchemy, Pydantic V2, Local Auth (TOTP MFA), mobile-first API design, and the exact data model from the SRS.
+description: Build and modify FastAPI backend for the Sira learning platform. Use when creating endpoints, domain models, services, RAG pipelines, or Celery tasks. Enforces the 4-layer architecture (Backend → AI/RAG → External Data), async SQLAlchemy, Pydantic V2, Local Auth (TOTP MFA), mobile-first API design, and the exact data model from the SRS.
 user-invocable: true
 ---
 
-# SantePublique AOF FastAPI Backend Builder
+# Sira FastAPI Backend Builder
 
-Build the production-grade FastAPI backend for SantePublique AOF — an adaptive, bilingual (FR/EN), mobile-first learning platform for public health professionals in West Africa. This backend sits in the second layer of a 4-layer architecture:
+Build the production-grade FastAPI backend for Sira — an adaptive, bilingual (FR/EN), mobile-first learning platform for public health professionals in West Africa. This backend sits in the second layer of a 4-layer architecture:
 
 ```
 Frontend (Next.js 15 PWA) → [THIS] Backend (FastAPI + PostgreSQL) → AI/RAG (Claude + pgvector) → External Data (DHIS2, DHS, WHO, PubMed)
@@ -14,7 +14,7 @@ Frontend (Next.js 15 PWA) → [THIS] Backend (FastAPI + PostgreSQL) → AI/RAG (
 
 ## Before writing any backend code
 
-1. Read the SRS requirement in `docs/SRS_SantePublique_AOF.md` — match functional requirement IDs (FR-01 through FR-06)
+1. Read the SRS requirement in `docs/SRS_Sira.md` — match functional requirement IDs (FR-01 through FR-06)
 2. Read the syllabus in `docs/syllabus_sante_publique_AOF.md` — understand the 4 levels, 15 modules, ~320 hours curriculum
 3. Check the data model (SRS Section 9) — use the exact table schemas defined there
 4. Check if similar functionality already exists in the codebase

--- a/.claude/skills/nextjs-app-router/SKILL.md
+++ b/.claude/skills/nextjs-app-router/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: nextjs-app-router
-description: Build Next.js 15 App Router pages and layouts for the SantePublique AOF learning platform. Use when creating pages, layouts, route handlers, or configuring Next.js features. Enforces server/client component patterns, next-intl, Tailwind, PWA, and mobile-first design.
+description: Build Next.js 15 App Router pages and layouts for the Sira learning platform. Use when creating pages, layouts, route handlers, or configuring Next.js features. Enforces server/client component patterns, next-intl, Tailwind, PWA, and mobile-first design.
 user-invocable: true
 ---
 
-# SantePublique AOF Next.js App Router Guide
+# Sira Next.js App Router Guide
 
-Build pages and layouts for SantePublique AOF using Next.js 15 App Router conventions.
+Build pages and layouts for Sira using Next.js 15 App Router conventions.
 
 ## Application structure
 

--- a/.claude/skills/react-components/SKILL.md
+++ b/.claude/skills/react-components/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: react-components
-description: Build React components for the SantePublique AOF learning platform. Use when creating or modifying React/TypeScript components. Enforces Tailwind CSS + shadcn/ui, mobile-first responsive design, offline-ready PWA patterns, accessibility, and FR/EN i18n.
+description: Build React components for the Sira learning platform. Use when creating or modifying React/TypeScript components. Enforces Tailwind CSS + shadcn/ui, mobile-first responsive design, offline-ready PWA patterns, accessibility, and FR/EN i18n.
 user-invocable: true
 ---
 
-# SantePublique AOF React Component Builder
+# Sira React Component Builder
 
-Build production-grade React 19 components for SantePublique AOF — a mobile-first, bilingual (FR/EN) learning platform for public health professionals in West Africa.
+Build production-grade React 19 components for Sira — a mobile-first, bilingual (FR/EN) learning platform for public health professionals in West Africa.
 
 ## Before writing any component
 

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: testing
-description: Write tests for the SantePublique AOF learning platform. Use when creating unit tests, integration tests, or E2E tests. Enforces pytest-asyncio patterns for the FastAPI backend, React Testing Library for frontend, and Playwright for E2E.
+description: Write tests for the Sira learning platform. Use when creating unit tests, integration tests, or E2E tests. Enforces pytest-asyncio patterns for the FastAPI backend, React Testing Library for frontend, and Playwright for E2E.
 user-invocable: true
 ---
 
-# SantePublique AOF Testing Skill
+# Sira Testing Skill
 
-Write comprehensive tests for the SantePublique AOF backend (FastAPI) and frontend (Next.js/React). Tests must cover learning workflows, AI/RAG content generation, offline behavior, and **mobile-first UX** — this platform targets mid-range Android phones on 2G/3G in West Africa.
+Write comprehensive tests for the Sira backend (FastAPI) and frontend (Next.js/React). Tests must cover learning workflows, AI/RAG content generation, offline behavior, and **mobile-first UX** — this platform targets mid-range Android phones on 2G/3G in West Africa.
 
 ## Backend testing (Python/pytest)
 

--- a/.claude/skills/ui-design/SKILL.md
+++ b/.claude/skills/ui-design/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: ui-design
-description: Design and review UI layouts for the SantePublique AOF learning platform. Use when planning page layouts, reviewing designs, or making visual decisions. Enforces the health/education design system with green/gold palette, mobile-first, offline indicators, and learning UX patterns.
+description: Design and review UI layouts for the Sira learning platform. Use when planning page layouts, reviewing designs, or making visual decisions. Enforces the health/education design system with green/gold palette, mobile-first, offline indicators, and learning UX patterns.
 user-invocable: true
 ---
 
-# SantePublique AOF UI Design System
+# Sira UI Design System
 
-Design interfaces for SantePublique AOF — a mobile-first, bilingual learning platform for public health professionals across 15 ECOWAS West African countries.
+Design interfaces for Sira — a mobile-first, bilingual learning platform for public health professionals across 15 ECOWAS West African countries.
 
 ## Design philosophy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**SantePublique AOF** — an adaptive, bilingual (FR/EN), mobile-first learning platform for public health professionals in West Africa. Uses AI (Claude API + RAG) to generate personalized content from 3 reference textbooks and real African health data (DHIS2, DHS, WHO AFRO).
+**Sira** (from Bambara *Donniya Sira* — "the path to knowledge") — an adaptive, bilingual (FR/EN), mobile-first learning platform for public health professionals in West Africa. Uses AI (Claude API + RAG) to generate personalized content from 3 reference textbooks and real African health data (DHIS2, DHS, WHO AFRO).
 
 **Current status:** Phase 0 scaffolding complete. Monorepo with `backend/` (FastAPI) and `frontend/` (Next.js 15) fully initialized. Backend has health endpoints with tests passing. Frontend has App Router with FR/EN i18n, Tailwind + shadcn/ui, and mobile-first navigation. Docker Compose, CI/CD, and Alembic are configured. Next: DB schema migrations, RAG pipeline.
 

--- a/backend/app/ai/prompts/syllabus_agent.py
+++ b/backend/app/ai/prompts/syllabus_agent.py
@@ -70,13 +70,13 @@ def get_syllabus_agent_system_prompt() -> str:
     Returns:
         System prompt string for Claude API.
     """
-    srs_raw = _read_doc("SRS_SantePublique_AOF.md")
+    srs_raw = _read_doc("SRS_Sira.md")
     syllabus_raw = _read_doc("syllabus_sante_publique_AOF.md")
 
     pedagogy_excerpt = _extract_pedagogy_section(srs_raw)
     module_format_excerpt = _extract_module_format(syllabus_raw)
 
-    prompt = f"""Tu es un agent de création de curricula pour la plateforme SantePublique AOF.
+    prompt = f"""Tu es un agent de création de curricula pour la plateforme Sira.
 Tu assistes les administrateurs à créer et modifier les modules du syllabus en suivant
 les règles pédagogiques de la plateforme.
 

--- a/backend/app/domain/services/email_service.py
+++ b/backend/app/domain/services/email_service.py
@@ -31,21 +31,21 @@ class EmailService:
             magic_url = f"{self.frontend_url}/auth/magic-link?token={magic_token}"
 
             if language == "en":
-                subject = "Reset your SantePublique AOF account access"
+                subject = "Reset your Sira account access"
                 html_content = f"""
                 <h2>Reset Your Account Access</h2>
-                <p>You requested to reset access to your SantePublique AOF account.</p>
+                <p>You requested to reset access to your Sira account.</p>
                 <p>Click the link below to continue:</p>
                 <p><a href="{magic_url}" style="background-color: #0066cc; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">Reset Account Access</a></p>
                 <p>This link will expire in 1 hour.</p>
                 <p>If you didn't request this, you can safely ignore this email.</p>
                 <hr>
-                <p style="color: #666; font-size: 12px;">SantePublique AOF - Advancing Public Health in West Africa</p>
+                <p style="color: #666; font-size: 12px;">Sira - Advancing Public Health in West Africa</p>
                 """
                 text_content = f"""
                 Reset Your Account Access
 
-                You requested to reset access to your SantePublique AOF account.
+                You requested to reset access to your Sira account.
 
                 Click the link below to continue:
                 {magic_url}
@@ -55,24 +55,24 @@ class EmailService:
                 If you didn't request this, you can safely ignore this email.
 
                 ---
-                SantePublique AOF - Advancing Public Health in West Africa
+                Sira - Advancing Public Health in West Africa
                 """
             else:  # French
-                subject = "Réinitialiser l'accès à votre compte SantePublique AOF"
+                subject = "Réinitialiser l'accès à votre compte Sira"
                 html_content = f"""
                 <h2>Réinitialiser l'accès à votre compte</h2>
-                <p>Vous avez demandé à réinitialiser l'accès à votre compte SantePublique AOF.</p>
+                <p>Vous avez demandé à réinitialiser l'accès à votre compte Sira.</p>
                 <p>Cliquez sur le lien ci-dessous pour continuer :</p>
                 <p><a href="{magic_url}" style="background-color: #0066cc; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">Réinitialiser l'accès au compte</a></p>
                 <p>Ce lien expirera dans 1 heure.</p>
                 <p>Si vous n'avez pas fait cette demande, vous pouvez ignorer cet email en toute sécurité.</p>
                 <hr>
-                <p style="color: #666; font-size: 12px;">SantePublique AOF - Faire progresser la santé publique en Afrique de l'Ouest</p>
+                <p style="color: #666; font-size: 12px;">Sira - Faire progresser la santé publique en Afrique de l'Ouest</p>
                 """
                 text_content = f"""
                 Réinitialiser l'accès à votre compte
 
-                Vous avez demandé à réinitialiser l'accès à votre compte SantePublique AOF.
+                Vous avez demandé à réinitialiser l'accès à votre compte Sira.
 
                 Cliquez sur le lien ci-dessous pour continuer :
                 {magic_url}
@@ -82,7 +82,7 @@ class EmailService:
                 Si vous n'avez pas fait cette demande, vous pouvez ignorer cet email en toute sécurité.
 
                 ---
-                SantePublique AOF - Faire progresser la santé publique en Afrique de l'Ouest
+                Sira - Faire progresser la santé publique en Afrique de l'Ouest
                 """
 
             # Send email using Resend
@@ -123,9 +123,9 @@ class EmailService:
             dashboard_url = f"{self.frontend_url}/dashboard"
 
             if language == "en":
-                subject = f"Welcome to SantePublique AOF, {name}!"
+                subject = f"Welcome to Sira, {name}!"
                 html_content = f"""
-                <h2>Welcome to SantePublique AOF!</h2>
+                <h2>Welcome to Sira!</h2>
                 <p>Hello {name},</p>
                 <p>Your account has been successfully created. You're now ready to begin your public health learning journey in West Africa.</p>
                 <p>What's next:</p>
@@ -136,12 +136,12 @@ class EmailService:
                 </ul>
                 <p><a href="{dashboard_url}" style="background-color: #0066cc; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">Start Learning</a></p>
                 <hr>
-                <p style="color: #666; font-size: 12px;">SantePublique AOF - Advancing Public Health in West Africa</p>
+                <p style="color: #666; font-size: 12px;">Sira - Advancing Public Health in West Africa</p>
                 """
             else:  # French
-                subject = f"Bienvenue sur SantePublique AOF, {name} !"
+                subject = f"Bienvenue sur Sira, {name} !"
                 html_content = f"""
-                <h2>Bienvenue sur SantePublique AOF !</h2>
+                <h2>Bienvenue sur Sira !</h2>
                 <p>Bonjour {name},</p>
                 <p>Votre compte a été créé avec succès. Vous êtes maintenant prêt(e) à commencer votre parcours d'apprentissage en santé publique en Afrique de l'Ouest.</p>
                 <p>Prochaines étapes :</p>
@@ -152,7 +152,7 @@ class EmailService:
                 </ul>
                 <p><a href="{dashboard_url}" style="background-color: #0066cc; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">Commencer l'apprentissage</a></p>
                 <hr>
-                <p style="color: #666; font-size: 12px;">SantePublique AOF - Faire progresser la santé publique en Afrique de l'Ouest</p>
+                <p style="color: #666; font-size: 12px;">Sira - Faire progresser la santé publique en Afrique de l'Ouest</p>
                 """
 
             # Send email using Resend
@@ -191,10 +191,10 @@ class EmailService:
         try:
             if language == "en":
                 if purpose == "registration":
-                    subject = "Your SantePublique AOF verification code"
+                    subject = "Your Sira verification code"
                     html_content = f"""
                     <h2>Verification Code</h2>
-                    <p>Thank you for registering with SantePublique AOF.</p>
+                    <p>Thank you for registering with Sira.</p>
                     <p>Your verification code is:</p>
                     <div style="background-color: #f5f5f5; padding: 20px; text-align: center; font-size: 24px; font-weight: bold; letter-spacing: 8px; border-radius: 8px; margin: 20px 0;">
                         {otp_code}
@@ -203,10 +203,10 @@ class EmailService:
                     <p style="color: #666;">This code will expire in 10 minutes.</p>
                     <p style="color: #666;">If you didn't request this code, please ignore this email.</p>
                     <hr>
-                    <p style="color: #666; font-size: 12px;">SantePublique AOF - Advancing Public Health in West Africa</p>
+                    <p style="color: #666; font-size: 12px;">Sira - Advancing Public Health in West Africa</p>
                     """
                 else:
-                    subject = "Your SantePublique AOF login code"
+                    subject = "Your Sira login code"
                     html_content = f"""
                     <h2>Login Verification</h2>
                     <p>Your login verification code is:</p>
@@ -216,14 +216,14 @@ class EmailService:
                     <p>Enter this code in the app to complete your login.</p>
                     <p style="color: #666;">This code will expire in 10 minutes.</p>
                     <hr>
-                    <p style="color: #666; font-size: 12px;">SantePublique AOF - Advancing Public Health in West Africa</p>
+                    <p style="color: #666; font-size: 12px;">Sira - Advancing Public Health in West Africa</p>
                     """
             else:  # French
                 if purpose == "registration":
-                    subject = "Votre code de vérification SantePublique AOF"
+                    subject = "Votre code de vérification Sira"
                     html_content = f"""
                     <h2>Code de vérification</h2>
-                    <p>Merci de vous être inscrit(e) sur SantePublique AOF.</p>
+                    <p>Merci de vous être inscrit(e) sur Sira.</p>
                     <p>Votre code de vérification est :</p>
                     <div style="background-color: #f5f5f5; padding: 20px; text-align: center; font-size: 24px; font-weight: bold; letter-spacing: 8px; border-radius: 8px; margin: 20px 0;">
                         {otp_code}
@@ -232,10 +232,10 @@ class EmailService:
                     <p style="color: #666;">Ce code expirera dans 10 minutes.</p>
                     <p style="color: #666;">Si vous n'avez pas demandé ce code, ignorez cet email.</p>
                     <hr>
-                    <p style="color: #666; font-size: 12px;">SantePublique AOF - Faire progresser la santé publique en Afrique de l'Ouest</p>
+                    <p style="color: #666; font-size: 12px;">Sira - Faire progresser la santé publique en Afrique de l'Ouest</p>
                     """
                 else:
-                    subject = "Votre code de connexion SantePublique AOF"
+                    subject = "Votre code de connexion Sira"
                     html_content = f"""
                     <h2>Vérification de connexion</h2>
                     <p>Votre code de vérification de connexion est :</p>
@@ -245,7 +245,7 @@ class EmailService:
                     <p>Saisissez ce code dans l'application pour terminer votre connexion.</p>
                     <p style="color: #666;">Ce code expirera dans 10 minutes.</p>
                     <hr>
-                    <p style="color: #666; font-size: 12px;">SantePublique AOF - Faire progresser la santé publique en Afrique de l'Ouest</p>
+                    <p style="color: #666; font-size: 12px;">Sira - Faire progresser la santé publique en Afrique de l'Ouest</p>
                     """
 
             # Send email using Resend

--- a/backend/app/domain/services/totp_service.py
+++ b/backend/app/domain/services/totp_service.py
@@ -18,7 +18,7 @@ class TOTPService:
     def __init__(self):
         from app.domain.services.platform_settings_service import SettingsCache
 
-        self.issuer_name = "SantePublique AOF"
+        self.issuer_name = "Sira"
         self.backup_codes_count = SettingsCache.instance().get("auth-backup-codes-count", 8)
 
     def generate_secret(self) -> str:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -71,7 +71,7 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(
-    title="SantePublique AOF API",
+    title="Sira API",
     description="Adaptive bilingual learning platform for public health in West Africa",
     version="0.1.0",
     lifespan=lifespan,

--- a/docs/SRS_Sira.md
+++ b/docs/SRS_Sira.md
@@ -1,5 +1,5 @@
 # Software Requirements Specification
-## SantePublique AOF Learning Platform
+## Sira Learning Platform
 
 > **Application Web Mobile-First Bilingue pour la Formation en Sante Publique — Afrique de l'Ouest**  
 > Version : 1.0-draft | Statut : Draft pour validation | Audience : Développeurs, Product Owner, Parties prenantes
@@ -26,7 +26,7 @@
 
 ## 1. Introduction et Portée
 
-Ce document définit les exigences fonctionnelles et non-fonctionnelles pour le développement de **SantePublique AOF**, une plateforme d'apprentissage en ligne adaptative, bilingue (FR/EN) et mobile-first, destinée aux professionnels de santé et étudiants en Afrique de l'Ouest.
+Ce document définit les exigences fonctionnelles et non-fonctionnelles pour le développement de **Sira**, une plateforme d'apprentissage en ligne adaptative, bilingue (FR/EN) et mobile-first, destinée aux professionnels de santé et étudiants en Afrique de l'Ouest.
 
 La plateforme génère dynamiquement du contenu pédagogique à partir de 3 ouvrages de référence en santé publique, contextualise chaque leçon dans le contexte de l'Afrique de l'Ouest, et adapte l'expérience au niveau de progression de chaque utilisateur.
 
@@ -1107,4 +1107,4 @@ user_course_enrollment {
 
 ---
 
-*SantePublique AOF Platform · SRS v1.0 · 2025 · Basé sur : Donaldson's Essential Public Health · Principles of Public Health Practice (Scutchfield & Keck) · Biostatistics for the Biological and Health Sciences (Triola) · Sources de données : WHO AFRO · ECOWAS/CEDEAO · DHIS2 · DHS Program · World Bank*
+*Sira Platform · SRS v1.0 · 2025 · Basé sur : Donaldson's Essential Public Health · Principles of Public Health Practice (Scutchfield & Keck) · Biostatistics for the Biological and Health Sciences (Triola) · Sources de données : WHO AFRO · ECOWAS/CEDEAO · DHIS2 · DHS Program · World Bank*

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1,6 +1,6 @@
 {
   "Common": {
-    "appName": "Tutor",
+    "appName": "Sira",
     "loading": "Loading...",
     "offline": "You are offline — cached content available",
     "error": "An error occurred"

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1,6 +1,6 @@
 {
   "Common": {
-    "appName": "Tutor",
+    "appName": "Sira",
     "loading": "Chargement...",
     "offline": "Vous êtes hors ligne — contenu en cache disponible",
     "error": "Une erreur est survenue"


### PR DESCRIPTION
## Summary
- Rename app from "SantePublique AOF" to **Sira** (Bambara: *Donniya Sira* = "path to knowledge")
- Updates UI header (i18n), email templates, AI prompts, API docs title, TOTP issuer, SRS doc, CLAUDE.md, and all skill files
- Internal identifiers (JWT iss/aud, DB name, Celery app, health checks) left unchanged to avoid breaking deployed systems

## Test plan
- [ ] App header shows "Sira" in both FR and EN
- [ ] Emails (OTP, welcome, magic link) show "Sira" branding
- [ ] Authenticator app shows "Sira" as issuer
- [ ] API docs at /docs show "Sira API" title

🤖 Generated with [Claude Code](https://claude.com/claude-code)