### PR TITLE
fix(quiz): symmetric auth/subscription gating on generate and submit endpoints

### DIFF
--- a/backend/app/api/v1/quiz.py
+++ b/backend/app/api/v1/quiz.py
@@ -14,7 +14,7 @@ from app.ai.claude_service import ClaudeService
 from app.ai.rag.embeddings import EmbeddingService
 from app.ai.rag.retriever import SemanticRetriever
 from app.api.deps import get_db
-from app.api.deps_local_auth import require_active_subscription
+from app.api.deps_local_auth import AuthenticatedUser, get_current_user, require_active_subscription
 from app.api.v1.schemas.quiz import (
     ErrorResponse,
     QuizAttemptRequest,
@@ -30,7 +30,6 @@ from app.domain.models.content import GeneratedContent
 from app.domain.models.module import Module
 from app.domain.models.progress import UserModuleProgress
 from app.domain.models.quiz import QuizAttempt, SummativeAssessmentAttempt
-from app.domain.models.user import User
 from app.domain.services.platform_settings_service import SettingsCache
 from app.domain.services.progress_service import ProgressService
 from app.domain.services.quiz_service import QuizService
@@ -39,6 +38,51 @@ from app.tasks.content_generation import generate_quiz_task
 
 logger = structlog.get_logger()
 router = APIRouter(prefix="/quiz", tags=["quiz"])
+
+
+async def _check_subscription_or_first_unit(user: AuthenticatedUser, unit_id: str) -> None:
+    """Allow first unit of a module for free; require subscription for others.
+
+    If unit_id ends with '-U01' or user is admin → allow.
+    Otherwise checks subscription via SubscriptionService.
+    Falls back to DB ModuleUnit.order_index == 0 check.
+    Raises 403 with code 'subscription_required' if no subscription.
+    """
+    import uuid as _uuid
+
+    from app.domain.models.module_unit import ModuleUnit
+    from app.domain.services.subscription_service import SubscriptionService
+    from app.infrastructure.persistence.database import get_db_session
+
+    if user.role == "admin":
+        return
+
+    if unit_id and unit_id.upper().endswith("-U01"):
+        return
+
+    async for session in get_db_session():
+        sub = await SubscriptionService().get_active_subscription(
+            _uuid.UUID(user.id), session
+        )
+        if sub is not None:
+            return
+
+        if unit_id:
+            result = await session.execute(
+                select(ModuleUnit.order_index).where(ModuleUnit.unit_number == unit_id)
+            )
+            order = result.scalar_one_or_none()
+            if order is not None and order == 0:
+                return
+        break
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail={
+            "code": "subscription_required",
+            "message": "An active subscription is required to access this content. The first lesson of each module is free.",
+        },
+    )
 
 
 async def _resolve_module_uuid(module_id_str: str, session: AsyncSession) -> UUID:
@@ -106,6 +150,7 @@ async def generate_quiz(
     request: QuizGenerationRequest,
     quiz_service: QuizService = Depends(get_quiz_service),
     session: AsyncSession = Depends(get_db),
+    current_user: AuthenticatedUser = Depends(get_current_user),
 ) -> JSONResponse:
     """
     Generate or retrieve cached quiz content.
@@ -127,6 +172,8 @@ async def generate_quiz(
     - Country-contextualized examples
     """
     try:
