### PR TITLE
feat(api): subscription webhook + status endpoints

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -17,6 +17,7 @@ from app.api.v1.placement import router as placement_router
 from app.api.v1.progress import router as progress_router
 from app.api.v1.quiz import router as quiz_router
 from app.api.v1.source_images import router as source_images_router
+from app.api.v1.subscriptions import router as subscriptions_router
 from app.api.v1.tutor import router as tutor_router
 from app.api.v1.users import router as users_router
 
@@ -40,3 +41,4 @@ api_v1_router.include_router(courses_router)
 api_v1_router.include_router(course_preassessment_router)
 api_v1_router.include_router(module_media_router)
 api_v1_router.include_router(source_images_router)
+api_v1_router.include_router(subscriptions_router)

--- a/backend/app/api/v1/subscriptions.py
+++ b/backend/app/api/v1/subscriptions.py
@@ -1,0 +1,160 @@
+"""Subscription API endpoints for Orange Money payment processing."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from pydantic import BaseModel, field_validator
+from structlog import get_logger
+
+from app.api.deps import get_db as get_db_session
+from app.api.deps_local_auth import get_current_user
+from app.domain.services.subscription_service import SubscriptionService
+from app.infrastructure.config.settings import get_settings
+
+logger = get_logger(__name__)
+
+router = APIRouter(tags=["Subscriptions"])
+
+
+class WebhookPayload(BaseModel):
+    phone_number: str
+    amount_xof: int
+    reference: str
+
+
+class WebhookResponse(BaseModel):
+    status: str
+    subscription_activated: bool
+
+
+class FreeTierInfo(BaseModel):
+    daily_messages: int
+    first_lesson_free: bool
+
+
+class SubscriptionStatusResponse(BaseModel):
+    has_subscription: bool
+    subscription_status: str | None = None
+    days_remaining: int | None = None
+    daily_message_limit: int | None = None
+    expires_at: str | None = None
+    free_tier: FreeTierInfo | None = None
+
+
+class PhoneNumberRequest(BaseModel):
+    phone_number: str
+
+    @field_validator("phone_number")
+    @classmethod
+    def validate_phone(cls, v: str) -> str:
+        cleaned = re.sub(r"[\s\-\(\)]", "", v)
+        if not re.match(r"^\+?[0-9]{8,15}$", cleaned):
+            raise ValueError("Phone number must be international format with 8-15 digits")
+        return cleaned
+
+
+class PhoneNumberResponse(BaseModel):
+    phone_number: str
+    message: str
+
+
+@router.post(
+    "/subscriptions/webhook/validate",
+    response_model=WebhookResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def validate_webhook(
+    payload: WebhookPayload,
+    x_webhook_secret: str | None = Header(default=None),
+    db=Depends(get_db_session),
+) -> WebhookResponse:
+    settings = get_settings()
+    if not x_webhook_secret or x_webhook_secret != settings.subscription_webhook_secret:
+        logger.warning("Webhook secret mismatch", provided=bool(x_webhook_secret))
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid webhook secret",
+        )
+
+    service = SubscriptionService()
+    result = await service.process_payment(
+        phone_number=payload.phone_number,
+        amount_xof=payload.amount_xof,
+        external_reference=payload.reference,
+        session=db,
+    )
+
+    logger.info(
+        "Webhook processed",
+        reference=payload.reference,
+        activated=result.get("subscription_activated"),
+    )
+
+    return WebhookResponse(
+        status=result["status"],
+        subscription_activated=result["subscription_activated"],
+    )
+
+
+@router.get(
+    "/subscriptions/me",
+    response_model=SubscriptionStatusResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def get_my_subscription(
+    current_user=Depends(get_current_user),
+    db=Depends(get_db_session),
+) -> SubscriptionStatusResponse:
+    user_id = uuid.UUID(current_user.id) if isinstance(current_user.id, str) else current_user.id
+
+    service = SubscriptionService()
+    subscription = await service.get_active_subscription(user_id=user_id, session=db)
+
+    if subscription is None:
+        return SubscriptionStatusResponse(
+            has_subscription=False,
+            free_tier=FreeTierInfo(daily_messages=5, first_lesson_free=True),
+        )
+
+    now = datetime.now(tz=UTC)
+    delta = subscription.expires_at - now
+    days_remaining = max(0, delta.days)
+
+    return SubscriptionStatusResponse(
+        has_subscription=True,
+        subscription_status=subscription.status,
+        days_remaining=days_remaining,
+        daily_message_limit=subscription.daily_message_limit,
+        expires_at=subscription.expires_at.isoformat(),
+    )
+
+
+@router.post(
+    "/users/phone",
+    response_model=PhoneNumberResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def update_phone_number(
+    payload: PhoneNumberRequest,
+    current_user=Depends(get_current_user),
+    db=Depends(get_db_session),
+) -> PhoneNumberResponse:
+    user_id = uuid.UUID(current_user.id) if isinstance(current_user.id, str) else current_user.id
+
+    service = SubscriptionService()
+    await service.link_phone_number(
+        user_id=user_id,
+        phone_number=payload.phone_number,
+        session=db,
+    )
+
+    logger.info("Phone number linked", user_id=str(user_id), phone=payload.phone_number)
+
+    return PhoneNumberResponse(
+        phone_number=payload.phone_number,
+        message="Phone number updated and pending payments resolved",
+    )

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -46,6 +46,9 @@ class Settings(BaseSettings):
     cors_origins: str = "http://localhost:3000"
     api_v1_prefix: str = "/api/v1"
 
+    # Subscription webhook
+    subscription_webhook_secret: str = ""
+
     # Admin seeding
     admin_email: str = ""
 


### PR DESCRIPTION
## Summary

Implements Orange Money subscription API endpoints for payment confirmation, subscription status, and phone number management.

## Changes

- **New** `backend/app/api/v1/subscriptions.py` — 3 endpoints:
  - `POST /subscriptions/webhook/validate` — validates `X-Webhook-Secret` header against `settings.subscription_webhook_secret`, returns 403 on mismatch, delegates to `SubscriptionService.process_payment()`
  - `GET /subscriptions/me` — JWT-protected, returns active subscription (status, days_remaining, daily_message_limit, expires_at) or free tier info `{"has_subscription": false, "free_tier": {"daily_messages": 5, "first_lesson_free": true}}`
  - `POST /users/phone` — JWT-protected, validates phone format (international, 8-15 digits via `field_validator`), calls `SubscriptionService.link_phone_number()` to resolve pending payments
- **Modified** `backend/app/infrastructure/config/settings.py` — added `subscription_webhook_secret: str = ""` (env: `SUBSCRIPTION_WEBHOOK_SECRET`)
- **Modified** `backend/app/api/v1/router.py` — registered `subscriptions_router`

## Test plan

- [ ] Webhook returns 403 when `X-Webhook-Secret` is missing or wrong
- [ ] Webhook processes payment and returns `{"status": "ok", "subscription_activated": true/false}`
- [ ] `GET /subscriptions/me` returns subscription data for subscribed users
- [ ] `GET /subscriptions/me` returns free tier info for unsubscribed users
- [ ] `POST /users/phone` validates phone format and links phone number
- [ ] `POST /users/phone` resolves pending payments via `link_phone_number()`

Closes #857

Generated with [Claude Code](https://claude.ai/code)