### PR TITLE
fix(api): normalize pre-assessment options to [{id, text}] format

### DIFF
--- a/backend/app/api/v1/course_preassessment.py
+++ b/backend/app/api/v1/course_preassessment.py
@@ -106,7 +106,8 @@ async def get_course_preassessment_questions(
             else:
                 options = [
                     {"id": opt.get("id", ""), "text": opt.get("text", "")}
-                    if isinstance(opt, dict) else {"id": "", "text": str(opt)}
+                    if isinstance(opt, dict)
+                    else {"id": "", "text": str(opt)}
                     for opt in raw_options
                 ]
             questions.append(

--- a/backend/app/api/v1/placement.py
+++ b/backend/app/api/v1/placement.py
@@ -106,7 +106,7 @@ async def get_placement_test_questions(
         )
         # Normalize options to [{id, text}] for legacy dict format compat
         normalized_questions = []
-        for q in (preassessment.questions or []):
+        for q in preassessment.questions or []:
             raw_opts = q.get("options", [])
             if isinstance(raw_opts, dict):
                 opts = [{"id": k, "text": v} for k, v in raw_opts.items()]

--- a/backend/app/domain/services/preassessment_generation_service.py
+++ b/backend/app/domain/services/preassessment_generation_service.py
@@ -268,9 +268,7 @@ class PreAssessmentGenerationService:
             if not all(k in options for k in ("a", "b", "c", "d")):
                 raise ValueError(f"{context}: options dict must have keys a, b, c, d")
             # Convert dict to [{id, text}] list for API/frontend compatibility
-            question["options"] = [
-                {"id": k, "text": v} for k, v in options.items()
-            ]
+            question["options"] = [{"id": k, "text": v} for k, v in options.items()]
         elif isinstance(options, list):
             if len(options) != 4:
                 raise ValueError(f"{context}: options list must have exactly 4 items")


### PR DESCRIPTION
## Summary
- Fix `_validate_question()` normalizer to store options as `[{id: "a", text: "..."}]` list instead of `{"a": "..."}` dict
- Fix `course_preassessment.py` serving endpoint to handle both legacy dict and new list formats
- Fix deprecated `placement.py` endpoint with same backward-compat handling

Closes #958

## Test plan
- [x] 507 tests pass, 0 failures
- [ ] Manual: `GET /courses/{id}/preassessment/questions` returns options as `[{id, text}]`
- [ ] Verify existing pre-assessments in DB (legacy dict format) still serve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)