### PR TITLE
merge: dev → main — regenerate syllabus + migration 041

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -370,6 +370,85 @@ async def generate_course_structure(
     return {"task_id": task.id, "status": "started"}
 
 
+@router.post("/{course_id}/regenerate-syllabus")
+async def regenerate_course_syllabus(
+    course_id: uuid.UUID,
+    mode: str = "reuse",
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    db=Depends(get_db_session),
+) -> dict:
+    """Regenerate syllabus for an unpublished course with 0 enrollments.
+
+    mode=reuse (default): reuses cached syllabus_context — skips PDF extraction.
+    mode=fresh: clears syllabus_context and re-extracts + re-summarizes from PDFs.
+    """
+    result = await db.execute(select(Course).where(Course.id == course_id))
+    course = result.scalar_one_or_none()
+    if not course:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
+
+    if course.status == "published":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Cannot regenerate syllabus for a published course",
+        )
+
+    enroll_count = await db.execute(
+        select(func.count())
+        .select_from(UserCourseEnrollment)
+        .where(UserCourseEnrollment.course_id == course_id)
+    )
+    if enroll_count.scalar_one() > 0:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Cannot regenerate syllabus: course has enrolled learners",
+        )
+
+    if course.creation_step == "generating":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A generation task is already in progress",
+        )
+
+    from app.domain.services.platform_settings_service import SettingsCache
+
+    cache = SettingsCache.instance()
+    hard = int(cache.get("ai-syllabus-hard-time-limit-seconds") or 3600)
+    soft = int(cache.get("ai-syllabus-soft-time-limit-seconds") or 2700)
+
+    cached_resource_text: str | None = None
+
+    if mode == "reuse":
+        if not course.syllabus_context:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="No cached syllabus context found. Use mode=fresh to re-extract from PDFs.",
+            )
+        cached_resource_text = course.syllabus_context
+    else:
+        course.syllabus_context = None
+
+    task = generate_course_syllabus.apply_async(
+        args=[str(course_id), course.estimated_hours],
+        kwargs={"cached_resource_text": cached_resource_text},
+        time_limit=hard,
+        soft_time_limit=soft,
+    )
+
+    course.creation_step = "generating"
+    course.syllabus_task_id = task.id
+    await db.commit()
+
+    logger.info(
+        "Syllabus regeneration triggered",
+        course_id=str(course_id),
+        mode=mode,
+        task_id=task.id,
+        admin_id=current_user.id,
+    )
+    return {"task_id": task.id, "status": "started", "mode": mode}
+
+
 @router.get("/{course_id}/generate-status")
 async def get_generate_status(
     course_id: uuid.UUID,

--- a/backend/app/domain/models/course.py
+++ b/backend/app/domain/models/course.py
@@ -42,6 +42,7 @@ class Course(Base):
     creation_step: Mapped[str] = mapped_column(String(20), server_default="upload", nullable=False)
     preassessment_enabled: Mapped[bool] = mapped_column(server_default="false")
     preassessment_mandatory: Mapped[bool] = mapped_column(server_default="false")
+    syllabus_context: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     published_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 

--- a/backend/app/tasks/syllabus_generation.py
+++ b/backend/app/tasks/syllabus_generation.py
@@ -52,7 +52,9 @@ class SyllabusTask(Task):
     time_limit=3600,  # 60 min hard limit
     soft_time_limit=2700,  # 45 min soft limit
 )
