### PR TITLE
feat(wizard): add stop/restart button for stuck indexation tasks

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -621,6 +621,59 @@ async def get_rag_index_status(
     return response
 
 
+@router.post("/{course_id}/cancel-indexation", response_model=CourseResponse)
+async def cancel_indexation(
+    course_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    db=Depends(get_db_session),
+) -> CourseResponse:
+    """Revoke a running RAG indexation task and reset the course back to 'generated'.
+
+    Safe to call even when the task has already failed or is stale — idempotent.
+    After this call the admin can re-trigger indexation via POST /index-resources.
+    """
+    result = await db.execute(select(Course).where(Course.id == course_id))
+    course = result.scalar_one_or_none()
+    if not course:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
+
+    if course.creation_step not in ("indexing", "generated"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Cannot cancel: course is at step '{course.creation_step}', not in an indexing state.",
+        )
+
+    if course.indexation_task_id:
+        try:
+            task_result = AsyncResult(course.indexation_task_id)
+            task_result.revoke(terminate=True, signal="SIGTERM")
+            logger.info(
+                "Celery task revoked",
+                task_id=course.indexation_task_id,
+                course_id=str(course_id),
+                admin_id=current_user.id,
+            )
+        except Exception as revoke_exc:
+            logger.warning(
+                "Could not revoke Celery task (may have already finished)",
+                task_id=course.indexation_task_id,
+                error=str(revoke_exc),
+            )
+
+    course.creation_step = "generated"
+    course.indexation_task_id = None
+    await db.commit()
+    await db.refresh(course)
+    img_count = await _fetch_image_count(db, course.rag_collection_id)
+
+    logger.info(
+        "Indexation cancelled, creation_step reset to 'generated'",
+        course_id=str(course_id),
+        admin_id=current_user.id,
+    )
+    return _course_to_response(course, image_count=img_count)
+
+
 @router.post("/{course_id}/reindex-images")
 async def trigger_image_reindexation(
     course_id: uuid.UUID,

--- a/frontend/components/admin/course-wizard-client.tsx
+++ b/frontend/components/admin/course-wizard-client.tsx
@@ -18,6 +18,8 @@ import {
   AlertCircle,
   Clock,
   ChevronDown,
+  StopCircle,
+  RotateCcw,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -219,6 +221,11 @@ export function CourseWizardClient({
   const [indexError, setIndexError] = useState<string | null>(null);
   const [isReindexingImages, setIsReindexingImages] = useState(false);
   const [reindexImagesError, setReindexImagesError] = useState<string | null>(null);
+  const [isCancellingIndexation, setIsCancellingIndexation] = useState(false);
+  const [cancelIndexationError, setCancelIndexationError] = useState<string | null>(null);
+  const [indexStaleWarning, setIndexStaleWarning] = useState(false);
+  const lastIndexProgressValueRef = useRef(0);
+  const lastIndexProgressTimeRef = useRef<number | null>(null);
   const [isPublishing, setIsPublishing] = useState(false);
   const [publishSuccess, setPublishSuccess] = useState(false);
   const [publishError, setPublishError] = useState<string | null>(null);
@@ -693,10 +700,35 @@ export function CourseWizardClient({
     }
   }, [courseId, t]);
 
+  const cancelIndexation = useCallback(async () => {
+    if (!courseId) return;
+    setIsCancellingIndexation(true);
+    setCancelIndexationError(null);
+    if (pollRef.current) clearTimeout(pollRef.current);
+
+    try {
+      await apiFetch(`/api/v1/admin/courses/${courseId}/cancel-indexation`, { method: "POST" });
+      setIsIndexing(false);
+      setIndexStaleWarning(false);
+      setTaskId(null);
+      setIndexStatus(null);
+      lastIndexProgressValueRef.current = 0;
+      lastIndexProgressTimeRef.current = null;
+    } catch {
+      setCancelIndexationError(t("index.cancelError"));
+    } finally {
+      setIsCancellingIndexation(false);
+    }
+  }, [courseId, t]);
+
   const startIndexation = useCallback(async () => {
     if (!courseId) return;
     setIsIndexing(true);
     setIndexError(null);
+    setIndexStaleWarning(false);
+    setCancelIndexationError(null);
+    lastIndexProgressValueRef.current = 0;
+    lastIndexProgressTimeRef.current = Date.now();
 
     try {
       const result = await apiFetch<{ task_id: string; status: string }>(
@@ -740,8 +772,21 @@ export function CourseWizardClient({
           task: status.task,
         });
 
+        const newProgress = status.task?.progress ?? 0;
+        if (newProgress !== lastIndexProgressValueRef.current) {
+          lastIndexProgressValueRef.current = newProgress;
+          lastIndexProgressTimeRef.current = Date.now();
+          setIndexStaleWarning(false);
+        } else if (lastIndexProgressTimeRef.current !== null) {
+          const staleSince = Date.now() - lastIndexProgressTimeRef.current;
+          if (staleSince > 60 * 1000) {
+            setIndexStaleWarning(true);
+          }
+        }
+
         if (status.task?.state === "SUCCESS") {
           setIsIndexing(false);
+          setIndexStaleWarning(false);
           queryClient.invalidateQueries({ queryKey: ["admin-courses"] });
           return;
         }
@@ -752,6 +797,7 @@ export function CourseWizardClient({
         ) {
           setIndexError(t("index.error"));
           setIsIndexing(false);
+          setIndexStaleWarning(false);
           return;
         }
 
@@ -760,6 +806,10 @@ export function CourseWizardClient({
         pollRef.current = setTimeout(poll, 5000);
       }
     };
+
+    if (lastIndexProgressTimeRef.current === null) {
+      lastIndexProgressTimeRef.current = Date.now();
+    }
 
     pollRef.current = setTimeout(poll, 2000);
     return () => {
@@ -1317,6 +1367,35 @@ export function CourseWizardClient({
                           {t("index.imagesProgress", { count: indexStatus.images_indexed })}
                         </p>
                       )}
+
+                      {indexStaleWarning && (
+                        <div className="flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 p-2 text-xs text-amber-700 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-400">
+                          <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+                          {t("index.staleWarning")}
+                        </div>
+                      )}
+
+                      {cancelIndexationError && (
+                        <div className="flex items-center gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-2 text-xs text-destructive">
+                          <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+                          {cancelIndexationError}
+                        </div>
+                      )}
+
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={cancelIndexation}
+                        disabled={isCancellingIndexation}
+                        className="w-full min-h-[44px] border-destructive/50 text-destructive hover:bg-destructive/5 hover:text-destructive"
+                      >
+                        {isCancellingIndexation ? (
+                          <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent mr-2" />
+                        ) : (
+                          <StopCircle className="mr-2 h-4 w-4" />
+                        )}
+                        {t("index.cancelIndexation")}
+                      </Button>
                     </div>
 
                     <p className="text-xs text-muted-foreground text-center">
@@ -1325,10 +1404,24 @@ export function CourseWizardClient({
                   </div>
                 )}
 
+                {!isIndexing && indexError && (
+                  <Button
+                    onClick={startIndexation}
+                    variant="outline"
+                    size="sm"
+                    className="w-full min-h-[44px]"
+                  >
+                    <RotateCcw className="mr-2 h-4 w-4" />
+                    {t("index.retryIndexation")}
+                  </Button>
+                )}
+
                 {indexError && (
-                  <div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
-                    <AlertCircle className="h-4 w-4 shrink-0" />
-                    {indexError}
+                  <div className="flex flex-col gap-2">
+                    <div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+                      <AlertCircle className="h-4 w-4 shrink-0" />
+                      {indexError}
+                    </div>
                   </div>
                 )}
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1080,7 +1080,7 @@
       "exportCsv": "Export CSV",
       "previous": "Previous",
       "next": "Next",
-      "showing": "Showing {from}\u2013{to} of {total}",
+      "showing": "Showing {from}–{to} of {total}",
       "clearFilters": "Clear filters",
       "statuses": {
         "payment_processed": "Processed",
@@ -1283,7 +1283,12 @@
         "inProgress": "Indexation in progress",
         "noImagesIndexed": "No images were indexed. You can re-index images separately without re-running the full pipeline (no extra OpenAI cost).",
         "reindexImages": "Re-index images",
-        "reindexImagesError": "Image re-indexation failed."
+        "reindexImagesError": "Image re-indexation failed.",
+        "cancelIndexation": "Cancel indexation",
+        "retryIndexation": "Retry indexation",
+        "staleWarning": "No progress detected for over 60 seconds. The task may be stuck.",
+        "cancelError": "Failed to cancel indexation.",
+        "cancelSuccess": "Indexation cancelled. You can restart it."
       },
       "closeWhileRunning": {
         "title": "Indexation still running",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1080,7 +1080,7 @@
       "exportCsv": "Exporter CSV",
       "previous": "Précédent",
       "next": "Suivant",
-      "showing": "Affichage {from}\u2013{to} sur {total}",
+      "showing": "Affichage {from}–{to} sur {total}",
       "clearFilters": "Effacer les filtres",
       "statuses": {
         "payment_processed": "Traité",
@@ -1283,7 +1283,12 @@
         "inProgress": "Indexation en cours",
         "noImagesIndexed": "Aucune image indexée. Vous pouvez ré-indexer les images séparément sans relancer le pipeline complet (sans coût OpenAI supplémentaire).",
         "reindexImages": "Ré-indexer les images",
-        "reindexImagesError": "La ré-indexation des images a échoué."
+        "reindexImagesError": "La ré-indexation des images a échoué.",
+        "cancelIndexation": "Annuler l'indexation",
+        "retryIndexation": "Relancer l'indexation",
+        "staleWarning": "Aucune progression détectée depuis plus de 60 secondes. La tâche est peut-être bloquée.",
+        "cancelError": "Impossible d'annuler l'indexation.",
+        "cancelSuccess": "Indexation annulée. Vous pouvez la relancer."
       },
       "closeWhileRunning": {
         "title": "Indexation en cours",


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/admin/courses/{id}/cancel-indexation` backend endpoint that revokes the Celery task and resets `creation_step` → `generated` / clears `indexation_task_id`
- Adds **Cancel indexation** button in the wizard index step (always visible while indexing)
- Adds stale-task detection: if progress doesn't change for >60 s, shows an amber warning
- Adds **Retry indexation** button after a failed/cancelled task
- Adds i18n keys for cancel/retry in both `en.json` and `fr.json`

## Changes

- `backend/app/api/v1/admin_courses.py` — new `cancel-indexation` endpoint
- `frontend/components/admin/course-wizard-client.tsx` — stale detection + cancel/retry UI
- `frontend/messages/en.json` + `fr.json` — 5 new i18n keys each

## Test plan

- [ ] Backend tests pass (`uv run pytest`)
- [ ] Frontend lint passes (`npm run lint`)
- [ ] Manually start indexation, click "Cancel indexation" → step resets to `generated`
- [ ] With a stuck course (`creation_step=indexing`), open wizard → stale warning appears after 60 s
- [ ] "Retry indexation" button visible after cancel/failure, clicking re-triggers indexation
- [ ] Verified on mobile viewport (320px)

Closes #1113

Generated with [Claude Code](https://claude.ai/code)