### PR TITLE
fix: sms_relay migration enum error

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -17,6 +17,9 @@ from app.api.v1.module_media import router as module_media_router
 from app.api.v1.placement import router as placement_router
 from app.api.v1.progress import router as progress_router
 from app.api.v1.quiz import router as quiz_router
+from app.api.v1.sms_relay import (
+    router as sms_relay_router,
+)
 from app.api.v1.source_images import router as source_images_router
 from app.api.v1.subscriptions import router as subscriptions_router
 from app.api.v1.tutor import router as tutor_router
@@ -42,5 +45,6 @@ api_v1_router.include_router(admin_taxonomy_router)
 api_v1_router.include_router(courses_router)
 api_v1_router.include_router(course_preassessment_router)
 api_v1_router.include_router(module_media_router)
+api_v1_router.include_router(sms_relay_router)
 api_v1_router.include_router(source_images_router)
 api_v1_router.include_router(subscriptions_router)

--- a/backend/app/api/v1/sms_relay.py
+++ b/backend/app/api/v1/sms_relay.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 from structlog import get_logger
 
 from app.api.deps import get_db as get_db_session
-from app.api.deps_local_auth import get_current_user, require_role
+from app.api.deps_local_auth import require_role
 from app.domain.models.sms_relay import SmsProcessingStatus
 from app.domain.models.user import UserRole
 from app.domain.services.sms_relay_service import SmsRelayService

--- a/backend/app/api/v1/sms_relay.py
+++ b/backend/app/api/v1/sms_relay.py
@@ -23,6 +23,7 @@ router = APIRouter(tags=["SMS Relay"])
 
 # ---------- Auth dependency ----------
 
+
 async def verify_relay_api_key(
     authorization: str = Header(...),
 ) -> str:
