### PR TITLE
feat(admin): Orange Money number in platform settings

### DIFF
--- a/backend/app/infrastructure/config/platform_defaults.py
+++ b/backend/app/infrastructure/config/platform_defaults.py
@@ -546,6 +546,33 @@ SETTING_DEFINITIONS: list[SettingDef] = [
         "Credits charged per module offline download.",
         {"min": 0, "max": 100000},
     ),
+    # ── Payments ───────────────────────────────────────────
+    SettingDef(
+        "payments-orange-money-number",
+        "payments",
+        "+221 77 000 0000",
+        "string",
+        "Orange Money payment number",
+        "Phone number displayed to users for Orange Money transfers.",
+    ),
+    SettingDef(
+        "payments-subscription-price-xof",
+        "payments",
+        2000,
+        "integer",
+        "Subscription price (FCFA)",
+        "Monthly subscription price displayed on the subscribe page.",
+        {"min": 0, "max": 100000},
+    ),
+    SettingDef(
+        "payments-subscription-duration-days",
+        "payments",
+        28,
+        "integer",
+        "Subscription duration (days)",
+        "Days of access per payment.",
+        {"min": 1, "max": 365},
+    ),
     # ── AI Prompts ─────────────────────────────────────────
     SettingDef(
         "ai-prompt-lesson-system",

--- a/frontend/app/[locale]/(app)/subscribe/page.tsx
+++ b/frontend/app/[locale]/(app)/subscribe/page.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { apiFetch } from "@/lib/api";
+import { apiFetch, getPublicSettings } from "@/lib/api";
 import {
   Phone,
   CheckCircle,
@@ -36,6 +36,7 @@ export default function SubscribePage() {
     text: string;
   } | null>(null);
   const [loading, setLoading] = useState(true);
+  const [orangeMoneyNumber, setOrangeMoneyNumber] = useState<string | null>(null);
 
   const fetchStatus = useCallback(async () => {
     try {
@@ -57,6 +58,13 @@ export default function SubscribePage() {
           setCurrentPhone(user.phone_number);
           setPhone(user.phone_number);
         }
+      })
+      .catch(() => {});
+    // Fetch Orange Money number from platform settings
+    getPublicSettings()
+      .then((settings) => {
+        const num = settings["payments-orange-money-number"];
+        if (typeof num === "string" && num) setOrangeMoneyNumber(num);
       })
       .catch(() => {});
   }, [fetchStatus]);
@@ -190,7 +198,7 @@ export default function SubscribePage() {
                 {t("orangeMoneyLabel")}
               </p>
               <p className="text-2xl font-bold text-orange-700 tracking-wider">
-                {t("orangeMoneyNumber")}
+                {orangeMoneyNumber ?? t("orangeMoneyNumber")}
               </p>
               <p className="text-sm font-medium text-orange-600 mt-1">
                 {t("amount")}

--- a/frontend/components/admin/settings-client.tsx
+++ b/frontend/components/admin/settings-client.tsx
@@ -23,6 +23,7 @@ const CATEGORY_LABELS: Record<string, string> = {
   ai_prompts: "AI Prompt Templates",
   tutor: "AI Tutor",
   pagination: "Pagination",
+  payments: "Payments & Billing",
 };
 
 export function SettingsClient() {


### PR DESCRIPTION
## Summary
- Add `payments-orange-money-number`, `payments-subscription-price-xof`, and `payments-subscription-duration-days` to platform settings (new `payments` category)
- Add "Payments & Billing" tab to admin settings page
- Subscribe page now fetches Orange Money number from public settings API, falling back to the i18n placeholder
- Admins can change the payment number from Settings > Payments & Billing without redeploying

## Test plan
- [ ] Open `/admin/settings` — verify "Payments & Billing" tab appears with 3 settings
- [ ] Edit the Orange Money number, save — verify it persists
- [ ] Open `/subscribe` — verify the new number appears in the orange box
- [ ] Reset the setting to default — verify placeholder `+221 77 000 0000` shows again

🤖 Generated with [Claude Code](https://claude.com/claude-code)