### PR TITLE
feat(tutor): scope AI tutor to enrolled courses + per-thread course filter (#476)

### DIFF
--- a/backend/app/ai/prompts/tutor.py
+++ b/backend/app/ai/prompts/tutor.py
@@ -20,6 +20,7 @@ class TutorContext:
     previous_session_context: str | None = None  # Compacted context from prior session
     progress_snapshot: str | None = None  # Short learner progress summary
     tutor_mode: str = "socratic"  # "socratic" (guided questions) or "explanatory" (direct answers)
+    course_filter_names: list[str] | None = None  # Human-readable names of filtered courses
 
 
 def get_socratic_system_prompt(context: TutorContext, rag_chunks: list[dict[str, Any]]) -> str:
@@ -61,7 +62,7 @@ def get_socratic_system_prompt(context: TutorContext, rag_chunks: list[dict[str,
 - Pays: {country_context}
 - Module actuel: {_format_current_module(context)}
 - Mode: {"Socratique (guidage par questions)" if context.tutor_mode == "socratic" else "Explicatif (réponses directes)"}
-{_format_progress_section(context.progress_snapshot)}{_format_memory_section(context.learner_memory)}{_format_previous_session_section(context.previous_session_context)}
+{_format_progress_section(context.progress_snapshot)}{_format_memory_section(context.learner_memory)}{_format_previous_session_section(context.previous_session_context)}{_format_course_filter_section(context.course_filter_names)}
 
 {pedagogical_section}
 
@@ -178,6 +179,19 @@ une fois qu'on aura exploré cette idée ensemble ?"
 Réponds maintenant dans cette approche socratique stricte."""
 
     return prompt
+
+
+def _format_course_filter_section(course_filter_names: list[str] | None) -> str:
+    """Format the course filter as a PÉRIMÈTRE DE RÉPONSE section."""
+    if not course_filter_names:
+        return ""
+    course_list = ", ".join(course_filter_names)
+    return f"""
+## PÉRIMÈTRE DE RÉPONSE
+L'apprenant a limité cette conversation aux cours suivants: {course_list}
+- Réponds UNIQUEMENT avec du contenu pertinent à ces cours
+- Si la question sort du périmètre, indique poliment que le sujet sera couvert dans un autre cours
+- Cite uniquement les sources pertinentes aux cours sélectionnés"""
 
 
 def _format_memory_section(learner_memory: str | None) -> str:

--- a/backend/app/api/v1/schemas/tutor.py
+++ b/backend/app/api/v1/schemas/tutor.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class FileUploadResponse(BaseModel):
@@ -44,6 +44,17 @@ class TutorChatRequest(BaseModel):
         description="Tutor mode: socratic (guided questions) or explanatory (direct answers)",
     )
     file_ids: list[str] = Field(default_factory=list, description="Uploaded file IDs to attach")
+    course_filter: list[UUID] | None = Field(
+        None,
+        description="Optional list of course IDs (max 2) to scope this conversation",
+    )
+
+    @field_validator("course_filter")
+    @classmethod
+    def validate_course_filter(cls, v: list[UUID] | None) -> list[UUID] | None:
+        if v is not None and len(v) > 2:
+            raise ValueError("course_filter may contain at most 2 course IDs")
+        return v
 
 
 class TutorChatResponse(BaseModel):

--- a/backend/app/api/v1/tutor.py
+++ b/backend/app/api/v1/tutor.py
@@ -158,6 +158,7 @@ async def chat_with_tutor(
                 conversation_id=request.conversation_id,
                 tutor_mode=request.tutor_mode,
                 file_content_blocks=file_content_blocks,
+                course_filter=request.course_filter,
             ):
                 yield f"data: {json.dumps(chunk)}\n\n"
 

--- a/backend/app/domain/models/conversation.py
+++ b/backend/app/domain/models/conversation.py
@@ -26,6 +26,7 @@ class TutorConversation(Base):
     compacted_context: Mapped[str | None] = mapped_column(Text, nullable=True)
     compacted_at: Mapped[datetime | None] = mapped_column(nullable=True)
     message_count: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
+    course_filter: Mapped[list | None] = mapped_column(JSON, nullable=True)
 
     user: Mapped[User] = relationship(back_populates="tutor_conversations")
     module: Mapped[Module] = relationship(back_populates="tutor_conversations")

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -755,9 +755,7 @@ class TutorService:
         """Return human-readable course names for the given filter IDs."""
         if not course_filter:
             return []
-        result = await session.execute(
-            select(Course).where(Course.id.in_(course_filter))
-        )
+        result = await session.execute(select(Course).where(Course.id.in_(course_filter)))
         courses = result.scalars().all()
         names = []
         for c in courses:

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -22,6 +22,7 @@ from app.ai.prompts.tutor import (
 from app.ai.rag.embeddings import EmbeddingService
 from app.ai.rag.retriever import SemanticRetriever
 from app.domain.models.conversation import TutorConversation
+from app.domain.models.course import Course, UserCourseEnrollment
 from app.domain.models.module import Module
 from app.domain.models.user import User
 from app.domain.services.learner_memory_service import LearnerMemoryService
@@ -214,6 +215,7 @@ class TutorService:
         conversation_id: uuid.UUID | None = None,
         tutor_mode: str = "socratic",
         file_content_blocks: list[dict[str, Any]] | None = None,
+        course_filter: list[uuid.UUID] | None = None,
     ) -> AsyncGenerator[dict[str, Any], None]:
         """
         Send a message to the AI tutor and stream the response using agentic tool_use.
@@ -260,6 +262,13 @@ class TutorService:
                 user_id, module_id, conversation_id, session
             )
 
+            course_filter = await self._resolve_course_filter(
+                user_id=user_id,
+                conversation=conversation,
+                requested_filter=course_filter,
+                session=session,
+            )
+
             session_ctx = await self.session_manager.build_session_context(
                 user=user,
                 conversation=conversation,
@@ -294,6 +303,10 @@ class TutorService:
                     )
                     module_number = module_obj.module_number
 
+            course_filter_names = await self._resolve_course_names(
+                course_filter, user.preferred_language, session
+            )
+
             context = TutorContext(
                 user_level=user.current_level,
                 user_language=user.preferred_language,
@@ -307,6 +320,7 @@ class TutorService:
                 learner_memory=session_ctx.learner_memory,
                 previous_session_context=session_ctx.previous_compact,
                 progress_snapshot=session_ctx.progress_snapshot,
+                course_filter_names=course_filter_names,
             )
 
             system_prompt = get_socratic_system_prompt(context, [])
@@ -332,6 +346,7 @@ class TutorService:
                 user_id=user_id,
                 user_level=user.current_level,
                 user_language=user.preferred_language,
+                course_filter=course_filter,
             )
 
             tool_call_count = 0
@@ -687,6 +702,67 @@ class TutorService:
             "total_conversations": total_conversations,
             "most_discussed_topics": most_discussed_topics,
         }
+
+    async def _resolve_course_filter(
+        self,
+        user_id: uuid.UUID,
+        conversation: TutorConversation,
+        requested_filter: list[uuid.UUID] | None,
+        session: AsyncSession,
+    ) -> list[uuid.UUID] | None:
+        """Resolve and persist the course_filter for a conversation.
+
+        Priority:
+        1. If request supplies a filter → use it and persist on the conversation
+        2. If the conversation already has a stored filter → reuse it
+        3. Otherwise → default to the learner's most recently enrolled course
+        4. If no enrollments → None (search all)
+        """
+        if requested_filter is not None:
+            conversation.course_filter = [str(cid) for cid in requested_filter]
+            session.add(conversation)
+            await session.flush()
+            return requested_filter
+
+        if conversation.course_filter:
+            try:
+                return [uuid.UUID(cid) for cid in conversation.course_filter]
+            except (ValueError, TypeError):
+                pass
+
+        result = await session.execute(
+            select(UserCourseEnrollment)
+            .where(UserCourseEnrollment.user_id == user_id)
+            .order_by(UserCourseEnrollment.enrolled_at.desc())
+            .limit(1)
+        )
+        enrollment = result.scalar_one_or_none()
+        if enrollment:
+            default_filter = [enrollment.course_id]
+            conversation.course_filter = [str(enrollment.course_id)]
+            session.add(conversation)
+            await session.flush()
+            return default_filter
+
+        return None
+
+    async def _resolve_course_names(
+        self,
+        course_filter: list[uuid.UUID] | None,
+        language: str,
+        session: AsyncSession,
+    ) -> list[str]:
+        """Return human-readable course names for the given filter IDs."""
+        if not course_filter:
+            return []
+        result = await session.execute(
+            select(Course).where(Course.id.in_(course_filter))
+        )
+        courses = result.scalars().all()
+        names = []
+        for c in courses:
+            names.append(c.title_fr if language == "fr" else c.title_en)
+        return names
 
     async def _check_daily_limit(self, user_id: str | uuid.UUID, session: AsyncSession) -> int:
         """Check how many messages user has sent today."""

--- a/backend/app/domain/services/tutor_tools.py
+++ b/backend/app/domain/services/tutor_tools.py
@@ -235,9 +235,7 @@ class TutorToolExecutor:
             )
             return json.dumps({"error": f"Tool execution failed: {str(e)}"})
 
