### PR TITLE
fix(admin): syllabus page + course detail bug (#965)

### DIFF
--- a/backend/app/api/v1/admin/syllabus.py
+++ b/backend/app/api/v1/admin/syllabus.py
@@ -25,6 +25,7 @@ from app.api.v1.schemas.admin_syllabus import (
     SyllabusAgentRequest,
 )
 from app.domain.models.module import Module
+from app.domain.models.module_unit import ModuleUnit
 from app.domain.models.user import UserRole
 from app.domain.services.syllabus_agent_service import SyllabusAgentService
 from app.infrastructure.config.settings import get_settings
@@ -56,8 +57,11 @@ async def list_modules(
     session: AsyncSession = Depends(get_db_session),
     agent_service: SyllabusAgentService = Depends(get_syllabus_agent_service),
 ) -> ModuleListResponse:
-    """Return structured view of all modules for the admin syllabus page."""
-    modules = await agent_service.get_modules_list(session)
+    """Return modules for the admin syllabus page, filtered by owner."""
+    modules = await agent_service.get_modules_list(
+        session,
+        user_id=str(current_user.id),
+    )
     return ModuleListResponse(modules=modules, total=len(modules))
 
 
@@ -105,11 +109,24 @@ async def get_module(
     current_user: AuthenticatedUser = Depends(_require_admin),
     session: AsyncSession = Depends(get_db_session),
 ) -> dict:
-    """Get a single module's full data for editing."""
-    result = await session.execute(select(Module).where(Module.id == module_id))
+    """Get a single module's full data for editing, including units."""
+    result = await session.execute(
+        select(Module).where(Module.id == module_id)
+    )
     module = result.scalar_one_or_none()
     if not module:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Module not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Module not found",
+        )
+
+    # Fetch units for this module
+    units_result = await session.execute(
+        select(ModuleUnit)
+        .where(ModuleUnit.module_id == module_id)
+        .order_by(ModuleUnit.order_index)
+    )
+    units = units_result.scalars().all()
 
     books = module.books_sources or {}
     return {
@@ -122,7 +139,9 @@ async def get_module(
         "description_en": module.description_en,
         "estimated_hours": module.estimated_hours,
         "bloom_level": module.bloom_level,
-        "prereq_modules": [str(p) for p in (module.prereq_modules or [])],
+        "prereq_modules": [
+            str(p) for p in (module.prereq_modules or [])
+        ],
         "objectives_fr": books.get("objectives_fr", []),
         "objectives_en": books.get("objectives_en", []),
         "key_contents_fr": books.get("key_contents_fr", []),
@@ -131,6 +150,18 @@ async def get_module(
         "aof_context_en": books.get("aof_context_en", ""),
         "activities": books.get("activities", {}),
         "source_references": books.get("source_references", []),
+        "units": [
+            {
+                "id": str(u.id),
+                "unit_number": u.unit_number,
+                "title_fr": u.title_fr,
+                "title_en": u.title_en,
+                "description_fr": u.description_fr,
+                "description_en": u.description_en,
+                "order_index": u.order_index,
+            }
+            for u in units
+        ],
     }
 
 
@@ -141,7 +172,13 @@ async def update_module(
     current_user: AuthenticatedUser = Depends(_require_admin),
     session: AsyncSession = Depends(get_db_session),
 ) -> ModuleSaveResponse:
-    """Update a module directly (inline edit from preview panel)."""
+    """Update a module directly (inline edit from preview panel).
+
+    NOTE: This updates the module record in-place. Already-generated
+    lessons/quizzes are NOT automatically regenerated. To apply
+    syllabus changes to learner-facing content, re-trigger content
+    generation for the affected module units.
+    """
     result = await session.execute(select(Module).where(Module.id == module_id))
     module = result.scalar_one_or_none()
     if not module:

--- a/backend/app/api/v1/courses.py
+++ b/backend/app/api/v1/courses.py
@@ -223,17 +223,35 @@ async def my_enrollments(
     return [_course_to_list_item(c, enrolled=True) for c in courses]
 
 
-@router.get("/{course_id}", response_model=CourseDetailResponse)
+@router.get("/{course_id_or_slug}", response_model=CourseDetailResponse)
 async def get_course_detail(
-    course_id: uuid.UUID,
+    course_id_or_slug: str,
     current_user=Depends(get_optional_user),
     db=Depends(get_db_session),
 ) -> CourseDetailResponse:
-    """Get course detail with syllabus and modules. No auth required (public catalog)."""
-    result = await db.execute(select(Course).where(Course.id == course_id))
-    course = result.scalar_one_or_none()
+    """Get course detail with syllabus and modules. No auth required (public catalog).
+
+    Accepts either a UUID or a slug as the path parameter.
+    """
+    # Try UUID lookup first, fall back to slug
+    course: Course | None = None
+    try:
+        cid = uuid.UUID(course_id_or_slug)
+        result = await db.execute(select(Course).where(Course.id == cid))
+        course = result.scalar_one_or_none()
+    except ValueError:
+        pass
+
+    if not course:
+        result = await db.execute(
+            select(Course).where(Course.slug == course_id_or_slug)
+        )
+        course = result.scalar_one_or_none()
+
     if not course:
         raise HTTPException(status_code=404, detail="Course not found")
+
+    course_id = course.id
 
     # Fetch modules with units
     modules_result = await db.execute(

--- a/backend/app/api/v1/schemas/admin_syllabus.py
+++ b/backend/app/api/v1/schemas/admin_syllabus.py
@@ -52,6 +52,10 @@ class ModuleCardResponse(BaseModel):
     bloom_level: str | None = None
     unit_count: int = 0
     source_references: list[str] = Field(default_factory=list)
+    course_id: UUID | None = None
+    course_title_fr: str | None = None
+    course_title_en: str | None = None
+    course_slug: str | None = None
 
 
 class ModuleListResponse(BaseModel):

--- a/backend/app/domain/services/syllabus_agent_service.py
+++ b/backend/app/domain/services/syllabus_agent_service.py
@@ -25,6 +25,7 @@ from sqlalchemy.orm import selectinload
 from app.ai.prompts.syllabus_agent import get_syllabus_agent_system_prompt, get_tool_definitions
 from app.ai.rag.embeddings import EmbeddingService
 from app.ai.rag.retriever import SemanticRetriever
+from app.domain.models.course import Course
 from app.domain.models.module import Module
 
 logger = structlog.get_logger()
@@ -423,17 +424,41 @@ class SyllabusAgentService:
         except Exception as e:
             logger.warning("Audit log write failed (non-fatal)", error=str(e))
 
-    async def get_modules_list(self, session: AsyncSession) -> list[dict]:
-        """Return module list for the admin syllabus view."""
-        result = await session.execute(
-            select(Module).options(selectinload(Module.units)).order_by(Module.module_number)
+    async def get_modules_list(
+        self,
+        session: AsyncSession,
+        user_id: str | None = None,
+    ) -> list[dict]:
+        """Return module list for the admin syllabus view.
+
+        Filters modules to only those belonging to courses created by
+        the given user_id. Unlinked modules (no course) are included.
+        """
+        stmt = (
+            select(Module)
+            .options(
+                selectinload(Module.units),
+                selectinload(Module.course),
+            )
+            .order_by(Module.module_number)
         )
-        modules = result.scalars().all()
+
+        if user_id:
+            stmt = stmt.outerjoin(
+                Course, Module.course_id == Course.id
+            ).where(
+                (Course.created_by == uuid.UUID(user_id))
+                | (Module.course_id.is_(None))
+            )
+
+        result = await session.execute(stmt)
+        modules = result.scalars().unique().all()
         out = []
         for m in modules:
             books = m.books_sources or {}
             sources = books.get("source_references", [])
             unit_count = len(m.units)
+            course = m.course
             out.append(
                 {
                     "id": str(m.id),
@@ -447,6 +472,10 @@ class SyllabusAgentService:
                     "bloom_level": m.bloom_level,
                     "unit_count": unit_count,
                     "source_references": sources,
+                    "course_id": str(course.id) if course else None,
+                    "course_title_fr": course.title_fr if course else None,
+                    "course_title_en": course.title_en if course else None,
+                    "course_slug": course.slug if course else None,
                 }
             )
         return out

--- a/frontend/app/[locale]/(app)/courses/[courseSlug]/page.tsx
+++ b/frontend/app/[locale]/(app)/courses/[courseSlug]/page.tsx
@@ -75,7 +75,7 @@ export default function CourseDetailPage() {
 
   const [course, setCourse] = useState<CourseDetail | null>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [enrolling, setEnrolling] = useState(false);
   const [enrolled, setEnrolled] = useState(false);
   const [expandedModules, setExpandedModules] = useState<Set<string>>(new Set());
@@ -87,8 +87,9 @@ export default function CourseDetailPage() {
         setEnrolled(data.enrolled);
         setLoading(false);
       })
-      .catch(() => {
-        setError(true);
+      .catch((err: Error) => {
+        const is404 = err.message?.includes("404") || err.message?.includes("not found");
+        setError(is404 ? "notFound" : "serverError");
         setLoading(false);
       });
   }, [courseSlug]);
@@ -129,7 +130,9 @@ export default function CourseDetailPage() {
   if (error || !course) {
     return (
       <div className="container mx-auto max-w-3xl px-4 py-12 text-center">
-        <p className="text-muted-foreground">{tDetail("notFound")}</p>
+        <p className="text-muted-foreground">
+          {error === "serverError" ? tDetail("serverError") : tDetail("notFound")}
+        </p>
         <Button variant="outline" className="mt-4" onClick={() => router.push("/courses")}>
           <ArrowLeft className="mr-2 h-4 w-4" />
           {tDetail("backToCatalog")}
@@ -168,7 +171,7 @@ export default function CourseDetailPage() {
         <div className="flex items-start justify-between gap-2">
           <h1 className="text-2xl sm:text-3xl font-bold text-stone-900">{title}</h1>
           <ShareButton
-            url={`/${locale}/courses/${course.id}`}
+            url={`/${locale}/courses/${course.slug || course.id}`}
             title={title}
             description={description || undefined}
             variant="button"

--- a/frontend/app/[locale]/admin/syllabus/syllabus-client.tsx
+++ b/frontend/app/[locale]/admin/syllabus/syllabus-client.tsx
@@ -1,25 +1,26 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
-import { useTranslations } from 'next-intl';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useTranslations, useLocale } from 'next-intl';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
-import { Loader2, AlertCircle } from 'lucide-react';
+import { Loader2, AlertCircle, ChevronDown, ChevronRight, BookOpen } from 'lucide-react';
 import { AdminModuleCard, NewModuleCard, type AdminModuleCardData } from '@/components/admin/module-card';
 import { SyllabusEditor } from '@/components/admin/syllabus-editor';
 import { authClient, AuthError } from '@/lib/auth';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
-const LEVEL_GROUPS: Record<number, { titleFr: string; titleEn: string }> = {
-  1: { titleFr: 'Niveau 1 — Fondements (60h)', titleEn: 'Level 1 — Foundations (60h)' },
-  2: { titleFr: 'Niveau 2 — Intermédiaire (90h)', titleEn: 'Level 2 — Intermediate (90h)' },
-  3: { titleFr: 'Niveau 3 — Avancé (100h)', titleEn: 'Level 3 — Advanced (100h)' },
-  4: { titleFr: 'Niveau 4 — Expert (70h)', titleEn: 'Level 4 — Expert (70h)' },
-};
+interface CourseGroup {
+  course_id: string | null;
+  course_title: string;
+  course_slug: string | null;
+  modules: AdminModuleCardData[];
+}
 
 export function SyllabusPageClient() {
   const t = useTranslations('AdminSyllabus');
+  const locale = useLocale() as 'fr' | 'en';
   const router = useRouter();
 
   const [modules, setModules] = useState<AdminModuleCardData[]>([]);
@@ -27,6 +28,7 @@ export function SyllabusPageClient() {
   const [error, setError] = useState<string | null>(null);
   const [editorOpen, setEditorOpen] = useState(false);
   const [editingModule, setEditingModule] = useState<AdminModuleCardData | null>(null);
+  const [collapsedCourses, setCollapsedCourses] = useState<Set<string>>(new Set());
 
   const fetchModules = useCallback(async () => {
     setIsLoading(true);
@@ -67,6 +69,46 @@ export function SyllabusPageClient() {
   useEffect(() => {
     fetchModules();
   }, [fetchModules]);
+
+  const courseGroups: CourseGroup[] = useMemo(() => {
+    const grouped = new Map<string, CourseGroup>();
+
+    for (const mod of modules) {
+      const key = mod.course_id ?? '__unlinked__';
+      if (!grouped.has(key)) {
+        const title = mod.course_id
+          ? (locale === 'fr' ? mod.course_title_fr : mod.course_title_en) || mod.course_title_fr || t('untitledCourse')
+          : t('unlinkedModules');
+        grouped.set(key, {
+          course_id: mod.course_id ?? null,
+          course_title: title,
+          course_slug: mod.course_slug ?? null,
+          modules: [],
+        });
+      }
+      grouped.get(key)!.modules.push(mod);
+    }
+
+    // Sort: courses with modules first, unlinked last
+    const entries = Array.from(grouped.values());
+    return entries.sort((a, b) => {
+      if (!a.course_id) return 1;
+      if (!b.course_id) return -1;
+      return a.course_title.localeCompare(b.course_title);
+    });
+  }, [modules, locale, t]);
+
+  const toggleCourse = (key: string) => {
+    setCollapsedCourses((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
 
   const handleEdit = (module: AdminModuleCardData) => {
     setEditingModule(module);
@@ -109,33 +151,57 @@ export function SyllabusPageClient() {
     );
   }
 
-  const grouped: Record<number, AdminModuleCardData[]> = { 1: [], 2: [], 3: [], 4: [] };
-  for (const mod of modules) {
-    const lvl = mod.level as 1 | 2 | 3 | 4;
-    if (grouped[lvl]) grouped[lvl].push(mod);
-  }
-
   return (
     <>
-      <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-8">
-        {([1, 2, 3, 4] as const).map((level) => (
-          <section key={level}>
-            <div className="flex items-center justify-between mb-3">
-              <h2 className="text-lg font-semibold">
-                {t('level')} {level}
-                <span className="ml-2 text-sm font-normal text-muted-foreground">
-                  ({grouped[level].length} {t('modules')})
-                </span>
-              </h2>
-            </div>
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-              {grouped[level].map((mod) => (
-                <AdminModuleCard key={mod.id} module={mod} onEdit={handleEdit} />
-              ))}
-              {level === 4 && <NewModuleCard onCreate={handleCreate} />}
-            </div>
-          </section>
-        ))}
+      <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-6">
+        {courseGroups.map((group) => {
+          const key = group.course_id ?? '__unlinked__';
+          const isCollapsed = collapsedCourses.has(key);
+          const totalHours = group.modules.reduce((sum, m) => sum + m.estimated_hours, 0);
+          const totalUnits = group.modules.reduce((sum, m) => sum + m.unit_count, 0);
+
+          return (
+            <section key={key} className="border rounded-lg bg-card">
+              <button
+                type="button"
+                onClick={() => toggleCourse(key)}
+                className="w-full flex items-center gap-3 p-4 hover:bg-muted/50 transition-colors text-left"
+              >
+                {isCollapsed ? (
+                  <ChevronRight className="h-5 w-5 text-muted-foreground shrink-0" />
+                ) : (
+                  <ChevronDown className="h-5 w-5 text-muted-foreground shrink-0" />
+                )}
+                <BookOpen className="h-5 w-5 text-primary shrink-0" />
+                <div className="flex-1 min-w-0">
+                  <h2 className="text-base font-semibold truncate">
+                    {group.course_title}
+                  </h2>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    {group.modules.length} {t('modules')} &middot; {totalUnits} {t('units')} &middot; {totalHours}h
+                  </p>
+                </div>
+              </button>
+
+              {!isCollapsed && (
+                <div className="px-4 pb-4">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+                    {group.modules.map((mod) => (
+                      <AdminModuleCard key={mod.id} module={mod} onEdit={handleEdit} />
+                    ))}
+                  </div>
+                </div>
+              )}
+            </section>
+          );
+        })}
+
+        {courseGroups.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <BookOpen className="h-12 w-12 text-muted-foreground/30 mb-3" />
+            <p className="text-sm text-muted-foreground">{t('noModules')}</p>
+          </div>
+        )}
 
         <div className="flex justify-center pt-4 pb-8">
           <Button onClick={handleCreate} size="lg" className="gap-2">

--- a/frontend/components/admin/module-card.tsx
+++ b/frontend/components/admin/module-card.tsx
@@ -18,6 +18,10 @@ export interface AdminModuleCardData {
   bloom_level?: string | null;
   unit_count: number;
   source_references: string[];
+  course_id?: string | null;
+  course_title_fr?: string | null;
+  course_title_en?: string | null;
+  course_slug?: string | null;
 }
 
 interface AdminModuleCardProps {

--- a/frontend/components/admin/syllabus-editor.tsx
+++ b/frontend/components/admin/syllabus-editor.tsx
@@ -6,7 +6,6 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { Send, Save, Download, Loader2, X, Bot, User } from 'lucide-react';
@@ -21,6 +20,16 @@ interface ChatMessage {
   role: 'user' | 'assistant';
   content: string;
   toolCalls?: { tool: string; result_summary: string }[];
+}
+
+interface ModuleUnit {
+  id: string;
+  unit_number: string;
+  title_fr: string | null;
+  title_en: string | null;
+  description_fr: string | null;
+  description_en: string | null;
+  order_index: number;
 }
 
 interface ModuleDraft {
@@ -44,6 +53,7 @@ interface ModuleDraft {
   source_references: string[];
   estimated_hours: number;
   bloom_level?: string;
+  units?: ModuleUnit[];
 }
 
 interface SyllabusEditorProps {
@@ -61,6 +71,7 @@ export function SyllabusEditor({ editingModule, onClose, onSaved }: SyllabusEdit
   const [input, setInput] = useState('');
   const [isStreaming, setIsStreaming] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const [isLoadingModule, setIsLoadingModule] = useState(false);
   const [draft, setDraft] = useState<ModuleDraft | null>(null);
   const [conversationHistory, setConversationHistory] = useState<
     { role: string; content: string }[]
@@ -69,14 +80,60 @@ export function SyllabusEditor({ editingModule, onClose, onSaved }: SyllabusEdit
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
+  // Fetch actual module data when editing an existing module
   useEffect(() => {
     const welcome = editingModule
       ? `${t('welcomeEdit')} **M${String(editingModule.module_number).padStart(2, '0')} — ${locale === 'fr' ? editingModule.title_fr : editingModule.title_en}**. ${t('welcomeEditHint')}`
       : t('welcomeCreate');
 
     setMessages([{ id: 'welcome', role: 'assistant', content: welcome }]);
-    setDraft(null);
     setConversationHistory([]);
+
+    if (editingModule) {
+      setIsLoadingModule(true);
+      (async () => {
+        try {
+          const token = await authClient.getValidToken();
+          const res = await fetch(
+            `${API_BASE}/api/v1/admin/syllabus/${editingModule.id}`,
+            { headers: { Authorization: `Bearer ${token}` } }
+          );
+          if (res.ok) {
+            const data = await res.json();
+            const activities = data.activities || {};
+            setDraft({
+              module_number: data.module_number,
+              level: data.level,
+              title_fr: data.title_fr,
+              title_en: data.title_en,
+              description_fr: data.description_fr || '',
+              description_en: data.description_en || '',
+              objectives_fr: data.objectives_fr || [],
+              objectives_en: data.objectives_en || [],
+              key_contents_fr: data.key_contents_fr || [],
+              key_contents_en: data.key_contents_en || [],
+              aof_context_fr: data.aof_context_fr || '',
+              aof_context_en: data.aof_context_en || '',
+              activities: {
+                quiz_topics: activities.quiz_topics || [],
+                flashcard_count: activities.flashcard_count ?? 20,
+                case_study_scenario: activities.case_study_scenario || '',
+              },
+              source_references: data.source_references || [],
+              estimated_hours: data.estimated_hours,
+              bloom_level: data.bloom_level,
+              units: data.units || [],
+            });
+          }
+        } catch {
+          // Non-fatal — editor still usable without pre-loaded data
+        } finally {
+          setIsLoadingModule(false);
+        }
+      })();
+    } else {
+      setDraft(null);
+    }
   }, [editingModule, t, locale]);
 
   useEffect(() => {
@@ -238,25 +295,27 @@ export function SyllabusEditor({ editingModule, onClose, onSaved }: SyllabusEdit
 
     const caseStudyMatch = content.match(/Étude de cas\s*:\s*([^\n]+)/i);
 
-    setDraft({
-      level: levelMatch ? parseInt(levelMatch[1]) : 1,
+    setDraft((prev) => ({
+      ...(prev ?? {}),
+      level: levelMatch ? parseInt(levelMatch[1]) : (prev?.level ?? 1),
       title_fr: titleFrMatch[1].trim(),
       title_en: titleFrMatch[2].trim(),
       objectives_fr: objectivesFr,
       objectives_en: objectivesEn,
       key_contents_fr: keyContentsFr,
       key_contents_en: keyContentsEn,
-      aof_context_fr: aofFrMatch?.[1]?.trim() ?? '',
-      aof_context_en: aofEnMatch?.[1]?.trim() ?? '',
+      aof_context_fr: aofFrMatch?.[1]?.trim() ?? (prev?.aof_context_fr ?? ''),
+      aof_context_en: aofEnMatch?.[1]?.trim() ?? (prev?.aof_context_en ?? ''),
       activities: {
-        quiz_topics: [],
-        flashcard_count: 20,
-        case_study_scenario: caseStudyMatch?.[1]?.trim() ?? '',
+        quiz_topics: prev?.activities?.quiz_topics ?? [],
+        flashcard_count: prev?.activities?.flashcard_count ?? 20,
+        case_study_scenario: caseStudyMatch?.[1]?.trim() ?? (prev?.activities?.case_study_scenario ?? ''),
       },
-      source_references: [],
-      estimated_hours: durationMatch ? parseInt(durationMatch[1]) : 20,
-      bloom_level: bloomMatch?.[1]?.toLowerCase() ?? undefined,
-    });
+      source_references: prev?.source_references ?? [],
+      estimated_hours: durationMatch ? parseInt(durationMatch[1]) : (prev?.estimated_hours ?? 20),
+      bloom_level: bloomMatch?.[1]?.toLowerCase() ?? prev?.bloom_level,
+      units: prev?.units,
+    }));
   };
 
   const handleSave = async () => {
@@ -341,6 +400,7 @@ export function SyllabusEditor({ editingModule, onClose, onSaved }: SyllabusEdit
 
   return (
     <div className="fixed inset-0 z-50 bg-background flex flex-col md:flex-row">
+      {/* Mobile header */}
       <div className="flex items-center justify-between p-4 border-b md:hidden">
         <h2 className="font-semibold">
           {editingModule ? t('editModule') : t('createModule')}
@@ -350,8 +410,10 @@ export function SyllabusEditor({ editingModule, onClose, onSaved }: SyllabusEdit
         </Button>
       </div>
 
+      {/* Left panel — AI Chat */}
       <div className="flex flex-col flex-1 min-h-0 md:w-1/2 md:border-r">
-        <div className="hidden md:flex items-center justify-between p-4 border-b">
+        {/* Desktop header */}
+        <div className="hidden md:flex items-center justify-between p-4 border-b shrink-0">
           <h2 className="font-semibold">
             {editingModule ? t('editModule') : t('createModule')}
           </h2>
@@ -360,7 +422,8 @@ export function SyllabusEditor({ editingModule, onClose, onSaved }: SyllabusEdit
           </Button>
         </div>
 
-        <ScrollArea className="flex-1 p-4">
+        {/* Chat messages — scrollable */}
+        <div className="flex-1 overflow-y-auto p-4">
           <div className="space-y-4">
             {messages.map((msg) => (
               <div
@@ -408,9 +471,10 @@ export function SyllabusEditor({ editingModule, onClose, onSaved }: SyllabusEdit
             ))}
             <div ref={messagesEndRef} />
           </div>
-        </ScrollArea>
+        </div>
 
-        <div className="p-4 border-t flex gap-2">
+        {/* Chat input — pinned at bottom */}
+        <div className="shrink-0 p-4 border-t bg-background flex gap-2">
           <Textarea
             ref={inputRef}
             value={input}
@@ -442,8 +506,10 @@ export function SyllabusEditor({ editingModule, onClose, onSaved }: SyllabusEdit
         </div>
       </div>
 
+      {/* Right panel — Structured preview */}
       <div className="flex flex-col flex-1 min-h-0 md:w-1/2">
-        <div className="flex items-center justify-between p-4 border-b">
+        {/* Preview header — pinned */}
+        <div className="flex items-center justify-between p-4 border-b shrink-0 bg-background">
           <h3 className="font-semibold text-sm">{t('previewTitle')}</h3>
           <div className="flex gap-2">
             {editingModule && (
@@ -473,11 +539,17 @@ export function SyllabusEditor({ editingModule, onClose, onSaved }: SyllabusEdit
           </div>
         </div>
 
-        <ScrollArea className="flex-1 p-4">
-          {draft ? (
+        {/* Preview content — scrollable */}
+        <div className="flex-1 overflow-y-auto p-4">
+          {isLoadingModule ? (
+            <div className="flex items-center justify-center h-full">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : draft ? (
             <ModuleDraftPreview
               draft={draft}
               onChange={setDraft}
+              locale={locale}
               t={t}
             />
           ) : (
@@ -486,7 +558,7 @@ export function SyllabusEditor({ editingModule, onClose, onSaved }: SyllabusEdit
               <p>{t('previewEmpty')}</p>
             </div>
           )}
-        </ScrollArea>
+        </div>
       </div>
     </div>
   );
@@ -495,10 +567,11 @@ export function SyllabusEditor({ editingModule, onClose, onSaved }: SyllabusEdit
 interface ModuleDraftPreviewProps {
   draft: ModuleDraft;
   onChange: (draft: ModuleDraft) => void;
+  locale: 'fr' | 'en';
   t: ReturnType<typeof useTranslations<'AdminSyllabus'>>;
 }
 
-function ModuleDraftPreview({ draft, onChange, t }: ModuleDraftPreviewProps) {
+function ModuleDraftPreview({ draft, onChange, locale, t }: ModuleDraftPreviewProps) {
   const update = (key: keyof ModuleDraft, value: unknown) =>
     onChange({ ...draft, [key]: value });
 
@@ -677,6 +750,34 @@ function ModuleDraftPreview({ draft, onChange, t }: ModuleDraftPreviewProps) {
                   {ref}
                 </Badge>
               ))}
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* Module units read-only display */}
+      {draft.units && draft.units.length > 0 && (
+        <>
+          <Separator />
+          <div>
+            <Label className="text-xs">{t('units')} ({draft.units.length})</Label>
+            <div className="mt-2 space-y-1.5">
+              {draft.units.map((unit) => {
+                const unitTitle = locale === 'fr'
+                  ? (unit.title_fr || unit.title_en)
+                  : (unit.title_en || unit.title_fr);
+                return (
+                  <div
+                    key={unit.id}
+                    className="flex items-center gap-2 text-sm text-muted-foreground py-1 px-2 rounded bg-muted/50"
+                  >
+                    <span className="font-mono text-xs text-muted-foreground/70 shrink-0">
+                      {unit.unit_number}
+                    </span>
+                    <span className="truncate">{unitTitle}</span>
+                  </div>
+                );
+              })}
             </div>
           </div>
         </>

--- a/frontend/components/learning/course-card.tsx
+++ b/frontend/components/learning/course-card.tsx
@@ -51,7 +51,7 @@ export function CourseCard({ course }: CourseCardProps) {
   };
 
   const handleViewDetail = () => {
-    router.push(`/courses/${course.id}`);
+    router.push(`/courses/${course.slug || course.id}`);
   };
 
   return (
@@ -84,7 +84,7 @@ export function CourseCard({ course }: CourseCardProps) {
               <CheckCircle className="h-5 w-5 text-teal-600 mt-0.5" aria-hidden="true" />
             )}
             <ShareButton
-              url={`/${locale}/courses/${course.id}`}
+              url={`/${locale}/courses/${course.slug || course.id}`}
               title={title}
               description={description || undefined}
             />

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -851,7 +851,8 @@
     "syllabus": "Syllabus",
     "units": "units",
     "backToCatalog": "Back to catalog",
-    "notFound": "Course not found."
+    "notFound": "Course not found.",
+    "serverError": "Unable to load this course. Please try again."
   },
   "Privacy": {
     "title": "Privacy & Analytics",
@@ -1341,7 +1342,10 @@
     "flashcardCount": "Flashcard count",
     "bloomLevel": "Bloom level",
     "estimatedHours": "Duration (h)",
-    "moduleNumber": "Module number"
+    "moduleNumber": "Module number",
+    "untitledCourse": "Untitled course",
+    "unlinkedModules": "Unlinked modules",
+    "noModules": "No modules found. Create a course first."
   },
   "AuthGuard": {
     "loading": "Loading..."

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -851,7 +851,8 @@
     "syllabus": "Programme",
     "units": "unités",
     "backToCatalog": "Retour au catalogue",
-    "notFound": "Cours non trouvé."
+    "notFound": "Cours non trouvé.",
+    "serverError": "Impossible de charger ce cours. Veuillez réessayer."
   },
   "Privacy": {
     "title": "Confidentialité et analytique",
@@ -1341,7 +1342,10 @@
     "flashcardCount": "Nombre de flashcards",
     "bloomLevel": "Niveau Bloom",
     "estimatedHours": "Durée (h)",
-    "moduleNumber": "Numéro de module"
+    "moduleNumber": "Numéro de module",
+    "untitledCourse": "Cours sans titre",
+    "unlinkedModules": "Modules non rattachés",
+    "noModules": "Aucun module trouvé. Créez un cours d'abord."
   },
   "AuthGuard": {
     "loading": "Chargement..."


### PR DESCRIPTION
## Summary
- **Course detail bug**: Backend now accepts both UUID and slug for `/courses/{id}`, frontend uses slug URLs, error messages differentiate 404 vs server errors
- **Syllabus page**: Modules filtered by course owner (`created_by`), grouped by course (collapsible sections) instead of by level
- **Syllabus editor**: Fetches actual module data (titles, objectives, units) on mount instead of starting blank; sticky chat input + sticky Save/Export header; native scrolling
- **i18n**: Added `serverError`, `untitledCourse`, `unlinkedModules`, `noModules` keys (FR/EN)

## Test plan
- [ ] Visit `/courses/{slug}` and `/courses/{uuid}` — both should load the course
- [ ] Visit a non-existent course UUID — should show "Course not found"
- [ ] Visit `/admin/syllabus` — modules grouped under their parent course
- [ ] Click edit on a module — preview panel pre-populated with actual data + units listed
- [ ] Verify chat input stays pinned at bottom during long conversations
- [ ] Verify Save/Export buttons stay visible while scrolling the preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #965