### PR TITLE
fix(onboarding): rename 'Tutor' to 'Sira' and fix competence description

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -168,7 +168,7 @@
   },
   "Dashboard": {
     "title": "Dashboard",
-    "welcome": "Welcome to Tutor",
+    "welcome": "Welcome to Sira",
     "subtitle": "Your public health learning platform",
     "streak": "Day streak",
     "nextReview": "Next review",
@@ -462,7 +462,7 @@
     "goToModules": "Go to Modules"
   },
   "Onboarding": {
-    "welcome": "Welcome to Tutor",
+    "welcome": "Welcome to Sira",
     "subtitle": "Let's set up your personalized learning experience",
     "step": "Step {current} of {total}",
     "next": "Next",
@@ -518,7 +518,7 @@
     },
     "step4": {
       "title": "Skill Level",
-      "description": "How would you assess your public health knowledge?",
+      "description": "How would you assess your competence in your field?",
       "selectLevel": "Select your level",
       "levels": {
         "debutant": "Beginner (Débutant)",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -168,7 +168,7 @@
   },
   "Dashboard": {
     "title": "Tableau de bord",
-    "welcome": "Bienvenue sur Tutor",
+    "welcome": "Bienvenue sur Sira",
     "subtitle": "Votre plateforme d'apprentissage en santé publique",
     "streak": "Jours consécutifs",
     "nextReview": "Prochaine révision",
@@ -462,7 +462,7 @@
     "goToModules": "Aller aux modules"
   },
   "Onboarding": {
-    "welcome": "Bienvenue sur Tutor",
+    "welcome": "Bienvenue sur Sira",
     "subtitle": "Configurons votre expérience d'apprentissage personnalisée",
     "step": "Étape {current} de {total}",
     "next": "Suivant",
@@ -518,7 +518,7 @@
     },
     "step4": {
       "title": "Niveau de Compétence",
-      "description": "Comment évalueriez-vous vos connaissances en santé publique ?",
+      "description": "Comment évalueriez-vous votre compétence dans votre domaine ?",
       "selectLevel": "Sélectionnez votre niveau",
       "levels": {
         "debutant": "Débutant",


### PR DESCRIPTION
## Summary
- Rename app name from "Tutor" to "Sira" in Dashboard and Onboarding welcome strings (FR + EN)
- Update `Onboarding.step4.description` to generic competence wording instead of "public health"-specific

Closes #1116

Generated with [Claude Code](https://claude.ai/code)