### PR TITLE
fix(syllabus): derive database_url_sync — Docker Phase 3 fix (#1033)

### DIFF
--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -10,7 +10,11 @@ class Settings(BaseSettings):
 
     # Database
     database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/santepublique_aof"
-    database_url_sync: str = "postgresql://postgres:postgres@localhost:5432/santepublique_aof"
+
+    @property
+    def database_url_sync(self) -> str:
+        """Derive sync URL from async URL by stripping the +asyncpg dialect."""
+        return self.database_url.replace("+asyncpg", "")
 
     # Redis
     redis_url: str = "redis://localhost:6379/0"


### PR DESCRIPTION
## Summary
- Fixes `OperationalError: Connection refused` in syllabus Phase 3 (Docker)
- `database_url_sync` now derived from `database_url` via @property

Ref #1033

🤖 Generated with [Claude Code](https://claude.com/claude-code)