### PR TITLE
fix: admin bypasses enrollment guard (frontend)

### DIFF
--- a/frontend/components/shared/enrollment-guard.tsx
+++ b/frontend/components/shared/enrollment-guard.tsx
@@ -44,6 +44,20 @@ export function EnrollmentGuard({ moduleId, children }: EnrollmentGuardProps) {
       return;
     }
 
+    // Admin bypasses enrollment check
+    try {
+      const stored = typeof window !== "undefined" ? localStorage.getItem("user") : null;
+      if (stored) {
+        const user = JSON.parse(stored);
+        if (user.role === "admin") {
+          setGuardStatus("allowed");
+          return;
+        }
+      }
+    } catch {
+      // ignore parse errors
+    }
+
     fetchEnrollmentStatus(moduleId, token).then((enrolled) => {
       setGuardStatus(enrolled ? "allowed" : "denied");
     });


### PR DESCRIPTION
Admin was blocked by frontend EnrollmentGuard component. Now checks user role from localStorage and skips enrollment check for admin.