@@ -42,6 +43,7 @@ async def verify_relay_api_key(
 
 
 # ---------- Schemas ----------
+
 
 class SmsPayload(BaseModel):
     id: str
@@ -94,6 +96,7 @@ class RelayStatusResponse(BaseModel):
 
 # ---------- Endpoints ----------
 
+
 @router.post(
     "/sms",
     response_model=SmsResponse,
@@ -144,9 +147,7 @@ async def receive_heartbeat(
 
     settings = get_settings()
     trusted = (
-        settings.sms_relay_trusted_senders_list
-        if settings.sms_relay_trusted_senders
-        else None
+        settings.sms_relay_trusted_senders_list if settings.sms_relay_trusted_senders else None
     )
 
     return HeartbeatResponse(
@@ -161,18 +162,14 @@ async def receive_heartbeat(
     status_code=status.HTTP_200_OK,
 )
 async def get_relay_status(
-    current_user=Depends(
-        require_role(UserRole.admin)
-    ),
+    current_user=Depends(require_role(UserRole.admin)),
     db=Depends(get_db_session),
 ) -> RelayStatusResponse:
     settings = get_settings()
     service = SmsRelayService()
 
     devices = await service.get_all_devices(db)
-    cutoff = datetime.datetime.now(
-        tz=datetime.UTC
-    ) - timedelta(
+    cutoff = datetime.datetime.now(tz=datetime.UTC) - timedelta(
         minutes=settings.sms_relay_heartbeat_timeout_minutes
     )
 
@@ -184,11 +181,7 @@ async def get_relay_status(
             signal=d.signal,
             pending=d.pending,
             failed=d.failed,
-            last_sms_at=(
-                d.last_sms_at.isoformat()
-                if d.last_sms_at
-                else None
-            ),
+            last_sms_at=(d.last_sms_at.isoformat() if d.last_sms_at else None),
             last_heartbeat_at=d.last_heartbeat_at.isoformat(),
             app_version=d.app_version,
             is_stale=d.last_heartbeat_at < cutoff,
@@ -196,12 +189,8 @@ async def get_relay_status(
         for d in devices
     ]
 
-    recent_count = await service.count_by_status(
-        SmsProcessingStatus.payment_processed, db
-    )
-    failed_count = await service.count_by_status(
-        SmsProcessingStatus.parse_failed, db
-    )
+    recent_count = await service.count_by_status(SmsProcessingStatus.payment_processed, db)
+    failed_count = await service.count_by_status(SmsProcessingStatus.parse_failed, db)
 
     return RelayStatusResponse(
         devices=device_list,

--- a/backend/app/api/v1/sms_relay.py
+++ b/backend/app/api/v1/sms_relay.py
@@ -1,0 +1,210 @@
+"""SMS relay API endpoints for heartbeat and SMS ingestion."""
+
+from __future__ import annotations
+
+import datetime
+from datetime import timedelta
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from pydantic import BaseModel
+from structlog import get_logger
+
+from app.api.deps import get_db as get_db_session
+from app.api.deps_local_auth import get_current_user, require_role
+from app.domain.models.sms_relay import SmsProcessingStatus
+from app.domain.models.user import UserRole
+from app.domain.services.sms_relay_service import SmsRelayService
+from app.infrastructure.config.settings import get_settings
+
+logger = get_logger(__name__)
+
+router = APIRouter(tags=["SMS Relay"])
+
+
+# ---------- Auth dependency ----------
+
+async def verify_relay_api_key(
+    authorization: str = Header(...),
+) -> str:
+    settings = get_settings()
+    if not settings.sms_relay_api_key:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="SMS relay not configured",
+        )
+    expected = f"Bearer {settings.sms_relay_api_key}"
+    if authorization != expected:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid API key",
+        )
+    return settings.sms_relay_api_key
+
+
+# ---------- Schemas ----------
+
+class SmsPayload(BaseModel):
+    id: str
+    device_id: str
+    sender: str
+    body: str
+    ts: datetime.datetime
+    v: int | str | None = None
+
+
+class SmsResponse(BaseModel):
+    status: str = "ok"
+
+
+class HeartbeatPayload(BaseModel):
+    device_id: str
+    battery: int | None = None
+    charging: bool | None = None
+    signal: int | None = None
+    pending: int | None = None
+    failed: int | None = None
+    last_sms_at: datetime.datetime | None = None
+    v: int | str | None = None
+
+
+class HeartbeatResponse(BaseModel):
+    status: str = "ok"
+    trusted_senders: list[str] | None = None
+    update_url: str | None = None
+
+
+class DeviceStatusResponse(BaseModel):
+    device_id: str
+    battery: int | None
+    charging: bool | None
+    signal: int | None
+    pending: int | None
+    failed: int | None
+    last_sms_at: str | None
+    last_heartbeat_at: str
+    app_version: str | None
+    is_stale: bool
+
+
+class RelayStatusResponse(BaseModel):
+    devices: list[DeviceStatusResponse]
+    recent_sms_count: int
+    failed_parse_count: int
+
+
+# ---------- Endpoints ----------
+
+@router.post(
+    "/sms",
+    response_model=SmsResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def receive_sms(
+    payload: SmsPayload,
+    _key: str = Depends(verify_relay_api_key),
+    db=Depends(get_db_session),
+) -> SmsResponse:
+    service = SmsRelayService()
+    app_version = str(payload.v) if payload.v else None
+    await service.ingest_sms(
+        sms_id=payload.id,
+        device_id=payload.device_id,
+        sender=payload.sender,
+        body=payload.body,
+        ts=payload.ts,
+        app_version=app_version,
+        session=db,
+    )
+    return SmsResponse(status="ok")
+
+
+@router.post(
+    "/heartbeat",
+    response_model=HeartbeatResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def receive_heartbeat(
+    payload: HeartbeatPayload,
+    _key: str = Depends(verify_relay_api_key),
+    db=Depends(get_db_session),
+) -> HeartbeatResponse:
+    service = SmsRelayService()
+    app_version = str(payload.v) if payload.v else None
+    await service.upsert_heartbeat(
+        device_id=payload.device_id,
+        battery=payload.battery,
+        charging=payload.charging,
+        signal=payload.signal,
+        pending=payload.pending,
+        failed=payload.failed,
+        last_sms_at=payload.last_sms_at,
+        app_version=app_version,
+        session=db,
+    )
+
+    settings = get_settings()
+    trusted = (
+        settings.sms_relay_trusted_senders_list
+        if settings.sms_relay_trusted_senders
+        else None
+    )
+
+    return HeartbeatResponse(
+        status="ok",
+        trusted_senders=trusted,
+    )
+
+
+@router.get(
+    "/admin/relay/status",
+    response_model=RelayStatusResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def get_relay_status(
+    current_user=Depends(
+        require_role(UserRole.admin)
+    ),
+    db=Depends(get_db_session),
+) -> RelayStatusResponse:
+    settings = get_settings()
+    service = SmsRelayService()
+
+    devices = await service.get_all_devices(db)
+    cutoff = datetime.datetime.now(
+        tz=datetime.UTC
+    ) - timedelta(
+        minutes=settings.sms_relay_heartbeat_timeout_minutes
+    )
+
+    device_list = [
+        DeviceStatusResponse(
+            device_id=d.device_id,
+            battery=d.battery,
+            charging=d.charging,
+            signal=d.signal,
+            pending=d.pending,
+            failed=d.failed,
+            last_sms_at=(
+                d.last_sms_at.isoformat()
+                if d.last_sms_at
+                else None
+            ),
+            last_heartbeat_at=d.last_heartbeat_at.isoformat(),
+            app_version=d.app_version,
+            is_stale=d.last_heartbeat_at < cutoff,
+        )
+        for d in devices
+    ]
+
+    recent_count = await service.count_by_status(
+        SmsProcessingStatus.payment_processed, db
+    )
+    failed_count = await service.count_by_status(
+        SmsProcessingStatus.parse_failed, db
+    )
+
+    return RelayStatusResponse(
+        devices=device_list,
+        recent_sms_count=recent_count,
+        failed_parse_count=failed_count,
+    )

--- a/backend/app/domain/models/__init__.py
+++ b/backend/app/domain/models/__init__.py
@@ -16,6 +16,11 @@ from app.domain.models.module_unit import ModuleUnit
 from app.domain.models.preassessment import CoursePreAssessment
 from app.domain.models.progress import UserModuleProgress
 from app.domain.models.quiz import PlacementTestAttempt, QuizAttempt, SummativeAssessmentAttempt
+from app.domain.models.sms_relay import (
+    InboundSms,
+    RelayDevice,
+    SmsProcessingStatus,
+)
 from app.domain.models.source_image import ImageType, SourceImage, SourceImageChunk
 from app.domain.models.subscription import (
     PaymentStatus,
@@ -52,6 +57,7 @@ __all__ = [
     "PlacementTestAttempt",
     "QuizAttempt",
     "RefreshToken",
+    "RelayDevice",
     "SummativeAssessmentAttempt",
     "TOTPSecret",
     "CourseTaxonomy",
@@ -61,11 +67,13 @@ __all__ = [
     "UserModuleProgress",
     "User",
     "ImageType",
+    "InboundSms",
     "PaymentStatus",
     "PaymentType",
     "SourceImage",
     "SourceImageChunk",
     "Subscription",
     "SubscriptionPayment",
+    "SmsProcessingStatus",
     "SubscriptionStatus",
 ]

--- a/backend/app/domain/models/sms_relay.py
+++ b/backend/app/domain/models/sms_relay.py
@@ -32,31 +32,19 @@ class SmsProcessingStatus(enum.StrEnum):
 class RelayDevice(Base):
     __tablename__ = "relay_devices"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        primary_key=True, default=uuid.uuid4
-    )
-    device_id: Mapped[str] = mapped_column(
-        String(100), unique=True, nullable=False
-    )
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    device_id: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
     battery: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    charging: Mapped[bool | None] = mapped_column(
-        Boolean, nullable=True
-    )
+    charging: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     signal: Mapped[int | None] = mapped_column(Integer, nullable=True)
     pending: Mapped[int | None] = mapped_column(Integer, nullable=True)
     failed: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    last_sms_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
-    app_version: Mapped[str | None] = mapped_column(
-        String(20), nullable=True
-    )
+    last_sms_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    app_version: Mapped[str | None] = mapped_column(String(20), nullable=True)
     last_heartbeat_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),
@@ -67,51 +55,29 @@ class RelayDevice(Base):
 class InboundSms(Base):
     __tablename__ = "inbound_sms"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        primary_key=True, default=uuid.uuid4
-    )
-    sms_id: Mapped[str] = mapped_column(
-        String(100), unique=True, nullable=False
-    )
-    device_id: Mapped[str] = mapped_column(
-        String(100), nullable=False, index=True
-    )
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    sms_id: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
+    device_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
     sender: Mapped[str] = mapped_column(String(50), nullable=False)
     body: Mapped[str] = mapped_column(Text, nullable=False)
-    sms_received_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False
-    )
-    app_version: Mapped[str | None] = mapped_column(
-        String(20), nullable=True
-    )
+    sms_received_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    app_version: Mapped[str | None] = mapped_column(String(20), nullable=True)
     processing_status: Mapped[SmsProcessingStatus] = mapped_column(
         Enum(SmsProcessingStatus, name="smsprocessingstatus"),
         nullable=False,
         server_default="pending",
         default=SmsProcessingStatus.pending,
     )
-    parsed_amount: Mapped[int | None] = mapped_column(
-        Integer, nullable=True
-    )
-    parsed_phone: Mapped[str | None] = mapped_column(
-        String(20), nullable=True
-    )
-    parsed_reference: Mapped[str | None] = mapped_column(
-        String(255), nullable=True
-    )
-    parsed_provider: Mapped[str | None] = mapped_column(
-        String(50), nullable=True
-    )
-    error_message: Mapped[str | None] = mapped_column(
-        Text, nullable=True
-    )
+    parsed_amount: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    parsed_phone: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    parsed_reference: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    parsed_provider: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
     payment_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("subscription_payments.id", ondelete="SET NULL"),
         nullable=True,
     )
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     __table_args__ = (
         Index("ix_inbound_sms_status", "processing_status"),

--- a/backend/app/domain/models/sms_relay.py
+++ b/backend/app/domain/models/sms_relay.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.domain.models.base import Base
+
+
+class SmsProcessingStatus(enum.StrEnum):
+    pending = "pending"
+    parsed = "parsed"
+    payment_processed = "payment_processed"
+    parse_failed = "parse_failed"
+    duplicate = "duplicate"
+    ignored = "ignored"
+
+
+class RelayDevice(Base):
+    __tablename__ = "relay_devices"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True, default=uuid.uuid4
+    )
+    device_id: Mapped[str] = mapped_column(
+        String(100), unique=True, nullable=False
+    )
+    battery: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    charging: Mapped[bool | None] = mapped_column(
+        Boolean, nullable=True
+    )
+    signal: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    pending: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    failed: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    last_sms_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    app_version: Mapped[str | None] = mapped_column(
+        String(20), nullable=True
+    )
+    last_heartbeat_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
+class InboundSms(Base):
+    __tablename__ = "inbound_sms"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True, default=uuid.uuid4
+    )
+    sms_id: Mapped[str] = mapped_column(
+        String(100), unique=True, nullable=False
+    )
+    device_id: Mapped[str] = mapped_column(
+        String(100), nullable=False, index=True
+    )
+    sender: Mapped[str] = mapped_column(String(50), nullable=False)
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    sms_received_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    app_version: Mapped[str | None] = mapped_column(
+        String(20), nullable=True
+    )
+    processing_status: Mapped[SmsProcessingStatus] = mapped_column(
+        Enum(SmsProcessingStatus, name="smsprocessingstatus"),
+        nullable=False,
+        server_default="pending",
+        default=SmsProcessingStatus.pending,
+    )
+    parsed_amount: Mapped[int | None] = mapped_column(
+        Integer, nullable=True
+    )
+    parsed_phone: Mapped[str | None] = mapped_column(
+        String(20), nullable=True
+    )
+    parsed_reference: Mapped[str | None] = mapped_column(
+        String(255), nullable=True
+    )
+    parsed_provider: Mapped[str | None] = mapped_column(
+        String(50), nullable=True
+    )
+    error_message: Mapped[str | None] = mapped_column(
+        Text, nullable=True
+    )
+    payment_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("subscription_payments.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    __table_args__ = (
+        Index("ix_inbound_sms_status", "processing_status"),
+        Index("ix_inbound_sms_created", "created_at"),
+    )

--- a/backend/app/domain/services/email_service.py
+++ b/backend/app/domain/services/email_service.py
@@ -174,6 +174,58 @@ class EmailService:
             logger.error("Failed to send welcome email", email=email, error=str(e))
             return False
 
+    async def send_relay_alert(
+        self,
+        to_email: str,
+        device_id: str,
+        last_seen: str,
+        battery: int | None,
+    ) -> bool:
+        """Send alert when SMS relay device goes silent."""
+        try:
+            subject = (
+                f"[SIRA] SMS relay {device_id} offline"
+            )
+            battery_info = (
+                f"{battery}%" if battery is not None else "unknown"
+            )
+            html_content = f"""
+            <h2>SMS Relay Device Alert</h2>
+            <p>The SMS relay device <strong>{device_id}</strong>
+            has not sent a heartbeat since
+            <strong>{last_seen}</strong>.</p>
+            <p>Last known battery: {battery_info}</p>
+            <p>Please check the physical device.</p>
+            <hr>
+            <p style="color: #666; font-size: 12px;">
+            Sira - Advancing Public Health in West Africa
+            </p>
+            """
+
+            resend.Emails.send(
+                {
+                    "from": self.from_email,
+                    "to": [to_email],
+                    "subject": subject,
+                    "html": html_content,
+                }
+            )
+
+            logger.info(
+                "Relay alert email sent",
+                to=to_email,
+                device_id=device_id,
+            )
+            return True
+
+        except Exception as e:
+            logger.error(
+                "Failed to send relay alert",
+                device_id=device_id,
+                error=str(e),
+            )
+            return False
+
     async def send_otp_email(
         self, email: str, otp_code: str, purpose: str, language: str = "fr"
     ) -> bool:

--- a/backend/app/domain/services/email_service.py
+++ b/backend/app/domain/services/email_service.py
@@ -183,12 +183,8 @@ class EmailService:
     ) -> bool:
         """Send alert when SMS relay device goes silent."""
         try:
-            subject = (
-                f"[SIRA] SMS relay {device_id} offline"
-            )
-            battery_info = (
-                f"{battery}%" if battery is not None else "unknown"
-            )
+            subject = f"[SIRA] SMS relay {device_id} offline"
+            battery_info = f"{battery}%" if battery is not None else "unknown"
             html_content = f"""
             <h2>SMS Relay Device Alert</h2>
             <p>The SMS relay device <strong>{device_id}</strong>

--- a/backend/app/domain/services/sms_parser.py
+++ b/backend/app/domain/services/sms_parser.py
@@ -10,9 +10,7 @@ ORANGE_MONEY_PATTERN = re.compile(
     r"\s+du\s+(\d{8,15})",
     re.IGNORECASE,
 )
-TRANS_ID_PATTERN = re.compile(
-    r"Trans\s+ID:\s*(\S+)", re.IGNORECASE
-)
+TRANS_ID_PATTERN = re.compile(r"Trans\s+ID:\s*(\S+)", re.IGNORECASE)
 
 
 @dataclass(frozen=True)
@@ -26,9 +24,7 @@ class ParsedPayment:
 class SmsParser:
     """Registry of provider-specific SMS parsers."""
 
-    def parse(
-        self, body: str, sender: str, fallback_ref: str = ""
-    ) -> ParsedPayment | None:
+    def parse(self, body: str, sender: str, fallback_ref: str = "") -> ParsedPayment | None:
         """Try each parser in order. Return first match."""
         for parser in [self._parse_orange_money]:
             result = parser(body, sender, fallback_ref)
@@ -37,9 +33,7 @@ class SmsParser:
         return None
 
     @staticmethod
-    def _parse_orange_money(
-        body: str, sender: str, fallback_ref: str
-    ) -> ParsedPayment | None:
+    def _parse_orange_money(body: str, sender: str, fallback_ref: str) -> ParsedPayment | None:
         m = ORANGE_MONEY_PATTERN.search(body)
         if m is None:
             return None
@@ -48,11 +42,7 @@ class SmsParser:
         phone = _normalize_phone(m.group(2))
 
         tid = TRANS_ID_PATTERN.search(body)
-        reference = (
-            tid.group(1).rstrip(".")
-            if tid
-            else fallback_ref
-        )
+        reference = tid.group(1).rstrip(".") if tid else fallback_ref
 
         return ParsedPayment(
             amount=amount,
@@ -92,13 +82,13 @@ def _normalize_phone(raw: str) -> str:
         # Strip country codes (224=Guinea, 221=Senegal, etc.)
         for prefix in ("224", "221", "223", "225", "226"):
             if phone.startswith(prefix) and len(phone) > 8:
-                phone = phone[len(prefix):]
+                phone = phone[len(prefix) :]
                 break
     elif phone.startswith("00"):
         phone = phone[2:]
         for prefix in ("224", "221", "223", "225", "226"):
             if phone.startswith(prefix) and len(phone) > 8:
-                phone = phone[len(prefix):]
+                phone = phone[len(prefix) :]
                 break
     elif phone.startswith("0") and len(phone) > 8:
         phone = phone[1:]

--- a/backend/app/domain/services/sms_parser.py
+++ b/backend/app/domain/services/sms_parser.py
@@ -1,0 +1,105 @@
+"""SMS body parsers for mobile money payment extraction."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+ORANGE_MONEY_PATTERN = re.compile(
+    r"[Vv]ous\s+avez\s+re[cç]u\s+([\d\s.,]+)\s*FCFA"
+    r"\s+du\s+(\d{8,15})",
+    re.IGNORECASE,
+)
+TRANS_ID_PATTERN = re.compile(
+    r"Trans\s+ID:\s*(\S+)", re.IGNORECASE
+)
+
+
+@dataclass(frozen=True)
+class ParsedPayment:
+    amount: int
+    phone_number: str
+    reference: str
+    provider: str
+
+
+class SmsParser:
+    """Registry of provider-specific SMS parsers."""
+
+    def parse(
+        self, body: str, sender: str, fallback_ref: str = ""
+    ) -> ParsedPayment | None:
+        """Try each parser in order. Return first match."""
+        for parser in [self._parse_orange_money]:
+            result = parser(body, sender, fallback_ref)
+            if result is not None:
+                return result
+        return None
+
+    @staticmethod
+    def _parse_orange_money(
+        body: str, sender: str, fallback_ref: str
+    ) -> ParsedPayment | None:
+        m = ORANGE_MONEY_PATTERN.search(body)
+        if m is None:
+            return None
+
+        amount = _normalize_amount(m.group(1))
+        phone = _normalize_phone(m.group(2))
+
+        tid = TRANS_ID_PATTERN.search(body)
+        reference = (
+            tid.group(1).rstrip(".")
+            if tid
+            else fallback_ref
+        )
+
+        return ParsedPayment(
+            amount=amount,
+            phone_number=phone,
+            reference=reference,
+            provider="orange_money",
+        )
+
+
+def _normalize_amount(raw: str) -> int:
+    """Convert '65,000.00' or '65 000' to 65000."""
+    cleaned = raw.strip()
+    # Remove spaces
+    cleaned = cleaned.replace(" ", "")
+    # Determine if comma or period is decimal separator
+    # '65,000.00' -> comma=thousands, period=decimal
+    # '65.000,00' -> period=thousands, comma=decimal
+    last_comma = cleaned.rfind(",")
+    last_period = cleaned.rfind(".")
+    if last_comma > last_period:
+        # comma is decimal: 65.000,00
+        cleaned = cleaned.replace(".", "")
+        cleaned = cleaned.replace(",", ".")
+    else:
+        # period is decimal or no decimal: 65,000.00
+        cleaned = cleaned.replace(",", "")
+    # Take integer part only (FCFA is whole numbers)
+    return int(float(cleaned))
+
+
+def _normalize_phone(raw: str) -> str:
+    """Strip country code prefix to get local number."""
+    phone = raw.strip()
+    # +224 76801718 -> 76801718
+    if phone.startswith("+"):
+        phone = phone[1:]
+        # Strip country codes (224=Guinea, 221=Senegal, etc.)
+        for prefix in ("224", "221", "223", "225", "226"):
+            if phone.startswith(prefix) and len(phone) > 8:
+                phone = phone[len(prefix):]
+                break
+    elif phone.startswith("00"):
+        phone = phone[2:]
+        for prefix in ("224", "221", "223", "225", "226"):
+            if phone.startswith(prefix) and len(phone) > 8:
+                phone = phone[len(prefix):]
+                break
+    elif phone.startswith("0") and len(phone) > 8:
+        phone = phone[1:]
+    return phone

--- a/backend/app/domain/services/sms_relay_service.py
+++ b/backend/app/domain/services/sms_relay_service.py
@@ -26,7 +26,6 @@ _parser = SmsParser()
 
 
 class SmsRelayService:
-
     async def upsert_heartbeat(
         self,
         device_id: str,
@@ -41,9 +40,7 @@ class SmsRelayService:
     ) -> RelayDevice:
         now = datetime.datetime.now(tz=datetime.UTC)
         result = await session.execute(
-            select(RelayDevice).where(
-                RelayDevice.device_id == device_id
-            )
+            select(RelayDevice).where(RelayDevice.device_id == device_id)
         )
         device = result.scalar_one_or_none()
 
@@ -91,11 +88,7 @@ class SmsRelayService:
         session: AsyncSession,
     ) -> InboundSms:
         # Dedup check
-        existing = await session.execute(
-            select(InboundSms).where(
-                InboundSms.sms_id == sms_id
-            )
-        )
+        existing = await session.execute(select(InboundSms).where(InboundSms.sms_id == sms_id))
         found = existing.scalar_one_or_none()
         if found is not None:
             logger.info(
@@ -120,11 +113,7 @@ class SmsRelayService:
             await session.flush()
         except IntegrityError:
             await session.rollback()
-            result = await session.execute(
-                select(InboundSms).where(
-                    InboundSms.sms_id == sms_id
-                )
-            )
+            result = await session.execute(select(InboundSms).where(InboundSms.sms_id == sms_id))
             return result.scalar_one()
 
         # Parse SMS body
@@ -132,12 +121,8 @@ class SmsRelayService:
         parsed = _parser.parse(body, sender, fallback_ref)
 
         if parsed is None:
-            sms.processing_status = (
-                SmsProcessingStatus.parse_failed
-            )
-            sms.error_message = (
-                "No parser matched the SMS body"
-            )
+            sms.processing_status = SmsProcessingStatus.parse_failed
+            sms.error_message = "No parser matched the SMS body"
             await session.commit()
             logger.warning(
                 "SMS parse failed",
@@ -161,9 +146,7 @@ class SmsRelayService:
                 external_reference=parsed.reference,
                 session=session,
             )
-            sms.processing_status = (
-                SmsProcessingStatus.payment_processed
-            )
+            sms.processing_status = SmsProcessingStatus.payment_processed
             logger.info(
                 "SMS payment processed",
                 sms_id=sms_id,
@@ -173,12 +156,8 @@ class SmsRelayService:
                 result=result,
             )
         except Exception as exc:
-            sms.processing_status = (
-                SmsProcessingStatus.parse_failed
-            )
-            sms.error_message = (
-                f"Payment processing error: {exc}"
-            )
+            sms.processing_status = SmsProcessingStatus.parse_failed
+            sms.error_message = f"Payment processing error: {exc}"
             logger.error(
                 "SMS payment processing failed",
                 sms_id=sms_id,
@@ -193,23 +172,15 @@ class SmsRelayService:
         timeout_minutes: int,
         session: AsyncSession,
     ) -> list[RelayDevice]:
-        cutoff = datetime.datetime.now(
-            tz=datetime.UTC
-        ) - timedelta(minutes=timeout_minutes)
+        cutoff = datetime.datetime.now(tz=datetime.UTC) - timedelta(minutes=timeout_minutes)
         result = await session.execute(
-            select(RelayDevice).where(
-                RelayDevice.last_heartbeat_at < cutoff
-            )
+            select(RelayDevice).where(RelayDevice.last_heartbeat_at < cutoff)
         )
         return list(result.scalars().all())
 
-    async def get_all_devices(
-        self, session: AsyncSession
-    ) -> list[RelayDevice]:
+    async def get_all_devices(self, session: AsyncSession) -> list[RelayDevice]:
         result = await session.execute(
-            select(RelayDevice).order_by(
-                RelayDevice.last_heartbeat_at.desc()
-            )
+            select(RelayDevice).order_by(RelayDevice.last_heartbeat_at.desc())
         )
         return list(result.scalars().all())
 
@@ -219,14 +190,9 @@ class SmsRelayService:
         session: AsyncSession,
         status_filter: SmsProcessingStatus | None = None,
     ) -> list[InboundSms]:
-        q = select(InboundSms).order_by(
-            InboundSms.created_at.desc()
-        )
+        q = select(InboundSms).order_by(InboundSms.created_at.desc())
         if status_filter is not None:
-            q = q.where(
-                InboundSms.processing_status
-                == status_filter
-            )
+            q = q.where(InboundSms.processing_status == status_filter)
         q = q.limit(limit)
         result = await session.execute(q)
         return list(result.scalars().all())
@@ -239,8 +205,6 @@ class SmsRelayService:
         from sqlalchemy import func
 
         result = await session.execute(
-            select(func.count()).where(
-                InboundSms.processing_status == status
-            )
+            select(func.count()).where(InboundSms.processing_status == status)
         )
         return result.scalar() or 0

--- a/backend/app/domain/services/sms_relay_service.py
+++ b/backend/app/domain/services/sms_relay_service.py
@@ -1,0 +1,246 @@
+"""SMS relay service for heartbeat and SMS ingestion."""
+
+from __future__ import annotations
+
+import datetime
+from datetime import timedelta
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.models.sms_relay import (
+    InboundSms,
+    RelayDevice,
+    SmsProcessingStatus,
+)
+from app.domain.services.sms_parser import SmsParser
+from app.domain.services.subscription_service import (
+    SubscriptionService,
+)
+
+logger = structlog.get_logger(__name__)
+
+_parser = SmsParser()
+
+
+class SmsRelayService:
+
+    async def upsert_heartbeat(
+        self,
+        device_id: str,
+        battery: int | None,
+        charging: bool | None,
+        signal: int | None,
+        pending: int | None,
+        failed: int | None,
+        last_sms_at: datetime.datetime | None,
+        app_version: str | None,
+        session: AsyncSession,
+    ) -> RelayDevice:
+        now = datetime.datetime.now(tz=datetime.UTC)
+        result = await session.execute(
+            select(RelayDevice).where(
+                RelayDevice.device_id == device_id
+            )
+        )
+        device = result.scalar_one_or_none()
+
+        if device is not None:
+            device.battery = battery
+            device.charging = charging
+            device.signal = signal
+            device.pending = pending
+            device.failed = failed
+            device.last_sms_at = last_sms_at
+            device.app_version = app_version
+            device.last_heartbeat_at = now
+            device.updated_at = now
+        else:
+            device = RelayDevice(
+                device_id=device_id,
+                battery=battery,
+                charging=charging,
+                signal=signal,
+                pending=pending,
+                failed=failed,
+                last_sms_at=last_sms_at,
+                app_version=app_version,
+                last_heartbeat_at=now,
+            )
+            session.add(device)
+
+        await session.commit()
+        logger.info(
+            "Heartbeat recorded",
+            device_id=device_id,
+            battery=battery,
+            signal=signal,
+        )
+        return device
+
+    async def ingest_sms(
+        self,
+        sms_id: str,
+        device_id: str,
+        sender: str,
+        body: str,
+        ts: datetime.datetime,
+        app_version: str | None,
+        session: AsyncSession,
+    ) -> InboundSms:
+        # Dedup check
+        existing = await session.execute(
+            select(InboundSms).where(
+                InboundSms.sms_id == sms_id
+            )
+        )
+        found = existing.scalar_one_or_none()
+        if found is not None:
+            logger.info(
+                "Duplicate SMS ignored",
+                sms_id=sms_id,
+            )
+            return found
+
+        sms = InboundSms(
+            sms_id=sms_id,
+            device_id=device_id,
+            sender=sender,
+            body=body,
+            sms_received_at=ts,
+            app_version=app_version,
+            processing_status=SmsProcessingStatus.pending,
+        )
+        session.add(sms)
+
+        # Flush to catch unique constraint race
+        try:
+            await session.flush()
+        except IntegrityError:
+            await session.rollback()
+            result = await session.execute(
+                select(InboundSms).where(
+                    InboundSms.sms_id == sms_id
+                )
+            )
+            return result.scalar_one()
+
+        # Parse SMS body
+        fallback_ref = f"SMS-{sms_id}"
+        parsed = _parser.parse(body, sender, fallback_ref)
+
+        if parsed is None:
+            sms.processing_status = (
+                SmsProcessingStatus.parse_failed
+            )
+            sms.error_message = (
+                "No parser matched the SMS body"
+            )
+            await session.commit()
+            logger.warning(
+                "SMS parse failed",
+                sms_id=sms_id,
+                sender=sender,
+            )
+            return sms
+
+        sms.parsed_amount = parsed.amount
+        sms.parsed_phone = parsed.phone_number
+        sms.parsed_reference = parsed.reference
+        sms.parsed_provider = parsed.provider
+        sms.processing_status = SmsProcessingStatus.parsed
+
+        # Process payment via existing service
+        try:
+            sub_service = SubscriptionService()
+            result = await sub_service.process_payment(
+                phone_number=parsed.phone_number,
+                amount_xof=parsed.amount,
+                external_reference=parsed.reference,
+                session=session,
+            )
+            sms.processing_status = (
+                SmsProcessingStatus.payment_processed
+            )
+            logger.info(
+                "SMS payment processed",
+                sms_id=sms_id,
+                amount=parsed.amount,
+                phone=parsed.phone_number,
+                reference=parsed.reference,
+                result=result,
+            )
+        except Exception as exc:
+            sms.processing_status = (
+                SmsProcessingStatus.parse_failed
+            )
+            sms.error_message = (
+                f"Payment processing error: {exc}"
+            )
+            logger.error(
+                "SMS payment processing failed",
+                sms_id=sms_id,
+                error=str(exc),
+            )
+
+        await session.commit()
+        return sms
+
+    async def get_stale_devices(
+        self,
+        timeout_minutes: int,
+        session: AsyncSession,
+    ) -> list[RelayDevice]:
+        cutoff = datetime.datetime.now(
+            tz=datetime.UTC
+        ) - timedelta(minutes=timeout_minutes)
+        result = await session.execute(
+            select(RelayDevice).where(
+                RelayDevice.last_heartbeat_at < cutoff
+            )
+        )
+        return list(result.scalars().all())
+
+    async def get_all_devices(
+        self, session: AsyncSession
+    ) -> list[RelayDevice]:
+        result = await session.execute(
+            select(RelayDevice).order_by(
+                RelayDevice.last_heartbeat_at.desc()
+            )
+        )
+        return list(result.scalars().all())
+
+    async def get_recent_sms(
+        self,
+        limit: int,
+        session: AsyncSession,
+        status_filter: SmsProcessingStatus | None = None,
+    ) -> list[InboundSms]:
+        q = select(InboundSms).order_by(
+            InboundSms.created_at.desc()
+        )
+        if status_filter is not None:
+            q = q.where(
+                InboundSms.processing_status
+                == status_filter
+            )
+        q = q.limit(limit)
+        result = await session.execute(q)
+        return list(result.scalars().all())
+
+    async def count_by_status(
+        self,
+        status: SmsProcessingStatus,
+        session: AsyncSession,
+    ) -> int:
+        from sqlalchemy import func
+
+        result = await session.execute(
+            select(func.count()).where(
+                InboundSms.processing_status == status
+            )
+        )
+        return result.scalar() or 0

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -49,6 +49,12 @@ class Settings(BaseSettings):
     # Subscription webhook
     subscription_webhook_secret: str = ""
 
+    # SMS Relay
+    sms_relay_api_key: str = ""
+    sms_relay_alert_email: str = ""
+    sms_relay_heartbeat_timeout_minutes: int = 60
+    sms_relay_trusted_senders: str = ""
+
     # Admin seeding
     admin_email: str = ""
 
@@ -81,6 +87,10 @@ class Settings(BaseSettings):
     @property
     def upload_allowed_types_list(self) -> list[str]:
         return [t.strip() for t in self.upload_allowed_types.split(",") if t.strip()]
+
+    @property
+    def sms_relay_trusted_senders_list(self) -> list[str]:
+        return [s.strip() for s in self.sms_relay_trusted_senders.split(",") if s.strip()]
 
 
 settings = Settings()

--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -22,6 +22,7 @@ celery_app = Celery(
         "app.tasks.rag_indexation",
         "app.tasks.syllabus_generation",
         "app.tasks.subscription",
+        "app.tasks.sms_relay",
     ],
 )
 
