### PR TITLE
fix(auth): login redirect regression + disable email registration

### DIFF
--- a/frontend/app/[locale]/(auth)/register-options/page.tsx
+++ b/frontend/app/[locale]/(auth)/register-options/page.tsx
@@ -25,26 +25,26 @@ export default function RegisterOptionsPage() {
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-4">
-            <div className="rounded-lg border p-4 space-y-3">
+            <div className="rounded-lg border p-4 space-y-3 opacity-50">
               <div className="flex items-center gap-3">
-                <div className="w-10 h-10 rounded-full bg-blue-100 flex items-center justify-center">
-                  <svg className="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center">
+                  <svg className="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 4.45a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                   </svg>
                 </div>
                 <div>
-                  <h3 className="font-semibold">{t('emailVerification')}</h3>
+                  <h3 className="font-semibold text-muted-foreground">{t('emailVerification')}</h3>
                   <p className="text-sm text-muted-foreground">{t('emailVerificationDesc')}</p>
                 </div>
               </div>
-              <Link
-                href="/register-email-otp"
-                className={cn(buttonVariants({ variant: "default" }), "w-full min-h-11")}
+              <span
+                aria-disabled="true"
+                className={cn(buttonVariants({ variant: "default" }), "w-full min-h-11 pointer-events-none bg-gray-300 hover:bg-gray-300 text-gray-500")}
               >
                 {t('continueWithEmail')}
-              </Link>
+              </span>
               <div className="text-xs text-muted-foreground">
-                {t('emailVerificationBenefits')}
+                {t('comingSoon')}
               </div>
             </div>
 

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -168,6 +168,9 @@ class AuthClient {
       localStorage.setItem('access_token', authResponse.access_token);
       localStorage.setItem('refresh_token', authResponse.refresh_token);
       localStorage.setItem('user', JSON.stringify(authResponse.user));
+      // Set cookie for server-side middleware auth check
+      const maxAge = authResponse.expires_in || 900;
+      document.cookie = `access_token=${authResponse.access_token}; path=/; max-age=${maxAge}; SameSite=Strict; Secure`;
     }
   }
 
@@ -179,6 +182,8 @@ class AuthClient {
       localStorage.removeItem('access_token');
       localStorage.removeItem('refresh_token');
       localStorage.removeItem('user');
+      // Clear middleware auth cookie
+      document.cookie = 'access_token=; path=/; max-age=0; SameSite=Strict; Secure';
     }
   }
 
@@ -259,6 +264,9 @@ class AuthClient {
     this.accessToken = response.access_token;
     if (typeof window !== 'undefined') {
       localStorage.setItem('access_token', response.access_token);
+      // Update middleware auth cookie
+      const maxAge = response.expires_in || 900;
+      document.cookie = `access_token=${response.access_token}; path=/; max-age=${maxAge}; SameSite=Strict; Secure`;
     }
   }
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -123,6 +123,7 @@
     "emailVerification": "Email Verification",
     "emailVerificationDesc": "Receive a 6-digit code via email",
     "emailVerificationBenefits": "✓ Simple and convenient ✓ Works on any device ✓ Perfect for mobile users",
+    "comingSoon": "Coming soon",
     "authenticatorApp": "Authenticator App",
     "authenticatorAppDesc": "Use Google Authenticator or Microsoft Authenticator",
     "authenticatorAppBenefits": "✓ More secure ✓ Works offline ✓ Industry standard for 2FA",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -123,6 +123,7 @@
     "emailVerification": "Vérification par Email",
     "emailVerificationDesc": "Recevez un code à 6 chiffres par email",
     "emailVerificationBenefits": "✓ Simple et pratique ✓ Fonctionne sur tous les appareils ✓ Parfait pour les utilisateurs mobiles",
+    "comingSoon": "Bientôt disponible",
     "authenticatorApp": "Application d'Authentification",
     "authenticatorAppDesc": "Utilisez Google Authenticator ou Microsoft Authenticator",
     "authenticatorAppBenefits": "✓ Plus sécurisé ✓ Fonctionne hors ligne ✓ Standard de l'industrie pour 2FA",


### PR DESCRIPTION
## Summary
- **Critical fix:** RBAC commit (5b88329) added server-side middleware auth checking for `access_token` cookie, but tokens were only in localStorage — blocking all logins
- `setTokens`/`clearTokens`/`refreshAccessToken` now sync `access_token` to a browser cookie for middleware visibility
- Email OTP registration grayed out ("coming soon") since Resend API key is not configured

## Test plan
- [ ] Login with TOTP credentials → redirects to /dashboard
- [ ] Refresh dashboard → stays authenticated
- [ ] Logout → cookie cleared, redirected to /login
- [ ] Direct nav to /dashboard without auth → middleware redirects to /login

🤖 Generated with [Claude Code](https://claude.com/claude-code)