### PR TITLE
fix(celery): prevent Redis backend cascading failures after task crash

### DIFF
--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -37,6 +37,8 @@ celery_app.conf.update(
     task_eager_propagates=True,
     task_ignore_result=False,
     result_expires=3600,  # 1 hour
+    result_backend_always_retry=True,
+    result_backend_max_retries=3,
     worker_prefetch_multiplier=4,
     task_acks_late=True,
     worker_disable_rate_limits=False,

--- a/backend/app/tasks/image_indexation.py
+++ b/backend/app/tasks/image_indexation.py
@@ -28,6 +28,7 @@ class ImageIndexTask(Task):
     base=ImageIndexTask,
     time_limit=1800,
     soft_time_limit=1500,
+    ignore_result=True,
 )
 def reindex_course_images(self, course_id: str, rag_collection_id: str) -> dict:
     """Re-index images for a course independently from text indexation.

--- a/backend/app/tasks/rag_indexation.py
+++ b/backend/app/tasks/rag_indexation.py
@@ -65,6 +65,7 @@ class RAGTask(Task):
     rate_limit="2/h",
     time_limit=1800,
     soft_time_limit=1500,
+    ignore_result=True,
 )
 def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict:
     """Index uploaded PDFs for a course into pgvector.

--- a/backend/app/tasks/syllabus_generation.py
+++ b/backend/app/tasks/syllabus_generation.py
@@ -51,6 +51,7 @@ class SyllabusTask(Task):
     retry_kwargs={"max_retries": 1, "countdown": 30},
     time_limit=3600,  # 60 min hard limit
     soft_time_limit=2700,  # 45 min soft limit
+    ignore_result=True,
 )
 def generate_course_syllabus(
     self, course_id: str, estimated_hours: int, cached_resource_text: str | None = None

--- a/backend/tests/test_celery_redis_fix.py
+++ b/backend/tests/test_celery_redis_fix.py
@@ -1,0 +1,55 @@
+"""Tests for Celery Redis backend cascading failure fix (issue #1121).
+
+Verifies that:
+- Fire-and-forget tasks have ignore_result=True to prevent corrupted Redis metadata
+  from poisoning subsequent tasks
+- Celery config includes result_backend_always_retry and result_backend_max_retries
+  as a belt-and-suspenders defence
+"""
+
+
+class TestCeleryConfigDefences:
+    """Verify global Celery config has Redis backend retry settings."""
+
+    def test_result_backend_always_retry_enabled(self):
+        from app.tasks.celery_app import celery_app
+
+        assert celery_app.conf.result_backend_always_retry is True
+
+    def test_result_backend_max_retries_set(self):
+        from app.tasks.celery_app import celery_app
+
+        assert celery_app.conf.result_backend_max_retries == 3
+
+
+class TestFireAndForgetTasksIgnoreResult:
+    """Verify that all fire-and-forget tasks have ignore_result=True.
+
+    These tasks track state via the courses.creation_step DB column, not via
+    the Celery result backend. Storing results in Redis is unused overhead
+    that causes cascading failures when a prior task leaves corrupted metadata.
+    """
+
+    def test_generate_course_syllabus_ignores_result(self):
+        from app.tasks.syllabus_generation import generate_course_syllabus
+
+        assert generate_course_syllabus.ignore_result is True, (
+            "generate_course_syllabus must have ignore_result=True — "
+            "state is tracked via courses.creation_step, not Celery backend"
+        )
+
+    def test_index_course_resources_ignores_result(self):
+        from app.tasks.rag_indexation import index_course_resources
+
+        assert index_course_resources.ignore_result is True, (
+            "index_course_resources must have ignore_result=True — "
+            "state is tracked via courses.creation_step, not Celery backend"
+        )
+
+    def test_reindex_course_images_ignores_result(self):
+        from app.tasks.image_indexation import reindex_course_images
+
+        assert reindex_course_images.ignore_result is True, (
+            "reindex_course_images must have ignore_result=True — "
+            "completion is tracked via logs/DB, not Celery backend"
+        )


### PR DESCRIPTION
## Summary
- Add `ignore_result=True` to all fire-and-forget tasks (`generate_course_syllabus`, `index_course_resources`, `reindex_course_images`) so failed tasks never write corrupted `exc_type`-less metadata to Redis
- Add `result_backend_always_retry=True` + `result_backend_max_retries=3` to global Celery config
- Add 5 unit tests verifying the fix

## Changes
- `backend/app/tasks/celery_app.py`
- `backend/app/tasks/syllabus_generation.py`
- `backend/app/tasks/rag_indexation.py`
- `backend/app/tasks/image_indexation.py`
- `backend/tests/test_celery_redis_fix.py` (new)

## Test plan
- [x] Backend tests pass
- [x] No functional regression (state tracked via courses.creation_step, not Celery backend)

Fixes #1121

🤖 Generated with [Claude Code](https://claude.ai/code)