### PR TITLE
fix(wizard): show Start Indexation button on resume (#1033)

### DIFF
--- a/frontend/components/admin/course-wizard-client.tsx
+++ b/frontend/components/admin/course-wizard-client.tsx
@@ -209,9 +209,8 @@ export function CourseWizardClient({
   }, [courseId, step]);
 
   useEffect(() => {
-    if (resumeCourseId && (resumeStep === "index" || resumeStep === "publish")) {
-      setIsIndexing(true);
-    }
+    // Only resume indexing state if there is an actual task to poll
+    // Otherwise the "Start indexation" button gets hidden with no way to trigger it
   }, [resumeCourseId, resumeStep]);
 
   const getAuthHeaders = useCallback(async (): Promise<Record<string, string>> => {


### PR DESCRIPTION
## Summary
- When resuming a course at the indexation step, `isIndexing` was set to `true` unconditionally
- This hid the "Start indexation" button and showed a stuck "Waiting to start..." spinner
- Fix: remove the unconditional flag so the button is visible when no task is running

Ref #1033

## Test plan
- [ ] Resume a course at the indexation step → button should be visible
- [ ] Click "Start indexation" → task should trigger and progress should show

🤖 Generated with [Claude Code](https://claude.com/claude-code)