### PR TITLE
feat: course detail page with full syllabus (#734)

### DIFF
--- a/backend/app/api/v1/courses.py
+++ b/backend/app/api/v1/courses.py
@@ -11,6 +11,7 @@ from app.api.deps import get_db as get_db_session
 from app.api.deps_local_auth import get_current_user, get_optional_user
 from app.domain.models.course import Course, UserCourseEnrollment
 from app.domain.models.module import Module
+from app.domain.models.module_unit import ModuleUnit
 from app.domain.models.progress import UserModuleProgress
 from app.domain.models.taxonomy import CourseTaxonomy, TaxonomyCategory
 
@@ -38,6 +39,32 @@ class CourseListItem(BaseModel):
     cover_image_url: str | None
     languages: str
     enrolled: bool = False
+
+
+class CourseModuleUnit(BaseModel):
+    id: str
+    unit_number: str
+    title_fr: str | None
+    title_en: str | None
+    order_index: int
+
+
+class CourseModuleDetail(BaseModel):
+    id: str
+    module_number: int
+    title_fr: str | None
+    title_en: str | None
+    description_fr: str | None
+    description_en: str | None
+    level: int
+    estimated_hours: int
+    bloom_level: str | None
+    units: list[CourseModuleUnit]
+
+
+class CourseDetailResponse(CourseListItem):
+    syllabus_json: dict | None
+    modules: list[CourseModuleDetail]
 
 
 class EnrollmentResponse(BaseModel):
@@ -194,6 +221,75 @@ async def my_enrollments(
     )
     courses = result.scalars().all()
     return [_course_to_list_item(c, enrolled=True) for c in courses]
+
+
+@router.get("/{course_id}", response_model=CourseDetailResponse)
+async def get_course_detail(
+    course_id: uuid.UUID,
+    current_user=Depends(get_optional_user),
+    db=Depends(get_db_session),
+) -> CourseDetailResponse:
+    """Get course detail with syllabus and modules. No auth required (public catalog)."""
+    result = await db.execute(select(Course).where(Course.id == course_id))
+    course = result.scalar_one_or_none()
+    if not course:
+        raise HTTPException(status_code=404, detail="Course not found")
+
+    # Fetch modules with units
+    modules_result = await db.execute(
+        select(Module).where(Module.course_id == course_id).order_by(Module.module_number)
+    )
+    modules = modules_result.scalars().all()
+
+    module_details = []
+    for mod in modules:
+        units_result = await db.execute(
+            select(ModuleUnit)
+            .where(ModuleUnit.module_id == mod.id)
+            .order_by(ModuleUnit.order_index)
+        )
+        units = units_result.scalars().all()
+        module_details.append(
+            CourseModuleDetail(
+                id=str(mod.id),
+                module_number=mod.module_number,
+                title_fr=mod.title_fr,
+                title_en=mod.title_en,
+                description_fr=mod.description_fr,
+                description_en=mod.description_en,
+                level=mod.level,
+                estimated_hours=mod.estimated_hours,
+                bloom_level=mod.bloom_level,
+                units=[
+                    CourseModuleUnit(
+                        id=str(u.id),
+                        unit_number=u.unit_number,
+                        title_fr=u.title_fr,
+                        title_en=u.title_en,
+                        order_index=u.order_index,
+                    )
+                    for u in units
+                ],
+            )
+        )
+
+    enrolled = False
+    if current_user:
+        enroll_result = await db.execute(
+            select(UserCourseEnrollment).where(
+                UserCourseEnrollment.user_id == uuid.UUID(current_user.id),
+                UserCourseEnrollment.course_id == course_id,
+                UserCourseEnrollment.status == "active",
+            )
+        )
+        enrolled = enroll_result.scalar_one_or_none() is not None
+
+    base = _course_to_list_item(course, enrolled=enrolled)
+    return CourseDetailResponse(
+        **base.model_dump(),
+        syllabus_json=course.syllabus_json,
+        modules=module_details,
+    )
 
 
 @router.post("/{course_id}/enroll", response_model=EnrollmentResponse)

--- a/frontend/app/[locale]/(app)/courses/[courseSlug]/page.tsx
+++ b/frontend/app/[locale]/(app)/courses/[courseSlug]/page.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useTranslations, useLocale } from "next-intl";
+import { useParams } from "next/navigation";
+import { useRouter, Link } from "@/i18n/routing";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Clock,
+  BookOpen,
+  GraduationCap,
+  ChevronDown,
+  ChevronRight,
+  CheckCircle,
+  ArrowLeft,
+} from "lucide-react";
+import { apiFetch, enrollInCourse } from "@/lib/api";
+
+interface ModuleUnit {
+  id: string;
+  unit_number: string;
+  title_fr: string | null;
+  title_en: string | null;
+  order_index: number;
+}
+
+interface CourseModule {
+  id: string;
+  module_number: number;
+  title_fr: string | null;
+  title_en: string | null;
+  description_fr: string | null;
+  description_en: string | null;
+  level: number;
+  estimated_hours: number;
+  bloom_level: string | null;
+  units: ModuleUnit[];
+}
+
+interface CourseDetail {
+  id: string;
+  slug: string;
+  title_fr: string;
+  title_en: string;
+  description_fr: string | null;
+  description_en: string | null;
+  course_domain: { value: string; label_fr: string; label_en: string }[];
+  course_level: { value: string; label_fr: string; label_en: string }[];
+  audience_type: { value: string; label_fr: string; label_en: string }[];
+  estimated_hours: number;
+  module_count: number;
+  cover_image_url: string | null;
+  enrolled: boolean;
+  syllabus_json: Record<string, unknown> | null;
+  modules: CourseModule[];
+}
+
+const LEVEL_COLORS: Record<string, string> = {
+  beginner: "bg-green-50 text-green-700 border-green-200",
+  intermediate: "bg-blue-50 text-blue-700 border-blue-200",
+  advanced: "bg-amber-50 text-amber-700 border-amber-200",
+  expert: "bg-red-50 text-red-700 border-red-200",
+};
+
+export default function CourseDetailPage() {
+  const t = useTranslations("Courses");
+  const tDetail = useTranslations("CourseDetail");
+  const locale = useLocale() as "fr" | "en";
+  const params = useParams();
+  const router = useRouter();
+  const courseSlug = params.courseSlug as string;
+
+  const [course, setCourse] = useState<CourseDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [enrolling, setEnrolling] = useState(false);
+  const [enrolled, setEnrolled] = useState(false);
+  const [expandedModules, setExpandedModules] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    apiFetch<CourseDetail>(`/api/v1/courses/${courseSlug}`)
+      .then((data) => {
+        setCourse(data);
+        setEnrolled(data.enrolled);
+        setLoading(false);
+      })
+      .catch(() => {
+        setError(true);
+        setLoading(false);
+      });
+  }, [courseSlug]);
+
+  const toggleModule = (moduleId: string) => {
+    setExpandedModules((prev) => {
+      const next = new Set(prev);
+      if (next.has(moduleId)) {
+        next.delete(moduleId);
+      } else {
+        next.add(moduleId);
+      }
+      return next;
+    });
+  };
+
+  const handleEnroll = async () => {
+    if (!course) return;
+    setEnrolling(true);
+    try {
+      await enrollInCourse(course.id);
+      setEnrolled(true);
+    } catch {
+      // ignore
+    } finally {
+      setEnrolling(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (error || !course) {
+    return (
+      <div className="container mx-auto max-w-3xl px-4 py-12 text-center">
+        <p className="text-muted-foreground">{tDetail("notFound")}</p>
+        <Button variant="outline" className="mt-4" onClick={() => router.push("/courses")}>
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          {tDetail("backToCatalog")}
+        </Button>
+      </div>
+    );
+  }
+
+  const title = locale === "fr" ? course.title_fr : course.title_en;
+  const description = locale === "fr" ? course.description_fr : course.description_en;
+
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-6 space-y-6 pb-24 md:pb-6">
+      {/* Back link */}
+      <Link
+        href="/courses"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        {tDetail("backToCatalog")}
+      </Link>
+
+      {/* Cover */}
+      {course.cover_image_url ? (
+        <div className="relative h-48 sm:h-64 overflow-hidden rounded-xl bg-teal-50">
+          <img src={course.cover_image_url} alt={title} className="w-full h-full object-cover" />
+        </div>
+      ) : (
+        <div className="h-48 sm:h-64 rounded-xl bg-gradient-to-br from-teal-600 to-amber-500 flex items-center justify-center">
+          <GraduationCap className="h-20 w-20 text-white opacity-80" />
+        </div>
+      )}
+
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl sm:text-3xl font-bold text-stone-900">{title}</h1>
+        {description && <p className="text-stone-600 mt-2">{description}</p>}
+
+        {/* Taxonomy badges */}
+        <div className="flex flex-wrap gap-1.5 mt-3">
+          {course.course_domain?.map((d) => (
+            <Badge key={d.value} variant="outline" className="text-xs text-amber-700 bg-amber-50 border-amber-200">
+              {locale === "fr" ? d.label_fr : d.label_en}
+            </Badge>
+          ))}
+          {course.course_level?.map((l) => (
+            <Badge
+              key={l.value}
+              variant="outline"
+              className={`text-xs ${LEVEL_COLORS[l.value] || "bg-stone-50 text-stone-700 border-stone-200"}`}
+            >
+              {locale === "fr" ? l.label_fr : l.label_en}
+            </Badge>
+          ))}
+          {course.audience_type?.map((a) => (
+            <Badge key={a.value} variant="outline" className="text-xs text-violet-700 bg-violet-50 border-violet-200">
+              {locale === "fr" ? a.label_fr : a.label_en}
+            </Badge>
+          ))}
+        </div>
+
+        {/* Stats */}
+        <div className="flex items-center gap-4 mt-3 text-sm text-stone-500">
+          <div className="flex items-center gap-1">
+            <Clock className="h-4 w-4" />
+            <span>{t("hours", { count: course.estimated_hours })}</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <BookOpen className="h-4 w-4" />
+            <span>{t("modules", { count: course.module_count })}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Syllabus — modules */}
+      {course.modules.length > 0 && (
+        <div>
+          <h2 className="text-lg font-semibold mb-3">{tDetail("syllabus")}</h2>
+          <div className="space-y-2">
+            {course.modules.map((mod) => {
+              const modTitle = locale === "fr" ? mod.title_fr : mod.title_en;
+              const modDesc = locale === "fr" ? mod.description_fr : mod.description_en;
+              const isExpanded = expandedModules.has(mod.id);
+
+              return (
+                <Card key={mod.id} className="overflow-hidden">
+                  <button
+                    type="button"
+                    onClick={() => toggleModule(mod.id)}
+                    className="w-full text-left p-4 flex items-start gap-3 hover:bg-stone-50 transition-colors"
+                  >
+                    <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-bold text-primary">
+                      {mod.module_number}
+                    </span>
+                    <div className="flex-1 min-w-0">
+                      <p className="font-medium text-sm text-stone-900 leading-tight">
+                        {modTitle}
+                      </p>
+                      <div className="flex items-center gap-2 mt-1 text-xs text-stone-500">
+                        <span>{mod.estimated_hours}h</span>
+                        <span>{mod.units.length} {tDetail("units")}</span>
+                        {mod.bloom_level && (
+                          <Badge variant="outline" className="text-[10px] py-0">
+                            {mod.bloom_level}
+                          </Badge>
+                        )}
+                      </div>
+                    </div>
+                    {isExpanded ? (
+                      <ChevronDown className="h-4 w-4 text-stone-400 shrink-0 mt-1" />
+                    ) : (
+                      <ChevronRight className="h-4 w-4 text-stone-400 shrink-0 mt-1" />
+                    )}
+                  </button>
+
+                  {isExpanded && (
+                    <CardContent className="pt-0 pb-4 px-4">
+                      {modDesc && (
+                        <p className="text-sm text-stone-600 mb-3 ml-10">{modDesc}</p>
+                      )}
+                      {mod.units.length > 0 && (
+                        <ul className="space-y-1.5 ml-10">
+                          {mod.units.map((unit) => {
+                            const unitTitle = locale === "fr" ? unit.title_fr : unit.title_en;
+                            return (
+                              <li key={unit.id} className="flex items-center gap-2 text-sm text-stone-600">
+                                <span className="h-1.5 w-1.5 rounded-full bg-stone-300 shrink-0" />
+                                <span className="font-mono text-xs text-stone-400">{unit.unit_number}</span>
+                                <span>{unitTitle}</span>
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      )}
+                    </CardContent>
+                  )}
+                </Card>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Sticky enroll CTA on mobile */}
+      <div className="fixed bottom-16 left-0 right-0 p-4 bg-background/95 backdrop-blur border-t md:static md:border-0 md:p-0 md:bg-transparent">
+        {enrolled ? (
+          <Button
+            className="w-full min-h-11 bg-teal-600 hover:bg-teal-700"
+            onClick={() => router.push(`/modules?course_id=${course.id}`)}
+          >
+            <CheckCircle className="mr-2 h-4 w-4" />
+            {t("viewModules")}
+          </Button>
+        ) : (
+          <Button
+            className="w-full min-h-11 bg-teal-600 hover:bg-teal-700"
+            onClick={handleEnroll}
+            disabled={enrolling}
+          >
+            {enrolling ? t("enrolling") : t("enroll")}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/learning/course-card.tsx
+++ b/frontend/components/learning/course-card.tsx
@@ -30,7 +30,8 @@ export function CourseCard({ course }: CourseCardProps) {
   const title = locale === 'fr' ? course.title_fr : course.title_en;
   const description = locale === 'fr' ? course.description_fr : course.description_en;
 
-  const handleEnroll = async () => {
+  const handleEnroll = async (e: React.MouseEvent) => {
+    e.stopPropagation();
     setEnrolling(true);
     setError(null);
     try {
@@ -43,12 +44,20 @@ export function CourseCard({ course }: CourseCardProps) {
     }
   };
 
-  const handleViewModules = () => {
+  const handleViewModules = (e: React.MouseEvent) => {
+    e.stopPropagation();
     router.push(`/modules?course_id=${course.id}`);
   };
 
+  const handleViewDetail = () => {
+    router.push(`/courses/${course.id}`);
+  };
+
   return (
-    <Card className="flex flex-col h-full border border-stone-200 hover:shadow-md transition-shadow duration-200">
+    <Card
+      className="flex flex-col h-full border border-stone-200 hover:shadow-md transition-shadow duration-200 cursor-pointer"
+      onClick={handleViewDetail}
+    >
       {course.cover_image_url && (
         <div className="relative h-40 overflow-hidden rounded-t-lg bg-teal-50">
           <img

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -821,6 +821,12 @@
       "other": "Other"
     }
   },
+  "CourseDetail": {
+    "syllabus": "Syllabus",
+    "units": "units",
+    "backToCatalog": "Back to catalog",
+    "notFound": "Course not found."
+  },
   "Privacy": {
     "title": "Privacy & Analytics",
     "description": "Manage how your usage data is collected",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -821,6 +821,12 @@
       "other": "Autre"
     }
   },
+  "CourseDetail": {
+    "syllabus": "Programme",
+    "units": "unités",
+    "backToCatalog": "Retour au catalogue",
+    "notFound": "Cours non trouvé."
+  },
   "Privacy": {
     "title": "Confidentialité et analytique",
     "description": "Gérez la collecte de vos données d'utilisation",


### PR DESCRIPTION
## Summary
- **Backend**: New `GET /api/v1/courses/{course_id}` public endpoint — returns course metadata, syllabus_json, modules with units
- **Frontend**: New `/courses/{courseId}` page — cover, description, taxonomy badges, collapsible module/unit list, sticky mobile enroll CTA
- Course cards in catalog now click through to detail page (buttons stop propagation)
- FR/EN i18n strings

## Test plan
- [ ] Click course card in catalog → detail page loads
- [ ] Modules collapsible, show units when expanded
- [ ] Enroll button works, switches to "View Modules" after enrollment
- [ ] Back to catalog link works
- [ ] Mobile-responsive (sticky CTA at bottom)
- [ ] Public (no auth required to view)

Closes #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)