### PR TITLE
fix(lessons): resolve unit ID mismatch causing content unavailable error

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -640,7 +640,7 @@ async def admin_generate_module_content(
 
     dispatched = []
     for unit in units:
-        unit_id = f"M{module.module_number:02d}-U{unit.order_index + 1:02d}"
+        unit_id = unit.unit_number
         task = generate_lesson_task.delay(
             str(module_id),
             unit_id,

--- a/frontend/app/[locale]/(app)/modules/[moduleId]/lessons/[unitId]/page.tsx
+++ b/frontend/app/[locale]/(app)/modules/[moduleId]/lessons/[unitId]/page.tsx
@@ -36,7 +36,7 @@ export default async function LessonPage({ params }: LessonPageProps) {
   const moduleTitle = language === 'fr' ? (moduleData?.title_fr || moduleId) : (moduleData?.title_en || moduleId);
   const unitTitle = language === 'fr' ? (unit?.title_fr || unitId) : (unit?.title_en || unitId);
   const moduleLevel = moduleData?.level || 1;
-  const isCaseStudy = unitId.toLowerCase().includes('u05');
+  const isCaseStudy = unitId.toLowerCase().includes('u05') || (unit !== undefined && unit.order_index === 4);
 
   return (
     <EnrollmentGuard moduleId={moduleId}>

--- a/frontend/components/shared/enrollment-guard.tsx
+++ b/frontend/components/shared/enrollment-guard.tsx
@@ -13,7 +13,7 @@ interface EnrollmentGuardProps {
 async function fetchEnrollmentStatus(moduleId: string, token: string): Promise<boolean> {
   try {
     const res = await fetch(
-      `${API_BASE}/api/v1/progress/modules?module_id=${encodeURIComponent(moduleId)}`,
+      `${API_BASE}/api/v1/progress/modules/${encodeURIComponent(moduleId)}`,
       {
         headers: { Authorization: `Bearer ${token}` },
         cache: "no-store",


### PR DESCRIPTION
## Summary

Fixes P0 bug where lesson viewer shows 'content unavailable' for courses created through the admin wizard.

Three root causes identified and fixed:

- **`enrollment-guard.tsx`**: Was calling `/api/v1/progress/modules?module_id=…` (query param) which is not supported — the backend expects `/api/v1/progress/modules/{moduleId}` (path param). This caused the enrollment check to always fail, showing "denied" to any user on any admin-created course.
- **`lesson page`**: `isCaseStudy` detection used `unitId.includes('u05')` which only matches legacy `M01-U05` format, not new `1.5` format. Fixed to also check `unit.order_index === 4`.
- **`admin_courses.py`**: When triggering bulk content generation, was building unit_id as `M{N}-U{N}` (legacy format) but units in DB have `unit_number` like `1.1`. The lesson endpoint caches/fetches by unit_id, so there was a permanent cache miss. Fixed to use `unit.unit_number` directly.

## Changes

- `frontend/components/shared/enrollment-guard.tsx` — fix API URL to use path param
- `frontend/app/[locale]/(app)/modules/[moduleId]/lessons/[unitId]/page.tsx` — extend case study detection
- `backend/app/api/v1/admin_courses.py` — use `unit.unit_number` for content generation dispatch

## Test plan

- [ ] Enroll in a legacy course (seed data) → unit links work
- [ ] Create course via admin wizard → generate syllabus → publish → enroll → click unit → lesson loads
- [ ] 5th unit in a new course renders as case study viewer
- [ ] Backend tests pass
- [ ] Frontend lint passes

Closes #899

Generated with [Claude Code](https://claude.ai/code)