### PR TITLE
fix(curricula): scoped navigation stays within curriculum context

### DIFF
--- a/frontend/app/[locale]/(app)/curricula/[slug]/page.tsx
+++ b/frontend/app/[locale]/(app)/curricula/[slug]/page.tsx
@@ -15,6 +15,7 @@ import {
   type CourseResponse,
   type TaxonomyItem,
 } from '@/lib/api';
+import { setCurriculumContext } from '@/lib/curriculum-context';
 
 interface FilterSection {
   key: string;
@@ -80,6 +81,11 @@ export default function CurriculumPage() {
   const pathname = usePathname();
 
   const slug = params.slug as string;
+
+  // Set curriculum context cookie so sidebar/nav stays scoped
+  useEffect(() => {
+    setCurriculumContext(slug);
+  }, [slug]);
 
   const [curriculum, setCurriculum] = useState<CurriculumPublicDetailResponse | null>(null);
   const [courses, setCourses] = useState<CourseResponse[]>([]);

--- a/frontend/app/[locale]/(app)/dashboard/dashboard-client.tsx
+++ b/frontend/app/[locale]/(app)/dashboard/dashboard-client.tsx
@@ -6,10 +6,14 @@ import { useRouter } from '@/i18n/routing';
 import { ModuleMap } from '@/components/learning/module-map';
 import { getMyEnrollments, type CourseWithEnrollment } from '@/lib/api';
 
-export function DashboardClient() {
+export function DashboardClient({ curriculumSlug }: { curriculumSlug?: string }) {
   const t = useTranslations('Dashboard');
   const locale = useLocale() as 'en' | 'fr';
   const router = useRouter();
+
+  const coursesHref = curriculumSlug
+    ? `/curricula/${curriculumSlug}`
+    : '/courses';
 
   const [enrollments, setEnrollments] = useState<CourseWithEnrollment[]>([]);
   const [loading, setLoading] = useState(true);
@@ -55,7 +59,7 @@ export function DashboardClient() {
         <p className="text-stone-600 text-sm">{t('noEnrollments')}</p>
         <button
           className="mt-4 text-teal-600 text-sm font-medium underline-offset-2 hover:underline min-h-11"
-          onClick={() => router.push('/courses')}
+          onClick={() => router.push(coursesHref)}
         >
           {t('browseCourses')}
         </button>
@@ -72,7 +76,7 @@ export function DashboardClient() {
         />
         <button
           className="w-full text-center text-teal-600 text-sm font-medium underline-offset-2 hover:underline min-h-11 rounded-lg border border-dashed border-teal-200 py-3 hover:bg-teal-50 transition-colors"
-          onClick={() => router.push('/courses')}
+          onClick={() => router.push(coursesHref)}
         >
           {t('browseMoreCourses')}
         </button>
@@ -127,7 +131,7 @@ export function DashboardClient() {
       })}
       <button
         className="w-full text-center text-teal-600 text-sm font-medium underline-offset-2 hover:underline min-h-11 rounded-lg border border-dashed border-teal-200 py-3 hover:bg-teal-50 transition-colors"
-        onClick={() => router.push('/courses')}
+        onClick={() => router.push(coursesHref)}
       >
         {t('browseMoreCourses')}
       </button>

--- a/frontend/app/[locale]/(app)/dashboard/page.tsx
+++ b/frontend/app/[locale]/(app)/dashboard/page.tsx
@@ -4,8 +4,13 @@ import { DashboardStats } from "@/components/dashboard/dashboard-stats";
 import { UpcomingReviews } from "@/components/dashboard/upcoming-reviews";
 import { CurriculaSection } from "@/components/shared/curricula-section";
 
-export default async function DashboardPage() {
+interface DashboardPageProps {
+  searchParams: Promise<{ curriculum?: string }>;
+}
+
+export default async function DashboardPage({ searchParams }: DashboardPageProps) {
   const t = await getTranslations("Dashboard");
+  const { curriculum } = await searchParams;
 
   return (
     <div className="p-4 md:p-6">
@@ -21,10 +26,10 @@ export default async function DashboardPage() {
       </div>
 
       <div className="mt-8">
-        <DashboardClient />
+        <DashboardClient curriculumSlug={curriculum} />
       </div>
 
-      <CurriculaSection />
+      {!curriculum && <CurriculaSection />}
     </div>
   );
 }

--- a/frontend/components/layout/bottom-nav.tsx
+++ b/frontend/components/layout/bottom-nav.tsx
@@ -16,13 +16,19 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useState, useEffect, useRef } from "react";
+import { getCurriculumContext } from "@/lib/curriculum-context";
 
 export function BottomNav() {
   const t = useTranslations("Navigation");
   const pathname = usePathname();
   const locale = useLocale();
   const [moreOpen, setMoreOpen] = useState(false);
+  const [curriculumSlug, setCurriculumSlug] = useState<string | null>(null);
   const moreRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setCurriculumSlug(getCurriculumContext());
+  }, [pathname]);
 
   useEffect(() => {
     if (!moreOpen) return;
@@ -37,13 +43,17 @@ export function BottomNav() {
 
   const primaryItems = [
     {
-      href: `/${locale}/dashboard`,
+      href: curriculumSlug
+        ? `/${locale}/dashboard?curriculum=${curriculumSlug}`
+        : `/${locale}/dashboard`,
       label: t("dashboard"),
       icon: Home,
       description: t("dashboardDescription"),
     },
     {
-      href: `/${locale}/courses`,
+      href: curriculumSlug
+        ? `/${locale}/curricula/${curriculumSlug}`
+        : `/${locale}/courses`,
       label: t("courses"),
       icon: GraduationCap,
       description: t("coursesDescription"),

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -24,6 +24,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { authClient } from "@/lib/auth";
 import { useQueryClient } from "@tanstack/react-query";
+import { getCurriculumContext } from "@/lib/curriculum-context";
 
 function getUserRole(): string | null {
   if (typeof window === "undefined") return null;
@@ -50,10 +51,12 @@ export function Sidebar() {
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const [userRole, setUserRole] = useState<string | null>(null);
+  const [curriculumSlug, setCurriculumSlug] = useState<string | null>(null);
 
   useEffect(() => {
     startTransition(() => setUserRole(getUserRole()));
-  }, []);
+    setCurriculumSlug(getCurriculumContext());
+  }, [pathname]);
 
   const handleLogout = async () => {
     setIsLoggingOut(true);
@@ -68,13 +71,17 @@ export function Sidebar() {
 
   const navItems = [
     {
-      href: `/${locale}/dashboard`,
+      href: curriculumSlug
+        ? `/${locale}/dashboard?curriculum=${curriculumSlug}`
+        : `/${locale}/dashboard`,
       label: t("dashboard"),
       icon: Home,
       description: t("dashboardDescription")
     },
     {
-      href: `/${locale}/courses`,
+      href: curriculumSlug
+        ? `/${locale}/curricula/${curriculumSlug}`
+        : `/${locale}/courses`,
       label: t("courses"),
       icon: GraduationCap,
       description: t("coursesDescription")

--- a/frontend/lib/curriculum-context.ts
+++ b/frontend/lib/curriculum-context.ts
@@ -1,0 +1,19 @@
+const COOKIE_NAME = 'curriculum_context';
+
+export function getCurriculumContext(): string | null {
+  if (typeof document === 'undefined') return null;
+  const match = document.cookie.match(
+    new RegExp(`(?:^|; )${COOKIE_NAME}=([^;]*)`)
+  );
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+export function setCurriculumContext(slug: string) {
+  if (typeof document === 'undefined') return;
+  document.cookie = `${COOKIE_NAME}=${encodeURIComponent(slug)};path=/;max-age=${60 * 60 * 24 * 30};samesite=lax`;
+}
+
+export function clearCurriculumContext() {
+  if (typeof document === 'undefined') return;
+  document.cookie = `${COOKIE_NAME}=;path=/;max-age=0`;
+}


### PR DESCRIPTION
## Summary
- Sidebar and bottom nav now stay within curriculum context when user arrived via `/curricula/{slug}`
- Dashboard hides "Browse Curricula" section when in curriculum context
- "Browse more courses" link goes to curriculum page when scoped
- Uses cookie-based context propagation (`curriculum_context`)

## Test plan
- [ ] Visit `/curricula/{slug}` → sidebar "Courses" links back to curriculum, "Dashboard" includes `?curriculum=`
- [ ] Dashboard with `?curriculum=` hides "Browse Curricula" section
- [ ] Default `/dashboard` still shows "Browse Curricula"

🤖 Generated with [Claude Code](https://claude.com/claude-code)