### PR TITLE
feat(analytics): add usage tracking calls at all 7 feature usage points

### DIFF
--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
-import { useTranslations } from 'next-intl';
+import { useTranslations, useLocale } from 'next-intl';
+import { track } from '@/lib/analytics';
 import { X, MoreVertical, Trash2, Menu, HelpCircle, BookOpen } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -60,6 +61,7 @@ export function ChatPanel({
   onOpenConversations,
 }: ChatPanelProps) {
   const t = useTranslations('ChatTutor');
+  const locale = useLocale();
   const router = useRouter();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -172,6 +174,10 @@ export function ChatPanel({
     setCurrentUsage((prev) => prev + 1);
     setIsLoading(true);
     setIsTyping(true);
+    track('tutor_message_sent', {
+      module_id: moduleId ?? '',
+      language: locale,
+    });
 
     try {
       const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';

--- a/frontend/components/learning/flashcard-deck.tsx
+++ b/frontend/components/learning/flashcard-deck.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
+import { track } from '@/lib/analytics';
 
 interface FlashcardData {
   id: string;
@@ -22,6 +23,13 @@ interface FlashcardData {
   difficulty: number;
 }
 
+const RATING_TO_NUMBER: Record<string, number> = {
+  again: 1,
+  hard: 2,
+  good: 3,
+  easy: 4,
+};
+
 interface FlashcardDeckProps {
   cards: FlashcardData[];
   onReview: (cardId: string, reviewId: string, rating: string) => void;
@@ -32,6 +40,7 @@ interface FlashcardDeckProps {
   }) => void;
   isLoading?: boolean;
   language: 'fr' | 'en';
+  moduleId?: string;
 }
 
 type Rating = 'again' | 'hard' | 'good' | 'easy';
@@ -41,7 +50,8 @@ export function FlashcardDeck({
   onReview, 
   onSessionComplete, 
   isLoading = false, 
-  language = 'fr' 
+  language = 'fr',
+  moduleId = '',
 }: FlashcardDeckProps) {
   const t = useTranslations('Flashcards');
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -75,6 +85,10 @@ export function FlashcardDeck({
 
     // Record the review
     onReview(currentCard.id, currentCard.review_id, rating);
+    track('flashcard_reviewed', {
+      module_id: moduleId,
+      rating: RATING_TO_NUMBER[rating] ?? 0,
+    });
     
     const newRatings = [...reviewedRatings, rating];
     setReviewedRatings(newRatings);

--- a/frontend/components/learning/lesson-viewer.tsx
+++ b/frontend/components/learning/lesson-viewer.tsx
@@ -19,6 +19,7 @@ import type { SourceImageMeta } from '@/lib/api';
 import { useCurrentUser } from '@/lib/hooks/use-current-user';
 import { useRouter } from 'next/navigation';
 import { useLocale } from 'next-intl';
+import { track } from '@/lib/analytics';
 
 const POLL_INTERVAL_MS = 3000;
 const POLL_TIMEOUT_MS = 3 * 60 * 1000;
@@ -192,10 +193,16 @@ export function LessonViewer({
           pollStartRef.current = Date.now();
           pollStatus((res as GeneratingResponse).task_id, pollStartRef.current);
         } else {
-          setLessonData(res as LessonData);
+          const lesson = res as LessonData;
+          setLessonData(lesson);
           setIsLoading(false);
           setIsRefreshing(false);
           setForceRegenerate(false);
+          track('lesson_viewed', {
+            module_id: lesson.module_id,
+            unit_id: lesson.unit_id,
+            language: lesson.language,
+          });
         }
       } catch (err) {
         console.error('Error loading lesson:', err);

--- a/frontend/components/learning/module-lock-gate.tsx
+++ b/frontend/components/learning/module-lock-gate.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Link } from '@/i18n/routing';
 import { ChevronLeft, Lock, BookOpen, CheckCircle, Clock } from 'lucide-react';
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { getModuleDetailWithProgress, getModuleUnits, type ModuleDetailWithProgressResponse } from '@/lib/api';
+import { track } from '@/lib/analytics';
 import { ModuleProgressOverlay } from '@/components/learning/module-progress-overlay';
 import { ModuleMediaPlayer } from '@/components/learning/module-media-player';
 
@@ -22,6 +23,7 @@ export function ModuleLockGate({ moduleId, language }: ModuleLockGateProps) {
   const tCard = useTranslations('ModuleCard');
   const [moduleData, setModuleData] = useState<ModuleDetailWithProgressResponse | null>(null);
   const [loading, setLoading] = useState(true);
+  const unlockedTracked = useRef(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -32,6 +34,13 @@ export function ModuleLockGate({ moduleId, language }: ModuleLockGateProps) {
         if (!cancelled) {
           setModuleData(data);
           setLoading(false);
+          if (data.status !== 'locked' && !unlockedTracked.current) {
+            unlockedTracked.current = true;
+            track('module_unlocked', {
+              module_id: data.id,
+              level: data.level,
+            });
+          }
         }
       } catch {
         try {

--- a/frontend/components/quiz/quiz-container.tsx
+++ b/frontend/components/quiz/quiz-container.tsx
@@ -12,6 +12,7 @@ import { QuizResults } from './quiz-results';
 import type { Quiz, QuizAttemptResponse } from '@/lib/api';
 import { generateQuiz, apiFetch } from '@/lib/api';
 import { useSettings } from '@/lib/settings-context';
+import { track } from '@/lib/analytics';
 import { useCurrentUser } from '@/lib/hooks/use-current-user';
 
 const POLL_INTERVAL_MS = 3000;
@@ -152,11 +153,22 @@ export function QuizContainer({
   
   const handleStartQuiz = () => {
     setState('in-progress');
+    track('quiz_started', {
+      module_id: moduleId,
+      level,
+      language,
+    });
   };
   
   const handleQuizComplete = (quizResult: QuizAttemptResponse) => {
     setResult(quizResult);
     setState('completed');
+    track('quiz_completed', {
+      module_id: moduleId,
+      score: quizResult.score,
+      passed: quizResult.passed,
+      duration_seconds: quizResult.total_time_seconds,
+    });
   };
   
   const handleQuizError = (errorMessage: string) => {

--- a/frontend/components/shared/locale-switcher.tsx
+++ b/frontend/components/shared/locale-switcher.tsx
@@ -4,6 +4,7 @@ import { useLocale, useTranslations } from "next-intl";
 import { useRouter, usePathname } from "next/navigation";
 import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
+import { track } from "@/lib/analytics";
 
 export function LocaleSwitcher() {
   const locale = useLocale();
@@ -27,6 +28,7 @@ export function LocaleSwitcher() {
       localStorage.setItem("preferred-locale", nextLocale);
     }
     
+    track("language_switched", { from: locale, to: nextLocale });
     router.push(newPath);
   }
 


### PR DESCRIPTION
## Summary
- Instruments all 7 analytics event types from `analytics.ts` at their respective feature usage points
- All calls use the typed `track()` function; no modifications to `analytics.ts`
- Events fire only on user interaction (no spurious triggers)

## Changes
- `frontend/components/learning/lesson-viewer.tsx` — fires `lesson_viewed` when lesson content loads
- `frontend/components/quiz/quiz-container.tsx` — fires `quiz_started` on start button click and `quiz_completed` on results received (with score, passed, duration_seconds)
- `frontend/components/learning/flashcard-deck.tsx` — adds `moduleId` optional prop; fires `flashcard_reviewed` on rating submitted (converts string rating to 1-4 number)
- `frontend/components/chat/chat-panel.tsx` — fires `tutor_message_sent` on message send (with module_id and locale as language)
- `frontend/components/shared/locale-switcher.tsx` — fires `language_switched` on locale change (from/to)
- `frontend/components/learning/module-lock-gate.tsx` — fires `module_unlocked` once when module data loads and status is not locked (uses useRef to prevent duplicate fires)

## Test plan
- [ ] Backend tests pass
- [ ] Frontend lint passes (0 errors — verified locally)
- [ ] All 7 events fire at correct user interaction points
- [ ] No events fire on spurious renders
- [ ] Event properties match typed shapes in analytics.ts

Closes #659

Generated with [Claude Code](https://claude.ai/code)