-def generate_course_syllabus(self, course_id: str, estimated_hours: int) -> dict:
+def generate_course_syllabus(
+    self, course_id: str, estimated_hours: int, cached_resource_text: str | None = None
+) -> dict:
     """Generate course module structure using Claude API and save to DB.
 
     Fix for SoftTimeLimitExceeded (issue #876):
@@ -131,17 +133,26 @@ def generate_course_syllabus(self, course_id: str, estimated_hours: int) -> dict
     level_slugs = course_data["level_slugs"]
     audience_slugs = course_data["audience_slugs"]
 
-    # ── Phase 1.5: Extract text from uploaded PDFs ──────────────────────────
-    self.update_state(
-        state="GENERATING",
-        meta={"step": "extracting_pdf_text", "progress": 15, "modules_count": 0},
-    )
-
-    resource_text = None
+    # ── Phase 1.5: Extract text from uploaded PDFs (skipped if cached) ────────
     from pathlib import Path
 
     course_dir = Path("uploads/course_resources") / course_id
-    if course_dir.exists():
+
+    if cached_resource_text is not None:
+        resource_text = cached_resource_text
+        logger.info(
+            "Using cached syllabus_context — skipping PDF extraction",
+            course_id=course_id,
+            chars=len(resource_text),
+        )
+    else:
+        self.update_state(
+            state="GENERATING",
+            meta={"step": "extracting_pdf_text", "progress": 15, "modules_count": 0},
+        )
+        resource_text = None
+
+    if cached_resource_text is None and course_dir.exists():
         import fitz  # PyMuPDF
 
         pdf_files = sorted(course_dir.glob("*.pdf"))
@@ -284,6 +295,13 @@ def generate_course_syllabus(self, course_id: str, estimated_hours: int) -> dict
     )
     try:
         with Session(sync_engine) as session:
+            session.execute(
+                delete(ModuleUnit).where(
+                    ModuleUnit.module_id.in_(
+                        select(Module.id).where(Module.course_id == uuid.UUID(course_id))
+                    )
+                )
+            )
             session.execute(delete(Module).where(Module.course_id == uuid.UUID(course_id)))
 
             saved_modules = []
@@ -330,17 +348,20 @@ def generate_course_syllabus(self, course_id: str, estimated_hours: int) -> dict
 
             import json
 
-            session.execute(
-                text(
-                    "UPDATE courses SET module_count = :mc, syllabus_json = :sj,"
-                    " creation_step = 'generated' WHERE id = :cid"
-                ),
-                {
-                    "mc": len(module_dicts),
-                    "sj": json.dumps(module_dicts),
-                    "cid": course_id,
-                },
+            update_sql = (
+                "UPDATE courses SET module_count = :mc, syllabus_json = :sj,"
+                " creation_step = 'generated'"
             )
+            params: dict = {
+                "mc": len(module_dicts),
+                "sj": json.dumps(module_dicts),
+                "cid": course_id,
+            }
+            if cached_resource_text is None and resource_text is not None:
+                update_sql += ", syllabus_context = :ctx"
+                params["ctx"] = resource_text
+            update_sql += " WHERE id = :cid"
+            session.execute(text(update_sql), params)
 
             session.commit()
 

--- a/backend/migrations/versions/041_add_syllabus_context_to_courses.py
+++ b/backend/migrations/versions/041_add_syllabus_context_to_courses.py
@@ -1,0 +1,26 @@
+"""add syllabus_context to courses
+
+Revision ID: 041
+Revises: 040
+Create Date: 2026-04-07
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "041"
+down_revision = "040"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "courses",
+        sa.Column("syllabus_context", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("courses", "syllabus_context")

--- a/frontend/components/admin/course-wizard-client.tsx
+++ b/frontend/components/admin/course-wizard-client.tsx
@@ -228,6 +228,9 @@ export function CourseWizardClient({
   const [publishSummaryModuleCount, setPublishSummaryModuleCount] = useState<number>(0);
   const [isFetchingPublishSummary, setIsFetchingPublishSummary] = useState(false);
   const [showCloseConfirm, setShowCloseConfirm] = useState(false);
+  const [showFreshConfirm, setShowFreshConfirm] = useState(false);
+  const [isRegenerating, setIsRegenerating] = useState(false);
+  const [regenerateError, setRegenerateError] = useState<string | null>(null);
   const [isFetchingExistingFiles, setIsFetchingExistingFiles] = useState(false);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -537,6 +540,36 @@ export function CourseWizardClient({
       setIsCreatingCourse(false);
     }
   }, [courseInfo, courseId, getAuthHeaders, t, pendingFiles]);
+
+  const regenerateSyllabus = useCallback(async (mode: "reuse" | "fresh") => {
+    if (!courseId || isGenerating || isRegenerating) return;
+    setIsRegenerating(true);
+    setRegenerateError(null);
+    setGenerateError(null);
+    setGenerateTaskId(null);
+    setGenerateTaskState(null);
+    setGenerationProgress(0);
+    setGenerationStep(undefined);
+    setGenerationStartTime(Date.now());
+    setGenerationElapsed(0);
+    lastProgressValueRef.current = 0;
+    lastProgressTimeRef.current = Date.now();
+    setShowTimeoutWarning(false);
+    setGeneratedModules([]);
+
+    try {
+      const result = await apiFetch<{ task_id: string; status: string }>(
+        `/api/v1/admin/courses/${courseId}/regenerate-syllabus?mode=${mode}`,
+        { method: "POST" }
+      );
+      setGenerateTaskId(result.task_id);
+      setIsGenerating(true);
+    } catch {
+      setRegenerateError(t("generate.regenerateError"));
+    } finally {
+      setIsRegenerating(false);
+    }
+  }, [courseId, isGenerating, isRegenerating, t]);
 
   const generateSyllabus = useCallback(async (force?: boolean) => {
     if (!courseId || isGenerating) return;
@@ -1175,6 +1208,41 @@ export function CourseWizardClient({
                         </div>
                       ))}
                     </div>
+
+                    {!isGenerating && (
+                      <div className="flex flex-col gap-2 pt-1">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => regenerateSyllabus("reuse")}
+                          disabled={isRegenerating}
+                          className="min-h-[44px] w-full"
+                        >
+                          {isRegenerating ? (
+                            <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent mr-2" />
+                          ) : (
+                            <Sparkles className="mr-2 h-4 w-4" />
+                          )}
+                          {t("generate.regenerate")}
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setShowFreshConfirm(true)}
+                          disabled={isRegenerating}
+                          className="min-h-[44px] w-full border-destructive/50 text-destructive hover:bg-destructive/5 hover:text-destructive"
+                        >
+                          <Trash2 className="mr-2 h-4 w-4" />
+                          {t("generate.regenerateFresh")}
+                        </Button>
+                        {regenerateError && (
+                          <div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+                            <AlertCircle className="h-4 w-4 shrink-0" />
+                            {regenerateError}
+                          </div>
+                        )}
+                      </div>
+                    )}
                   </div>
                 )}
               </div>