@@ -66,6 +67,10 @@ celery_app.conf.beat_schedule = {
     "expire-subscriptions": {
         "task": "app.tasks.subscription.expire_subscriptions",
         "schedule": crontab(hour=0, minute=30),
+    },
+    "check-relay-heartbeat": {
+        "task": "app.tasks.sms_relay.check_relay_heartbeat",
+        "schedule": crontab(minute="*/15"),
     },
 }
 

--- a/backend/app/tasks/sms_relay.py
+++ b/backend/app/tasks/sms_relay.py
@@ -33,9 +33,7 @@ def check_relay_heartbeat(self) -> dict:
             async with async_session_factory() as session:
                 service = SmsRelayService()
                 stale = await service.get_stale_devices(
-                    timeout_minutes=(
-                        settings.sms_relay_heartbeat_timeout_minutes
-                    ),
+                    timeout_minutes=(settings.sms_relay_heartbeat_timeout_minutes),
                     session=session,
                 )
 
@@ -45,9 +43,7 @@ def check_relay_heartbeat(self) -> dict:
                 email_service = EmailService()
                 alerted = 0
                 for device in stale:
-                    key = ALERT_COOLDOWN_KEY.format(
-                        device_id=device.device_id
-                    )
+                    key = ALERT_COOLDOWN_KEY.format(device_id=device.device_id)
                     if redis_client.get(key):
                         continue
 
