### PR TITLE
fix(syllabus): derive database_url_sync — Phase 3 Docker fix (#1033 B1)

### DIFF
--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -10,7 +10,11 @@ class Settings(BaseSettings):
 
     # Database
     database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/santepublique_aof"
-    database_url_sync: str = "postgresql://postgres:postgres@localhost:5432/santepublique_aof"
+
+    @property
+    def database_url_sync(self) -> str:
+        """Derive sync URL from async URL by stripping the +asyncpg dialect."""
+        return self.database_url.replace("+asyncpg", "")
 
     # Redis
     redis_url: str = "redis://localhost:6379/0"


### PR DESCRIPTION
## Summary
- Phase 3 of syllabus generation crashes with `OperationalError: Connection refused` on `localhost:5432`
- `database_url_sync` was a static field defaulting to `localhost`, but Docker uses host `postgres`
- Fix: replace with `@property` that derives sync URL from `database_url` by stripping `+asyncpg`

**Server log:** `connection to server at "localhost" ... Connection refused`

Ref #1033 (Blocker B1)

## Test plan
- [x] `pytest tests/test_syllabus_generation_task.py` — 4/4 pass
- [ ] Deploy → create course → generate syllabus → verify Phase 3 saves modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)