### PR TITLE
fix(syllabus): add missing Course import in _fetch_course to fix NameError

### DIFF
--- a/backend/app/tasks/syllabus_generation.py
+++ b/backend/app/tasks/syllabus_generation.py
@@ -58,6 +58,8 @@ def generate_course_syllabus(self, course_id: str, estimated_hours: int) -> dict
     async def _fetch_course():
         from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+        from app.domain.models.course import Course
+
         engine = create_async_engine(settings.database_url, echo=False, pool_size=2, max_overflow=0)
         try:
             async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)


### PR DESCRIPTION
## Summary

Add the missing `from app.domain.models.course import Course` import inside the `_fetch_course()` inner function in `backend/app/tasks/syllabus_generation.py`.

During the refactor in commit `8b3d4d8` (fix for SoftTimeLimitExceeded #876), the `Course` import was relocated to Phase 3 (line 216) but `_fetch_course()` in Phase 1 still references `Course` at line 66. This caused a `NameError: name 'Course' is not defined` on every syllabus generation attempt.

## Changes

- `backend/app/tasks/syllabus_generation.py`: Added `from app.domain.models.course import Course` inside `_fetch_course()` alongside the existing SQLAlchemy imports

## Test plan

- [ ] Backend tests pass: `cd backend && uv run pytest tests/test_syllabus_generation_task.py -v`
- [ ] Manually verified: create a course with PDF resources → generate syllabus → confirm modules appear

Closes #1027

Generated with [Claude Code](https://claude.ai/code)