@@ -58,9 +54,7 @@ def check_relay_heartbeat(self) -> dict:
                         battery=device.battery,
                     )
                     if sent:
-                        redis_client.set(
-                            key, "1", ex=ALERT_COOLDOWN_TTL
-                        )
+                        redis_client.set(key, "1", ex=ALERT_COOLDOWN_TTL)
                         alerted += 1
 
                 return alerted

--- a/backend/app/tasks/sms_relay.py
+++ b/backend/app/tasks/sms_relay.py
@@ -1,0 +1,79 @@
+"""Celery tasks for SMS relay monitoring."""
+
+import asyncio
+
+import structlog
+
+from app.domain.services.email_service import EmailService
+from app.domain.services.sms_relay_service import SmsRelayService
+from app.infrastructure.cache.redis import redis_client
+from app.infrastructure.config.settings import settings
+from app.infrastructure.persistence.database import (
+    async_session_factory,
+)
+from app.tasks.celery_app import celery_app
+
+logger = structlog.get_logger(__name__)
+
+ALERT_COOLDOWN_KEY = "relay_alert_sent:{device_id}"
+ALERT_COOLDOWN_TTL = 3600  # 1 hour
+
+
+@celery_app.task(
+    name="app.tasks.sms_relay.check_relay_heartbeat",
+    bind=True,
+    max_retries=3,
+    default_retry_delay=60,
+)
+def check_relay_heartbeat(self) -> dict:
+    """Check for stale relay devices and alert admin."""
+    try:
+
+        async def _run() -> int:
+            async with async_session_factory() as session:
+                service = SmsRelayService()
+                stale = await service.get_stale_devices(
+                    timeout_minutes=(
+                        settings.sms_relay_heartbeat_timeout_minutes
+                    ),
+                    session=session,
+                )
+
+                if not stale or not settings.sms_relay_alert_email:
+                    return 0
+
+                email_service = EmailService()
+                alerted = 0
+                for device in stale:
+                    key = ALERT_COOLDOWN_KEY.format(
+                        device_id=device.device_id
+                    )
+                    if redis_client.get(key):
+                        continue
+
+                    sent = await email_service.send_relay_alert(
+                        to_email=settings.sms_relay_alert_email,
+                        device_id=device.device_id,
+                        last_seen=device.last_heartbeat_at.isoformat(),
+                        battery=device.battery,
+                    )
+                    if sent:
+                        redis_client.set(
+                            key, "1", ex=ALERT_COOLDOWN_TTL
+                        )
+                        alerted += 1
+
+                return alerted
+
+        count = asyncio.run(_run())
+        logger.info(
+            "check_relay_heartbeat completed",
+            stale_alerted=count,
+        )
+        return {"stale_alerted": count}
+    except Exception as exc:
+        logger.error(
+            "check_relay_heartbeat failed",
+            error=str(exc),
+        )
+        raise self.retry(exc=exc) from exc

