### PR TITLE
fix(admin): show backend error detail instead of generic message on action failure

### DIFF
--- a/frontend/components/admin/courses-client.tsx
+++ b/frontend/components/admin/courses-client.tsx
@@ -118,7 +118,7 @@ export function CoursesClient() {
       setPendingAction(null);
       setActionError(null);
     },
-    onError: () => setActionError(t('actionError')),
+    onError: (err: Error) => setActionError(err.message || t('actionError')),
   });
 
   const indexMutation = useMutation({
@@ -129,7 +129,7 @@ export function CoursesClient() {
       setPendingAction(null);
       setActionError(null);
     },
-    onError: () => setActionError(t('indexError')),
+    onError: (err: Error) => setActionError(err.message || t('indexError')),
   });
 
   const archiveMutation = useMutation({
@@ -140,7 +140,7 @@ export function CoursesClient() {
       setPendingAction(null);
       setActionError(null);
     },
-    onError: () => setActionError(t('actionError')),
+    onError: (err: Error) => setActionError(err.message || t('actionError')),
   });
 
   const handleConfirmAction = () => {


### PR DESCRIPTION
## Summary
When admin actions (publish, archive, index) fail, the UI was showing a generic \"L'action a échoué\" toast instead of the actual backend error message. For example, when publishing a course without RAG indexation, the backend returns `{"detail": "No RAG content indexed for this course"}` which was being discarded.

## Changes
- `frontend/components/admin/courses-client.tsx`: Updated `onError` callbacks in `publishMutation`, `indexMutation`, and `archiveMutation` to use `err.message` (which `apiFetch` already extracts from the backend's `detail` field) with the generic translation as fallback.

## How it works
`apiFetch` in `frontend/lib/api.ts` already parses the response body and throws `new Error(body.detail)` — the mutations just weren't using the error message. Now they do: `(err: Error) => setActionError(err.message || t('actionError'))`.

## Test plan
- [ ] Frontend lint passes (0 errors)
- [ ] Publish a course without RAG indexation → error toast shows "No RAG content indexed for this course" instead of generic message
- [ ] Archive action failure shows backend error detail
- [ ] Index action failure shows backend error detail
- [ ] When no message is available, falls back to generic translation

Closes #891

Generated with [Claude Code](https://claude.ai/code)