### PR TITLE
feat: subscription-gated course access + first-lesson-free (#858)

### DIFF
--- a/backend/app/api/deps_local_auth.py
+++ b/backend/app/api/deps_local_auth.py
@@ -124,6 +124,81 @@ async def get_optional_user(
         return None
 
 
+async def require_active_subscription(
+    request: Request,
+    user: AuthenticatedUser = Depends(get_current_user),
+) -> AuthenticatedUser:
+    """Require an active subscription to access content.
+
+    Admin users bypass this check (they have auto-provisioned subscriptions).
+    First unit of each module is free — caller must check separately if needed.
+
+    Raises:
+        HTTPException: 403 if no active subscription.
+    """
+    from ..domain.services.subscription_service import SubscriptionService
+    from ..infrastructure.persistence.database import get_db_session
+
+    async for session in get_db_session():
+        sub = await SubscriptionService().get_active_subscription(uuid.UUID(user.id), session)
+        if sub is not None:
+            return user
+        break
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail={
+            "code": "subscription_required",
+            "message": "An active subscription is required to access this content.",
+        },
+    )
+
+
+async def require_subscription_or_first_unit(
+    request: Request,
+    user: AuthenticatedUser = Depends(get_current_user),
+) -> AuthenticatedUser:
+    """Allow first unit of a module for free; require subscription for others.
+
+    Reads `unit_id` from path params (e.g. 'M01-U01'). If unit ends with
+    '-U01' or order_index == 0 in DB, access is free. Otherwise requires
+    an active subscription.
+    """
+    from ..domain.models.module_unit import ModuleUnit
+    from ..domain.services.subscription_service import SubscriptionService
+    from ..infrastructure.persistence.database import get_db_session
+
+    unit_id = request.path_params.get("unit_id") or request.path_params.get("unitId")
+
+    # Quick check: if unit_id looks like first unit (M01-U01, U01, etc.)
+    if unit_id and unit_id.upper().endswith("-U01"):
+        return user
+
+    # Check subscription
+    async for session in get_db_session():
+        sub = await SubscriptionService().get_active_subscription(uuid.UUID(user.id), session)
+        if sub is not None:
+            return user
+
+        # No subscription — check if this is order_index 0 in DB
+        if unit_id:
+            result = await session.execute(
+                select(ModuleUnit.order_index).where(ModuleUnit.unit_number == unit_id)
+            )
+            order = result.scalar_one_or_none()
+            if order is not None and order == 0:
+                return user
+        break
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail={
+            "code": "subscription_required",
+            "message": "An active subscription is required to access this content. The first lesson of each module is free.",
+        },
+    )
+
+
 def require_enrollment(course_id_param: str = "course_id") -> Callable:
     """Factory for enrollment-based access control dependency.
 

--- a/backend/app/api/v1/content.py
+++ b/backend/app/api/v1/content.py
@@ -16,7 +16,11 @@ from app.ai.claude_service import ClaudeService
 from app.ai.rag.embeddings import EmbeddingService
 from app.ai.rag.retriever import SemanticRetriever
 from app.api.deps import get_db
-from app.api.deps_local_auth import get_current_user
+from app.api.deps_local_auth import (
+    get_current_user,
+    require_active_subscription,
+    require_subscription_or_first_unit,
+)
 from app.api.v1.schemas.content import (
     CaseStudyResponse,
     ErrorResponse,
@@ -367,7 +371,7 @@ async def get_or_generate_lesson_by_module_and_unit(
     force_regenerate: bool = False,
     lesson_service: LessonGenerationService = Depends(get_lesson_service),
     session: AsyncSession = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_subscription_or_first_unit),
 ) -> JSONResponse:
     """
     Get or generate lesson content by module and unit ID.
@@ -614,7 +618,7 @@ async def stream_lesson_by_module_and_unit(
 async def get_lesson(
     lesson_id: UUID,
     session: AsyncSession = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_active_subscription),
 ) -> LessonResponse:
     """
     Retrieve a previously generated lesson by ID.
@@ -685,7 +689,7 @@ async def generate_flashcards(
     request: FlashcardGenerationRequest,
     flashcard_service: FlashcardGenerationService = Depends(get_flashcard_service),
     session: AsyncSession = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_active_subscription),
 ) -> FlashcardSetResponse:
     """
     Generate or retrieve cached bilingual flashcard set.
@@ -783,7 +787,7 @@ async def generate_quiz(
     request: QuizGenerationRequest,
     quiz_service: QuizService = Depends(get_quiz_service),
     session: AsyncSession = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_active_subscription),
 ) -> QuizResponse:
     """
     Generate formative quiz with 10 multiple-choice questions.
@@ -871,7 +875,7 @@ async def generate_quiz(
 async def get_quiz(
     quiz_id: UUID,
     session: AsyncSession = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_active_subscription),
 ) -> QuizResponse:
     """
     Retrieve a previously generated quiz by ID.
