### PR TITLE
feat(tutor): course-aware AI tutor prompt and RAG scoping

### DIFF
--- a/backend/app/ai/prompts/tutor.py
+++ b/backend/app/ai/prompts/tutor.py
@@ -16,6 +16,8 @@ class TutorContext:
     module_number: int | None = None  # 1-15
     context_type: str | None = None  # "module" | "lesson" | "quiz" | None
     context_id: str | None = None
+    course_title: str | None = None  # Human-readable course title (fr or en)
+    course_domain: str | None = None  # e.g. "Santé Publique", "Marketing", ...
     learner_memory: str | None = None  # Pre-formatted memory text for system prompt
     previous_session_context: str | None = None  # Compacted context from prior session
     progress_snapshot: str | None = None  # Short learner progress summary
@@ -29,7 +31,7 @@ def get_socratic_system_prompt(context: TutorContext, rag_chunks: list[dict[str,
     Implements 10 pedagogical rules as specified in the issue:
     1. Guide with questions, don't give direct answers
     2. Decompose complex concepts into progressive steps
-    3. Use AOF-contextualized analogies and concrete examples
+    3. Use country-contextualized analogies and concrete examples (8/10 from learner's country)
     4. Encourage the learner after every effort
     5. Provide hints before correcting
     6. Reformulate differently after 2 failed attempts, then explain clearly
@@ -52,7 +54,8 @@ def get_socratic_system_prompt(context: TutorContext, rag_chunks: list[dict[str,
 
     pedagogical_section = _get_pedagogical_rules(context.tutor_mode)
 
-    prompt = f"""Tu es un tuteur IA spécialisé en santé publique pour l'Afrique de l'Ouest.
+    course_label = context.course_title or "santé publique"
+    prompt = f"""Tu es un tuteur IA spécialisé en {course_label} pour l'Afrique de l'Ouest.
 {_get_mode_intro(context.tutor_mode)}
 
 ## CONTEXTE DE L'APPRENANT
@@ -75,7 +78,7 @@ Tu as accès à 6 outils que tu peux appeler de manière autonome:
 ### `search_source_images(query, image_type?)`
 Utilise cet outil quand:
 - L'apprenant demande à voir une figure, un diagramme ou une illustration spécifique
-- Un visuel aiderait à expliquer un concept (anatomie, épidémiologie, flux de données, etc.)
+- Un visuel aiderait à expliquer un concept
 - Tu veux enrichir une explication avec une illustration des manuels de référence
 - Résultats: retourne des métadonnées + un marqueur `{{{{source_image:UUID}}}}` à inclure dans ta réponse
 - **Important:** Intègre le marqueur `{{{{source_image:UUID}}}}` directement dans ton texte pour afficher la figure
@@ -83,7 +86,7 @@ Utilise cet outil quand:
 ### `search_knowledge_base(query, module_id?)`
 Utilise cet outil CHAQUE FOIS que tu dois:
 - Citer une source ou vérifier un concept
-- Trouver des informations précises sur un sujet de santé publique
+- Trouver des informations précises sur un sujet du cours
 - Appuyer ta guidance Socratique sur des références bibliographiques
 - Répondre à des questions nécessitant des données factuelles
 - Les résultats incluent aussi `available_figures` — des figures liées aux chunks trouvés
@@ -110,7 +113,7 @@ Utilise cet outil pour:
 ### `save_learner_preference(preference_type, value)`
 Utilise cet outil quand tu détectes un pattern récurrent:
 - L'apprenant répond mieux aux analogies qu'aux définitions formelles
-- L'apprenant préfère les exemples concrets du contexte AOF
+- L'apprenant préfère les exemples concrets de son pays ou d'Afrique de l'Ouest
 - L'apprenant a des difficultés avec certains types de concepts
 - L'apprenant préfère une approche plus directe ou plus Socratique
 
@@ -240,10 +243,10 @@ def _get_pedagogical_rules(tutor_mode: str) -> str:
 - Pour les concepts complexes, décompose en sections numérotées
 - Résume les points clés à la fin si nécessaire
 
-### 3. ANALOGIES ET EXEMPLES AOF
+### 3. ANALOGIES ET EXEMPLES CONTEXTUALISÉS
+- Privilégier les exemples du pays de l'apprenant (8 exemples sur 10 du pays, 2 de la région Afrique de l'Ouest)
 - Utilise des analogies tirées de la vie quotidienne en Afrique de l'Ouest
-- Donne des exemples concrets de santé publique dans la région
-- Contextualise avec des données réelles (paludisme, méningite, fièvre jaune, etc.)
+- Contextualise avec des données réelles du pays et de la région
 
 ### 4. CITATIONS OBLIGATOIRES
 - Cite TOUJOURS tes sources: (Livre, Chapitre, Page)
@@ -266,18 +269,17 @@ def _get_pedagogical_rules(tutor_mode: str) -> str:
 - Ne donne JAMAIS de réponses directes
 - Pose des questions qui orientent l'apprenant vers la découverte
 - Utilise des questions ouvertes qui stimulent la réflexion
-- Exemple: Au lieu de "La surveillance épidémiologique consiste à...",
-  dis "Que penses-tu qu'il faut observer pour détecter une épidémie ?"
+- Exemple: Au lieu de donner une définition, pose la question qui amène l'apprenant à la formuler
 
 ### 2. DÉCOMPOSITION PROGRESSIVE
 - Découpe les concepts complexes en étapes logiques
 - Assure-toi que chaque étape est comprise avant de passer à la suivante
 - Utilise une progression "du simple au complexe"
 
-### 3. ANALOGIES ET EXEMPLES AOF
+### 3. ANALOGIES ET EXEMPLES CONTEXTUALISÉS
+- Privilégier les exemples du pays de l'apprenant (8 exemples sur 10 du pays, 2 de la région Afrique de l'Ouest)
 - Utilise des analogies tirées de la vie quotidienne en Afrique de l'Ouest
-- Donne des exemples concrets de santé publique dans la région
-- Contextualise avec des données réelles (paludisme, méningite, fièvre jaune, etc.)
+- Contextualise avec des données réelles du pays et de la région
 
 ### 4. ENCOURAGEMENT CONSTANT
 - Encourage chaque effort de l'apprenant
@@ -326,16 +328,16 @@ def _get_language_instruction(language: str) -> str:
 def _get_level_instruction(level: int) -> str:
     """Get level-specific instruction."""
     level_map = {
-        1: "Débutant (L1) - Fondamentaux de la santé publique",
-        2: "Intermédiaire (L2) - Épidémiologie et surveillance",
-        3: "Avancé (L3) - Statistiques et programmation sanitaire",
-        4: "Expert (L4) - Politique et systèmes de santé",
+        1: "Débutant (L1) - Fondamentaux",
+        2: "Intermédiaire (L2) - Application et analyse",
+        3: "Avancé (L3) - Analyse approfondie et synthèse",
+        4: "Expert (L4) - Évaluation et création",
     }
     return level_map.get(level, "Non spécifié")
 
 
 def _get_country_context(country: str) -> str:
-    """Get country-specific context for AOF region."""
+    """Get country-specific context for West Africa region."""
     country_map = {
         "BF": "Burkina Faso - Focus paludisme, méningite, malnutrition",
         "BJ": "Bénin - Focus paludisme, fièvre typhoïde, santé maternelle",

--- a/backend/app/api/v1/schemas/tutor.py
+++ b/backend/app/api/v1/schemas/tutor.py
@@ -33,6 +33,9 @@ class TutorChatRequest(BaseModel):
     """Request schema for tutor chat."""
 
     message: str = Field(..., min_length=1, max_length=2000, description="User message")
+    course_id: UUID | None = Field(
+        None, description="Course ID for context (derived from enrollment if absent)"
+    )
     module_id: UUID | None = Field(None, description="Current module ID for context")
     context_type: str | None = Field(
         None, description="Context type: 'module', 'lesson', 'quiz', or None"

--- a/backend/app/api/v1/tutor.py
+++ b/backend/app/api/v1/tutor.py
@@ -158,6 +158,7 @@ async def chat_with_tutor(
                 conversation_id=request.conversation_id,
                 tutor_mode=request.tutor_mode,
                 file_content_blocks=file_content_blocks,
+                course_id=request.course_id,
             ):
                 yield f"data: {json.dumps(chunk)}\n\n"
 

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -22,6 +22,7 @@ from app.ai.prompts.tutor import (
 from app.ai.rag.embeddings import EmbeddingService
 from app.ai.rag.retriever import SemanticRetriever
 from app.domain.models.conversation import TutorConversation
+from app.domain.models.course import Course, UserCourseEnrollment
 from app.domain.models.module import Module
 from app.domain.models.user import User
 from app.domain.services.learner_memory_service import LearnerMemoryService
@@ -214,6 +215,7 @@ class TutorService:
         conversation_id: uuid.UUID | None = None,
         tutor_mode: str = "socratic",
         file_content_blocks: list[dict[str, Any]] | None = None,
+        course_id: uuid.UUID | None = None,
     ) -> AsyncGenerator[dict[str, Any], None]:
         """
         Send a message to the AI tutor and stream the response using agentic tool_use.
@@ -230,6 +232,7 @@ class TutorService:
             context_id: Optional context-specific ID
             conversation_id: Optional existing conversation ID
             file_content_blocks: Optional list of Claude API content blocks (images/text) from uploads
+            course_id: Optional course ID (derived from enrollment if absent)
 
         Yields:
             Stream chunks with tutor response data
@@ -286,6 +289,7 @@ class TutorService:
             # Resolve module title for human-readable system prompt
             module_title = None
             module_number = None
+            module_obj = None
             if module_id:
                 module_obj = await session.get(Module, module_id)
                 if module_obj:
@@ -295,6 +299,17 @@ class TutorService:
                         else module_obj.title_en
                     )
                     module_number = module_obj.module_number
+
+            # Resolve course context: explicit > from module > from enrollment
+            course = await self._resolve_course(course_id, module_id, module_obj, user_id, session)
+            course_title = None
+            course_domain = None
+            rag_collection_id = None
+            if course:
+                lang = user.preferred_language
+                course_title = course.title_fr if lang == "fr" else course.title_en
+                course_domain = course_domain or course_title
+                rag_collection_id = course.rag_collection_id
 
             context = TutorContext(
                 user_level=user.current_level,
@@ -306,6 +321,8 @@ class TutorService:
                 context_type=context_type,
                 tutor_mode=tutor_mode,
                 context_id=str(context_id) if context_id else None,
+                course_title=course_title,
+                course_domain=course_domain,
                 learner_memory=session_ctx.learner_memory,
                 previous_session_context=session_ctx.previous_compact,
                 progress_snapshot=session_ctx.progress_snapshot,
@@ -334,6 +351,7 @@ class TutorService:
                 user_id=user_id,
                 user_level=user.current_level,
                 user_language=user.preferred_language,
+                rag_collection_id=rag_collection_id,
             )
 
             tool_call_count = 0
@@ -774,6 +792,43 @@ class TutorService:
         await session.flush()
 
         return conversation
+
+    async def _resolve_course(
+        self,
+        course_id: uuid.UUID | None,
+        module_id: uuid.UUID | None,
+        module_obj: Module | None,
+        user_id: uuid.UUID,
+        session: AsyncSession,
+    ) -> Course | None:
+        """Resolve course: explicit course_id > module's course > active enrollment."""
+        # 1. Explicit course_id
+        if course_id:
+            course = await session.get(Course, course_id)
+            if course:
+                return course
+
+        # 2. From module's course_id
+        if module_obj and module_obj.course_id:
+            course = await session.get(Course, module_obj.course_id)
+            if course:
+                return course
+
+        # 3. Fallback: most recent active enrollment
+        result = await session.execute(
+            select(UserCourseEnrollment)
+            .where(
+                UserCourseEnrollment.user_id == user_id,
+                UserCourseEnrollment.status == "active",
+            )
+            .order_by(UserCourseEnrollment.enrolled_at.desc())
+            .limit(1)
+        )
+        enrollment = result.scalar_one_or_none()
+        if enrollment:
+            return await session.get(Course, enrollment.course_id)
+
+        return None
 
     async def _retrieve_relevant_context(
         self, query: str, user: User, module_id: uuid.UUID | None, session: AsyncSession

--- a/backend/app/domain/services/tutor_tools.py
+++ b/backend/app/domain/services/tutor_tools.py
@@ -176,6 +176,7 @@ class TutorToolExecutor:
         user_level: int,
         user_language: str,
         learner_memory_service: LearnerMemoryService | None = None,
+        rag_collection_id: str | None = None,
     ):
         self.retriever = retriever
         self.anthropic = anthropic_client
@@ -183,6 +184,7 @@ class TutorToolExecutor:
         self.user_level = user_level
         self.user_language = user_language
         self.learner_memory_service = learner_memory_service or LearnerMemoryService()
+        self.rag_collection_id = rag_collection_id
 
     async def execute(
         self,
@@ -261,6 +263,10 @@ class TutorToolExecutor:
                         books_sources = module.books_sources
             except (ValueError, TypeError):
                 pass
+
+        # Fallback: if no module scoping, use course-level rag_collection_id
+        if not books_sources and self.rag_collection_id:
+            books_sources = {self.rag_collection_id: []}
 
         results = await self.retriever.search_for_module(
             query=query,

--- a/backend/tests/test_tutor_compaction.py
+++ b/backend/tests/test_tutor_compaction.py
@@ -263,6 +263,7 @@ async def test_message_count_updated_on_send(tutor_service, sample_user):
         patch.object(
             tutor_service, "_get_previous_compact", new_callable=AsyncMock, return_value=None
         ),
+        patch.object(tutor_service, "_resolve_course", new_callable=AsyncMock, return_value=None),
     ):
         chunks = []
         async for chunk in tutor_service.send_message(

--- a/backend/tests/test_tutor_service.py
+++ b/backend/tests/test_tutor_service.py
@@ -154,6 +154,12 @@ async def test_send_message_yields_content_type_chunks(
             new_callable=AsyncMock,
             return_value=None,
         ),
+        patch.object(
+            tutor_service,
+            "_resolve_course",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
     ):
         mock_session.add = MagicMock()
         mock_session.commit = AsyncMock()
@@ -212,6 +218,12 @@ async def test_send_message_yields_sources_cited_type(
         patch.object(
             tutor_service,
             "_get_previous_compact",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch.object(
+            tutor_service,
+            "_resolve_course",
             new_callable=AsyncMock,
             return_value=None,
         ),
@@ -343,6 +355,12 @@ async def test_send_message_never_yields_text_type(tutor_service, sample_user, s
         patch.object(
             tutor_service,
             "_get_previous_compact",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch.object(
+            tutor_service,
+            "_resolve_course",
             new_callable=AsyncMock,
             return_value=None,
         ),

--- a/backend/tests/test_tutor_tools.py
+++ b/backend/tests/test_tutor_tools.py
@@ -479,6 +479,12 @@ async def test_tool_use_loop_executes_tool_and_gets_final_response(
             new_callable=AsyncMock,
             return_value=None,
         ),
+        patch.object(
+            tutor_service,
+            "_resolve_course",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
         patch("app.domain.services.tutor_service.TutorToolExecutor") as mock_executor_cls,
     ):
         mock_executor = AsyncMock()
@@ -544,6 +550,12 @@ async def test_max_tool_calls_enforced(
             new_callable=AsyncMock,
             return_value=None,
         ),
+        patch.object(
+            tutor_service,
+            "_resolve_course",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
         patch("app.domain.services.tutor_service.TutorToolExecutor") as mock_executor_cls,
     ):
         mock_executor = AsyncMock()
@@ -605,6 +617,12 @@ async def test_no_tool_use_yields_content_chunks(
             new_callable=AsyncMock,
             return_value=None,
         ),
+        patch.object(
+            tutor_service,
+            "_resolve_course",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
     ):
         mock_session.add = MagicMock()
         mock_session.commit = AsyncMock()
@@ -658,6 +676,12 @@ async def test_finished_chunk_includes_tool_calls_made(
         patch.object(
             tutor_service,
             "_get_previous_compact",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch.object(
+            tutor_service,
+            "_resolve_course",
             new_callable=AsyncMock,
             return_value=None,
         ),

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -44,6 +44,7 @@ interface ChatPanelProps {
   isOpen: boolean;
   onClose: () => void;
   moduleId?: string;
+  courseId?: string;
   conversationId?: string | null;
   className?: string;
   embedded?: boolean;
@@ -55,6 +56,7 @@ export function ChatPanel({
   isOpen,
   onClose,
   moduleId,
+  courseId,
   conversationId,
   className,
   embedded = false,
@@ -202,6 +204,7 @@ export function ChatPanel({
         body: JSON.stringify({
           message: messageContent,
           conversation_id: activeConversationId ?? null,
+          course_id: courseId ?? null,
           module_id: moduleId ?? null,
           tutor_mode: tutorMode,
           file_ids: attachedFiles.map((f) => f.fileId),


### PR DESCRIPTION
## Summary
- Tutor system prompt now uses the enrolled course title instead of hardcoded "santé publique"
- RAG `search_knowledge_base` tool scopes to the course's collection even when no `module_id` is passed
- Course resolved via 3-level fallback: explicit `course_id` > module's course > active enrollment
- All "AOF" references replaced with "Afrique de l'Ouest"
- Added 8/10 country priority rule (8 examples from learner's country, 2 from region)
- Level labels genericized to Bloom taxonomy (not public-health-specific)

## Files changed
- `backend/app/ai/prompts/tutor.py` — course fields in TutorContext, dynamic intro, AOF→West Africa
- `backend/app/domain/services/tutor_service.py` — course resolution + `_resolve_course()` method
- `backend/app/domain/services/tutor_tools.py` — `rag_collection_id` fallback in `search_knowledge_base`
- `backend/app/api/v1/schemas/tutor.py` + `tutor.py` — `course_id` in API
- `frontend/components/chat/chat-panel.tsx` — sends `course_id` when available
- 3 test files — mock `_resolve_course` in existing tests

## Backward compatibility
- `course_id` is optional in the API; existing clients work without changes
- When no `course_id` or `module_id` is provided, falls back to active enrollment
- Socratic/explanatory mode toggle unchanged
- All 513 tests pass

## Test plan
- [x] `get_socratic_system_prompt` with `course_title="Marketing"` → uses "Marketing" not "santé publique"
- [x] Without `course_title` → falls back to "santé publique"
- [x] No "AOF" remains in tutor.py, "8 exemples sur 10" present
- [x] All 513 unit tests pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)