### PR TITLE
fix: curricula migration enum creation with asyncpg

### DIFF
--- a/backend/migrations/versions/042_add_curricula.py
+++ b/backend/migrations/versions/042_add_curricula.py
@@ -16,7 +16,8 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute("CREATE TYPE curriculumstatus AS ENUM ('draft', 'published', 'archived')")
+    curriculumstatus = sa.Enum("draft", "published", "archived", name="curriculumstatus")
+    curriculumstatus.create(op.get_bind(), checkfirst=True)
 
     op.create_table(
         "curricula",


### PR DESCRIPTION
## Summary
- Fix migration 042: use `sa.Enum.create(checkfirst=True)` instead of explicit `CREATE TYPE` + `create_type=False` which fails with asyncpg

The `create_type=False` flag on `sa.Enum` inside `create_table` is not respected by SQLAlchemy's asyncpg dialect, causing `DuplicateObjectError`. This blocked the curricula tables from being created on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)