### PR TITLE
fix(db): add migration for missing generated_at column in course_preassessments

### DIFF
--- a/backend/migrations/versions/035_add_generated_at_to_course_preassessments.py
+++ b/backend/migrations/versions/035_add_generated_at_to_course_preassessments.py
@@ -1,0 +1,34 @@
+"""add generated_at column to course_preassessments
+
+Revision ID: 035
+Revises: 034
+Create Date: 2026-04-06
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "035"
+down_revision = "034"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name = 'course_preassessments' AND column_name = 'generated_at'"
+        )
+    )
+    if result.fetchone() is None:
+        op.add_column(
+            "course_preassessments",
+            sa.Column("generated_at", sa.DateTime(timezone=True), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("course_preassessments", "generated_at")


### PR DESCRIPTION
## Summary
Adds Alembic migration `035` to add the missing `generated_at` column (`DateTime` with timezone, nullable) to the `course_preassessments` table.

The migration uses an `information_schema` check to safely skip the column addition if it already exists (in case migration 031 ran with the column already present).

## Changes
- `backend/migrations/versions/035_add_generated_at_to_course_preassessments.py` — new migration

## Test plan
- [ ] `alembic upgrade head` runs without error on a DB missing the column
- [ ] `alembic upgrade head` is idempotent on a DB that already has the column (guard clause handles this)
- [ ] Pre-assessment endpoints no longer return 500

Closes #920

🤖 Generated with [Claude Code](https://claude.ai/code)