-    async def _aggregate_books_sources(
-        self, session: AsyncSession
-    ) -> dict[str, Any] | None:
+    async def _aggregate_books_sources(self, session: AsyncSession) -> dict[str, Any] | None:
         """Aggregate books_sources from all modules of the filtered courses."""
         if not self.course_filter:
             return None

--- a/backend/app/domain/services/tutor_tools.py
+++ b/backend/app/domain/services/tutor_tools.py
@@ -176,6 +176,7 @@ class TutorToolExecutor:
         user_level: int,
         user_language: str,
         learner_memory_service: LearnerMemoryService | None = None,
+        course_filter: list[uuid.UUID] | None = None,
     ):
         self.retriever = retriever
         self.anthropic = anthropic_client
@@ -183,6 +184,7 @@ class TutorToolExecutor:
         self.user_level = user_level
         self.user_language = user_language
         self.learner_memory_service = learner_memory_service or LearnerMemoryService()
+        self.course_filter = course_filter
 
     async def execute(
         self,
@@ -233,10 +235,36 @@ class TutorToolExecutor:
             )
             return json.dumps({"error": f"Tool execution failed: {str(e)}"})
 
+    async def _aggregate_books_sources(
+        self, session: AsyncSession
+    ) -> dict[str, Any] | None:
+        """Aggregate books_sources from all modules of the filtered courses."""
+        if not self.course_filter:
+            return None
+
+        result = await session.execute(
+            select(Module).where(Module.course_id.in_(self.course_filter))
+        )
+        modules = result.scalars().all()
+
+        merged: dict[str, Any] = {}
+        for module in modules:
+            if module.books_sources:
+                for key, val in module.books_sources.items():
+                    if key not in merged:
+                        merged[key] = val
+                    elif isinstance(val, list) and isinstance(merged[key], list):
+                        existing_set = set(str(v) for v in merged[key])
+                        for item in val:
+                            if str(item) not in existing_set:
+                                merged[key].append(item)
+                                existing_set.add(str(item))
+        return merged if merged else None
+
     async def _search_knowledge_base(
         self, tool_input: dict[str, Any], session: AsyncSession
     ) -> str:
