### PR TITLE
feat(tutor): course selector + enrollment guard

### DIFF
--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -801,12 +801,30 @@ class TutorService:
         user_id: uuid.UUID,
         session: AsyncSession,
     ) -> Course | None:
-        """Resolve course: explicit course_id > module's course > active enrollment."""
-        # 1. Explicit course_id
+        """Resolve course: explicit course_id > module's course > active enrollment.
+
+        When course_id is explicit, verifies the user is enrolled (active)
+        to prevent access to paid content. Falls back to enrollment if not.
+        """
+        # 1. Explicit course_id — verify enrollment
         if course_id:
-            course = await session.get(Course, course_id)
-            if course:
-                return course
+            enrolled = await session.execute(
+                select(UserCourseEnrollment).where(
+                    UserCourseEnrollment.user_id == user_id,
+                    UserCourseEnrollment.course_id == course_id,
+                    UserCourseEnrollment.status == "active",
+                )
+            )
+            if enrolled.scalar_one_or_none():
+                course = await session.get(Course, course_id)
+                if course:
+                    return course
+            else:
+                logger.warning(
+                    "Tutor course_id not enrolled, falling back",
+                    user_id=str(user_id),
+                    course_id=str(course_id),
+                )
 
         # 2. From module's course_id
         if module_obj and module_obj.course_id:

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslations, useLocale } from 'next-intl';
 import { track } from '@/lib/analytics';
 import { Link } from '@/i18n/routing';
-import { X, MoreVertical, Trash2, Menu, HelpCircle, BookOpen } from 'lucide-react';
+import { X, MoreVertical, Trash2, Menu, HelpCircle, BookOpen, GraduationCap, ChevronDown } from 'lucide-react';
+import { getMyEnrollments, type CourseWithEnrollment } from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -84,8 +85,15 @@ export function ChatPanel({
     return 'socratic';
   });
   const scrollAreaRef = useRef<HTMLDivElement>(null);
+  const [enrolledCourses, setEnrolledCourses] = useState<CourseWithEnrollment[]>([]);
+  const [activeCourseId, setActiveCourseId] = useState<string | null>(courseId ?? null);
 
   const isLimitReached = currentUsage >= maxDailyUsage;
+
+  const activeCourse = enrolledCourses.find((c) => c.id === activeCourseId);
+  const activeCourseLabel = activeCourse
+    ? (locale === 'fr' ? activeCourse.title_fr : activeCourse.title_en)
+    : null;
 
   const welcomeMessage: ChatMessage = {
     id: 'welcome',
@@ -97,6 +105,19 @@ export function ChatPanel({
   useEffect(() => {
     localStorage.setItem('tutorMode', tutorMode);
   }, [tutorMode]);
+
+  // Fetch enrolled courses for course selector
+  useEffect(() => {
+    getMyEnrollments()
+      .then((courses) => {
+        setEnrolledCourses(courses);
+        // Auto-select first course if none set
+        if (!activeCourseId && courses.length > 0) {
+          setActiveCourseId(courses[0].id);
+        }
+      })
+      .catch(() => {});
+  }, []);  // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     fetchTutorStats()
@@ -204,7 +225,7 @@ export function ChatPanel({
         body: JSON.stringify({
           message: messageContent,
           conversation_id: activeConversationId ?? null,
-          course_id: courseId ?? null,
+          course_id: activeCourseId ?? null,
           module_id: moduleId ?? null,
           tutor_mode: tutorMode,
           file_ids: attachedFiles.map((f) => f.fileId),
@@ -381,6 +402,33 @@ export function ChatPanel({
             <h2 className="text-base font-semibold">{t('title')}</h2>
           </div>
           <div className="flex items-center gap-1">
+            {enrolledCourses.length > 1 ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger>
+                  <Button variant="outline" size="sm" className="h-9 max-w-[160px] gap-1 text-xs">
+                    <GraduationCap className="h-3.5 w-3.5 shrink-0" />
+                    <span className="truncate">{activeCourseLabel || t('title')}</span>
+                    <ChevronDown className="h-3 w-3 shrink-0" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  {enrolledCourses.map((course) => (
+                    <DropdownMenuItem
+                      key={course.id}
+                      onClick={() => setActiveCourseId(course.id)}
+                      className={course.id === activeCourseId ? 'bg-accent' : ''}
+                    >
+                      {locale === 'fr' ? course.title_fr : course.title_en}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : activeCourseLabel ? (
+              <span className="text-xs text-muted-foreground truncate max-w-[160px] flex items-center gap-1">
+                <GraduationCap className="h-3.5 w-3.5 shrink-0" />
+                {activeCourseLabel}
+              </span>
+            ) : null}
             <Button
               variant={tutorMode === 'socratic' ? 'default' : 'outline'}
               size="sm"


### PR DESCRIPTION
## Summary
- Tutor chat now shows which course is active and lets users switch between enrolled courses
- Backend verifies enrollment before accepting an explicit `course_id` (prevents paid content access)

## Backend: enrollment guard
`backend/app/domain/services/tutor_service.py` — `_resolve_course()`:
- When `course_id` is explicitly provided, checks `UserCourseEnrollment` with `status="active"`
- If not enrolled, logs warning and falls back to active enrollment
- Module-derived and enrollment-derived paths are inherently safe

## Frontend: course selector
`frontend/components/chat/chat-panel.tsx`:
- Fetches enrolled courses via existing `getMyEnrollments()` on mount
- Auto-selects the most recent enrolled course
- **1 course**: shows course name as a label (no dropdown)
- **Multiple courses**: shows a dropdown to switch between them
- Sends `activeCourseId` in the POST body instead of the prop `courseId`

## Test plan
- [x] 47 tutor backend tests pass
- [x] TypeScript compiles (no new errors)
- [ ] Manual: open tutor with 1 enrollment → label shown
- [ ] Manual: open tutor with 2+ enrollments → dropdown works
- [ ] Manual: send course_id for unenrolled course → falls back

🤖 Generated with [Claude Code](https://claude.com/claude-code)