### PR TITLE
feat(syllabus): use full PDF text for syllabus generation (#878)

### DIFF
--- a/backend/app/domain/services/course_agent_service.py
+++ b/backend/app/domain/services/course_agent_service.py
@@ -41,6 +41,7 @@ class CourseAgentService:
         course_level: list[str] | None = None,
         audience_type: list[str] | None = None,
         estimated_hours: int = 20,
+        resource_text: str | None = None,
     ) -> list[dict[str, Any]]:
         """
         Generate a course module outline using Claude API.
@@ -66,6 +67,18 @@ class CourseAgentService:
             levels_str = ", ".join(course_level) if course_level else "All levels"
             audience_str = ", ".join(audience_type) if audience_type else "Professionals"
 
+            resource_context = ""
+            if resource_text:
+                resource_context = (
+                    f"\n## Reference materials (full text)\n"
+                    f"The following is the complete extracted text from the course's "
+                    f"reference materials. You MUST base the syllabus on this content — "
+                    f"every module and unit should map to actual chapters, topics, and "
+                    f"concepts found in these materials. Do NOT invent topics that are "
+                    f"not covered in the references.\n\n"
+                    f"{resource_text}\n\n"
+                )
+
             prompt = (
                 f"You are an expert instructional designer specializing in bilingual (FR/EN) "
                 f"adaptive e-learning. You design curricula using Bloom's "
@@ -77,6 +90,7 @@ class CourseAgentService:
                 f"- Level(s): {levels_str}\n"
                 f"- Target audience: {audience_str}\n"
                 f"- Estimated total hours: {estimated_hours}\n\n"
+                f"{resource_context}"
                 f"## Design principles (mandatory)\n"
                 f"- Progressive complexity: start with foundational concepts (remember/understand), "
                 f"build to applied skills (apply/analyze), end with expert synthesis (evaluate/create)\n"

--- a/backend/app/tasks/syllabus_generation.py
+++ b/backend/app/tasks/syllabus_generation.py
@@ -82,10 +82,58 @@ def generate_course_syllabus(self, course_id: str, estimated_hours: int) -> dict
             level_slugs = [tc.slug for tc in cats if tc.type == "level"]
             audience_slugs = [tc.slug for tc in cats if tc.type == "audience"]
 
-        # Phase 2: Call Claude API (no DB session needed)
+        # Phase 1.5: Extract text from uploaded PDFs for context
         self.update_state(
             state="GENERATING",
-            meta={"step": "calling_claude", "progress": 20, "modules_count": 0},
+            meta={"step": "extracting_pdf_text", "progress": 15, "modules_count": 0},
+        )
+
+        resource_text = None
+        from pathlib import Path
+
+        course_dir = Path("uploads/course_resources") / course_id
+        if course_dir.exists():
+            import fitz  # PyMuPDF
+
+            pdf_texts = []
+            for pdf_path in sorted(course_dir.glob("*.pdf")):
+                try:
+                    doc = fitz.open(str(pdf_path))
+                    book_name = pdf_path.stem.replace("_", " ")
+                    pages_text = []
+                    for page in doc:
+                        text = page.get_text().strip()
+                        if text:
+                            pages_text.append(text)
+                    doc.close()
+                    full_text = "\n\n".join(pages_text)
+                    pdf_texts.append(f"### {book_name}\n{full_text}")
+                    logger.info(
+                        "Extracted PDF text",
+                        pdf=book_name,
+                        pages=len(pages_text),
+                        chars=len(full_text),
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Failed to extract PDF text",
+                        pdf=str(pdf_path),
+                        error=str(e),
+                    )
+
+            if pdf_texts:
+                resource_text = "\n\n---\n\n".join(pdf_texts)
+                logger.info(
+                    "Full PDF text extracted for syllabus context",
+                    course_id=course_id,
+                    pdf_count=len(pdf_texts),
+                    total_chars=len(resource_text),
+                )
+
+        # Phase 2: Call Claude API
+        self.update_state(
+            state="GENERATING",
+            meta={"step": "calling_claude", "progress": 25, "modules_count": 0},
         )
 
         agent = CourseAgentService()
@@ -96,6 +144,7 @@ def generate_course_syllabus(self, course_id: str, estimated_hours: int) -> dict
             course_level=level_slugs,
             audience_type=audience_slugs,
             estimated_hours=estimated_hours or course_hours,
+            resource_text=resource_text,
         )
 
         self.update_state(


### PR DESCRIPTION
## Summary
- Syllabus generation now extracts full text from uploaded PDFs via PyMuPDF and includes it in the Claude prompt
- Previously only course metadata (title, domain, level) was sent — PDFs were completely ignored
- Claude now designs the syllabus based on actual reference material content

Closes #878

## Test plan
- [ ] Create course with PDFs → generate syllabus → modules reflect actual PDF content
- [ ] Verify syllabus topics map to chapters in the reference materials

🤖 Generated with [Claude Code](https://claude.com/claude-code)