### PR TITLE
fix(tutor): respond in active locale & render source image tags properly

### DIFF
--- a/backend/app/ai/prompts/tutor.py
+++ b/backend/app/ai/prompts/tutor.py
@@ -58,6 +58,9 @@ def get_socratic_system_prompt(context: TutorContext, rag_chunks: list[dict[str,
     prompt = f"""Tu es un tuteur IA spécialisé en {course_label} pour l'Afrique de l'Ouest.
 {_get_mode_intro(context.tutor_mode)}
 
+## LANGUE DE RÉPONSE OBLIGATOIRE
+{language_instruction}
+
 ## CONTEXTE DE L'APPRENANT
 - Niveau: {level_instruction}
 - Langue: {language_instruction}
@@ -318,9 +321,9 @@ def _get_pedagogical_rules(tutor_mode: str) -> str:
 def _get_language_instruction(language: str) -> str:
     """Get language-specific instruction."""
     if language == "fr":
-        return "Français (langue principale), avec traductions en anglais si nécessaire"
+        return "Français — Tu DOIS répondre ENTIÈREMENT en français. N'utilise PAS l'anglais sauf si l'apprenant le demande explicitement dans son message."
     else:
-        return "English (primary language), with French translations when needed"
+        return "English — You MUST respond ENTIRELY in English. Do NOT use French unless the learner explicitly requests it in their message."
 
 
 def _get_level_instruction(level: int) -> str:

--- a/backend/app/api/v1/schemas/tutor.py
+++ b/backend/app/api/v1/schemas/tutor.py
@@ -47,6 +47,9 @@ class TutorChatRequest(BaseModel):
         description="Tutor mode: socratic (guided questions) or explanatory (direct answers)",
     )
     file_ids: list[str] = Field(default_factory=list, description="Uploaded file IDs to attach")
+    locale: str | None = Field(
+        None, description="Active UI locale ('fr' or 'en') from the frontend"
+    )
 
 
 class TutorChatResponse(BaseModel):

--- a/backend/app/api/v1/tutor.py
+++ b/backend/app/api/v1/tutor.py
@@ -159,6 +159,7 @@ async def chat_with_tutor(
                 tutor_mode=request.tutor_mode,
                 file_content_blocks=file_content_blocks,
                 course_id=request.course_id,
+                locale=request.locale,
             ):
                 yield f"data: {json.dumps(chunk)}\n\n"
 

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -24,6 +24,7 @@ from app.ai.rag.retriever import SemanticRetriever
 from app.domain.models.conversation import TutorConversation
 from app.domain.models.course import Course, UserCourseEnrollment
 from app.domain.models.module import Module
+from app.domain.models.source_image import SourceImage
 from app.domain.models.user import User
 from app.domain.services.learner_memory_service import LearnerMemoryService
 from app.domain.services.platform_settings_service import SettingsCache
@@ -216,6 +217,7 @@ class TutorService:
         tutor_mode: str = "socratic",
         file_content_blocks: list[dict[str, Any]] | None = None,
         course_id: uuid.UUID | None = None,
+        locale: str | None = None,
     ) -> AsyncGenerator[dict[str, Any], None]:
         """
         Send a message to the AI tutor and stream the response using agentic tool_use.
@@ -286,6 +288,12 @@ class TutorService:
                 "data": {"conversation_id": str(conversation.id)},
             }
 
+            effective_language = locale if locale in ("fr", "en") else user.preferred_language
+
+            if locale in ("fr", "en") and user.preferred_language != locale:
+                user.preferred_language = locale
+                session.add(user)
+
             # Resolve module title for human-readable system prompt
             module_title = None
             module_number = None
@@ -294,9 +302,7 @@ class TutorService:
                 module_obj = await session.get(Module, module_id)
                 if module_obj:
                     module_title = (
-                        module_obj.title_fr
-                        if user.preferred_language == "fr"
-                        else module_obj.title_en
+                        module_obj.title_fr if effective_language == "fr" else module_obj.title_en
                     )
                     module_number = module_obj.module_number
 
@@ -306,14 +312,13 @@ class TutorService:
             course_domain = None
             rag_collection_id = None
             if course:
-                lang = user.preferred_language
-                course_title = course.title_fr if lang == "fr" else course.title_en
+                course_title = course.title_fr if effective_language == "fr" else course.title_en
                 course_domain = course_domain or course_title
                 rag_collection_id = course.rag_collection_id
 
             context = TutorContext(
                 user_level=user.current_level,
-                user_language=user.preferred_language,
+                user_language=effective_language,
                 user_country=user.country or "SN",
                 module_id=str(module_id) if module_id else None,
                 module_title=module_title,
@@ -350,7 +355,7 @@ class TutorService:
                 anthropic_client=self.anthropic,
                 user_id=user_id,
                 user_level=user.current_level,
-                user_language=user.preferred_language,
+                user_language=effective_language,
                 rag_collection_id=rag_collection_id,
             )
 
@@ -476,17 +481,47 @@ class TutorService:
 
                             img_result = _json.loads(tool_result_str)
                             prefix = "{{source_image:"
+                            img_ids_to_fetch: list[str] = []
                             for fig in img_result.get("figures", []):
                                 ref: str = fig.get("ref", "")
                                 if ref.startswith(prefix) and ref.endswith("}}"):
-                                    img_id = ref[len(prefix) : -2]
-                                    source_image_refs.append(
-                                        {
-                                            "id": img_id,
-                                            "figure_number": fig.get("figure_number"),
-                                            "caption": fig.get("caption"),
-                                        }
+                                    img_ids_to_fetch.append(ref[len(prefix) : -2])
+
+                            if img_ids_to_fetch:
+                                try:
+                                    db_imgs = await session.execute(
+                                        select(SourceImage).where(
+                                            SourceImage.id.in_(
+                                                [uuid.UUID(i) for i in img_ids_to_fetch]
+                                            )
+                                        )
                                     )
+                                    db_img_map = {str(r.id): r for r in db_imgs.scalars().all()}
+                                except Exception:
+                                    db_img_map = {}
+
+                                seen_img_ids: set[str] = {r["id"] for r in source_image_refs}
+                                for img_id in img_ids_to_fetch:
+                                    if img_id in seen_img_ids:
+                                        continue
+                                    seen_img_ids.add(img_id)
+                                    db_img = db_img_map.get(img_id)
+                                    if db_img:
+                                        meta = db_img.to_meta_dict()
+                                        source_image_refs.append(
+                                            {
+                                                "id": img_id,
+                                                "figure_number": meta.get("figure_number"),
+                                                "caption": meta.get("caption"),
+                                                "caption_fr": meta.get("caption"),
+                                                "caption_en": meta.get("caption"),
+                                                "attribution": meta.get("attribution"),
+                                                "image_type": meta.get("image_type", "unknown"),
+                                                "storage_url": meta.get("storage_url"),
+                                                "alt_text_fr": meta.get("alt_text_fr"),
+                                                "alt_text_en": meta.get("alt_text_en"),
+                                            }
+                                        )
                         except Exception:
                             pass
 

--- a/frontend/components/chat/chat-message.tsx
+++ b/frontend/components/chat/chat-message.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/lib/utils';
 import { AttachedFileCard } from '@/components/chat/file-preview';
 import { SourceImage } from '@/components/learning/source-image';
 import type { SourceImageMeta } from '@/lib/api';
+import { splitWithSourceImageMarkers } from '@/lib/source-image-utils';
 
 export interface ChatSource {
   title: string;
@@ -36,35 +37,6 @@ export interface ChatMessage {
 
 interface ChatMessageProps {
   message: ChatMessage;
-}
-
-const SOURCE_IMAGE_RE = /\{\{source_image:([0-9a-f-]{36})\}\}/g;
-
-function splitWithSourceImageMarkers(
-  text: string,
-  imageMap: Map<string, SourceImageMeta>
-): Array<{ type: 'markdown'; text: string } | { type: 'source_image'; meta: SourceImageMeta }> {
-  const parts: Array<{ type: 'markdown'; text: string } | { type: 'source_image'; meta: SourceImageMeta }> = [];
-  let lastIndex = 0;
-  let match: RegExpExecArray | null;
-
-  SOURCE_IMAGE_RE.lastIndex = 0;
-  while ((match = SOURCE_IMAGE_RE.exec(text)) !== null) {
-    if (match.index > lastIndex) {
-      parts.push({ type: 'markdown', text: text.slice(lastIndex, match.index) });
-    }
-    const meta = imageMap.get(match[1]);
-    if (meta) {
-      parts.push({ type: 'source_image', meta });
-    } else {
-      parts.push({ type: 'markdown', text: text.slice(match.index, SOURCE_IMAGE_RE.lastIndex) });
-    }
-    lastIndex = SOURCE_IMAGE_RE.lastIndex;
-  }
-  if (lastIndex < text.length) {
-    parts.push({ type: 'markdown', text: text.slice(lastIndex) });
-  }
-  return parts;
 }
 
 const mdClass =

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -229,6 +229,7 @@ export function ChatPanel({
           module_id: moduleId ?? null,
           tutor_mode: tutorMode,
           file_ids: attachedFiles.map((f) => f.fileId),
+          locale: locale,
         }),
       });
 

--- a/frontend/components/learning/lesson-viewer.tsx
+++ b/frontend/components/learning/lesson-viewer.tsx
@@ -16,6 +16,7 @@ import { SourceImage } from './source-image';
 import { SourceCitations } from './source-citations';
 import { apiFetch, checkUnitQuizPassed } from '@/lib/api';
 import type { SourceImageMeta } from '@/lib/api';
+import { SOURCE_IMAGE_RE, splitWithSourceImageMarkers } from '@/lib/source-image-utils';
 import { useCurrentUser } from '@/lib/hooks/use-current-user';
 import { useRouter } from 'next/navigation';
 import { useLocale } from 'next-intl';
@@ -44,33 +45,6 @@ interface LessonData {
   content: LessonContent;
   cached: boolean;
   source_image_refs?: SourceImageMeta[];
-}
-
-const SOURCE_IMAGE_RE = /\{\{source_image:([0-9a-f-]{36})\}\}/g;
-
-function splitWithSourceImageMarkers(
-  text: string,
-  imageMap: Map<string, SourceImageMeta>
-): Array<{ type: 'markdown'; text: string } | { type: 'source_image'; meta: SourceImageMeta }> {
-  const parts: Array<{ type: 'markdown'; text: string } | { type: 'source_image'; meta: SourceImageMeta }> = [];
-  let lastIndex = 0;
-  let match: RegExpExecArray | null;
-
-  SOURCE_IMAGE_RE.lastIndex = 0;
-  while ((match = SOURCE_IMAGE_RE.exec(text)) !== null) {
-    if (match.index > lastIndex) {
-      parts.push({ type: 'markdown', text: text.slice(lastIndex, match.index) });
-    }
-    const meta = imageMap.get(match[1]);
-    if (meta) {
-      parts.push({ type: 'source_image', meta });
-    }
-    lastIndex = SOURCE_IMAGE_RE.lastIndex;
-  }
-  if (lastIndex < text.length) {
-    parts.push({ type: 'markdown', text: text.slice(lastIndex) });
-  }
-  return parts;
 }
 
 interface GeneratingResponse {

--- a/frontend/lib/source-image-utils.ts
+++ b/frontend/lib/source-image-utils.ts
@@ -1,0 +1,34 @@
+import type { SourceImageMeta } from '@/lib/api';
+
+export const SOURCE_IMAGE_RE = /\{\{source_image:([0-9a-f-]{36})\}\}/g;
+
+export type SourceImagePart =
+  | { type: 'markdown'; text: string }
+  | { type: 'source_image'; meta: SourceImageMeta };
+
+export function splitWithSourceImageMarkers(
+  text: string,
+  imageMap: Map<string, SourceImageMeta>
+): SourceImagePart[] {
+  const parts: SourceImagePart[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  SOURCE_IMAGE_RE.lastIndex = 0;
+  while ((match = SOURCE_IMAGE_RE.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push({ type: 'markdown', text: text.slice(lastIndex, match.index) });
+    }
+    const meta = imageMap.get(match[1]);
+    if (meta) {
+      parts.push({ type: 'source_image', meta });
+    } else {
+      parts.push({ type: 'markdown', text: text.slice(match.index, SOURCE_IMAGE_RE.lastIndex) });
+    }
+    lastIndex = SOURCE_IMAGE_RE.lastIndex;
+  }
+  if (lastIndex < text.length) {
+    parts.push({ type: 'markdown', text: text.slice(lastIndex) });
+  }
+  return parts;
+}


### PR DESCRIPTION
## Summary
- **Language**: Frontend now sends `locale` in tutor chat request; backend uses it as `effective_language` and syncs `user.preferred_language`. System prompt includes explicit MUST directive for response language.
- **Image tags**: Backend queries DB for full `SourceImageRef` metadata (alt text, attribution) instead of using minimal tool-result data. Frontend parsing code deduplicated into shared `lib/source-image-utils.ts`.

Closes #1085

## Test plan
- [ ] Set UI to FR → tutor responds in French
- [ ] Switch to EN mid-conversation → next response in English  
- [ ] Trigger source image in tutor → renders as image, not raw tag
- [ ] Lesson content images still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)