### PR TITLE
feat(onboarding): add 7 new professional roles to step 3

### DIFF
--- a/frontend/components/onboarding/steps/role-step.tsx
+++ b/frontend/components/onboarding/steps/role-step.tsx
@@ -15,20 +15,34 @@ interface RoleStepProps {
 }
 
 const roles = [
+  'eleve',
+  'etudiant',
+  'universitaire',
   'medecin',
   'infirmier',
   'data-analyst',
-  'etudiant',
   'cadre',
+  'consultant',
+  'commercant',
+  'entrepreneur',
+  'coach',
+  'influencer',
   'autre'
 ];
 
 const roleIcons: { [key: string]: string } = {
+  'eleve': '📚',
+  'etudiant': '🎓',
+  'universitaire': '🏛️',
   'medecin': '👩‍⚕️',
   'infirmier': '👨‍⚕️',
   'data-analyst': '📊',
-  'etudiant': '🎓',
   'cadre': '💼',
+  'consultant': '🧠',
+  'commercant': '🛒',
+  'entrepreneur': '🚀',
+  'coach': '🏅',
+  'influencer': '📱',
   'autre': '👤'
 };
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -501,11 +501,18 @@
       "description": "Tell us about your professional background",
       "selectRole": "Select your role",
       "roles": {
+        "eleve": "Pupil (pre-university)",
+        "etudiant": "Student (Étudiant)",
+        "universitaire": "Academic (Universitaire)",
         "medecin": "Physician (Médecin)",
         "infirmier": "Nurse (Infirmier)",
         "data-analyst": "Data Analyst",
-        "etudiant": "Student (Étudiant)",
         "cadre": "Manager/Administrator (Cadre)",
+        "consultant": "Consultant",
+        "commercant": "Trader/Merchant (Commerçant)",
+        "entrepreneur": "Entrepreneur",
+        "coach": "Coach",
+        "influencer": "Influencer",
         "autre": "Other (Autre)"
       }
     },

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -501,11 +501,18 @@
       "description": "Parlez-nous de votre parcours professionnel",
       "selectRole": "Sélectionnez votre rôle",
       "roles": {
+        "eleve": "Élève (pré-universitaire)",
+        "etudiant": "Étudiant",
+        "universitaire": "Universitaire",
         "medecin": "Médecin",
         "infirmier": "Infirmier",
         "data-analyst": "Analyste de données",
-        "etudiant": "Étudiant",
         "cadre": "Cadre/Administrateur",
+        "consultant": "Consultant",
+        "commercant": "Commerçant",
+        "entrepreneur": "Entrepreneur",
+        "coach": "Coach",
+        "influencer": "Influenceur",
         "autre": "Autre"
       }
     },


### PR DESCRIPTION
## Summary
- Added 7 new professional roles to onboarding step 3: `eleve`, `universitaire`, `consultant`, `commercant`, `entrepreneur`, `coach`, `influencer`
- Roles are ordered per spec: education group → health/professional group → business/other group → `autre` last
- FR/EN translations added for all new roles

## Changes
- `frontend/components/onboarding/steps/role-step.tsx` — updated `roles` array (13 total) and `roleIcons` map
- `frontend/messages/fr.json` — added 7 French translations under `Onboarding.step3.roles`
- `frontend/messages/en.json` — added 7 English translations under `Onboarding.step3.roles`

## Test plan
- [ ] Frontend lint passes (no new errors)
- [ ] Onboarding step 3 shows all 13 roles in correct order
- [ ] Each role displays correct icon and bilingual label
- [ ] No DB migration needed (`professional_role` is free text)

Closes #1109

Generated with [Claude Code](https://claude.ai/code)