### PR TITLE
feat(subscription): make free unit count configurable via platform settings

### DIFF
--- a/backend/app/api/deps_local_auth.py
+++ b/backend/app/api/deps_local_auth.py
@@ -158,20 +158,27 @@ async def require_subscription_or_first_unit(
     request: Request,
     user: AuthenticatedUser = Depends(get_current_user),
 ) -> AuthenticatedUser:
-    """Allow first unit of a module for free; require subscription for others.
+    """Allow free units of a module for free; require subscription for others.
 
-    Reads `unit_id` from path params (e.g. 'M01-U01'). If unit ends with
-    '-U01' or order_index == 0 in DB, access is free. Otherwise requires
-    an active subscription.
+    Reads `unit_id` from path params (e.g. 'M01-U02'). The number of free units
+    is controlled by the 'subscription-free-units-count' platform setting (default: 2).
+    Falls back to DB order_index check when unit_id format is unrecognised.
     """
+    import re
+
     from ..domain.models.module_unit import ModuleUnit
+    from ..domain.services.platform_settings_service import SettingsCache
     from ..domain.services.subscription_service import SubscriptionService
     from ..infrastructure.persistence.database import get_db_session
 
+    if user.role == "admin":
+        return user
+
     unit_id = request.path_params.get("unit_id") or request.path_params.get("unitId")
 
-    # Quick check: if unit_id looks like first unit (M01-U01, U01, etc.)
-    if unit_id and unit_id.upper().endswith("-U01"):
+    free_count = SettingsCache.instance().get("subscription-free-units-count", 2)
+    m = re.search(r"-U0*(\d+)$", unit_id.upper()) if unit_id else None
+    if m and int(m.group(1)) <= free_count:
         return user
 
     # Check subscription
@@ -180,13 +187,13 @@ async def require_subscription_or_first_unit(
         if sub is not None:
             return user
 
-        # No subscription — check if this is order_index 0 in DB
+        # No subscription — fall back to DB order_index check
         if unit_id:
             result = await session.execute(
                 select(ModuleUnit.order_index).where(ModuleUnit.unit_number == unit_id)
             )
             order = result.scalar_one_or_none()
-            if order is not None and order == 0:
+            if order is not None and order < free_count:
                 return user
         break
 

--- a/backend/app/api/v1/quiz.py
+++ b/backend/app/api/v1/quiz.py
@@ -41,11 +41,11 @@ router = APIRouter(prefix="/quiz", tags=["quiz"])
 
 
 async def _check_subscription_or_first_unit(user: AuthenticatedUser, unit_id: str) -> None:
-    """Allow first unit of a module for free; require subscription for others.
+    """Allow free units of a module; require subscription for others.
 
-    If unit_id ends with '-U01' or user is admin → allow.
-    Otherwise checks subscription via SubscriptionService.
-    Falls back to DB ModuleUnit.order_index == 0 check.
+    The number of free units is controlled by the 'subscription-free-units-count' platform
+    setting (default: 2). Admin users always bypass this check.
+    Falls back to DB ModuleUnit.order_index check when unit_id format is unrecognised.
     Raises 403 with code 'subscription_required' if no subscription.
     """
     import uuid as _uuid
@@ -57,7 +57,9 @@ async def _check_subscription_or_first_unit(user: AuthenticatedUser, unit_id: st
     if user.role == "admin":
         return
 
-    if unit_id and unit_id.upper().endswith("-U01"):
+    free_count = SettingsCache.instance().get("subscription-free-units-count", 2)
+    m = re.search(r"-U0*(\d+)$", unit_id.upper()) if unit_id else None
+    if m and int(m.group(1)) <= free_count:
         return
 
     async for session in get_db_session():
@@ -70,7 +72,7 @@ async def _check_subscription_or_first_unit(user: AuthenticatedUser, unit_id: st
                 select(ModuleUnit.order_index).where(ModuleUnit.unit_number == unit_id)
             )
             order = result.scalar_one_or_none()
-            if order is not None and order == 0:
+            if order is not None and order < free_count:
                 return
         break
 

--- a/backend/app/infrastructure/config/platform_defaults.py
+++ b/backend/app/infrastructure/config/platform_defaults.py
@@ -564,6 +564,16 @@ SETTING_DEFINITIONS: list[SettingDef] = [
         "Credits charged per module offline download.",
         {"min": 0, "max": 100000},
     ),
+    # ── Subscription & Access ──────────────────────────────
+    SettingDef(
+        "subscription-free-units-count",
+        "subscription",
+        2,
+        "integer",
+        "Free units per module",
+        "Number of free units per module before subscription required.",
+        {"min": 1, "max": 10},
+    ),
     # ── Payments ───────────────────────────────────────────
     SettingDef(
         "payments-orange-money-number",


### PR DESCRIPTION
## Summary
- Add `subscription-free-units-count` platform setting (default: 2, range 1-10)
- Update `_check_subscription_or_first_unit` in quiz.py to use setting
- Update `require_subscription_or_first_unit` in deps_local_auth.py to use setting
- DB fallback uses `order_index < free_count` instead of `== 0`

Closes #1079

## Test plan
- [ ] Default: first 2 units free for unsubscribed users
- [ ] Change setting to 3 → first 3 units free
- [ ] Admin bypasses check regardless
- [ ] Subscribed users unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)