### PR TITLE
merge: admin enrollment bypass + Phase 2 services

### DIFF
--- a/backend/app/api/deps_local_auth.py
+++ b/backend/app/api/deps_local_auth.py
@@ -165,7 +165,7 @@ def require_enrollment(course_id_param: str = "course_id") -> Callable:
             enrollment = result.scalar_one_or_none()
             break
 
-        if not enrollment and user.role not in ("admin", "expert"):
+        if not enrollment and user.role != "admin":
             logger.warning(
                 "Access denied - not enrolled in course",
                 user_id=user.id,


### PR DESCRIPTION
## Summary
- fix(rbac): admin bypasses enrollment check (experts must enroll)
- feat: SubscriptionService + Celery beat expiry task
- feat: usage tracking calls at 7 feature points
- feat: usage_events migration 034
- fix: syllabus generation async session

## Test plan
- [ ] Admin can access all course content without enrollment
- [ ] Expert still needs enrollment
- [ ] Migration 034 runs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)