-        """Execute search_knowledge_base tool."""
+        """Execute search_knowledge_base tool with course_filter scoping."""
         query = tool_input["query"]
         module_id_str = tool_input.get("module_id")
 
@@ -250,6 +278,9 @@ class TutorToolExecutor:
             except (ValueError, TypeError):
                 pass
 
+        if books_sources is None and self.course_filter:
+            books_sources = await self._aggregate_books_sources(session)
+
         results = await self.retriever.search_for_module(
             query=query,
             user_level=self.user_level,
@@ -258,6 +289,18 @@ class TutorToolExecutor:
             top_k=5,
             session=session,
         )
+
+        out_of_scope_fallback = False
+        if not results and self.course_filter:
+            results = await self.retriever.search_for_module(
+                query=query,
+                user_level=self.user_level,
+                user_language=self.user_language,
+                books_sources=None,
+                top_k=5,
+                session=session,
+            )
+            out_of_scope_fallback = True
 
         chunks = []
         chunk_ids = []
@@ -303,16 +346,20 @@ class TutorToolExecutor:
             query=query,
             results_count=len(chunks),
             figures_count=len(available_figures),
+            out_of_scope_fallback=out_of_scope_fallback,
             user_id=str(self.user_id),
         )
-        return json.dumps(
-            {
-                "query": query,
-                "results": chunks,
-                "count": len(chunks),
-                "available_figures": available_figures,
-            }
-        )
+        payload: dict[str, Any] = {
+            "query": query,
+            "results": chunks,
+            "count": len(chunks),
+            "available_figures": available_figures,
+        }
+        if out_of_scope_fallback:
+            payload["out_of_scope_notice"] = (
+                "Ce contenu provient d'un cours auquel vous n'êtes pas inscrit."
+            )
+        return json.dumps(payload)
 
     async def _get_learner_progress(self, tool_input: dict[str, Any], session: AsyncSession) -> str:
         """Execute get_learner_progress tool."""

