### PR TITLE
feat(auth): password register/login UI + page updates (#1002)

### DIFF
--- a/frontend/app/[locale]/(auth)/login/page.tsx
+++ b/frontend/app/[locale]/(auth)/login/page.tsx
@@ -1,9 +1,43 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { PasswordLoginForm } from '@/components/auth/password-login-form';
 import { TOTPLoginForm } from '@/components/auth/totp-login-form';
 
 export default function LoginPage() {
+  const [useAuthenticator, setUseAuthenticator] = useState(false);
+  const t = useTranslations('Auth');
+
   return (
     <div className="flex min-h-screen items-center justify-center p-4">
-      <TOTPLoginForm />
+      <div className="w-full max-w-md space-y-3">
+        {useAuthenticator ? (
+          <>
+            <TOTPLoginForm />
+            <div className="text-center">
+              <button
+                onClick={() => setUseAuthenticator(false)}
+                className="text-sm text-muted-foreground hover:text-foreground hover:underline min-h-[44px] px-4"
+              >
+                {t('usePasswordLogin')}
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <PasswordLoginForm />
+            <div className="text-center">
+              <button
+                onClick={() => setUseAuthenticator(true)}
+                className="text-sm text-muted-foreground hover:text-foreground hover:underline min-h-[44px] px-4"
+              >
+                {t('useAuthenticatorLogin')}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/app/[locale]/(auth)/register-options/page.tsx
+++ b/frontend/app/[locale]/(auth)/register-options/page.tsx
@@ -25,9 +25,29 @@ export default function RegisterOptionsPage() {
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-4">
+            <div className="rounded-lg border border-green-200 bg-green-50 p-4 space-y-3">
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 rounded-full bg-green-100 flex items-center justify-center flex-shrink-0">
+                  <svg className="w-5 h-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                  </svg>
+                </div>
+                <div>
+                  <h3 className="font-semibold">{t('continueWithPassword')}</h3>
+                  <p className="text-sm text-muted-foreground">{t('passwordAuthDesc')}</p>
+                </div>
+              </div>
+              <Link
+                href="/register-password"
+                className={cn(buttonVariants({ variant: 'default' }), 'w-full min-h-11')}
+              >
+                {t('continueWithPassword')}
+              </Link>
+            </div>
+
             <div className="rounded-lg border p-4 space-y-3 opacity-50">
               <div className="flex items-center gap-3">
-                <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center">
+                <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
                   <svg className="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 4.45a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                   </svg>
@@ -39,7 +59,7 @@ export default function RegisterOptionsPage() {
               </div>
               <span
                 aria-disabled="true"
-                className={cn(buttonVariants({ variant: "default" }), "w-full min-h-11 pointer-events-none bg-gray-300 hover:bg-gray-300 text-gray-500")}
+                className={cn(buttonVariants({ variant: 'default' }), 'w-full min-h-11 pointer-events-none bg-gray-300 hover:bg-gray-300 text-gray-500')}
               >
                 {t('continueWithEmail')}
               </span>
@@ -48,28 +68,26 @@ export default function RegisterOptionsPage() {
               </div>
             </div>
 
-            <div className="space-y-4">
-              <div className="rounded-lg border p-4 space-y-3">
-                <div className="flex items-center gap-3">
-                  <div className="w-10 h-10 rounded-full bg-green-100 flex items-center justify-center">
-                    <svg className="w-5 h-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.031 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
-                    </svg>
-                  </div>
-                  <div>
-                    <h3 className="font-semibold">{t('authenticatorApp')}</h3>
-                    <p className="text-sm text-muted-foreground">{t('authenticatorAppDesc')}</p>
-                  </div>
+            <div className="rounded-lg border p-4 space-y-3">
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
+                  <svg className="w-5 h-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.031 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+                  </svg>
                 </div>
-                <Link
-                  href="/register-totp"
-                  className={cn(buttonVariants({ variant: "outline" }), "w-full min-h-11")}
-                >
-                  {t('continueWithAuthenticator')}
-                </Link>
-                <div className="text-xs text-muted-foreground">
-                  {t('authenticatorAppBenefits')}
+                <div>
+                  <h3 className="font-semibold">{t('authenticatorApp')}</h3>
+                  <p className="text-sm text-muted-foreground">{t('authenticatorAppDesc')}</p>
                 </div>
+              </div>
+              <Link
+                href="/register-totp"
+                className={cn(buttonVariants({ variant: 'outline' }), 'w-full min-h-11')}
+              >
+                {t('continueWithAuthenticator')}
+              </Link>
+              <div className="text-xs text-muted-foreground">
+                {t('authenticatorAppBenefits')}
               </div>
             </div>
 

--- a/frontend/app/[locale]/(auth)/register-password/page.tsx
+++ b/frontend/app/[locale]/(auth)/register-password/page.tsx
@@ -1,0 +1,9 @@
+import { PasswordRegisterForm } from '@/components/auth/password-register-form';
+
+export default function RegisterPasswordPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <PasswordRegisterForm />
+    </div>
+  );
+}

--- a/frontend/components/auth/password-login-form.tsx
+++ b/frontend/components/auth/password-login-form.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslations } from 'next-intl';
+import { z } from 'zod';
+import { Link, useRouter } from '@/i18n/routing';
+
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { authClient, AuthError } from '@/lib/auth';
+
+const createSchema = (t: (key: string) => string) =>
+  z.object({
+    identifier: z.string().min(1, t('phoneOrEmailRequired')),
+    password: z.string().min(1, t('passwordRequired')),
+  });
+
+type FormData = z.infer<ReturnType<typeof createSchema>>;
+
+export function PasswordLoginForm() {
+  const t = useTranslations('Auth');
+  const tCommon = useTranslations('Common');
+  const router = useRouter();
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+
+  const schema = createSchema(t);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setError,
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+  });
+
+  const onSubmit = async (data: FormData) => {
+    setIsLoading(true);
+
+    try {
+      await authClient.loginPassword({
+        identifier: data.identifier,
+        password: data.password,
+      });
+
+      router.push('/dashboard');
+    } catch (error) {
+      if (error instanceof AuthError) {
+        if (
+          error.message.toLowerCase().includes('invalid') ||
+          error.message.toLowerCase().includes('incorrect') ||
+          error.message.toLowerCase().includes('not found') ||
+          error.status === 401
+        ) {
+          setError('root', { message: t('invalidPassword') });
+        } else if (
+          error.message.toLowerCase().includes('locked') ||
+          error.status === 423
+        ) {
+          setError('root', { message: t('accountLocked') });
+        } else {
+          setError('root', { message: error.message });
+        }
+      } else {
+        setError('root', { message: t('loginFailed') });
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader className="text-center">
+        <CardTitle className="text-2xl">{tCommon('appName')}</CardTitle>
+        <CardDescription>{t('signIn')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="identifier">
+              {t('phoneOrEmail')} *
+            </label>
+            <input
+              {...register('identifier')}
+              id="identifier"
+              type="text"
+              autoComplete="email"
+              className="flex h-11 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              placeholder={t('phoneOrEmailPlaceholder')}
+            />
+            {errors.identifier && (
+              <p className="text-sm text-red-600">{errors.identifier.message}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium" htmlFor="password">
+                {t('password')} *
+              </label>
+              <Link
+                href="/magic-link"
+                className="text-xs text-primary hover:underline"
+              >
+                {t('forgotPassword')}
+              </Link>
+            </div>
+            <div className="relative">
+              <input
+                {...register('password')}
+                id="password"
+                type={showPassword ? 'text' : 'password'}
+                autoComplete="current-password"
+                className="flex h-11 w-full rounded-md border border-input bg-background px-3 py-2 pr-12 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                placeholder="••••••"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 min-w-[44px] min-h-[44px] flex items-center justify-center text-muted-foreground hover:text-foreground"
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+              >
+                {showPassword ? (
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                  </svg>
+                ) : (
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                  </svg>
+                )}
+              </button>
+            </div>
+            {errors.password && (
+              <p className="text-sm text-red-600">{errors.password.message}</p>
+            )}
+          </div>
+
+          {errors.root && (
+            <p className="text-sm text-red-600 text-center">{errors.root.message}</p>
+          )}
+
+          <Button type="submit" className="w-full min-h-11" disabled={isLoading}>
+            {isLoading ? tCommon('loading') : t('signIn')}
+          </Button>
+
+          <div className="text-center text-sm">
+            <span className="text-muted-foreground">{t('noAccount')} </span>
+            <Link href="/register-options" className="font-medium text-primary hover:underline">
+              {t('signUp')}
+            </Link>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/auth/password-register-form.tsx
+++ b/frontend/components/auth/password-register-form.tsx
@@ -1,0 +1,243 @@
+'use client';
+
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useLocale, useTranslations } from 'next-intl';
+import { z } from 'zod';
+import { Link, useRouter } from '@/i18n/routing';
+
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { authClient, AuthError } from '@/lib/auth';
+
+const createSchema = (t: (key: string) => string) =>
+  z
+    .object({
+      name: z.string().min(2, t('nameRequired')).max(100, t('nameTooLong')),
+      identifier: z.string().min(1, t('phoneOrEmailRequired')),
+      password: z.string().min(6, t('passwordMinLength')),
+      confirmPassword: z.string().min(6, t('passwordMinLength')),
+      preferred_language: z.enum(['fr', 'en'], { message: t('languageRequired') }),
+    })
+    .refine((data) => data.password === data.confirmPassword, {
+      message: t('passwordsDoNotMatch'),
+      path: ['confirmPassword'],
+    });
+
+type FormData = z.infer<ReturnType<typeof createSchema>>;
+
+export function PasswordRegisterForm() {
+  const t = useTranslations('Auth');
+  const tCommon = useTranslations('Common');
+  const router = useRouter();
+  const locale = useLocale();
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  const schema = createSchema(t);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setError,
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      preferred_language: locale as 'fr' | 'en',
+    },
+  });
+
+  const onSubmit = async (data: FormData) => {
+    setIsLoading(true);
+
+    try {
+      await authClient.registerPassword({
+        identifier: data.identifier,
+        password: data.password,
+        name: data.name,
+        preferred_language: data.preferred_language,
+      });
+
+      router.push('/onboarding');
+    } catch (error) {
+      if (error instanceof AuthError) {
+        if (error.message.toLowerCase().includes('already exists') || error.message.toLowerCase().includes('already registered')) {
+          setError('identifier', { message: t('duplicateEmail') });
+        } else if (error.message.toLowerCase().includes('rate limit') || error.message.toLowerCase().includes('too many')) {
+          setError('root', { message: t('rateLimitExceeded') });
+        } else {
+          setError('root', { message: error.message });
+        }
+      } else {
+        setError('root', { message: t('registrationFailed') });
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader className="text-center">
+        <CardTitle className="text-2xl">{tCommon('appName')}</CardTitle>
+        <CardDescription>{t('registerWithPassword')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="name">
+              {t('name')} *
+            </label>
+            <input
+              {...register('name')}
+              id="name"
+              type="text"
+              autoComplete="name"
+              className="flex h-11 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              placeholder={t('namePlaceholder')}
+            />
+            {errors.name && (
+              <p className="text-sm text-red-600">{errors.name.message}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="identifier">
+              {t('phoneOrEmail')} *
+            </label>
+            <input
+              {...register('identifier')}
+              id="identifier"
+              type="text"
+              autoComplete="email"
+              className="flex h-11 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              placeholder={t('phoneOrEmailPlaceholder')}
+            />
+            {errors.identifier && (
+              <p className="text-sm text-red-600">{errors.identifier.message}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="password">
+              {t('password')} *
+            </label>
+            <div className="relative">
+              <input
+                {...register('password')}
+                id="password"
+                type={showPassword ? 'text' : 'password'}
+                autoComplete="new-password"
+                className="flex h-11 w-full rounded-md border border-input bg-background px-3 py-2 pr-12 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                placeholder="••••••"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 min-w-[44px] min-h-[44px] flex items-center justify-center text-muted-foreground hover:text-foreground"
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+              >
+                {showPassword ? (
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                  </svg>
+                ) : (
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                  </svg>
+                )}
+              </button>
+            </div>
+            {errors.password && (
+              <p className="text-sm text-red-600">{errors.password.message}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="confirmPassword">
+              {t('confirmPassword')} *
+            </label>
+            <div className="relative">
+              <input
+                {...register('confirmPassword')}
+                id="confirmPassword"
+                type={showConfirmPassword ? 'text' : 'password'}
+                autoComplete="new-password"
+                className="flex h-11 w-full rounded-md border border-input bg-background px-3 py-2 pr-12 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                placeholder="••••••"
+              />
+              <button
+                type="button"
+                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 min-w-[44px] min-h-[44px] flex items-center justify-center text-muted-foreground hover:text-foreground"
+                aria-label={showConfirmPassword ? 'Hide password' : 'Show password'}
+              >
+                {showConfirmPassword ? (
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                  </svg>
+                ) : (
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                  </svg>
+                )}
+              </button>
+            </div>
+            {errors.confirmPassword && (
+              <p className="text-sm text-red-600">{errors.confirmPassword.message}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="language">
+              {t('preferredLanguage')} *
+            </label>
+            <select
+              {...register('preferred_language')}
+              id="language"
+              className="flex h-11 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <option value="fr">Français</option>
+              <option value="en">English</option>
+            </select>
+            {errors.preferred_language && (
+              <p className="text-sm text-red-600">{errors.preferred_language.message}</p>
+            )}
+          </div>
+
+          {errors.root && (
+            <p className="text-sm text-red-600 text-center">{errors.root.message}</p>
+          )}
+
+          <Button type="submit" className="w-full min-h-11" disabled={isLoading}>
+            {isLoading ? tCommon('loading') : t('register')}
+          </Button>
+
+          <div className="text-center text-sm">
+            <span className="text-muted-foreground">{t('alreadyHaveAccount')} </span>
+            <Link href="/login" className="font-medium text-primary hover:underline">
+              {t('signIn')}
+            </Link>
+          </div>
+
+          <div className="text-center text-sm border-t pt-4">
+            <Link href="/register-options" className="text-muted-foreground hover:text-foreground text-xs">
+              {t('chooseVerificationMethod')}
+            </Link>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -7,7 +7,7 @@ const intlMiddleware = createMiddleware(routing);
 const PUBLIC_PATTERNS = [
   /^\/$/,
   /^\/(fr|en)$/,
-  /^\/(fr|en)\/(login|register|register-options|register-totp|register-email-otp|magic-link)(\/.*)*/,
+  /^\/(fr|en)\/(login|register|register-options|register-totp|register-email-otp|register-password|magic-link|forgot-password)(\/.*)*/,
   /^\/(fr|en)\/courses(\/[^/]+)?$/,
   /^\/api\//,
   /^\/_next\//,


### PR DESCRIPTION
## Summary

- Add `PasswordRegisterForm`: single-step form with name, email/phone identifier, password with show/hide toggle, confirm password, and language selector. Calls `authClient.registerPassword()` and redirects to `/onboarding`.
- Add `PasswordLoginForm`: login form with identifier, password show/hide toggle, forgot password link → `/magic-link`. Calls `authClient.loginPassword()` and redirects to `/dashboard`.
- Add `register-password` page rendering `PasswordRegisterForm`.
- Update `register-options` page: password auth is now the **primary** option (green highlight, top), email verification stays secondary (coming soon), authenticator app moved to bottom as tertiary.
- Update `login` page: defaults to password login with subtle toggle button to switch to authenticator (TOTP) form.
- Update `middleware.ts`: add `register-password` and `forgot-password` to `PUBLIC_PATTERNS`.

## Changes
- `frontend/components/auth/password-register-form.tsx` — new file
- `frontend/components/auth/password-login-form.tsx` — new file
- `frontend/app/[locale]/(auth)/register-password/page.tsx` — new file
- `frontend/app/[locale]/(auth)/register-options/page.tsx` — reordered options
- `frontend/app/[locale]/(auth)/login/page.tsx` — defaults to password login
- `frontend/middleware.ts` — added public routes

## Test plan
- [ ] `npm run build` passes (✅ verified)
- [ ] `npm run lint` passes (✅ no errors, 14 pre-existing warnings)
- [ ] Visit `/register-options` → password is primary option with green highlight
- [ ] Click through to `/register-password` → form renders, validation works
- [ ] Register → lands on `/onboarding` → existing flow works
- [ ] Visit `/login` → password login is default
- [ ] Login with password → lands on `/dashboard`
- [ ] Click "authenticator" toggle → existing TOTP form shows
- [ ] Existing TOTP registration at `/register-totp` still works

Closes #1002

Generated with [Claude Code](https://claude.ai/code)