### PR TITLE
fix(wizard): fix indexation UI showing wrong counts and hiding images

### DIFF
--- a/frontend/components/admin/course-wizard-client.tsx
+++ b/frontend/components/admin/course-wizard-client.tsx
@@ -83,6 +83,7 @@ interface TaskProgress {
 interface IndexStatus {
   indexed: boolean;
   chunks_indexed: number;
+  images_indexed?: number;
   task?: TaskProgress;
 }
 
@@ -498,6 +499,7 @@ export function CourseWizardClient({
         const status = await apiFetch<{
           indexed: boolean;
           chunks_indexed: number;
+          images_indexed?: number;
           task?: {
             state: string;
             step?: string;
@@ -514,10 +516,11 @@ export function CourseWizardClient({
         setIndexStatus({
           indexed: status.indexed,
           chunks_indexed: status.chunks_indexed,
+          images_indexed: status.images_indexed,
           task: status.task,
         });
 
-        if (status.indexed && status.chunks_indexed > 0) {
+        if (status.task?.state === "SUCCESS") {
           setIsIndexing(false);
           clearWizardState();
           return;
@@ -579,7 +582,7 @@ export function CourseWizardClient({
     if (step === "upload") return files.filter((f) => f.status === "uploaded").length > 0;
     if (step === "info") return courseInfo.title_fr.trim().length > 0 && courseInfo.title_en.trim().length > 0;
     if (step === "generate") return generatedModules.length > 0;
-    if (step === "index") return !!(indexStatus?.indexed && indexStatus.chunks_indexed > 0);
+    if (step === "index") return !!(indexStatus?.indexed && indexStatus.chunks_indexed > 0 && !isIndexing);
     return false;
   };
 
@@ -624,6 +627,8 @@ export function CourseWizardClient({
       case "embedding": return t("index.stepEmbedding");
       case "storing": return t("index.stepStoring");
       case "complete": return t("index.stepComplete");
+      case "extracting_images": return t("index.stepExtractingImages");
+      case "EXTRACTING_IMAGES": return t("index.stepExtractingImages");
       default: return t("index.taskPending");
     }
   };
@@ -957,7 +962,11 @@ export function CourseWizardClient({
                         <div className="flex items-center gap-2">
                           <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent shrink-0" />
                           <p className="text-sm font-medium">
-                            {taskProg ? getStepLabel(taskProg.step) : t("index.taskPending")}
+                            {taskProg
+                              ? (taskProg.state === "EXTRACTING_IMAGES"
+                                ? t("index.stepExtractingImages")
+                                : getStepLabel(taskProg.step))
+                              : t("index.taskPending")}
                           </p>
                         </div>
                         {taskProg?.estimated_seconds_remaining !== undefined && taskProg.estimated_seconds_remaining > 0 && (
@@ -993,6 +1002,12 @@ export function CourseWizardClient({
                           {t("index.chunksProgress", { count: taskProg.chunks_processed })}
                         </p>
                       )}
+
+                      {taskProg?.state === "EXTRACTING_IMAGES" && indexStatus?.images_indexed !== undefined && indexStatus.images_indexed > 0 && (
+                        <p className="text-xs text-muted-foreground">
+                          {t("index.imagesProgress", { count: indexStatus.images_indexed })}
+                        </p>
+                      )}
                     </div>
 
                     <p className="text-xs text-muted-foreground text-center">
@@ -1008,7 +1023,7 @@ export function CourseWizardClient({
                   </div>
                 )}
 
-                {indexStatus?.indexed && (
+                {indexStatus?.indexed && !isIndexing && (
                   <div className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-3 dark:border-green-900 dark:bg-green-950">
                     <CheckCircle2 className="h-5 w-5 text-green-600" />
                     <div>
@@ -1016,7 +1031,12 @@ export function CourseWizardClient({
                         {t("index.indexed")}
                       </p>
                       <p className="text-xs text-green-600 dark:text-green-500">
-                        {t("index.chunksIndexed", { count: indexStatus.chunks_indexed })}
+                        {indexStatus.images_indexed && indexStatus.images_indexed > 0
+                          ? t("index.chunksAndImagesIndexed", {
+                              chunks: indexStatus.chunks_indexed,
+                              images: indexStatus.images_indexed,
+                            })
+                          : t("index.chunksIndexed", { count: indexStatus.chunks_indexed })}
                       </p>
                     </div>
                   </div>
@@ -1044,6 +1064,12 @@ export function CourseWizardClient({
                       <span className="text-muted-foreground">{t("publish.summary.chunks")}</span>
                       <span className="font-medium">{indexStatus?.chunks_indexed ?? 0}</span>
                     </div>
+                    {indexStatus?.images_indexed !== undefined && indexStatus.images_indexed > 0 && (
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">{t("publish.summary.images")}</span>
+                        <span className="font-medium">{indexStatus.images_indexed}</span>
+                      </div>
+                    )}
                     <div className="flex justify-between">
                       <span className="text-muted-foreground">{t("publish.summary.status")}</span>
                       <Badge variant="outline" className="text-amber-600 border-amber-300">

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1139,6 +1139,9 @@
         "etaLessThan": "Less than a minute",
         "filesProgress": "File {current}/{total}",
         "chunksProgress": "{count} chunks processed",
+        "imagesProgress": "{count} images extracted",
+        "stepExtractingImages": "Extracting images from PDFs",
+        "chunksAndImagesIndexed": "{chunks} chunks and {images} images indexed",
         "resumeHint": "You can close and come back later. The task continues in the background.",
         "inProgress": "Indexation in progress"
       },
@@ -1162,6 +1165,7 @@
           "title": "Course summary",
           "modules": "Modules",
           "chunks": "RAG chunks",
+          "images": "Images indexed",
           "status": "Status"
         }
       }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1139,6 +1139,9 @@
         "etaLessThan": "Moins d'une minute",
         "filesProgress": "Fichier {current}/{total}",
         "chunksProgress": "{count} fragments traités",
+        "imagesProgress": "{count} images extraites",
+        "stepExtractingImages": "Extraction des images des PDFs",
+        "chunksAndImagesIndexed": "{chunks} fragments et {images} images indexés",
         "resumeHint": "Vous pouvez fermer et revenir plus tard. La tâche continue en arrière-plan.",
         "inProgress": "Indexation en cours"
       },
@@ -1162,6 +1165,7 @@
           "title": "Résumé du cours",
           "modules": "Modules",
           "chunks": "Fragments RAG",
+          "images": "Images indexées",
           "status": "Statut"
         }
       }


### PR DESCRIPTION
## Summary

Fixes two bugs in the course creation wizard Step 4 (RAG Indexation) reported in #941 and #926.

## Changes

- **`frontend/components/admin/course-wizard-client.tsx`**:
  - Fixed premature "complete" display: now waits for `task.state === "SUCCESS"` instead of just `indexed: true`
  - Fixed wrong chunk count: the final counts are read from the last poll response (after SUCCESS), not the first poll that returns `indexed: true`
  - Added `images_indexed` to `IndexStatus` interface and polling response type
  - Display `images_indexed` count in the completion message: _"393 chunks and 121 images indexed"_
  - Show live image extraction progress counter during `EXTRACTING_IMAGES` state
  - Handle `EXTRACTING_IMAGES` task state in `getStepLabel()` function
  - Added images row to publish summary card (only when images > 0)

- **`frontend/messages/en.json`** + **`frontend/messages/fr.json`**:
  - Added `index.imagesProgress` — "{count} images extracted"
  - Added `index.stepExtractingImages` — "Extracting images from PDFs"
  - Added `index.chunksAndImagesIndexed` — "{chunks} chunks and {images} images indexed"
  - Added `publish.summary.images` — "Images indexed"

## Test plan

- [ ] Create a course with 2 PDFs
- [ ] Start indexation and observe that the UI shows "complete" only when `task.state === "SUCCESS"` (not at 84% EXTRACTING_IMAGES)
- [ ] Verify completion message shows both chunk and image counts (e.g. "393 chunks and 121 images indexed")
- [ ] Verify image extraction counter appears during EXTRACTING_IMAGES phase
- [ ] Verify publish summary shows "Images indexed: 121" row
- [ ] Frontend lint passes (no ESLint warnings)
- [ ] Manually verified on 320px mobile viewport

Closes #941
Closes #926

Generated with [Claude Code](https://claude.ai/code)