### PR TITLE
fix: react-hooks lint for curriculum context setState

### DIFF
--- a/frontend/components/layout/bottom-nav.tsx
+++ b/frontend/components/layout/bottom-nav.tsx
@@ -15,7 +15,7 @@ import {
   X,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { useState, useEffect, useRef } from "react";
+import { startTransition, useState, useEffect, useRef } from "react";
 import { getCurriculumContext } from "@/lib/curriculum-context";
 
 export function BottomNav() {
@@ -27,7 +27,7 @@ export function BottomNav() {
   const moreRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    setCurriculumSlug(getCurriculumContext());
+    startTransition(() => setCurriculumSlug(getCurriculumContext()));
   }, [pathname]);
 
   useEffect(() => {

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -54,8 +54,10 @@ export function Sidebar() {
   const [curriculumSlug, setCurriculumSlug] = useState<string | null>(null);
 
   useEffect(() => {
-    startTransition(() => setUserRole(getUserRole()));
-    setCurriculumSlug(getCurriculumContext());
+    startTransition(() => {
+      setUserRole(getUserRole());
+      setCurriculumSlug(getCurriculumContext());
+    });
   }, [pathname]);
 
   const handleLogout = async () => {


### PR DESCRIPTION
Wrap setCurriculumSlug in startTransition to satisfy react-hooks/set-state-in-effect rule