### PR TITLE
merge: dev → main — resume polling + force-retry + migration 039

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -324,19 +324,21 @@ class GenerateStructureRequest(BaseModel):
 async def generate_course_structure(
     course_id: uuid.UUID,
     request: GenerateStructureRequest,
+    force: bool = False,
     current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
     db=Depends(get_db_session),
 ) -> dict:
     """
     Dispatch a Celery task to generate module outline for a course via Claude API.
     Returns immediately with task_id for polling. Admin only.
+    Use force=true to override a stuck 'generating' state (e.g. after worker crash).
     """
     result = await db.execute(select(Course).where(Course.id == course_id))
     course = result.scalar_one_or_none()
     if not course:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
 
-    if course.creation_step == "generating":
+    if course.creation_step == "generating" and not force:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"A task is already in progress (step: {course.creation_step})",
@@ -355,6 +357,7 @@ async def generate_course_structure(
     )
 
     course.creation_step = "generating"
+    course.syllabus_task_id = task.id
     await db.commit()
 
     logger.info(
@@ -384,16 +387,19 @@ async def get_generate_status(
     )
     modules_count = module_count_result.scalar_one()
 
+    resolved_task_id = task_id or course.syllabus_task_id
+
     response: dict = {
         "course_id": str(course_id),
         "modules_count": modules_count,
         "has_modules": modules_count > 0,
+        "creation_step": course.creation_step,
     }
 
-    if task_id:
-        task_result = AsyncResult(task_id)
+    if resolved_task_id:
+        task_result = AsyncResult(resolved_task_id)
         response["task"] = {
-            "id": task_id,
+            "id": resolved_task_id,
             "state": task_result.state,
             "meta": task_result.info if isinstance(task_result.info, dict) else {},
         }

--- a/backend/app/domain/models/course.py
+++ b/backend/app/domain/models/course.py
@@ -37,6 +37,7 @@ class Course(Base):
     )
     rag_collection_id: Mapped[str | None] = mapped_column(String)
     indexation_task_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    syllabus_task_id: Mapped[str | None] = mapped_column(String, nullable=True)
     syllabus_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     creation_step: Mapped[str] = mapped_column(String(20), server_default="upload", nullable=False)
     preassessment_enabled: Mapped[bool] = mapped_column(server_default="false")

--- a/backend/migrations/versions/039_add_syllabus_task_id_to_courses.py
+++ b/backend/migrations/versions/039_add_syllabus_task_id_to_courses.py
@@ -1,0 +1,26 @@
+"""add syllabus_task_id to courses
+
+Revision ID: 039
+Revises: 038
+Create Date: 2026-04-07
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "039"
+down_revision = "038"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "courses",
+        sa.Column("syllabus_task_id", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("courses", "syllabus_task_id")

--- a/frontend/components/admin/course-wizard-client.tsx
+++ b/frontend/components/admin/course-wizard-client.tsx
@@ -201,6 +201,7 @@ export function CourseWizardClient({
     resumeCreationStep === "generating"
   );
   const [generateError, setGenerateError] = useState<string | null>(null);
+  const [shouldForceGenerate, setShouldForceGenerate] = useState(false);
   const [generateTaskId, setGenerateTaskId] = useState<string | null>(null);
   const [generateTaskState, setGenerateTaskState] = useState<string | null>(null);
   const [generationProgress, setGenerationProgress] = useState(0);
@@ -286,11 +287,24 @@ export function CourseWizardClient({
 
     const checkOnResume = async () => {
       try {
-        const data = await apiFetch<{ has_modules: boolean; modules_count: number }>(
-          `/api/v1/admin/courses/${resumeCourseId}/generate-status`
-        );
+        const data = await apiFetch<{
+          has_modules: boolean;
+          modules_count: number;
+          creation_step: string;
+          task?: { id: string; state: string; meta?: Record<string, unknown> };
+        }>(`/api/v1/admin/courses/${resumeCourseId}/generate-status`);
+
         if (data.has_modules) {
           setGeneratedModules([{ id: "resumed", module_number: 1, title_fr: "", title_en: "" }]);
+        }
+
+        const activeStates = ["PENDING", "STARTED", "RETRY"];
+        if (data.task && activeStates.includes(data.task.state)) {
+          setIsGenerating(true);
+          setGenerateTaskId(data.task.id);
+          setGenerationStartTime(Date.now());
+        } else if (data.creation_step === "generating") {
+          setShouldForceGenerate(true);
         }
       } catch {
       } finally {
@@ -522,8 +536,9 @@ export function CourseWizardClient({
     }
   }, [courseInfo, courseId, getAuthHeaders, t, pendingFiles]);
 
-  const generateSyllabus = useCallback(async () => {
+  const generateSyllabus = useCallback(async (force?: boolean) => {
     if (!courseId || isGenerating) return;
+    const useForce = force ?? shouldForceGenerate;
     setIsGenerating(true);
     setGenerateError(null);
     setGenerateTaskId(null);
@@ -535,10 +550,12 @@ export function CourseWizardClient({
     lastProgressValueRef.current = 0;
     lastProgressTimeRef.current = Date.now();
     setShowTimeoutWarning(false);
+    setShouldForceGenerate(false);
 
     try {
+      const url = `/api/v1/admin/courses/${courseId}/generate-structure${useForce ? "?force=true" : ""}`;
       const result = await apiFetch<{ task_id: string; status: string }>(
-        `/api/v1/admin/courses/${courseId}/generate-structure`,
+        url,
         {
           method: "POST",
           body: JSON.stringify({
@@ -551,7 +568,7 @@ export function CourseWizardClient({
       setGenerateError(t("generate.error"));
       setIsGenerating(false);
     }
-  }, [courseId, courseInfo, isGenerating, t]);
+  }, [courseId, courseInfo, isGenerating, shouldForceGenerate, t]);
 
   useEffect(() => {
     if (!courseId || !isGenerating || !generateTaskId) return;
@@ -1053,7 +1070,7 @@ export function CourseWizardClient({
 
                 {generatedModules.length === 0 && !isGenerating && !isCheckingGenerateStatus && (
                   <Button
-                    onClick={generateSyllabus}
+                    onClick={() => generateSyllabus()}
                     className="w-full min-h-11"
                     disabled={isGenerating}
                   >
@@ -1104,7 +1121,7 @@ export function CourseWizardClient({
                     <Button
                       variant="outline"
                       size="sm"
-                      onClick={generateSyllabus}
+                      onClick={() => generateSyllabus()}
                       className="self-start min-h-[44px]"
                     >
                       <Sparkles className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary

- Resume polling for running tasks on wizard reopen
- Force-retry option when creation_step stuck at 'generating'
- Store syllabus_task_id on course record (migration 039)
- generate-status returns task state without explicit task_id

Fixes #1087

🤖 Generated with [Claude Code](https://claude.com/claude-code)