@@ -963,7 +967,7 @@ async def get_or_generate_case_study(
     force_regenerate: bool = False,
     case_study_service: CaseStudyGenerationService = Depends(get_case_study_service),
     session: AsyncSession = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_active_subscription),
 ) -> JSONResponse:
     """
     Get or generate case study content by module and unit ID.

--- a/backend/app/api/v1/flashcards.py
+++ b/backend/app/api/v1/flashcards.py
@@ -14,7 +14,7 @@ from app.ai.claude_service import ClaudeService
 from app.ai.rag.embeddings import EmbeddingService
 from app.ai.rag.retriever import SemanticRetriever
 from app.api.deps import get_db
-from app.api.deps_local_auth import get_current_user
+from app.api.deps_local_auth import require_active_subscription
 from app.api.v1.schemas.content import FlashcardSetResponse
 from app.api.v1.schemas.flashcards import (
     FlashcardDueResponse,
@@ -79,7 +79,7 @@ async def _resolve_module_id(module_id: str, session: AsyncSession) -> uuid.UUID
     },
 )
 async def get_due_flashcards(
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_active_subscription),
     session: AsyncSession = Depends(get_db),
 ) -> FlashcardDueResponse:
     """
@@ -227,7 +227,7 @@ async def get_due_flashcards(
 )
 async def submit_flashcard_review(
     review_request: FlashcardReviewRequest,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_active_subscription),
     session: AsyncSession = Depends(get_db),
 ) -> FlashcardReviewResponse:
     """
@@ -377,7 +377,7 @@ async def submit_flashcard_review(
 )
 async def complete_flashcard_session(
     session_request: FlashcardSessionRequest,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_active_subscription),
     session: AsyncSession = Depends(get_db),
 ) -> FlashcardSessionResponse:
     """
@@ -482,7 +482,7 @@ async def complete_flashcard_session(
     },
 )
 async def get_upcoming_reviews(
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_active_subscription),
     session: AsyncSession = Depends(get_db),
 ) -> UpcomingReviewsResponse:
     """
@@ -628,7 +628,7 @@ async def get_module_flashcards(
     language: str = "fr",
     country: str = "SN",
     level: int = 1,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_active_subscription),
     flashcard_service: FlashcardGenerationService = Depends(_get_flashcard_generation_service),
     session: AsyncSession = Depends(get_db),
 ) -> FlashcardSetResponse:

--- a/backend/app/api/v1/quiz.py
+++ b/backend/app/api/v1/quiz.py
@@ -14,7 +14,7 @@ from app.ai.claude_service import ClaudeService
 from app.ai.rag.embeddings import EmbeddingService
 from app.ai.rag.retriever import SemanticRetriever
 from app.api.deps import get_db
-from app.api.deps_local_auth import get_current_user
+from app.api.deps_local_auth import require_active_subscription
 from app.api.v1.schemas.quiz import (
     ErrorResponse,
     QuizAttemptRequest,
@@ -293,7 +293,7 @@ async def get_quiz(
 async def submit_quiz_attempt(
     request: QuizAttemptRequest,
     session: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_active_subscription),
 ) -> QuizAttemptResponse:
     """
     Submit a completed quiz attempt and get immediate feedback.
@@ -574,7 +574,7 @@ async def generate_summative_assessment(
 async def can_attempt_summative_assessment(
     module_id: UUID,
     session: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_active_subscription),
 ) -> SummativeAssessmentAttemptCheck:
     """
     Check if user can attempt summative assessment for a module.
@@ -679,7 +679,7 @@ async def can_attempt_summative_assessment(
 async def submit_summative_assessment_attempt(
     request: QuizAttemptRequest,
     session: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_active_subscription),
 ) -> SummativeAssessmentResponse:
     """
     Submit a completed summative assessment attempt.


### PR DESCRIPTION
## Summary
- Add `require_active_subscription` and `require_subscription_or_first_unit` dependencies
- Gate lesson, quiz, flashcard, case study endpoints behind subscription
- First unit of each module (U01 / order_index=0) is free for all users
- Admin bypasses via auto-provisioned subscription (9999 msg/day)

## Gated endpoints
- `GET /content/lessons/{module_id}/{unit_id}` — first unit free, rest require sub
- `GET /content/lessons/{lesson_id}` — require sub
- `POST /content/generate-flashcards` — require sub
- `POST /content/generate-quiz` — require sub
- `GET /content/quizzes/{quiz_id}` — require sub
- `GET /content/cases/{module_id}/{unit_id}` — require sub
- All quiz.py endpoints (3) — require sub
- All flashcards.py endpoints (5) — require sub

## Not gated (always free)
Auth, courses catalog, dashboard, progress, placement, subscriptions, health, tutor (5 msg/day free tier)

## Test plan
- [ ] Admin can access all content (auto-subscription)
- [ ] Free user can access first lesson (U01) of any module
- [ ] Free user gets 403 on second lesson
- [ ] Free user gets 403 on quiz/flashcard/case study
- [ ] Subscribed user accesses all content

Closes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)