### PR TITLE
feat(auth): password service + auth service methods (#999)

### DIFF
--- a/backend/app/domain/services/local_auth_service.py
+++ b/backend/app/domain/services/local_auth_service.py
@@ -4,15 +4,16 @@ from datetime import datetime, timedelta
 from typing import Any
 from uuid import UUID, uuid4
 
-from sqlalchemy import and_, delete, select
+from sqlalchemy import and_, delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
-from app.domain.models.auth import MagicLink, RefreshToken, TOTPSecret
+from app.domain.models.auth import MagicLink, PasswordResetToken, RefreshToken, TOTPSecret
 from app.domain.models.user import User, UserRole
 from app.domain.services.email_otp_service import EmailOTPService
 from app.domain.services.email_service import EmailService
 from app.domain.services.jwt_auth_service import JWTAuthService
+from app.domain.services.password_service import PasswordService
 from app.domain.services.platform_settings_service import SettingsCache
 from app.domain.services.totp_service import TOTPService
 from app.infrastructure.config.settings import settings
@@ -35,6 +36,7 @@ class LocalAuthService:
         self.totp_service = TOTPService()
         self.email_service = EmailService()
         self.email_otp_service = EmailOTPService(db)
+        self.password_service = PasswordService()
 
     async def register_user(
         self,
@@ -807,6 +809,391 @@ class LocalAuthService:
         except Exception as e:
             logger.error("Failed to send login OTP", email=email, error=str(e))
             raise AuthenticationError("Failed to send login verification code")
+
+    async def register_user_with_password(
+        self,
+        identifier: str,
+        password: str,
+        name: str,
+        preferred_language: str = "fr",
+        country: str | None = None,
+        professional_role: str | None = None,
+    ) -> dict[str, Any]:
+        """Register a new user with email or phone + password.
+
+        Args:
+            identifier: Email address (contains @) or phone number
+            password: Plaintext password (min 6 chars)
+            name: User full name
+            preferred_language: User preferred language (fr/en)
+            country: User's country (ECOWAS code)
+            professional_role: Professional role
+
+        Returns:
+            TokenResponse dict with access token and user info
+
+        Raises:
+            AuthenticationError: If user already exists or password invalid
+        """
+        try:
+            is_email = "@" in identifier
+            email: str | None = identifier if is_email else None
+            phone: str | None = identifier if not is_email else None
+
+            existing_user = await self.db.scalar(
+                select(User).where(
+                    or_(
+                        User.email == email if email else False,
+                        User.phone_number == phone if phone else False,
+                    )
+                )
+            )
+            if existing_user:
+                raise AuthenticationError("User already exists")
+
+            try:
+                self.password_service.validate_password(password)
+            except ValueError as exc:
+                raise AuthenticationError(str(exc))
+
+            hashed = self.password_service.hash_password(password)
+
+            initial_role = (
+                UserRole.admin
+                if email and settings.admin_email and email.lower() == settings.admin_email.lower()
+                else UserRole.user
+            )
+
+            user = User(
+                id=uuid4(),
+                email=email,
+                phone_number=phone,
+                name=name,
+                preferred_language=preferred_language,
+                country=country,
+                professional_role=professional_role,
+                current_level=1,
+                streak_days=0,
+                role=initial_role,
+                password_hash=hashed,
+                failed_password_attempts=0,
+                last_active=datetime.utcnow(),
+                created_at=datetime.utcnow(),
+            )
+            self.db.add(user)
+
+            refresh_token = self.jwt_service.create_refresh_token()
+            refresh_record = RefreshToken(
+                id=uuid4(),
+                user_id=user.id,
+                token_hash=self.jwt_service.hash_token(refresh_token),
+                expires_at=self.jwt_service.get_token_expiry("refresh"),
+                created_at=datetime.utcnow(),
+            )
+            self.db.add(refresh_record)
+
+            await self.db.commit()
+
+            if initial_role == UserRole.admin:
+                from app.domain.services.subscription_service import SubscriptionService
+
+                await SubscriptionService().ensure_admin_subscription(user.id, self.db)
+
+            access_token = self.jwt_service.create_access_token(
+                user_id=str(user.id),
+                email=email or "",
+                preferred_language=user.preferred_language,
+                country=user.country,
+                current_level=user.current_level,
+                role=user.role.value,
+            )
+
+            if email:
+                await self.email_service.send_welcome_email(email, name, preferred_language)
+
+            try:
+                from app.tasks.content_generation import prefetch_next_lessons_task
+
+                prefetch_next_lessons_task.delay(
+                    user_id=str(user.id),
+                    module_id="",
+                    current_unit_id="",
+                    language=user.preferred_language,
+                    country=user.country or "SN",
+                    level=user.current_level or 1,
+                    module_number=1,
+                )
+            except Exception as prefetch_exc:
+                logger.warning(
+                    "Failed to dispatch prefetch task on password registration",
+                    user_id=str(user.id),
+                    error=str(prefetch_exc),
+                )
+
+            logger.info(
+                "User registered with password", user_id=str(user.id), identifier=identifier
+            )
+
+            return {
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+                "token_type": "bearer",
+                "expires_in": self.jwt_service.access_token_expire_minutes * 60,
+                "user": {
+                    "id": str(user.id),
+                    "email": user.email,
+                    "name": user.name,
+                    "preferred_language": user.preferred_language,
+                    "country": user.country,
+                    "current_level": user.current_level,
+                },
+            }
+
+        except AuthenticationError:
+            await self.db.rollback()
+            raise
+        except Exception as e:
+            await self.db.rollback()
+            logger.error("Password registration failed", identifier=identifier, error=str(e))
+            raise AuthenticationError(f"Registration failed: {e}")
+
+    async def login_with_password(self, identifier: str, password: str) -> dict[str, Any]:
+        """Login with email or phone + password.
+
+        Args:
+            identifier: Email address or phone number
+            password: Plaintext password
+
+        Returns:
+            TokenResponse dict with access token and user info
+
+        Raises:
+            AuthenticationError: If credentials invalid or account locked
+        """
+        try:
+            is_email = "@" in identifier
+            email: str | None = identifier if is_email else None
+            phone: str | None = identifier if not is_email else None
+
+            user = await self.db.scalar(
+                select(User).where(
+                    or_(
+                        User.email == email if email else False,
+                        User.phone_number == phone if phone else False,
+                    )
+                )
+            )
+            if not user:
+                raise AuthenticationError("Invalid credentials")
+
+            if not user.password_hash:
+                raise AuthenticationError("Invalid credentials")
+
+            _cache = SettingsCache.instance()
+            _MAX_FAILED = _cache.get("auth-max-failed-password-attempts", 10)
+            _LOCKOUT_MINUTES = _cache.get("auth-password-lockout-minutes", 15)
+
+            if (
+                user.password_locked_until is not None
+                and user.password_locked_until > datetime.utcnow()
+            ):
+                remaining = int(
+                    (user.password_locked_until - datetime.utcnow()).total_seconds() / 60
+                )
+                raise AuthenticationError(
+                    f"Account temporarily locked due to too many failed attempts. "
+                    f"Try again in {remaining} minute(s)."
+                )
+
+            is_valid = self.password_service.verify_password(password, user.password_hash)
+
+            if not is_valid:
+                user.failed_password_attempts = (user.failed_password_attempts or 0) + 1
+                if user.failed_password_attempts >= _MAX_FAILED:
+                    user.password_locked_until = datetime.utcnow() + timedelta(
+                        minutes=_LOCKOUT_MINUTES
+                    )
+                    user.failed_password_attempts = 0
+                    await self.db.commit()
+                    raise AuthenticationError(
+                        f"Account locked for {_LOCKOUT_MINUTES} minutes after too many failed attempts."
+                    )
+                await self.db.commit()
+                raise AuthenticationError("Invalid credentials")
+
+            user.failed_password_attempts = 0
+            user.password_locked_until = None
+            user.last_active = datetime.utcnow()
+
+            access_token = self.jwt_service.create_access_token(
+                user_id=str(user.id),
+                email=user.email or "",
+                preferred_language=user.preferred_language,
+                country=user.country,
+                current_level=user.current_level,
+                role=user.role.value,
+            )
+
+            refresh_token = self.jwt_service.create_refresh_token()
+            refresh_record = RefreshToken(
+                id=uuid4(),
+                user_id=user.id,
+                token_hash=self.jwt_service.hash_token(refresh_token),
+                expires_at=self.jwt_service.get_token_expiry("refresh"),
+                created_at=datetime.utcnow(),
+                last_used_at=datetime.utcnow(),
+            )
+            self.db.add(refresh_record)
+
+            await self.db.commit()
+
+            logger.info("User logged in with password", user_id=str(user.id), identifier=identifier)
+
+            return {
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+                "token_type": "bearer",
+                "expires_in": self.jwt_service.access_token_expire_minutes * 60,
+                "user": {
+                    "id": str(user.id),
+                    "email": user.email,
+                    "name": user.name,
+                    "preferred_language": user.preferred_language,
+                    "country": user.country,
+                    "current_level": user.current_level,
+                },
+            }
+
+        except AuthenticationError:
+            await self.db.rollback()
+            raise
+        except Exception as e:
+            await self.db.rollback()
+            logger.error("Password login failed", identifier=identifier, error=str(e))
+            raise AuthenticationError(f"Login failed: {e}")
+
+    async def request_password_reset(self, identifier: str, ip_address: str | None = None) -> bool:
+        """Request a password reset token for a user.
+
+        Args:
+            identifier: Email address or phone number
+            ip_address: Client IP address
+
+        Returns:
+            True always (don't reveal user existence)
+        """
+        try:
+            is_email = "@" in identifier
+            email: str | None = identifier if is_email else None
+            phone: str | None = identifier if not is_email else None
+
+            user = await self.db.scalar(
+                select(User).where(
+                    or_(
+                        User.email == email if email else False,
+                        User.phone_number == phone if phone else False,
+                    )
+                )
+            )
+            if not user:
+                logger.warning(
+                    "Password reset requested for non-existent identifier",
+                    identifier=identifier,
+                )
+                return True
+
+            reset_token = self.jwt_service.generate_magic_link_token()
+            token_hash = self.jwt_service.hash_token(reset_token)
+
+            await self.db.execute(
+                delete(PasswordResetToken).where(
+                    and_(
+                        PasswordResetToken.user_id == user.id,
+                        PasswordResetToken.expires_at < datetime.utcnow(),
+                    )
+                )
+            )
+
+            reset_record = PasswordResetToken(
+                id=uuid4(),
+                user_id=user.id,
+                token_hash=token_hash,
+                expires_at=datetime.utcnow() + timedelta(hours=1),
+                created_at=datetime.utcnow(),
+                ip_address=ip_address,
+            )
+            self.db.add(reset_record)
+
+            await self.db.commit()
+
+            if user.email:
+                await self.email_service.send_magic_link(
+                    user.email, reset_token, user.preferred_language
+                )
+
+            logger.info("Password reset requested", user_id=str(user.id))
+            return True
+
+        except Exception as e:
+            await self.db.rollback()
+            logger.error("Password reset request failed", identifier=identifier, error=str(e))
+            return True
+
+    async def complete_password_reset(self, token: str, new_password: str) -> bool:
+        """Complete a password reset using a reset token.
+
+        Args:
+            token: Password reset token
+            new_password: New plaintext password
+
+        Returns:
+            True if reset was successful
+
+        Raises:
+            AuthenticationError: If token invalid or password too weak
+        """
+        try:
+            token_hash = self.jwt_service.hash_token(token)
+            reset_record = await self.db.scalar(
+                select(PasswordResetToken).where(
+                    and_(
+                        PasswordResetToken.token_hash == token_hash,
+                        PasswordResetToken.expires_at > datetime.utcnow(),
+                        PasswordResetToken.used_at.is_(None),
+                    )
+                )
+            )
+
+            if not reset_record:
+                raise AuthenticationError("Invalid or expired password reset token")
+
+            user = await self.db.scalar(select(User).where(User.id == reset_record.user_id))
+            if not user:
+                raise AuthenticationError("User not found")
+
+            try:
+                self.password_service.validate_password(new_password)
+            except ValueError as exc:
+                raise AuthenticationError(str(exc))
+
+            user.password_hash = self.password_service.hash_password(new_password)
+            user.failed_password_attempts = 0
+            user.password_locked_until = None
+
+            reset_record.used_at = datetime.utcnow()
+
+            await self.db.commit()
+
+            logger.info("Password reset completed", user_id=str(user.id))
+            return True
+
+        except AuthenticationError:
+            await self.db.rollback()
+            raise
+        except Exception as e:
+            await self.db.rollback()
+            logger.error("Password reset completion failed", error=str(e))
+            raise AuthenticationError(f"Password reset failed: {e}")
 
     async def verify_login_otp(
         self, otp_id: str, otp_code: str, ip_address: str | None = None

--- a/backend/app/domain/services/password_service.py
+++ b/backend/app/domain/services/password_service.py
@@ -1,0 +1,18 @@
+"""Password hashing and validation service."""
+
+import bcrypt
+
+
+class PasswordService:
+    def hash_password(self, password: str) -> str:
+        """Hash password with bcrypt (12 rounds default)."""
+        return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+
+    def verify_password(self, password: str, hashed: str) -> bool:
+        """Verify password against bcrypt hash."""
+        return bcrypt.checkpw(password.encode("utf-8"), hashed.encode("utf-8"))
+
+    def validate_password(self, password: str) -> None:
+        """Enforce minimum 6 characters. Raises ValueError if invalid."""
+        if len(password) < 6:
+            raise ValueError("Password must be at least 6 characters")


### PR DESCRIPTION
## Summary

- New `PasswordService` with bcrypt hash/verify/validate (12 rounds)
- `register_user_with_password`: detects email vs phone from `@`, checks existing with `or_()`, validates + hashes password, issues JWT immediately, sends welcome email, triggers prefetch task
- `login_with_password`: lockout check via `password_locked_until`, increments `failed_password_attempts`, locks after 10 attempts (15 min via `SettingsCache`), resets on success, issues JWT
- `request_password_reset`: silent on non-existent users, stores `PasswordResetToken` (SHA-256), cleans expired tokens, sends email if available
- `complete_password_reset`: validates token not expired/used, validates new password, rehashes, resets lockout counters

## Changes

- `backend/app/domain/services/password_service.py` — new file
- `backend/app/domain/services/local_auth_service.py` — 4 new methods + imports (`or_`, `PasswordResetToken`, `PasswordService`)

## Test plan

- [x] `PasswordService` manually verified: hash/verify/validate all work correctly
- [x] Ruff check + format: all clean
- [x] Python syntax check: OK
- [ ] Full test suite (requires DB): run `cd backend && uv run pytest` once DB is available

Closes #999

Generated with [Claude Code](https://claude.ai/code)