### PR TITLE
fix(syllabus): send full PDF text when within context limits

### DIFF
--- a/backend/app/tasks/syllabus_generation.py
+++ b/backend/app/tasks/syllabus_generation.py
@@ -95,39 +95,30 @@ def generate_course_syllabus(self, course_id: str, estimated_hours: int) -> dict
         if course_dir.exists():
             import fitz  # PyMuPDF
 
-            # Budget: ~150K tokens (~400K chars) total across all PDFs
-            MAX_CHARS_TOTAL = 400_000
+            # Extract full text first, then truncate only if needed
+            MAX_CHARS_TOTAL = 400_000  # ~150K tokens, fits Claude context
             pdf_files = sorted(course_dir.glob("*.pdf"))
-            chars_per_pdf = MAX_CHARS_TOTAL // max(len(pdf_files), 1)
 
-            pdf_texts = []
+            pdf_full_texts = []
+            total_all_chars = 0
             for pdf_path in pdf_files:
                 try:
                     doc = fitz.open(str(pdf_path))
                     book_name = pdf_path.stem.replace("_", " ")
                     toc = doc.get_toc()
-
-                    # Always extract text, but limit per PDF
                     pages_text = []
-                    total_chars = 0
                     for page in doc:
                         text = page.get_text().strip()
                         if text:
                             pages_text.append(text)
-                            total_chars += len(text)
-                            if total_chars >= chars_per_pdf:
-                                break
-
                     doc.close()
                     full_text = "\n\n".join(pages_text)
-
-                    # Prepend TOC if available for better structure
                     if toc:
                         toc_lines = [f"{'  ' * (lvl - 1)}{title}" for lvl, title, _ in toc]
                         toc_str = "\n".join(toc_lines[:100])
                         full_text = f"TABLE OF CONTENTS:\n{toc_str}\n\nCONTENT:\n{full_text}"
-
-                    pdf_texts.append(f"### {book_name}\n{full_text}")
+                    total_all_chars += len(full_text)
+                    pdf_full_texts.append((book_name, full_text, toc))
                     logger.info(
                         "Extracted PDF text",
                         pdf=book_name,
@@ -142,10 +133,31 @@ def generate_course_syllabus(self, course_id: str, estimated_hours: int) -> dict
                         error=str(e),
                     )
 
-            if pdf_texts:
+            if pdf_full_texts:
+                if total_all_chars <= MAX_CHARS_TOTAL:
+                    # Full text fits — send everything
+                    pdf_texts = [f"### {name}\n{text}" for name, text, _ in pdf_full_texts]
+                else:
+                    # Truncate: TOC + chapter intros per PDF
+                    chars_per_pdf = MAX_CHARS_TOTAL // len(pdf_full_texts)
+                    pdf_texts = []
+                    for name, text, toc in pdf_full_texts:
+                        if len(text) <= chars_per_pdf:
+                            pdf_texts.append(f"### {name}\n{text}")
+                        else:
+                            truncated = text[:chars_per_pdf]
+                            pdf_texts.append(
+                                f"### {name} (truncated to {chars_per_pdf} chars)\n{truncated}"
+                            )
+                    logger.info(
+                        "PDF text truncated to fit context",
+                        original_chars=total_all_chars,
+                        truncated_chars=MAX_CHARS_TOTAL,
+                    )
+
                 resource_text = "\n\n---\n\n".join(pdf_texts)
                 logger.info(
-                    "PDF text extracted for syllabus context",
+                    "PDF text prepared for syllabus context",
                     course_id=course_id,
                     pdf_count=len(pdf_texts),
                     total_chars=len(resource_text),


### PR DESCRIPTION
## Summary
- Send full PDF text to Claude when total fits within 400K char budget
- Only truncate per-PDF when the combined text exceeds the limit
- Fixes syllabus generating only 2 placeholder modules instead of real content-aware structure

## Test plan
- [ ] Re-trigger syllabus generation → should produce 10-15 modules based on actual PDF content

🤖 Generated with [Claude Code](https://claude.com/claude-code)