+        await _check_subscription_or_first_unit(current_user, request.unit_id)
+
         module_uuid = await _resolve_module_uuid(request.module_id, session)
 
         logger.info(
@@ -293,7 +340,7 @@ async def get_quiz(
 async def submit_quiz_attempt(
     request: QuizAttemptRequest,
     session: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_active_subscription),
+    current_user: AuthenticatedUser = Depends(get_current_user),
 ) -> QuizAttemptResponse:
     """
     Submit a completed quiz attempt and get immediate feedback.
@@ -335,6 +382,10 @@ async def submit_quiz_attempt(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail={"error": "quiz_not_found", "message": f"Quiz {request.quiz_id} not found"},
             )
+
+        await _check_subscription_or_first_unit(
+            current_user, quiz_content.content.get("unit_id", "")
+        )
 
         quiz_data = quiz_content.content
         questions = quiz_data["questions"]
@@ -574,7 +625,7 @@ async def generate_summative_assessment(
 async def can_attempt_summative_assessment(
     module_id: UUID,
     session: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_active_subscription),
+    current_user: AuthenticatedUser = Depends(require_active_subscription),
 ) -> SummativeAssessmentAttemptCheck:
     """
     Check if user can attempt summative assessment for a module.
@@ -679,7 +730,7 @@ async def can_attempt_summative_assessment(
 async def submit_summative_assessment_attempt(
     request: QuizAttemptRequest,
     session: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_active_subscription),
+    current_user: AuthenticatedUser = Depends(require_active_subscription),
 ) -> SummativeAssessmentResponse:
     """
     Submit a completed summative assessment attempt.

--- a/frontend/components/quiz/quiz-container.tsx
+++ b/frontend/components/quiz/quiz-container.tsx
@@ -10,7 +10,7 @@ import { Badge } from '@/components/ui/badge';
 import { QuizInterface } from './quiz-interface';
 import { QuizResults } from './quiz-results';
 import type { Quiz, QuizAttemptResponse } from '@/lib/api';
-import { generateQuiz, apiFetch } from '@/lib/api';
+import { ApiError, generateQuiz, apiFetch } from '@/lib/api';
 import { useSettings } from '@/lib/settings-context';
 import { track } from '@/lib/analytics';
 import { useCurrentUser } from '@/lib/hooks/use-current-user';
@@ -140,7 +140,18 @@ export function QuizContainer({
         }
       } catch (err) {
         console.error('Failed to load quiz:', err);
-        const errorMessage = err instanceof Error ? err.message : t('failedToLoad');
+        let errorMessage: string;
+        if (err instanceof ApiError) {
+          if (err.code === 'subscription_required' || err.status === 403) {
+            errorMessage = t('subscriptionRequired');
+          } else if (err.status === 401) {
+            errorMessage = t('authRequired');
+          } else {
+            errorMessage = err.message || t('failedToLoad');
+          }
+        } else {
+          errorMessage = err instanceof Error ? err.message : t('failedToLoad');
+        }
         setError(errorMessage);
         setState('error');
         onError?.(errorMessage);

--- a/frontend/components/quiz/quiz-interface.tsx
+++ b/frontend/components/quiz/quiz-interface.tsx
@@ -13,7 +13,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
 import { Badge } from '@/components/ui/badge';
 import type { Quiz, QuizAnswerSubmission, QuizAttemptResponse } from '@/lib/api';
-import { submitQuizAttempt } from '@/lib/api';
+import { ApiError, submitQuizAttempt } from '@/lib/api';
 
 interface QuizInterfaceProps {
   quiz: Quiz;
@@ -118,7 +118,17 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
       onComplete(result);
     } catch (error) {
       console.error('Quiz submission failed:', error);
-      onError(t('failedToSubmit'));
+      if (error instanceof ApiError) {
+        if (error.code === 'subscription_required' || error.status === 403) {
+          onError(t('subscriptionRequired'));
+        } else if (error.status === 401) {
+          onError(t('authRequired'));
+        } else {
+          onError(t('failedToSubmit'));
+        }
+      } else {
+        onError(t('failedToSubmit'));
+      }
     } finally {
       setIsSubmitting(false);
     }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,5 +1,12 @@
 export const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
+export class ApiError extends Error {
+  constructor(message: string, public status: number, public code?: string) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
 // Course Taxonomy Types (DB-driven, no hardcoded enums)
 export interface TaxonomyItem {
   value: string;
@@ -275,14 +282,16 @@ export async function apiFetch<T>(
   });
   if (!res.ok) {
     let message = `API error: ${res.status}`;
+    let code: string | undefined;
     try {
       const body = await res.json();
       if (body?.detail?.message) message = body.detail.message;
       else if (typeof body?.detail === 'string') message = body.detail;
+      if (body?.detail?.code) code = body.detail.code;
     } catch {
       // ignore parse errors — keep the status-code message
     }
-    throw new Error(message);
+    throw new ApiError(message, res.status, code);
   }
   return res.json();
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -314,7 +314,9 @@
     "lessonCompletedDesc": "You scored ≥80%. This lesson is now marked as complete in your progress.",
     "lessonNotValidated": "Lesson not validated",
     "lessonNotValidatedDesc": "You need at least {score}% to validate this lesson. Try again!",
-    "refreshContent": "Refresh content"
+    "refreshContent": "Refresh content",
+    "subscriptionRequired": "A subscription is required to access this content. The first unit of each module is free.",
+    "authRequired": "Please sign in to continue."
   },
   "ChatTutor": {
     "title": "AI Tutor",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -314,7 +314,9 @@
     "lessonCompletedDesc": "Vous avez obtenu un score ≥ 80%. Cette leçon est maintenant marquée comme terminée dans votre progression.",
     "lessonNotValidated": "Leçon non validée",
     "lessonNotValidatedDesc": "Vous devez obtenir au moins {score}% pour valider cette leçon. Réessayez !",
-    "refreshContent": "Actualiser le contenu"
+    "refreshContent": "Actualiser le contenu",
+    "subscriptionRequired": "Un abonnement est requis pour accéder à ce contenu. La première unité de chaque module est gratuite.",
+    "authRequired": "Veuillez vous connecter pour continuer."
   },
   "ChatTutor": {
     "title": "Tuteur IA",


### PR DESCRIPTION
## Summary
- Add `_check_subscription_or_first_unit` helper — first unit free, subscription required otherwise, admin bypass
- Add auth (`get_current_user`) + subscription check to quiz **generate** endpoint (was completely unprotected)
- Fix quiz **submit** endpoint to use freemium gating instead of blanket `require_active_subscription`
- Fix type annotations `User` → `AuthenticatedUser` on summative endpoints
- Frontend: `ApiError` class with status/code, specific error messages for subscription vs auth errors
- i18n: FR/EN `subscriptionRequired` and `authRequired` keys

Closes #1069

## Test plan
- [ ] User without subscription on first unit → quiz loads AND submits
- [ ] User without subscription on non-first unit → subscription error on generate
- [ ] User with subscription → all quizzes work
- [ ] Admin → all quizzes work
- [ ] `cd backend && python -m pytest tests/ -k quiz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)