@@ -1461,6 +1529,29 @@ export function CourseWizardClient({
             </Button>
             <Button onClick={handleForceClose}>
               {t("closeWhileRunning.confirmClose")}
+            </Button>
+          </div>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={showFreshConfirm} onOpenChange={setShowFreshConfirm}>
+        <AlertDialogContent>
+          <AlertDialogTitle>{t("generate.regenerateFreshConfirmTitle")}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {t("generate.regenerateFreshConfirmDescription")}
+          </AlertDialogDescription>
+          <div className="flex justify-end gap-3 mt-4">
+            <Button variant="outline" onClick={() => setShowFreshConfirm(false)}>
+              {t("generate.regenerateFreshConfirmCancel")}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                setShowFreshConfirm(false);
+                regenerateSyllabus("fresh");
+              }}
+            >
+              {t("generate.regenerateFreshConfirmAction")}
             </Button>
           </div>
         </AlertDialogContent>

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1239,7 +1239,14 @@
         "stepParsingResponse": "Processing AI response...",
         "stepSavingModules": "Saving course structure...",
         "elapsed": "Elapsed: {time}",
-        "timeoutWarning": "This is taking longer than expected. You can wait or try again."
+        "timeoutWarning": "This is taking longer than expected. You can wait or try again.",
+        "regenerate": "Regenerate syllabus",
+        "regenerateFresh": "Discard cache & regenerate",
+        "regenerateFreshConfirmTitle": "Discard cache and regenerate?",
+        "regenerateFreshConfirmDescription": "This will re-analyze all PDFs from scratch. The current module structure will be replaced.",
+        "regenerateFreshConfirmAction": "Discard & regenerate",
+        "regenerateFreshConfirmCancel": "Cancel",
+        "regenerateError": "Failed to regenerate syllabus."
       },
       "index": {
         "title": "RAG Indexation",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1239,7 +1239,14 @@
         "stepParsingResponse": "Traitement de la réponse IA...",
         "stepSavingModules": "Sauvegarde de la structure du cours...",
         "elapsed": "Écoulé : {time}",
-        "timeoutWarning": "Cela prend plus de temps que prévu. Vous pouvez attendre ou réessayer."
+        "timeoutWarning": "Cela prend plus de temps que prévu. Vous pouvez attendre ou réessayer.",
+        "regenerate": "Regénérer le syllabus",
+        "regenerateFresh": "Vider le cache et regénérer",
+        "regenerateFreshConfirmTitle": "Vider le cache et regénérer ?",
+        "regenerateFreshConfirmDescription": "Cela va ré-analyser tous les PDFs depuis le début. La structure des modules actuels sera remplacée.",
+        "regenerateFreshConfirmAction": "Vider et regénérer",
+        "regenerateFreshConfirmCancel": "Annuler",
+        "regenerateError": "Erreur lors de la regénération du syllabus."
       },
       "index": {
         "title": "Indexation RAG",


### PR DESCRIPTION
## Summary

- Regenerate syllabus: reuse cached summaries (fast) or full refresh from PDFs
- Pre-publish only — blocked for published courses and courses with enrollments
- Cache `syllabus_context` on first generation (migration 041)
- Fix ModuleUnit deletion before Module (FK cascade issue)
- Confirmation dialog for destructive "Discard & regenerate"

Fixes #1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)