### PR TITLE
Release: SMS payment subscription fixes + message credits

### DIFF
--- a/backend/app/ai/prompts/tutor.py
+++ b/backend/app/ai/prompts/tutor.py
@@ -58,6 +58,9 @@ def get_socratic_system_prompt(context: TutorContext, rag_chunks: list[dict[str,
     prompt = f"""Tu es un tuteur IA spécialisé en {course_label} pour l'Afrique de l'Ouest.
 {_get_mode_intro(context.tutor_mode)}
 
+## LANGUE DE RÉPONSE OBLIGATOIRE
+{language_instruction}
+
 ## CONTEXTE DE L'APPRENANT
 - Niveau: {level_instruction}
 - Langue: {language_instruction}
@@ -318,9 +321,9 @@ def _get_pedagogical_rules(tutor_mode: str) -> str:
 def _get_language_instruction(language: str) -> str:
     """Get language-specific instruction."""
     if language == "fr":
-        return "Français (langue principale), avec traductions en anglais si nécessaire"
+        return "Français — Tu DOIS répondre ENTIÈREMENT en français. N'utilise PAS l'anglais sauf si l'apprenant le demande explicitement dans son message."
     else:
-        return "English (primary language), with French translations when needed"
+        return "English — You MUST respond ENTIRELY in English. Do NOT use French unless the learner explicitly requests it in their message."
 
 
 def _get_level_instruction(level: int) -> str:

--- a/backend/app/api/v1/schemas/tutor.py
+++ b/backend/app/api/v1/schemas/tutor.py
@@ -47,6 +47,9 @@ class TutorChatRequest(BaseModel):
         description="Tutor mode: socratic (guided questions) or explanatory (direct answers)",
     )
     file_ids: list[str] = Field(default_factory=list, description="Uploaded file IDs to attach")
+    locale: str | None = Field(
+        None, description="Active UI locale ('fr' or 'en') from the frontend"
+    )
 
 
 class TutorChatResponse(BaseModel):
@@ -96,7 +99,8 @@ class TutorStatsResponse(BaseModel):
     """Response for tutor usage statistics."""
 
     daily_messages_used: int = Field(..., description="Messages used today")
-    daily_messages_limit: int = Field(..., description="Daily message limit")
+    daily_messages_limit: int = Field(..., description="Daily message limit (daily + credits)")
+    message_credits: int = Field(default=0, description="Non-resetting AI message credit pool")
     total_conversations: int = Field(..., description="Total conversation count")
     most_discussed_topics: list[str] = Field(
         default_factory=list, description="Most frequently discussed topics"

--- a/backend/app/api/v1/subscriptions.py
+++ b/backend/app/api/v1/subscriptions.py
@@ -41,6 +41,7 @@ class SubscriptionStatusResponse(BaseModel):
     subscription_status: str | None = None
     days_remaining: int | None = None
     daily_message_limit: int | None = None
+    message_credits: int = 0
     expires_at: str | None = None
     free_tier: FreeTierInfo | None = None
 
@@ -129,6 +130,7 @@ async def get_my_subscription(
         subscription_status=subscription.status,
         days_remaining=days_remaining,
         daily_message_limit=subscription.daily_message_limit,
+        message_credits=subscription.message_credits,
         expires_at=subscription.expires_at.isoformat(),
     )
 

--- a/backend/app/api/v1/tutor.py
+++ b/backend/app/api/v1/tutor.py
@@ -159,6 +159,7 @@ async def chat_with_tutor(
                 tutor_mode=request.tutor_mode,
                 file_content_blocks=file_content_blocks,
                 course_id=request.course_id,
+                locale=request.locale,
             ):
                 yield f"data: {json.dumps(chunk)}\n\n"
 
@@ -300,6 +301,7 @@ async def get_remaining_messages(
         "remaining_messages": max(0, remaining),
         "daily_limit": stats["daily_messages_limit"],
         "messages_used": stats["daily_messages_used"],
+        "message_credits": stats.get("message_credits", 0),
     }
 
 

--- a/backend/app/domain/models/subscription.py
+++ b/backend/app/domain/models/subscription.py
@@ -49,6 +49,9 @@ class Subscription(Base):
     daily_message_limit: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default="20", default=20
     )
+    message_credits: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0", default=0
+    )
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     activated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     pending_expires_at: Mapped[datetime | None] = mapped_column(
@@ -68,8 +71,8 @@ class SubscriptionPayment(Base):
     __tablename__ = "subscription_payments"
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
-    user_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=True, index=True
     )
     phone_number: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
     amount_xof: Mapped[int] = mapped_column(Integer, nullable=False)
@@ -85,4 +88,4 @@ class SubscriptionPayment(Base):
     )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    user: Mapped[User] = relationship(back_populates="subscription_payments")
+    user: Mapped[User | None] = relationship(back_populates="subscription_payments")

--- a/backend/app/domain/services/sms_parser.py
+++ b/backend/app/domain/services/sms_parser.py
@@ -73,23 +73,48 @@ def _normalize_amount(raw: str) -> int:
     return int(float(cleaned))
 
 
-def _normalize_phone(raw: str) -> str:
-    """Strip country code prefix to get local number."""
+_ECOWAS_COUNTRY_CODES = (
+    "224",
+    "221",
+    "223",
+    "225",
+    "226",
+    "227",
+    "228",
+    "229",
+    "231",
+    "233",
+    "234",
+)
+
+
+def normalize_phone(raw: str) -> str:
+    """Strip country code prefix to get local number (public utility).
+
+    Handles:
+    - +22670220689  -> 70220689
+    - 0022670220689 -> 70220689
+    - 70220689      -> 70220689 (unchanged)
+    - 070220689     -> 70220689 (leading 0 stripped if >8 digits remain)
+    """
     phone = raw.strip()
-    # +224 76801718 -> 76801718
     if phone.startswith("+"):
         phone = phone[1:]
-        # Strip country codes (224=Guinea, 221=Senegal, etc.)
-        for prefix in ("224", "221", "223", "225", "226"):
+        for prefix in _ECOWAS_COUNTRY_CODES:
             if phone.startswith(prefix) and len(phone) > 8:
                 phone = phone[len(prefix) :]
                 break
     elif phone.startswith("00"):
         phone = phone[2:]
-        for prefix in ("224", "221", "223", "225", "226"):
+        for prefix in _ECOWAS_COUNTRY_CODES:
             if phone.startswith(prefix) and len(phone) > 8:
                 phone = phone[len(prefix) :]
                 break
     elif phone.startswith("0") and len(phone) > 8:
         phone = phone[1:]
     return phone
+
+
+def _normalize_phone(raw: str) -> str:
+    """Strip country code prefix to get local number (internal alias)."""
+    return normalize_phone(raw)

--- a/backend/app/domain/services/subscription_service.py
+++ b/backend/app/domain/services/subscription_service.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from uuid import UUID
 
 import structlog
-from sqlalchemy import select, update
+from sqlalchemy import or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.domain.models.subscription import (
@@ -18,6 +18,8 @@ from app.domain.models.subscription import (
     SubscriptionStatus,
 )
 from app.domain.models.user import User, UserRole
+from app.domain.services.platform_settings_service import SettingsCache
+from app.domain.services.sms_parser import normalize_phone
 
 logger = structlog.get_logger(__name__)
 
@@ -41,7 +43,6 @@ class SubscriptionService:
         if sub is not None:
             return sub
 
-        # Auto-provision subscription for admin users
         user = await session.get(User, user_id)
         if user and user.role == UserRole.admin:
             return await self.ensure_admin_subscription(user_id, session)
@@ -93,28 +94,69 @@ class SubscriptionService:
             )
             return {
                 "status": "ok",
-                "subscription_activated": existing.payment_type == PaymentType.access,
-                "user_found": True,
+                "subscription_activated": existing.payment_type == PaymentType.access
+                and existing.status == PaymentStatus.confirmed,
+                "user_found": existing.user_id is not None,
             }
 
-        user_result = await session.execute(select(User).where(User.phone_number == phone_number))
+        normalized = normalize_phone(phone_number)
+        candidates = list({phone_number, normalized})
+        if len(normalized) == 8:
+            candidates.append(f"+226{normalized}")
+        user_result = await session.execute(select(User).where(User.phone_number.in_(candidates)))
         user = user_result.scalar_one_or_none()
-        user_found = user is not None
 
-        if not user_found:
+        if user is None:
             logger.info(
-                "No user found for phone number, recording unprocessed payment",
+                "No user found for phone number, saving pending payment",
                 phone_number=phone_number,
             )
+            payment = SubscriptionPayment(
+                user_id=None,
+                phone_number=normalized,
+                amount_xof=amount_xof,
+                payment_type=PaymentType.access,
+                external_reference=external_reference,
+                status=PaymentStatus.pending,
+            )
+            session.add(payment)
+            await session.commit()
             return {"status": "ok", "subscription_activated": False, "user_found": False}
 
+        sc = SettingsCache.instance()
+        min_price: int = sc.get("payments-subscription-price-xof", 1000)
         active_sub = await self.get_active_subscription(user.id, session)
         now = datetime.datetime.now(tz=datetime.UTC)
 
         if active_sub is None:
+            if amount_xof < min_price:
+                logger.info(
+                    "Payment below minimum activation price, saving as pending",
+                    user_id=str(user.id),
+                    amount_xof=amount_xof,
+                    min_price=min_price,
+                )
+                payment = SubscriptionPayment(
+                    user_id=user.id,
+                    phone_number=normalized,
+                    amount_xof=amount_xof,
+                    payment_type=PaymentType.access,
+                    external_reference=external_reference,
+                    status=PaymentStatus.pending,
+                )
+                session.add(payment)
+                await session.commit()
+                return {
+                    "status": "ok",
+                    "subscription_activated": False,
+                    "user_found": True,
+                    "insufficient_amount": True,
+                }
+
+            duration_days: int = sc.get("payments-subscription-duration-days", 30)
             payment = SubscriptionPayment(
                 user_id=user.id,
-                phone_number=phone_number,
+                phone_number=normalized,
                 amount_xof=amount_xof,
                 payment_type=PaymentType.access,
                 external_reference=external_reference,
@@ -124,10 +166,10 @@ class SubscriptionService:
 
             subscription = Subscription(
                 user_id=user.id,
-                phone_number=phone_number,
+                phone_number=normalized,
                 status=SubscriptionStatus.active,
                 daily_message_limit=20,
-                expires_at=now + timedelta(days=28),
+                expires_at=now + timedelta(days=duration_days),
                 activated_at=now,
             )
             session.add(subscription)
@@ -136,13 +178,16 @@ class SubscriptionService:
             logger.info(
                 "New subscription created",
                 user_id=str(user.id),
-                expires_at=str(now + timedelta(days=28)),
+                expires_at=str(now + timedelta(days=duration_days)),
             )
             return {"status": "ok", "subscription_activated": True, "user_found": True}
         else:
+            message_price: int = sc.get("payments-message-price-xof", 5)
+            credits = amount_xof // max(1, message_price)
+
             payment = SubscriptionPayment(
                 user_id=user.id,
-                phone_number=phone_number,
+                phone_number=normalized,
                 amount_xof=amount_xof,
                 payment_type=PaymentType.messages,
                 external_reference=external_reference,
@@ -150,13 +195,14 @@ class SubscriptionService:
             )
             session.add(payment)
 
-            active_sub.daily_message_limit += 50
+            active_sub.message_credits += credits
             await session.commit()
 
             logger.info(
-                "Message top-up applied",
+                "Message credits top-up applied",
                 user_id=str(user.id),
-                new_daily_limit=active_sub.daily_message_limit,
+                credits_added=credits,
+                new_credits=active_sub.message_credits,
             )
             return {"status": "ok", "subscription_activated": False, "user_found": True}
 
@@ -169,12 +215,16 @@ class SubscriptionService:
             logger.warning("User not found for phone linking", user_id=str(user_id))
             return
 
-        user.phone_number = phone_number
+        normalized = normalize_phone(phone_number)
+        user.phone_number = normalized
         await session.flush()
 
         unprocessed_result = await session.execute(
             select(SubscriptionPayment).where(
-                SubscriptionPayment.phone_number == phone_number,
+                or_(
+                    SubscriptionPayment.phone_number == phone_number,
+                    SubscriptionPayment.phone_number == normalized,
+                ),
                 SubscriptionPayment.status == PaymentStatus.pending,
             )
         )
@@ -183,12 +233,12 @@ class SubscriptionService:
         if unprocessed:
             logger.info(
                 "Found unprocessed payments for phone, auto-activating",
-                phone_number=phone_number,
+                phone_number=normalized,
                 count=len(unprocessed),
             )
             for payment in unprocessed:
                 await self.process_payment(
-                    phone_number=phone_number,
+                    phone_number=normalized,
                     amount_xof=payment.amount_xof,
                     external_reference=payment.external_reference,
                     session=session,

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -24,6 +24,7 @@ from app.ai.rag.retriever import SemanticRetriever
 from app.domain.models.conversation import TutorConversation
 from app.domain.models.course import Course, UserCourseEnrollment
 from app.domain.models.module import Module
+from app.domain.models.source_image import SourceImage
 from app.domain.models.user import User
 from app.domain.services.learner_memory_service import LearnerMemoryService
 from app.domain.services.platform_settings_service import SettingsCache
@@ -216,6 +217,7 @@ class TutorService:
         tutor_mode: str = "socratic",
         file_content_blocks: list[dict[str, Any]] | None = None,
         course_id: uuid.UUID | None = None,
+        locale: str | None = None,
     ) -> AsyncGenerator[dict[str, Any], None]:
         """
         Send a message to the AI tutor and stream the response using agentic tool_use.
@@ -241,8 +243,11 @@ class TutorService:
             user_id = uuid.UUID(user_id)
 
         subscription = await SubscriptionService().get_active_subscription(user_id, session)
-        effective_limit = subscription.daily_message_limit if subscription else 5
         messages_used = await self._check_daily_limit(user_id, session)
+        if subscription:
+            effective_limit = subscription.daily_message_limit + subscription.message_credits
+        else:
+            effective_limit = 5
         if messages_used >= effective_limit:
             yield {
                 "type": "error",
@@ -286,6 +291,12 @@ class TutorService:
                 "data": {"conversation_id": str(conversation.id)},
             }
 
+            effective_language = locale if locale in ("fr", "en") else user.preferred_language
+
+            if locale in ("fr", "en") and user.preferred_language != locale:
+                user.preferred_language = locale
+                session.add(user)
+
             # Resolve module title for human-readable system prompt
             module_title = None
             module_number = None
@@ -294,9 +305,7 @@ class TutorService:
                 module_obj = await session.get(Module, module_id)
                 if module_obj:
                     module_title = (
-                        module_obj.title_fr
-                        if user.preferred_language == "fr"
-                        else module_obj.title_en
+                        module_obj.title_fr if effective_language == "fr" else module_obj.title_en
                     )
                     module_number = module_obj.module_number
 
@@ -306,14 +315,13 @@ class TutorService:
             course_domain = None
             rag_collection_id = None
             if course:
-                lang = user.preferred_language
-                course_title = course.title_fr if lang == "fr" else course.title_en
+                course_title = course.title_fr if effective_language == "fr" else course.title_en
                 course_domain = course_domain or course_title
                 rag_collection_id = course.rag_collection_id
 
             context = TutorContext(
                 user_level=user.current_level,
-                user_language=user.preferred_language,
+                user_language=effective_language,
                 user_country=user.country or "SN",
                 module_id=str(module_id) if module_id else None,
                 module_title=module_title,
@@ -350,7 +358,7 @@ class TutorService:
                 anthropic_client=self.anthropic,
                 user_id=user_id,
                 user_level=user.current_level,
-                user_language=user.preferred_language,
+                user_language=effective_language,
                 rag_collection_id=rag_collection_id,
             )
 
@@ -476,17 +484,47 @@ class TutorService:
 
                             img_result = _json.loads(tool_result_str)
                             prefix = "{{source_image:"
+                            img_ids_to_fetch: list[str] = []
                             for fig in img_result.get("figures", []):
                                 ref: str = fig.get("ref", "")
                                 if ref.startswith(prefix) and ref.endswith("}}"):
-                                    img_id = ref[len(prefix) : -2]
-                                    source_image_refs.append(
-                                        {
-                                            "id": img_id,
-                                            "figure_number": fig.get("figure_number"),
-                                            "caption": fig.get("caption"),
-                                        }
+                                    img_ids_to_fetch.append(ref[len(prefix) : -2])
+
+                            if img_ids_to_fetch:
+                                try:
+                                    db_imgs = await session.execute(
+                                        select(SourceImage).where(
+                                            SourceImage.id.in_(
+                                                [uuid.UUID(i) for i in img_ids_to_fetch]
+                                            )
+                                        )
                                     )
+                                    db_img_map = {str(r.id): r for r in db_imgs.scalars().all()}
+                                except Exception:
+                                    db_img_map = {}
+
+                                seen_img_ids: set[str] = {r["id"] for r in source_image_refs}
+                                for img_id in img_ids_to_fetch:
+                                    if img_id in seen_img_ids:
+                                        continue
+                                    seen_img_ids.add(img_id)
+                                    db_img = db_img_map.get(img_id)
+                                    if db_img:
+                                        meta = db_img.to_meta_dict()
+                                        source_image_refs.append(
+                                            {
+                                                "id": img_id,
+                                                "figure_number": meta.get("figure_number"),
+                                                "caption": meta.get("caption"),
+                                                "caption_fr": meta.get("caption"),
+                                                "caption_en": meta.get("caption"),
+                                                "attribution": meta.get("attribution"),
+                                                "image_type": meta.get("image_type", "unknown"),
+                                                "storage_url": meta.get("storage_url"),
+                                                "alt_text_fr": meta.get("alt_text_fr"),
+                                                "alt_text_en": meta.get("alt_text_en"),
+                                            }
+                                        )
                         except Exception:
                             pass
 
@@ -519,6 +557,15 @@ class TutorService:
             conversation.messages = updated_messages
             conversation.message_count = len(updated_messages)
             session.add(conversation)
+
+            if (
+                subscription
+                and messages_used >= subscription.daily_message_limit
+                and subscription.message_credits > 0
+            ):
+                subscription.message_credits -= 1
+                session.add(subscription)
+
             await session.commit()
 
             if conversation.message_count > COMPACT_TRIGGER:
@@ -557,10 +604,12 @@ class TutorService:
                 "conversation_id": str(conversation.id),
             }
 
+            credits_after = subscription.message_credits if subscription else 0
             yield {
                 "type": "finished",
                 "data": {
-                    "remaining_messages": effective_limit - messages_used - 1,
+                    "remaining_messages": max(0, effective_limit - messages_used - 1),
+                    "message_credits": credits_after,
                     "conversation_id": str(conversation.id),
                     "tool_calls_made": tool_call_count,
                 },
@@ -722,7 +771,12 @@ class TutorService:
         daily_messages = await self._check_daily_limit(user_id, session)
 
         subscription = await SubscriptionService().get_active_subscription(user_id, session)
-        limit = subscription.daily_message_limit if subscription else 5
+        if subscription:
+            limit = subscription.daily_message_limit + subscription.message_credits
+            message_credits = subscription.message_credits
+        else:
+            limit = 5
+            message_credits = 0
 
         count_query = select(func.count(TutorConversation.id)).where(
             TutorConversation.user_id == user_id
@@ -735,6 +789,7 @@ class TutorService:
         return {
             "daily_messages_used": daily_messages,
             "daily_messages_limit": limit,
+            "message_credits": message_credits,
             "total_conversations": total_conversations,
             "most_discussed_topics": most_discussed_topics,
         }

--- a/backend/app/infrastructure/config/platform_defaults.py
+++ b/backend/app/infrastructure/config/platform_defaults.py
@@ -586,20 +586,29 @@ SETTING_DEFINITIONS: list[SettingDef] = [
     SettingDef(
         "payments-subscription-price-xof",
         "payments",
-        2000,
+        1000,
         "integer",
         "Subscription price (FCFA)",
-        "Monthly subscription price displayed on the subscribe page.",
+        "Minimum subscription activation price in FCFA.",
         {"min": 0, "max": 100000},
     ),
     SettingDef(
         "payments-subscription-duration-days",
         "payments",
-        28,
+        30,
         "integer",
         "Subscription duration (days)",
         "Days of access per payment.",
         {"min": 1, "max": 365},
+    ),
+    SettingDef(
+        "payments-message-price-xof",
+        "payments",
+        5,
+        "integer",
+        "Price per tutor message (FCFA)",
+        "XOF cost per tutor AI message credit.",
+        {"min": 1, "max": 1000},
     ),
     # ── AI Prompts ─────────────────────────────────────────
     SettingDef(

--- a/backend/migrations/versions/040_fix_subscription_payments.py
+++ b/backend/migrations/versions/040_fix_subscription_payments.py
@@ -1,0 +1,59 @@
+"""Fix subscription payments: add message_credits to subscriptions, make user_id nullable in payments.
+
+Revision ID: 040
+Revises: 039
+Create Date: 2026-04-07
+
+"""
+
+from alembic import op
+
+revision = "040"
+down_revision = "039"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE subscriptions
+        ADD COLUMN IF NOT EXISTS message_credits INTEGER NOT NULL DEFAULT 0
+        """
+    )
+
+    op.execute(
+        """
+        ALTER TABLE subscription_payments
+        ALTER COLUMN user_id DROP NOT NULL
+        """
+    )
+
+    op.execute(
+        """
+        ALTER TABLE subscription_payments
+        DROP CONSTRAINT IF EXISTS subscription_payments_user_id_fkey
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE subscription_payments
+        ADD CONSTRAINT subscription_payments_user_id_fkey
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE subscription_payments
+        ALTER COLUMN user_id SET NOT NULL
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE subscriptions
+        DROP COLUMN IF EXISTS message_credits
+        """
+    )

--- a/backend/tests/test_subscription_service.py
+++ b/backend/tests/test_subscription_service.py
@@ -1,0 +1,582 @@
+"""Tests for SubscriptionService — phone normalization, pending payments, settings, message credits."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.domain.models.subscription import (
+    PaymentStatus,
+    PaymentType,
+    Subscription,
+    SubscriptionStatus,
+)
+from app.domain.models.user import UserRole
+from app.domain.services.sms_parser import normalize_phone
+from app.domain.services.subscription_service import SubscriptionService
+
+# ---------------------------------------------------------------------------
+# Helper factories — use SimpleNamespace to avoid SQLAlchemy instrumentation
+# ---------------------------------------------------------------------------
+
+
+def _make_user(
+    phone: str | None = "70220689",
+    role: UserRole = UserRole.user,
+) -> SimpleNamespace:
+    uid = uuid.uuid4()
+    return SimpleNamespace(
+        id=uid,
+        email=f"user_{uid}@example.com",
+        name="Test User",
+        phone_number=phone,
+        preferred_language="fr",
+        country="BF",
+        professional_role="nurse",
+        current_level=1,
+        streak_days=0,
+        avatar_url=None,
+        role=role,
+        is_active=True,
+    )
+
+
+def _make_subscription(
+    user_id: uuid.UUID,
+    daily_limit: int = 20,
+    message_credits: int = 0,
+    expires_in_days: int = 30,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        phone_number="70220689",
+        status=SubscriptionStatus.active,
+        daily_message_limit=daily_limit,
+        message_credits=message_credits,
+        expires_at=datetime.now(tz=UTC) + timedelta(days=expires_in_days),
+        activated_at=datetime.now(tz=UTC),
+        pending_expires_at=None,
+    )
+
+
+def _make_pending_payment(
+    user_id: uuid.UUID | None,
+    phone: str,
+    amount: int,
+    reference: str,
+    status: PaymentStatus = PaymentStatus.pending,
+    payment_type: PaymentType = PaymentType.access,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        phone_number=phone,
+        amount_xof=amount,
+        payment_type=payment_type,
+        external_reference=reference,
+        status=status,
+        created_at=datetime.now(tz=UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phone normalization tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizePhone:
+    def test_normalize_burkina_international(self):
+        assert normalize_phone("+22670220689") == "70220689"
+
+    def test_normalize_burkina_international_00(self):
+        assert normalize_phone("0022670220689") == "70220689"
+
+    def test_normalize_local_unchanged(self):
+        assert normalize_phone("70220689") == "70220689"
+
+    def test_normalize_senegal_international(self):
+        assert normalize_phone("+221776801718") == "776801718"
+
+    def test_normalize_guinea_international(self):
+        assert normalize_phone("+22476801718") == "76801718"
+
+    def test_normalize_leading_zero(self):
+        assert normalize_phone("070220689") == "70220689"
+
+    def test_normalize_strips_spaces(self):
+        assert normalize_phone("  70220689  ") == "70220689"
+
+    def test_normalize_already_normalized(self):
+        assert normalize_phone("70220689") == "70220689"
+
+
+# ---------------------------------------------------------------------------
+# process_payment — phone mismatch fix
+# ---------------------------------------------------------------------------
+
+
+class TestProcessPaymentPhoneMismatch:
+    async def test_matches_international_phone(self):
+        """User stored as +22670220689, payment phone 70220689 → match."""
+        service = SubscriptionService()
+        user = _make_user(phone="+22670220689")
+
+        session = AsyncMock()
+        existing_payment_result = MagicMock()
+        existing_payment_result.scalar_one_or_none.return_value = None
+        user_result = MagicMock()
+        user_result.scalar_one_or_none.return_value = user
+
+        session.execute = AsyncMock(side_effect=[existing_payment_result, user_result])
+        session.add = MagicMock()
+        session.commit = AsyncMock()
+
+        with (
+            patch.object(service, "get_active_subscription", new=AsyncMock(return_value=None)),
+            patch("app.domain.services.subscription_service.SettingsCache.instance") as mock_sc,
+        ):
+            mock_sc.return_value.get.side_effect = lambda key, default=None: {
+                "payments-subscription-price-xof": 1000,
+                "payments-subscription-duration-days": 30,
+            }.get(key, default)
+            result = await service.process_payment(
+                phone_number="70220689",
+                amount_xof=1000,
+                external_reference="TXN001",
+                session=session,
+            )
+
+        assert result["user_found"] is True
+        assert result["subscription_activated"] is True
+
+    async def test_matches_local_phone(self):
+        """User stored as 70220689, payment phone 70220689 → match."""
+        service = SubscriptionService()
+        user = _make_user(phone="70220689")
+
+        session = AsyncMock()
+        existing_payment_result = MagicMock()
+        existing_payment_result.scalar_one_or_none.return_value = None
+        user_result = MagicMock()
+        user_result.scalar_one_or_none.return_value = user
+
+        session.execute = AsyncMock(side_effect=[existing_payment_result, user_result])
+        session.add = MagicMock()
+        session.commit = AsyncMock()
+
+        with (
+            patch.object(service, "get_active_subscription", new=AsyncMock(return_value=None)),
+            patch("app.domain.services.subscription_service.SettingsCache.instance") as mock_sc,
+        ):
+            mock_sc.return_value.get.side_effect = lambda key, default=None: {
+                "payments-subscription-price-xof": 1000,
+                "payments-subscription-duration-days": 30,
+            }.get(key, default)
+            result = await service.process_payment(
+                phone_number="70220689",
+                amount_xof=1000,
+                external_reference="TXN002",
+                session=session,
+            )
+
+        assert result["user_found"] is True
+        assert result["subscription_activated"] is True
+
+    async def test_no_match_wrong_number(self):
+        """Different phone number → no match → pending payment saved."""
+        service = SubscriptionService()
+
+        session = AsyncMock()
+        existing_payment_result = MagicMock()
+        existing_payment_result.scalar_one_or_none.return_value = None
+        user_result = MagicMock()
+        user_result.scalar_one_or_none.return_value = None
+
+        session.execute = AsyncMock(side_effect=[existing_payment_result, user_result])
+        session.add = MagicMock()
+        session.commit = AsyncMock()
+
+        result = await service.process_payment(
+            phone_number="70000000",
+            amount_xof=1000,
+            external_reference="TXN003",
+            session=session,
+        )
+
+        assert result["user_found"] is False
+        assert result["subscription_activated"] is False
+        session.add.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# process_payment — subscription activation
+# ---------------------------------------------------------------------------
+
+
+class TestSubscriptionActivation:
+    async def test_first_payment_activates_subscription(self):
+        """1000 XOF, no existing sub → subscription created."""
+        service = SubscriptionService()
+        user = _make_user()
+
+        session = AsyncMock()
+        existing_payment_result = MagicMock()
+        existing_payment_result.scalar_one_or_none.return_value = None
+        user_result = MagicMock()
+        user_result.scalar_one_or_none.return_value = user
+
+        session.execute = AsyncMock(side_effect=[existing_payment_result, user_result])
+        session.add = MagicMock()
+        session.commit = AsyncMock()
+
+        with (
+            patch.object(service, "get_active_subscription", new=AsyncMock(return_value=None)),
+            patch("app.domain.services.subscription_service.SettingsCache.instance") as mock_sc,
+        ):
+            mock_sc.return_value.get.side_effect = lambda key, default=None: {
+                "payments-subscription-price-xof": 1000,
+                "payments-subscription-duration-days": 30,
+            }.get(key, default)
+            result = await service.process_payment(
+                phone_number="70220689",
+                amount_xof=1000,
+                external_reference="TXN010",
+                session=session,
+            )
+
+        assert result["subscription_activated"] is True
+        assert result["user_found"] is True
+        assert session.add.call_count == 2
+
+    async def test_first_payment_uses_settings_duration(self):
+        """Verify expires_at uses payments-subscription-duration-days setting."""
+        service = SubscriptionService()
+        user = _make_user()
+
+        added_objects: list = []
+        session = AsyncMock()
+        existing_payment_result = MagicMock()
+        existing_payment_result.scalar_one_or_none.return_value = None
+        user_result = MagicMock()
+        user_result.scalar_one_or_none.return_value = user
+
+        session.execute = AsyncMock(side_effect=[existing_payment_result, user_result])
+        session.add = MagicMock(side_effect=lambda obj: added_objects.append(obj))
+        session.commit = AsyncMock()
+
+        with (
+            patch.object(service, "get_active_subscription", new=AsyncMock(return_value=None)),
+            patch("app.domain.services.subscription_service.SettingsCache.instance") as mock_sc,
+        ):
+            mock_sc.return_value.get.side_effect = lambda key, default=None: {
+                "payments-subscription-price-xof": 1000,
+                "payments-subscription-duration-days": 45,
+            }.get(key, default)
+            await service.process_payment(
+                phone_number="70220689",
+                amount_xof=1000,
+                external_reference="TXN011",
+                session=session,
+            )
+
+        subscriptions = [o for o in added_objects if isinstance(o, Subscription)]
+        assert len(subscriptions) == 1
+        sub = subscriptions[0]
+        delta = sub.expires_at - sub.activated_at
+        assert 44 <= delta.days <= 46
+
+    async def test_payment_below_minimum_does_not_activate(self):
+        """500 XOF < 1000 min → subscription_activated=False, payment saved as pending."""
+        service = SubscriptionService()
+        user = _make_user()
+
+        added_objects: list = []
+        session = AsyncMock()
+        existing_payment_result = MagicMock()
+        existing_payment_result.scalar_one_or_none.return_value = None
+        user_result = MagicMock()
+        user_result.scalar_one_or_none.return_value = user
+
+        session.execute = AsyncMock(side_effect=[existing_payment_result, user_result])
+        session.add = MagicMock(side_effect=lambda obj: added_objects.append(obj))
+        session.commit = AsyncMock()
+
+        with (
+            patch.object(service, "get_active_subscription", new=AsyncMock(return_value=None)),
+            patch("app.domain.services.subscription_service.SettingsCache.instance") as mock_sc,
+        ):
+            mock_sc.return_value.get.side_effect = lambda key, default=None: {
+                "payments-subscription-price-xof": 1000,
+            }.get(key, default)
+            result = await service.process_payment(
+                phone_number="70220689",
+                amount_xof=500,
+                external_reference="TXN012",
+                session=session,
+            )
+
+        assert result["subscription_activated"] is False
+        assert result.get("insufficient_amount") is True
+        from app.domain.models.subscription import SubscriptionPayment
+
+        payments = [o for o in added_objects if isinstance(o, SubscriptionPayment)]
+        assert len(payments) == 1
+        assert payments[0].status == PaymentStatus.pending
+
+    async def test_duplicate_reference_returns_existing(self):
+        """Same external_reference twice → idempotent."""
+        service = SubscriptionService()
+        existing = _make_pending_payment(
+            user_id=uuid.uuid4(),
+            phone="70220689",
+            amount=1000,
+            reference="TXN013",
+            status=PaymentStatus.confirmed,
+            payment_type=PaymentType.access,
+        )
+
+        session = AsyncMock()
+        existing_payment_result = MagicMock()
+        existing_payment_result.scalar_one_or_none.return_value = existing
+
+        session.execute = AsyncMock(return_value=existing_payment_result)
+        session.add = MagicMock()
+
+        result = await service.process_payment(
+            phone_number="70220689",
+            amount_xof=1000,
+            external_reference="TXN013",
+            session=session,
+        )
+
+        assert result["status"] == "ok"
+        session.add.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# process_payment — message credits top-up
+# ---------------------------------------------------------------------------
+
+
+class TestMessageCredits:
+    async def test_topup_adds_message_credits(self):
+        """5000 XOF while subscribed → message_credits += 1000 (at 5 XOF/msg)."""
+        service = SubscriptionService()
+        user = _make_user()
+        active_sub = _make_subscription(user.id, message_credits=0)
+
+        session = AsyncMock()
+        existing_payment_result = MagicMock()
+        existing_payment_result.scalar_one_or_none.return_value = None
+        user_result = MagicMock()
+        user_result.scalar_one_or_none.return_value = user
+
+        session.execute = AsyncMock(side_effect=[existing_payment_result, user_result])
+        session.add = MagicMock()
+        session.commit = AsyncMock()
+
+        with (
+            patch.object(
+                service, "get_active_subscription", new=AsyncMock(return_value=active_sub)
+            ),
+            patch("app.domain.services.subscription_service.SettingsCache.instance") as mock_sc,
+        ):
+            mock_sc.return_value.get.side_effect = lambda key, default=None: {
+                "payments-subscription-price-xof": 1000,
+                "payments-message-price-xof": 5,
+            }.get(key, default)
+            result = await service.process_payment(
+                phone_number="70220689",
+                amount_xof=5000,
+                external_reference="TXN020",
+                session=session,
+            )
+
+        assert result["subscription_activated"] is False
+        assert active_sub.message_credits == 1000
+
+    async def test_topup_uses_message_price_setting(self):
+        """Credits calculation uses payments-message-price-xof."""
+        service = SubscriptionService()
+        user = _make_user()
+        active_sub = _make_subscription(user.id, message_credits=10)
+
+        session = AsyncMock()
+        existing_payment_result = MagicMock()
+        existing_payment_result.scalar_one_or_none.return_value = None
+        user_result = MagicMock()
+        user_result.scalar_one_or_none.return_value = user
+
+        session.execute = AsyncMock(side_effect=[existing_payment_result, user_result])
+        session.add = MagicMock()
+        session.commit = AsyncMock()
+
+        with (
+            patch.object(
+                service, "get_active_subscription", new=AsyncMock(return_value=active_sub)
+            ),
+            patch("app.domain.services.subscription_service.SettingsCache.instance") as mock_sc,
+        ):
+            mock_sc.return_value.get.side_effect = lambda key, default=None: {
+                "payments-subscription-price-xof": 1000,
+                "payments-message-price-xof": 10,
+            }.get(key, default)
+            await service.process_payment(
+                phone_number="70220689",
+                amount_xof=1000,
+                external_reference="TXN021",
+                session=session,
+            )
+
+        assert active_sub.message_credits == 10 + 100
+
+
+# ---------------------------------------------------------------------------
+# process_payment — pending payments for unknown phones
+# ---------------------------------------------------------------------------
+
+
+class TestPendingPayments:
+    async def test_payment_unknown_phone_saved_as_pending(self):
+        """No user for phone → SubscriptionPayment created with status=pending, user_id=None."""
+        from app.domain.models.subscription import SubscriptionPayment
+
+        service = SubscriptionService()
+
+        added_objects: list = []
+        session = AsyncMock()
+        existing_payment_result = MagicMock()
+        existing_payment_result.scalar_one_or_none.return_value = None
+        user_result = MagicMock()
+        user_result.scalar_one_or_none.return_value = None
+
+        session.execute = AsyncMock(side_effect=[existing_payment_result, user_result])
+        session.add = MagicMock(side_effect=lambda obj: added_objects.append(obj))
+        session.commit = AsyncMock()
+
+        result = await service.process_payment(
+            phone_number="70111222",
+            amount_xof=2000,
+            external_reference="TXN030",
+            session=session,
+        )
+
+        assert result["user_found"] is False
+        assert result["subscription_activated"] is False
+        payments = [o for o in added_objects if isinstance(o, SubscriptionPayment)]
+        assert len(payments) == 1
+        assert payments[0].user_id is None
+        assert payments[0].status == PaymentStatus.pending
+
+    async def test_link_phone_processes_pending_payments(self):
+        """Save pending payment, then link phone → subscription activated."""
+        service = SubscriptionService()
+        user = _make_user(phone=None)
+        pending = _make_pending_payment(None, "70220689", 1000, "TXN031", PaymentStatus.pending)
+
+        session = AsyncMock()
+        user_result = MagicMock()
+        user_result.scalar_one_or_none.return_value = user
+
+        pending_result = MagicMock()
+        pending_result.scalars.return_value.all.return_value = [pending]
+
+        session.execute = AsyncMock(side_effect=[user_result, pending_result])
+        session.flush = AsyncMock()
+        session.commit = AsyncMock()
+        session.add = MagicMock()
+
+        process_mock = AsyncMock(
+            return_value={"status": "ok", "subscription_activated": True, "user_found": True}
+        )
+        with patch.object(service, "process_payment", process_mock):
+            await service.link_phone_number(
+                user_id=user.id,
+                phone_number="+22670220689",
+                session=session,
+            )
+
+        process_mock.assert_called_once_with(
+            phone_number="70220689",
+            amount_xof=1000,
+            external_reference="TXN031",
+            session=session,
+        )
+
+    async def test_link_phone_processes_multiple_pending(self):
+        """Multiple pending payments → all processed."""
+        service = SubscriptionService()
+        user = _make_user(phone=None)
+        pending1 = _make_pending_payment(None, "70220689", 1000, "TXN040", PaymentStatus.pending)
+        pending2 = _make_pending_payment(None, "70220689", 2000, "TXN041", PaymentStatus.pending)
+
+        session = AsyncMock()
+        user_result = MagicMock()
+        user_result.scalar_one_or_none.return_value = user
+
+        pending_result = MagicMock()
+        pending_result.scalars.return_value.all.return_value = [pending1, pending2]
+
+        session.execute = AsyncMock(side_effect=[user_result, pending_result])
+        session.flush = AsyncMock()
+        session.commit = AsyncMock()
+        session.add = MagicMock()
+
+        process_mock = AsyncMock(
+            return_value={"status": "ok", "subscription_activated": True, "user_found": True}
+        )
+        with patch.object(service, "process_payment", process_mock):
+            await service.link_phone_number(
+                user_id=user.id,
+                phone_number="70220689",
+                session=session,
+            )
+
+        assert process_mock.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Admin subscription regression
+# ---------------------------------------------------------------------------
+
+
+class TestAdminSubscription:
+    async def test_admin_auto_provision(self):
+        """ensure_admin_subscription creates non-expiring sub for admin."""
+        service = SubscriptionService()
+        user_id = uuid.uuid4()
+
+        session = AsyncMock()
+        existing_result = MagicMock()
+        existing_result.scalar_one_or_none.return_value = None
+
+        session.execute = AsyncMock(return_value=existing_result)
+        session.add = MagicMock()
+        session.commit = AsyncMock()
+
+        sub = await service.ensure_admin_subscription(user_id, session)
+
+        assert sub.daily_message_limit == 9999
+        assert sub.expires_at.year == 2099
+
+    async def test_admin_get_active_subscription_auto_provisions(self):
+        """get_active_subscription auto-provisions for admin user."""
+        service = SubscriptionService()
+        admin_user = _make_user(role=UserRole.admin)
+
+        session = AsyncMock()
+        no_active_sub = MagicMock()
+        no_active_sub.scalar_one_or_none.return_value = None
+
+        session.execute = AsyncMock(return_value=no_active_sub)
+        session.get = AsyncMock(return_value=admin_user)
+
+        ensure_mock = AsyncMock(return_value=_make_subscription(admin_user.id, daily_limit=9999))
+        with patch.object(service, "ensure_admin_subscription", ensure_mock):
+            sub = await service.get_active_subscription(admin_user.id, session)
+
+        assert sub is not None
+        ensure_mock.assert_called_once_with(admin_user.id, session)

--- a/backend/tests/test_tutor_compaction.py
+++ b/backend/tests/test_tutor_compaction.py
@@ -54,6 +54,7 @@ def mock_embedding_service():
 def mock_subscription_service():
     sub = MagicMock()
     sub.daily_message_limit = 20
+    sub.message_credits = 0
     with patch("app.domain.services.tutor_service.SubscriptionService") as MockSubSvc:
         MockSubSvc.return_value.get_active_subscription = AsyncMock(return_value=sub)
         yield MockSubSvc

--- a/backend/tests/test_tutor_service.py
+++ b/backend/tests/test_tutor_service.py
@@ -51,6 +51,7 @@ def mock_subscription_service():
     """Auto-mock SubscriptionService for all tutor tests."""
     sub = MagicMock()
     sub.daily_message_limit = 20
+    sub.message_credits = 0
     with patch("app.domain.services.tutor_service.SubscriptionService") as MockSubSvc:
         MockSubSvc.return_value.get_active_subscription = AsyncMock(return_value=sub)
         yield MockSubSvc

--- a/backend/tests/test_tutor_tools.py
+++ b/backend/tests/test_tutor_tools.py
@@ -114,6 +114,7 @@ def mock_learner_memory_service():
 def mock_subscription_service():
     sub = MagicMock()
     sub.daily_message_limit = 20
+    sub.message_credits = 0
     with patch("app.domain.services.tutor_service.SubscriptionService") as MockSubSvc:
         MockSubSvc.return_value.get_active_subscription = AsyncMock(return_value=sub)
         yield MockSubSvc

--- a/frontend/components/chat/chat-message.tsx
+++ b/frontend/components/chat/chat-message.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/lib/utils';
 import { AttachedFileCard } from '@/components/chat/file-preview';
 import { SourceImage } from '@/components/learning/source-image';
 import type { SourceImageMeta } from '@/lib/api';
+import { splitWithSourceImageMarkers } from '@/lib/source-image-utils';
 
 export interface ChatSource {
   title: string;
@@ -36,35 +37,6 @@ export interface ChatMessage {
 
 interface ChatMessageProps {
   message: ChatMessage;
-}
-
-const SOURCE_IMAGE_RE = /\{\{source_image:([0-9a-f-]{36})\}\}/g;
-
-function splitWithSourceImageMarkers(
-  text: string,
-  imageMap: Map<string, SourceImageMeta>
-): Array<{ type: 'markdown'; text: string } | { type: 'source_image'; meta: SourceImageMeta }> {
-  const parts: Array<{ type: 'markdown'; text: string } | { type: 'source_image'; meta: SourceImageMeta }> = [];
-  let lastIndex = 0;
-  let match: RegExpExecArray | null;
-
-  SOURCE_IMAGE_RE.lastIndex = 0;
-  while ((match = SOURCE_IMAGE_RE.exec(text)) !== null) {
-    if (match.index > lastIndex) {
-      parts.push({ type: 'markdown', text: text.slice(lastIndex, match.index) });
-    }
-    const meta = imageMap.get(match[1]);
-    if (meta) {
-      parts.push({ type: 'source_image', meta });
-    } else {
-      parts.push({ type: 'markdown', text: text.slice(match.index, SOURCE_IMAGE_RE.lastIndex) });
-    }
-    lastIndex = SOURCE_IMAGE_RE.lastIndex;
-  }
-  if (lastIndex < text.length) {
-    parts.push({ type: 'markdown', text: text.slice(lastIndex) });
-  }
-  return parts;
 }
 
 const mdClass =

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -229,6 +229,7 @@ export function ChatPanel({
           module_id: moduleId ?? null,
           tutor_mode: tutorMode,
           file_ids: attachedFiles.map((f) => f.fileId),
+          locale: locale,
         }),
       });
 

--- a/frontend/components/learning/lesson-viewer.tsx
+++ b/frontend/components/learning/lesson-viewer.tsx
@@ -16,6 +16,7 @@ import { SourceImage } from './source-image';
 import { SourceCitations } from './source-citations';
 import { apiFetch, checkUnitQuizPassed } from '@/lib/api';
 import type { SourceImageMeta } from '@/lib/api';
+import { SOURCE_IMAGE_RE, splitWithSourceImageMarkers } from '@/lib/source-image-utils';
 import { useCurrentUser } from '@/lib/hooks/use-current-user';
 import { useRouter } from 'next/navigation';
 import { useLocale } from 'next-intl';
@@ -44,33 +45,6 @@ interface LessonData {
   content: LessonContent;
   cached: boolean;
   source_image_refs?: SourceImageMeta[];
-}
-
-const SOURCE_IMAGE_RE = /\{\{source_image:([0-9a-f-]{36})\}\}/g;
-
-function splitWithSourceImageMarkers(
-  text: string,
-  imageMap: Map<string, SourceImageMeta>
-): Array<{ type: 'markdown'; text: string } | { type: 'source_image'; meta: SourceImageMeta }> {
-  const parts: Array<{ type: 'markdown'; text: string } | { type: 'source_image'; meta: SourceImageMeta }> = [];
-  let lastIndex = 0;
-  let match: RegExpExecArray | null;
-
-  SOURCE_IMAGE_RE.lastIndex = 0;
-  while ((match = SOURCE_IMAGE_RE.exec(text)) !== null) {
-    if (match.index > lastIndex) {
-      parts.push({ type: 'markdown', text: text.slice(lastIndex, match.index) });
-    }
-    const meta = imageMap.get(match[1]);
-    if (meta) {
-      parts.push({ type: 'source_image', meta });
-    }
-    lastIndex = SOURCE_IMAGE_RE.lastIndex;
-  }
-  if (lastIndex < text.length) {
-    parts.push({ type: 'markdown', text: text.slice(lastIndex) });
-  }
-  return parts;
 }
 
 interface GeneratingResponse {

--- a/frontend/lib/source-image-utils.ts
+++ b/frontend/lib/source-image-utils.ts
@@ -1,0 +1,34 @@
+import type { SourceImageMeta } from '@/lib/api';
+
+export const SOURCE_IMAGE_RE = /\{\{source_image:([0-9a-f-]{36})\}\}/g;
+
+export type SourceImagePart =
+  | { type: 'markdown'; text: string }
+  | { type: 'source_image'; meta: SourceImageMeta };
+
+export function splitWithSourceImageMarkers(
+  text: string,
+  imageMap: Map<string, SourceImageMeta>
+): SourceImagePart[] {
+  const parts: SourceImagePart[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  SOURCE_IMAGE_RE.lastIndex = 0;
+  while ((match = SOURCE_IMAGE_RE.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push({ type: 'markdown', text: text.slice(lastIndex, match.index) });
+    }
+    const meta = imageMap.get(match[1]);
+    if (meta) {
+      parts.push({ type: 'source_image', meta });
+    } else {
+      parts.push({ type: 'markdown', text: text.slice(match.index, SOURCE_IMAGE_RE.lastIndex) });
+    }
+    lastIndex = SOURCE_IMAGE_RE.lastIndex;
+  }
+  if (lastIndex < text.length) {
+    parts.push({ type: 'markdown', text: text.slice(lastIndex) });
+  }
+  return parts;
+}


### PR DESCRIPTION
## Summary
- fix(payments): phone normalization matches local `70220689` to stored `+22670220689`
- fix(payments): pending payments saved for unknown phones, processed on phone link
- fix(payments): subscription uses platform settings (price, duration, message price)
- feat(payments): message credits pool (non-resetting) for tutor AI top-ups
- fix(payments): amount validation against minimum activation price

Merges #1098 (closes #1096)

🤖 Generated with [Claude Code](https://claude.com/claude-code)