### PR TITLE
feat: admin auto-subscription + enrollment bypass

### DIFF
--- a/backend/app/domain/services/local_auth_service.py
+++ b/backend/app/domain/services/local_auth_service.py
@@ -108,6 +108,12 @@ class LocalAuthService:
 
             await self.db.commit()
 
+            # Auto-provision subscription for admin users
+            if initial_role == UserRole.admin:
+                from app.domain.services.subscription_service import SubscriptionService
+
+                await SubscriptionService().ensure_admin_subscription(user.id, self.db)
+
             logger.info("User registered successfully", user_id=str(user.id), email=email)
 
             return {
@@ -631,6 +637,12 @@ class LocalAuthService:
             )
             self.db.add(user)
             await self.db.commit()
+
+            # Auto-provision subscription for admin users
+            if initial_role == UserRole.admin:
+                from app.domain.services.subscription_service import SubscriptionService
+
+                await SubscriptionService().ensure_admin_subscription(user.id, self.db)
 
             # Send email OTP
             otp_result = await self.email_otp_service.send_registration_otp(

--- a/backend/app/domain/services/subscription_service.py
+++ b/backend/app/domain/services/subscription_service.py
@@ -17,9 +17,12 @@ from app.domain.models.subscription import (
     SubscriptionPayment,
     SubscriptionStatus,
 )
-from app.domain.models.user import User
+from app.domain.models.user import User, UserRole
 
 logger = structlog.get_logger(__name__)
+
+_ADMIN_EXPIRES = datetime.datetime(2099, 12, 31, tzinfo=datetime.UTC)
+_ADMIN_DAILY_LIMIT = 9999
 
 
 class SubscriptionService:
@@ -34,7 +37,41 @@ class SubscriptionService:
                 Subscription.expires_at > now,
             )
         )
-        return result.scalar_one_or_none()
+        sub = result.scalar_one_or_none()
+        if sub is not None:
+            return sub
+
+        # Auto-provision subscription for admin users
+        user = await session.get(User, user_id)
+        if user and user.role == UserRole.admin:
+            return await self.ensure_admin_subscription(user_id, session)
+
+        return None
+
+    async def ensure_admin_subscription(self, user_id: UUID, session: AsyncSession) -> Subscription:
+        """Auto-create non-expiring subscription for admin users."""
+        existing = await session.execute(
+            select(Subscription).where(
+                Subscription.user_id == user_id,
+                Subscription.status == SubscriptionStatus.active,
+            )
+        )
+        found = existing.scalar_one_or_none()
+        if found:
+            return found
+
+        subscription = Subscription(
+            user_id=user_id,
+            phone_number="admin",
+            status=SubscriptionStatus.active,
+            daily_message_limit=_ADMIN_DAILY_LIMIT,
+            expires_at=_ADMIN_EXPIRES,
+            activated_at=datetime.datetime.now(tz=datetime.UTC),
+        )
+        session.add(subscription)
+        await session.commit()
+        logger.info("Admin subscription auto-provisioned", user_id=str(user_id))
+        return subscription
 
     async def process_payment(
         self,


### PR DESCRIPTION
## Summary
- Admin users get auto-provisioned non-expiring subscription (9999 msg/day, expires 2099)
- Lazy auto-provision: if admin has no subscription, one is created on first access
- On registration: admin subscription created immediately
- No more scattered `if admin` bypass checks needed for subscription/tutor gating

## Test plan
- [ ] Admin can access course content without enrollment
- [ ] Admin tutor has effectively unlimited messages
- [ ] Regular users still limited to free tier (5 msg/day)

🤖 Generated with [Claude Code](https://claude.com/claude-code)