--- a/backend/migrations/versions/033_add_course_filter_to_tutor_conversations.py
+++ b/backend/migrations/versions/033_add_course_filter_to_tutor_conversations.py
@@ -1,0 +1,27 @@
+"""add course_filter to tutor_conversations
+
+Revision ID: 033
+Revises: 032
+Create Date: 2026-04-05
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSON
+
+revision = "033"
+down_revision = "032"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tutor_conversations",
+        sa.Column("course_filter", JSON, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("tutor_conversations", "course_filter")

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -2,8 +2,9 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { useTranslations } from 'next-intl';
-import { X, MoreVertical, Trash2, Menu, HelpCircle, BookOpen } from 'lucide-react';
+import { X, MoreVertical, Trash2, Menu, HelpCircle, BookOpen, ChevronDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -37,6 +38,7 @@ import {
   invalidateConversationsCache,
   deleteConversation as apiDeleteConversation,
 } from '@/lib/tutor-api';
+import { getMyEnrollments, type CourseWithEnrollment } from '@/lib/api';
 
 interface ChatPanelProps {
   isOpen: boolean;
@@ -77,6 +79,9 @@ export function ChatPanel({
     }
     return 'socratic';
   });
+  const [enrolledCourses, setEnrolledCourses] = useState<CourseWithEnrollment[]>([]);
+  const [selectedCourseIds, setSelectedCourseIds] = useState<string[]>([]);
+  const [showCourseDropdown, setShowCourseDropdown] = useState(false);
   const scrollAreaRef = useRef<HTMLDivElement>(null);
 
   const isLimitReached = currentUsage >= maxDailyUsage;
@@ -91,6 +96,17 @@ export function ChatPanel({
   useEffect(() => {
     localStorage.setItem('tutorMode', tutorMode);
   }, [tutorMode]);
+
+  useEffect(() => {
+    getMyEnrollments()
+      .then((enrollments) => {
+        setEnrolledCourses(enrollments);
+        if (enrollments.length > 0) {
+          setSelectedCourseIds([enrollments[0].id]);
+        }
+      })
+      .catch(() => {});
+  }, []);
 
   useEffect(() => {
     fetchTutorStats()
@@ -197,6 +213,7 @@ export function ChatPanel({
           module_id: moduleId ?? null,
           tutor_mode: tutorMode,
           file_ids: attachedFiles.map((f) => f.fileId),
+          course_filter: selectedCourseIds.length > 0 ? selectedCourseIds : null,
         }),
       });
 
@@ -395,6 +412,90 @@ export function ChatPanel({
             </Button>
           </div>
         </div>
+
+        {/* Course Filter */}
+        {enrolledCourses.length > 0 && (
+          <div className="px-3 py-2 border-b bg-background shrink-0">
+            <div className="relative">
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-9 w-full justify-between text-xs font-normal"
+                onClick={() => setShowCourseDropdown((v) => !v)}
+                aria-label={t('courseFilter.label')}
+              >
+                <span className="truncate text-left">
+                  {selectedCourseIds.length === 0
+                    ? t('courseFilter.allCourses')
+                    : selectedCourseIds.length === 1
+                      ? enrolledCourses.find((c) => c.id === selectedCourseIds[0])?.title_fr ?? t('courseFilter.label')
+                      : `${selectedCourseIds.length} ${t('courseFilter.label')}`}
+                </span>
+                <ChevronDown className="h-3.5 w-3.5 shrink-0 ml-1" />
+              </Button>
+              {showCourseDropdown && (
+                <div className="absolute top-full left-0 right-0 z-50 mt-1 bg-background border rounded-md shadow-md">
+                  {enrolledCourses.map((course) => {
+                    const isSelected = selectedCourseIds.includes(course.id);
+                    const isDisabled = !isSelected && selectedCourseIds.length >= 2;
+                    return (
+                      <button
+                        key={course.id}
+                        className={cn(
+                          'flex items-center w-full px-3 py-2.5 text-sm text-left',
+                          'min-h-[44px]',
+                          isDisabled
+                            ? 'opacity-40 cursor-not-allowed'
+                            : 'hover:bg-muted cursor-pointer',
+                          isSelected && 'bg-muted font-medium'
+                        )}
+                        disabled={isDisabled}
+                        onClick={() => {
+                          if (isDisabled) return;
+                          setSelectedCourseIds((prev) =>
+                            isSelected
+                              ? prev.filter((id) => id !== course.id)
+                              : [...prev, course.id]
+                          );
+                          setShowCourseDropdown(false);
+                        }}
+                      >
+                        <span className="flex-1 truncate">{course.title_fr}</span>
+                        {isSelected && (
+                          <span className="ml-2 text-primary text-xs">✓</span>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+            {selectedCourseIds.length > 0 && (
+              <div className="flex flex-wrap gap-1 mt-1.5">
+                {selectedCourseIds.map((id) => {
+                  const course = enrolledCourses.find((c) => c.id === id);
+                  if (!course) return null;
+                  return (
+                    <Badge
+                      key={id}
+                      variant="secondary"
+                      className="text-xs gap-1 pr-1"
+                    >
+                      <span className="max-w-[120px] truncate">{course.title_fr}</span>
+                      <button
+                        className="ml-0.5 hover:text-destructive min-w-[16px] min-h-[16px] flex items-center justify-center"
+                        onClick={() => setSelectedCourseIds((prev) => prev.filter((i) => i !== id))}
+                        aria-label={`Remove ${course.title_fr}`}
+                      >
+                        <X className="h-2.5 w-2.5" />
+                      </button>
+                    </Badge>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Usage Counter */}
         <UsageCounter

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -375,6 +375,13 @@
       "fileCard": "{name} ({size})",
       "captureCamera": "Take a photo",
       "acceptedTypes": "Images, PDF, CSV, XLSX, TXT, DOCX (max 10 MB)"
+    },
+    "courseFilter": {
+      "label": "Courses",
+      "placeholder": "Filter by course",
+      "noEnrollments": "No enrolled courses",
+      "maxReached": "Maximum 2 courses selected",
+      "allCourses": "All courses"
     }
   },
   "Flashcards": {

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -375,6 +375,13 @@
       "fileCard": "{name} ({size})",
       "captureCamera": "Prendre une photo",
       "acceptedTypes": "Images, PDF, CSV, XLSX, TXT, DOCX (max 10 Mo)"
+    },
+    "courseFilter": {
+      "label": "Cours",
+      "placeholder": "Filtrer par cours",
+      "noEnrollments": "Aucun cours inscrit",
+      "maxReached": "Maximum 2 cours sélectionnés",
+      "allCourses": "Tous les cours"
     }
   },
   "Flashcards": {


### PR DESCRIPTION
## Summary

- Scopes AI tutor RAG searches to the learner's enrolled courses by default
- Adds per-thread `course_filter` (max 2 course IDs) that persists on each conversation
- Adapts system prompt with PÉRIMÈTRE DE RÉPONSE section when filter is active
- Adds frontend course selector dropdown with removable badge chips

## Changes

### Backend
- **`backend/app/api/v1/schemas/tutor.py`**: `course_filter` field (list[UUID], max 2) added to `TutorChatRequest` with Pydantic `field_validator` that rejects >2 IDs
- **`backend/app/domain/models/conversation.py`**: `course_filter` JSON column on `TutorConversation`
- **`backend/migrations/versions/033_add_course_filter_to_tutor_conversations.py`**: Alembic migration 033
- **`backend/app/domain/services/tutor_service.py`**: `_resolve_course_filter` auto-defaults to most recently enrolled course; persists filter for all subsequent messages in the thread; `_resolve_course_names` returns human-readable titles
- **`backend/app/domain/services/tutor_tools.py`**: `TutorToolExecutor` accepts `course_filter`; `_aggregate_books_sources` merges `books_sources` from enrolled course modules; falls back to full RAG with `out_of_scope_notice` flag
- **`backend/app/ai/prompts/tutor.py`**: `TutorContext.course_filter_names` + `_format_course_filter_section` adds PÉRIMÈTRE DE RÉPONSE to system prompt

### Frontend
- **`frontend/components/chat/chat-panel.tsx`**: Course selector dropdown showing enrolled courses (max 2, toggleable) with removable Badge chips; `course_filter` sent in every chat request
- **`frontend/messages/en.json`** / **`frontend/messages/fr.json`**: `courseFilter` i18n strings

## Test plan
- [ ] Backend tests pass (`uv run pytest`)
- [ ] Frontend lint passes (`npm run lint` — 0 errors)
- [ ] Tutor defaults to most recent enrolled course when no filter specified
- [ ] Per-thread filter persists across messages in same conversation
- [ ] Validation rejects >2 course IDs
- [ ] Fallback fires with `out_of_scope_notice` when no RAG results within scope
- [ ] System prompt includes PÉRIMÈTRE DE RÉPONSE section when filter active
- [ ] Course selector UI visible on mobile viewport (44px touch targets)

Closes #476

Generated with [Claude Code](https://claude.ai/code)