--- a/backend/migrations/versions/036_add_sms_relay.py
+++ b/backend/migrations/versions/036_add_sms_relay.py
@@ -48,9 +48,7 @@ def upgrade() -> None:
             sa.DateTime(timezone=True),
             nullable=True,
         ),
-        sa.Column(
-            "app_version", sa.String(20), nullable=True
-        ),
+        sa.Column("app_version", sa.String(20), nullable=True),
         sa.Column(
             "last_heartbeat_at",
             sa.DateTime(timezone=True),
@@ -90,18 +88,14 @@ def upgrade() -> None:
             nullable=False,
             index=True,
         ),
-        sa.Column(
-            "sender", sa.String(50), nullable=False
-        ),
+        sa.Column("sender", sa.String(50), nullable=False),
         sa.Column("body", sa.Text(), nullable=False),
         sa.Column(
             "sms_received_at",
             sa.DateTime(timezone=True),
             nullable=False,
         ),
-        sa.Column(
-            "app_version", sa.String(20), nullable=True
-        ),
+        sa.Column("app_version", sa.String(20), nullable=True),
         sa.Column(
             "processing_status",
             sa.Enum(
@@ -117,12 +111,8 @@ def upgrade() -> None:
             nullable=False,
             server_default="pending",
         ),
-        sa.Column(
-            "parsed_amount", sa.Integer(), nullable=True
-        ),
-        sa.Column(
-            "parsed_phone", sa.String(20), nullable=True
-        ),
+        sa.Column("parsed_amount", sa.Integer(), nullable=True),
+        sa.Column("parsed_phone", sa.String(20), nullable=True),
         sa.Column(
             "parsed_reference",
             sa.String(255),
@@ -133,9 +123,7 @@ def upgrade() -> None:
             sa.String(50),
             nullable=True,
         ),
-        sa.Column(
-            "error_message", sa.Text(), nullable=True
-        ),
+        sa.Column("error_message", sa.Text(), nullable=True),
         sa.Column(
             "payment_id",
             sa.UUID(),

--- a/backend/migrations/versions/036_add_sms_relay.py
+++ b/backend/migrations/versions/036_add_sms_relay.py
@@ -1,0 +1,171 @@
+"""Add relay_devices and inbound_sms tables for SMS relay payment system.
+
+Revision ID: 036
+Revises: 035
+Create Date: 2026-04-06
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "036"
+down_revision = "035"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create enum type
+    op.execute(
+        "CREATE TYPE smsprocessingstatus AS ENUM "
+        "('pending','parsed','payment_processed',"
+        "'parse_failed','duplicate','ignored')"
+    )
+
+    # relay_devices table
+    op.create_table(
+        "relay_devices",
+        sa.Column(
+            "id",
+            sa.UUID(),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "device_id",
+            sa.String(100),
+            unique=True,
+            nullable=False,
+        ),
+        sa.Column("battery", sa.Integer(), nullable=True),
+        sa.Column("charging", sa.Boolean(), nullable=True),
+        sa.Column("signal", sa.Integer(), nullable=True),
+        sa.Column("pending", sa.Integer(), nullable=True),
+        sa.Column("failed", sa.Integer(), nullable=True),
+        sa.Column(
+            "last_sms_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "app_version", sa.String(20), nullable=True
+        ),
+        sa.Column(
+            "last_heartbeat_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+        ),
+    )
+
+    # inbound_sms table
+    op.create_table(
+        "inbound_sms",
+        sa.Column(
+            "id",
+            sa.UUID(),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "sms_id",
+            sa.String(100),
+            unique=True,
+            nullable=False,
+        ),
+        sa.Column(
+            "device_id",
+            sa.String(100),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "sender", sa.String(50), nullable=False
+        ),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column(
+            "sms_received_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "app_version", sa.String(20), nullable=True
+        ),
+        sa.Column(
+            "processing_status",
+            sa.Enum(
+                "pending",
+                "parsed",
+                "payment_processed",
+                "parse_failed",
+                "duplicate",
+                "ignored",
+                name="smsprocessingstatus",
+                create_type=False,
+            ),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column(
+            "parsed_amount", sa.Integer(), nullable=True
+        ),
+        sa.Column(
+            "parsed_phone", sa.String(20), nullable=True
+        ),
+        sa.Column(
+            "parsed_reference",
+            sa.String(255),
+            nullable=True,
+        ),
+        sa.Column(
+            "parsed_provider",
+            sa.String(50),
+            nullable=True,
+        ),
+        sa.Column(
+            "error_message", sa.Text(), nullable=True
+        ),
+        sa.Column(
+            "payment_id",
+            sa.UUID(),
+            sa.ForeignKey(
+                "subscription_payments.id",
+                ondelete="SET NULL",
+            ),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+        ),
+    )
+
+    # Additional indexes
+    op.create_index(
+        "ix_inbound_sms_status",
+        "inbound_sms",
+        ["processing_status"],
+    )
+    op.create_index(
+        "ix_inbound_sms_created",
+        "inbound_sms",
+        ["created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("inbound_sms")
+    op.drop_table("relay_devices")
+    op.execute("DROP TYPE IF EXISTS smsprocessingstatus")

--- a/backend/migrations/versions/036_add_sms_relay.py
+++ b/backend/migrations/versions/036_add_sms_relay.py
@@ -16,13 +16,6 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Create enum type
-    op.execute(
-        "CREATE TYPE smsprocessingstatus AS ENUM "
-        "('pending','parsed','payment_processed',"
-        "'parse_failed','duplicate','ignored')"
-    )
-
     # relay_devices table
     op.create_table(
         "relay_devices",
@@ -98,16 +91,7 @@ def upgrade() -> None:
         sa.Column("app_version", sa.String(20), nullable=True),
         sa.Column(
             "processing_status",
-            sa.Enum(
-                "pending",
-                "parsed",
-                "payment_processed",
-                "parse_failed",
-                "duplicate",
-                "ignored",
-                name="smsprocessingstatus",
-                create_type=False,
-            ),
+            sa.VARCHAR(50),
             nullable=False,
             server_default="pending",
         ),
@@ -156,4 +140,3 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_table("inbound_sms")
     op.drop_table("relay_devices")
-    op.execute("DROP TYPE IF EXISTS smsprocessingstatus")


### PR DESCRIPTION
Use VARCHAR instead of PG enum to fix DuplicateObjectError during migration.