### PR TITLE
fix(wizard): fetch existing resources when returning to upload step

### DIFF
--- a/frontend/components/admin/course-wizard-client.tsx
+++ b/frontend/components/admin/course-wizard-client.tsx
@@ -177,6 +177,7 @@ export function CourseWizardClient({
   const [publishSummaryModuleCount, setPublishSummaryModuleCount] = useState<number>(0);
   const [isFetchingPublishSummary, setIsFetchingPublishSummary] = useState(false);
   const [showCloseConfirm, setShowCloseConfirm] = useState(false);
+  const [isFetchingExistingFiles, setIsFetchingExistingFiles] = useState(false);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [pendingFiles, setPendingFiles] = useState<File[]>([]);
@@ -184,6 +185,34 @@ export function CourseWizardClient({
   const generatePollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const stepIndex = STEPS.indexOf(step);
+
+  useEffect(() => {
+    if (step !== "upload" || !courseId) return;
+
+    const fetchExistingFiles = async () => {
+      setIsFetchingExistingFiles(true);
+      try {
+        const data = await apiFetch<{ files: Array<{ name: string; size_bytes: number }> }>(
+          `/api/v1/admin/courses/${courseId}/resources`
+        );
+        const serverFiles: UploadedFile[] = (data.files ?? []).map((f) => ({
+          name: f.name,
+          size_bytes: f.size_bytes,
+          status: "uploaded" as const,
+        }));
+        setFiles((prev) => {
+          const localNames = new Set(prev.map((f) => f.name));
+          const toAdd = serverFiles.filter((f) => !localNames.has(f.name));
+          return [...prev, ...toAdd];
+        });
+      } catch {
+      } finally {
+        setIsFetchingExistingFiles(false);
+      }
+    };
+
+    fetchExistingFiles();
+  }, [step, courseId]);
 
   useEffect(() => {
     getCourseTaxonomy().then((tax) => {
@@ -731,6 +760,12 @@ export function CourseWizardClient({
                   className="hidden"
                   onChange={onFileInput}
                 />
+
+                {isFetchingExistingFiles && (
+                  <div className="flex items-center justify-center py-4">
+                    <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                  </div>
+                )}
 
                 {files.length > 0 && (
                   <div className="space-y-2">


### PR DESCRIPTION
## Summary

When navigating back to the Resources (upload) step after advancing in the course creation wizard, previously uploaded PDFs were not displayed. This also affected wizard resume (page refresh).

## Root Cause

The `files` state was initialized as an empty array and never populated from the server. The `handleBack()` function only changed the step without triggering any data fetch.

## Changes

- `frontend/components/admin/course-wizard-client.tsx`: Added a `useEffect` that fetches existing resources via `GET /api/v1/admin/courses/{courseId}/resources` whenever the user is on the `upload` step with an existing `courseId`. Merges server files with any locally-tracked files (avoiding duplicates). Shows a loading spinner while fetching.

## Behavior

- **Navigate back:** Files are re-fetched from the server and listed immediately
- **Wizard resume (page refresh):** Existing files are fetched on mount when `resumeCourseId` is provided
- **Add/remove:** Still works as before — local state is updated optimistically, and the server fetch merges without overwriting in-progress uploads
- **Mobile:** Loading spinner and file list are responsive at 320px+

## Test plan

- [ ] Upload PDFs → advance to Info step → click Back → files are listed
- [ ] Refresh browser at upload step with `resumeCourseId` → files are listed
- [ ] Add more files after navigating back → works correctly
- [ ] Remove a file after navigating back → works correctly
- [ ] Frontend lint: 0 errors

Closes #1061

Generated with [Claude Code](https://claude.ai/code)