### PR TITLE
fix(rag): use rag_collection_id as source for image extraction

### DIFF
--- a/backend/app/ai/rag/pipeline.py
+++ b/backend/app/ai/rag/pipeline.py
@@ -195,7 +195,8 @@ class RAGPipeline:
         for idx, img in enumerate(images):
             figure_label = img.figure_number or str(idx)
             safe_label = figure_label.replace(" ", "_").replace(".", "_")
-            key = f"source-images/{source}/{img.page_number}_{safe_label}.webp"
+            readable_name = pdf_path.stem.replace("_", " ")
+            key = f"source-images/{rag_collection_id or source}/{readable_name}/{img.page_number}_{safe_label}.webp"
 
             try:
                 storage_url = await storage.upload_bytes(

--- a/backend/app/tasks/rag_indexation.py
+++ b/backend/app/tasks/rag_indexation.py
@@ -213,7 +213,7 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
             try:
                 image_count = await pipeline.process_pdf_images(
                     pdf_path=str(pdf_path),
-                    source=book_name,
+                    source=rag_collection_id,
                     rag_collection_id=rag_collection_id,
                 )
                 total_images += image_count


### PR DESCRIPTION
## Summary
- Images stored with `source=book_name` (filename) but chunks use `source=rag_collection_id` (UUID)
- `ImageLinker` queries both tables with same source value — mismatch means 0 links created
- Fix: pass `rag_collection_id` as source to `process_pdf_images()`

## After deploy
Re-index the "Digital Investment in Public Health" course to create image-chunk links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)