### PR TITLE
feat(admin): show image indexation count on course card

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -18,6 +18,7 @@ from app.domain.models.document_chunk import DocumentChunk
 from app.domain.models.module import Module
 from app.domain.models.module_unit import ModuleUnit
 from app.domain.models.preassessment import CoursePreAssessment
+from app.domain.models.source_image import SourceImage
 from app.domain.models.taxonomy import TaxonomyCategory
 from app.domain.models.user import UserRole
 from app.tasks.content_generation import generate_lesson_task
@@ -58,6 +59,7 @@ class CourseResponse(BaseModel):
     languages: str
     estimated_hours: int
     module_count: int
+    image_count: int
     status: str
     cover_image_url: str | None
     created_by: str | None
@@ -69,7 +71,7 @@ class CourseResponse(BaseModel):
     published_at: str | None
 
 
-def _course_to_response(course: Course) -> CourseResponse:
+def _course_to_response(course: Course, image_count: int = 0) -> CourseResponse:
     cats = course.taxonomy_categories or []
     return CourseResponse(
         id=str(course.id),
@@ -84,6 +86,7 @@ def _course_to_response(course: Course) -> CourseResponse:
         languages=course.languages,
         estimated_hours=course.estimated_hours,
         module_count=course.module_count,
+        image_count=image_count,
         status=course.status,
         cover_image_url=course.cover_image_url,
         created_by=str(course.created_by) if course.created_by else None,
@@ -112,7 +115,22 @@ async def list_courses_admin(
     """List all courses (any status). Admin only."""
     result = await db.execute(select(Course).order_by(Course.created_at.desc()))
     courses = result.scalars().all()
-    return [_course_to_response(c) for c in courses]
+
+    # Fetch image counts for all courses in a single query
+    rag_ids = [c.rag_collection_id for c in courses if c.rag_collection_id]
+    image_counts: dict[str, int] = {}
+    if rag_ids:
+        img_result = await db.execute(
+            select(SourceImage.rag_collection_id, func.count().label("cnt"))
+            .where(SourceImage.rag_collection_id.in_(rag_ids))
+            .group_by(SourceImage.rag_collection_id)
+        )
+        image_counts = {row.rag_collection_id: row.cnt for row in img_result}
+
+    return [
+        _course_to_response(c, image_count=image_counts.get(c.rag_collection_id or "", 0))
+        for c in courses
+    ]
 
 
 @router.post("", response_model=CourseResponse, status_code=status.HTTP_201_CREATED)
@@ -180,7 +198,15 @@ async def get_course_admin(
     course = result.scalar_one_or_none()
     if not course:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
-    return _course_to_response(course)
+    img_count = 0
+    if course.rag_collection_id:
+        img_result = await db.execute(
+            select(func.count())
+            .select_from(SourceImage)
+            .where(SourceImage.rag_collection_id == course.rag_collection_id)
+        )
+        img_count = img_result.scalar_one()
+    return _course_to_response(course, image_count=img_count)
 
 
 @router.patch("/{course_id}", response_model=CourseResponse)
@@ -219,7 +245,15 @@ async def update_course(
 
     await db.commit()
     await db.refresh(course)
-    return _course_to_response(course)
+    img_count = 0
+    if course.rag_collection_id:
+        img_result = await db.execute(
+            select(func.count())
+            .select_from(SourceImage)
+            .where(SourceImage.rag_collection_id == course.rag_collection_id)
+        )
+        img_count = img_result.scalar_one()
+    return _course_to_response(course, image_count=img_count)
 
 
 @router.post("/{course_id}/publish", response_model=CourseResponse)
@@ -258,7 +292,15 @@ async def publish_course(
     await db.commit()
     await db.refresh(course)
     logger.info("Course published", course_id=str(course_id), admin_id=current_user.id)
-    return _course_to_response(course)
+    img_count = 0
+    if course.rag_collection_id:
+        img_result = await db.execute(
+            select(func.count())
+            .select_from(SourceImage)
+            .where(SourceImage.rag_collection_id == course.rag_collection_id)
+        )
+        img_count = img_result.scalar_one()
+    return _course_to_response(course, image_count=img_count)
 
 
 @router.post("/{course_id}/archive", response_model=CourseResponse)
@@ -277,7 +319,15 @@ async def archive_course(
     await db.commit()
     await db.refresh(course)
     logger.info("Course archived", course_id=str(course_id), admin_id=current_user.id)
-    return _course_to_response(course)
+    img_count = 0
+    if course.rag_collection_id:
+        img_result = await db.execute(
+            select(func.count())
+            .select_from(SourceImage)
+            .where(SourceImage.rag_collection_id == course.rag_collection_id)
+        )
+        img_count = img_result.scalar_one()
+    return _course_to_response(course, image_count=img_count)
 
 
 class GenerateStructureRequest(BaseModel):
@@ -439,11 +489,32 @@ async def get_rag_index_status(
     )
     chunks_indexed = chunk_count.scalar_one()
 
+    # Count source images extracted for this course
+    images_extracted_result = await db.execute(
+        select(func.count())
+        .select_from(SourceImage)
+        .where(SourceImage.rag_collection_id == course.rag_collection_id)
+    )
+    images_extracted = images_extracted_result.scalar_one()
+
+    # Count images successfully stored in MinIO (have a storage_key)
+    images_stored_result = await db.execute(
+        select(func.count())
+        .select_from(SourceImage)
+        .where(
+            SourceImage.rag_collection_id == course.rag_collection_id,
+            SourceImage.storage_key.isnot(None),
+        )
+    )
+    images_stored = images_stored_result.scalar_one()
+
     response: dict = {
         "course_id": str(course_id),
         "rag_collection_id": course.rag_collection_id,
         "chunks_indexed": chunks_indexed,
         "indexed": chunks_indexed > 0,
+        "images_extracted": images_extracted,
+        "images_stored": images_stored,
     }
 
     effective_task_id = task_id or course.indexation_task_id
@@ -460,6 +531,7 @@ async def get_rag_index_status(
             "files_processed": meta.get("files_processed", 0),
             "current_file": meta.get("current_file"),
             "chunks_processed": meta.get("chunks_processed", 0),
+            "images_processed": meta.get("images_processed", 0),
             "estimated_seconds_remaining": meta.get("estimated_seconds_remaining"),
         }
 

--- a/frontend/components/admin/courses-client.tsx
+++ b/frontend/components/admin/courses-client.tsx
@@ -14,6 +14,7 @@ import {
   AlertCircle,
   BookOpen,
   Database,
+  Image,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -51,6 +52,7 @@ export interface AdminCourse {
   created_at: string;
   updated_at?: string;
   module_count?: number;
+  image_count?: number;
   indexation_task_id?: string | null;
   rag_collection_id?: string | null;
   preassessment_enabled?: boolean;
@@ -492,6 +494,12 @@ function CourseRow({
             {course.module_count !== undefined && (
               <span className="text-xs text-muted-foreground">
                 {t('moduleCount', { count: course.module_count })}
+              </span>
+            )}
+            {course.image_count !== undefined && course.image_count > 0 && (
+              <span className="text-xs text-muted-foreground flex items-center gap-1">
+                <Image className="h-3 w-3" aria-hidden="true" />
+                {t('imageCount', { count: course.image_count })}
               </span>
             )}
           </div>

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1013,6 +1013,7 @@
     },
     "estimatedHours": "{hours} h estimated",
     "moduleCount": "{count, plural, one {# module} other {# modules}}",
+    "imageCount": "{count, plural, one {# image} other {# images}}",
     "generateStructure": "Generate structure",
     "generateError": "Generation failed. Please try again.",
     "publish": "Publish",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1013,6 +1013,7 @@
     },
     "estimatedHours": "{hours} h estimées",
     "moduleCount": "{count, plural, one {# module} other {# modules}}",
+    "imageCount": "{count, plural, one {# image} other {# images}}",
     "generateStructure": "Générer la structure",
     "generateError": "La génération a échoué. Veuillez réessayer.",
     "publish": "Publier",


### PR DESCRIPTION
## Summary

- Backend `GET /api/v1/admin/courses/{id}/index-status` now returns `images_extracted` (total `SourceImage` rows) and `images_stored` (rows with a non-null `storage_key`, i.e. successfully uploaded to MinIO)
- `CourseResponse` gains an `image_count` field (number of indexed images) — populated via a single batch query on the course list and per-course on detail/mutation endpoints
- Course card in `frontend/components/admin/courses-client.tsx` shows an **"X images"** chip (with `Image` icon from lucide-react) alongside the module count when `image_count > 0`
- i18n keys `AdminCourses.imageCount` added in EN and FR

## Changes

- `backend/app/api/v1/admin_courses.py` — import `SourceImage`, add `image_count` to `CourseResponse`, batch-fetch image counts in list endpoint, per-course fetch in detail/mutation endpoints, add `images_extracted`/`images_stored`/`images_processed` to `index-status` response
- `frontend/components/admin/courses-client.tsx` — add `image_count` to `AdminCourse` interface, render image count chip in `CourseRow`
- `frontend/messages/en.json` + `frontend/messages/fr.json` — add `AdminCourses.imageCount` translation key

## Test plan

- [ ] Backend tests pass
- [ ] Frontend lint passes (0 errors)
- [ ] `GET /api/v1/admin/courses` returns `image_count` field
- [ ] `GET /api/v1/admin/courses/{id}/index-status` returns `images_extracted` and `images_stored`
- [ ] Course card shows image count for indexed courses, hidden when 0
- [ ] Manually verified on mobile viewport (320px)

Closes #896

Generated with [Claude Code](https://claude.ai/code)