### PR TITLE
fix(rag): use rag_collection_id as chunk source — unblocks course publishing

### DIFF
--- a/backend/app/tasks/rag_indexation.py
+++ b/backend/app/tasks/rag_indexation.py
@@ -172,10 +172,10 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
                 },
             )
 
-            source_name = pdf_path.stem.replace("_", " ")
+            book_name = pdf_path.stem.replace("_", " ")
             chunks = await pipeline.process_pdf_document(
                 pdf_path=str(pdf_path),
-                source=source_name,
+                source=rag_collection_id,
             )
             total_chunks += chunks
 
@@ -213,7 +213,7 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
             try:
                 image_count = await pipeline.process_pdf_images(
                     pdf_path=str(pdf_path),
-                    source=source_name,
+                    source=book_name,
                     rag_collection_id=rag_collection_id,
                 )
                 total_images += image_count


### PR DESCRIPTION
## Summary
- RAG indexation stored chunks with PDF filename as source (e.g., "donaldson") but the publish endpoint checks `source == rag_collection_id`
- Result: every course publish fails with "No RAG content indexed"
- Fix: use the course's `rag_collection_id` as the chunk source
- Keep book name for image source attribution

## Test plan
- [ ] Re-run indexation → chunks stored with rag_collection_id
- [ ] Publish course → succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)