### PR TITLE
feat(analytics): wire PostHog provider into app layout + page view tracking

### DIFF
--- a/frontend/app/[locale]/layout.tsx
+++ b/frontend/app/[locale]/layout.tsx
@@ -5,6 +5,7 @@ import { routing } from "@/i18n/routing";
 import { QueryProvider } from "@/lib/query-provider";
 import { SettingsProvider } from "@/lib/settings-context";
 import { InstallPrompt } from "@/components/pwa/install-prompt";
+import { PostHogProvider } from "@/lib/posthog-provider";
 
 export default async function LocaleLayout({
   children,
@@ -23,12 +24,14 @@ export default async function LocaleLayout({
 
   return (
     <NextIntlClientProvider messages={messages}>
-      <QueryProvider>
-        <SettingsProvider>
-          {children}
-          <InstallPrompt />
-        </SettingsProvider>
-      </QueryProvider>
+      <PostHogProvider>
+        <QueryProvider>
+          <SettingsProvider>
+            {children}
+            <InstallPrompt />
+          </SettingsProvider>
+        </QueryProvider>
+      </PostHogProvider>
     </NextIntlClientProvider>
   );
 }

--- a/frontend/components/shared/auth-guard.tsx
+++ b/frontend/components/shared/auth-guard.tsx
@@ -4,6 +4,7 @@ import { startTransition, useEffect, useState } from "react";
 import { useRouter } from "@/i18n/routing";
 import { useLocale } from "next-intl";
 import { usePathname } from "next/navigation";
+import { identifyUser } from "@/lib/analytics";
 
 function getStoredToken(): string | null {
   if (typeof window === "undefined") return null;
@@ -36,6 +37,26 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
       localStorage.removeItem("user");
       router.replace("/login");
       return;
+    }
+    const storedUser = localStorage.getItem("user");
+    if (storedUser) {
+      try {
+        const user = JSON.parse(storedUser) as {
+          id?: string;
+          country?: string;
+          current_level?: number;
+          preferred_language?: string;
+        };
+        if (user.id) {
+          identifyUser(user.id, {
+            country: user.country,
+            level: user.current_level,
+            preferred_language: user.preferred_language,
+          });
+        }
+      } catch {
+        // ignore malformed user data
+      }
     }
     startTransition(() => setAuthorized(true));
   }, [locale, pathname, router]);


### PR DESCRIPTION
## Summary

- Import and wrap `PostHogProvider` in `frontend/app/[locale]/layout.tsx` around the app providers
- Call `identifyUser()` in `frontend/components/shared/auth-guard.tsx` after token validation succeeds, reading user metadata from `localStorage`

## Changes

- `frontend/app/[locale]/layout.tsx` — added `PostHogProvider` import and wraps `QueryProvider`/`SettingsProvider` tree
- `frontend/components/shared/auth-guard.tsx` — imports `identifyUser` from `@/lib/analytics` and calls it with user id, country, level, and preferred language on successful auth check

## Test plan

- [ ] Frontend lint passes (0 errors) ✅
- [ ] No new test failures ✅
- [ ] PostHog loads on app start (verify network tab shows PostHog requests when `NEXT_PUBLIC_POSTHOG_KEY` is set)
- [ ] `$pageview` events captured on route changes
- [ ] User identified after login (verify in PostHog dashboard)
- [ ] No events fire if `NEXT_PUBLIC_POSTHOG_KEY` is not set (graceful degradation — existing guard in provider and analytics)

Closes #658

Generated with [Claude Code](https://claude.ai/code)