### PR TITLE
fix(summarizer): use streaming + sequential processing for large PDF summarization (#1144)

### DIFF
--- a/backend/app/ai/pdf_summarizer.py
+++ b/backend/app/ai/pdf_summarizer.py
@@ -307,13 +307,24 @@ async def summarize_single_pdf(
         max_output_tokens=max_output_tokens,
     )
 
-    response = await client.messages.create(
+    token_count = 0
+    async with client.messages.stream(
         model=model,
         max_tokens=max_output_tokens,
         system=_SYLLABUS_SUMMARY_SYSTEM,
         messages=[{"role": "user", "content": prompt}],
-    )
-    result = response.content[0].text.strip()
+    ) as stream:
+        async for event in stream:
+            if hasattr(event, "type") and event.type == "content_block_delta":
+                token_count += 1
+                if token_count % 5000 == 0:
+                    logger.info(
+                        "Streaming progress",
+                        book=book_name,
+                        tokens_so_far=token_count,
+                    )
+        message = await stream.get_final_message()
+    result = message.content[0].text.strip()
     logger.info(
         "PDF summarized",
         book=book_name,
@@ -331,7 +342,7 @@ async def _combine_summaries(
     max_tokens: int = 64_000,
     target_words: int | None = None,
     max_concurrent: int = 5,
-    _shared_semaphore: asyncio.Semaphore | None = None,
+    _shared_semaphore: asyncio.Semaphore | None = None,  # kept for backward compat, unused
 ) -> str:
     """Combine per-resource summaries into one unified summary.
 
@@ -360,43 +371,37 @@ async def _combine_summaries(
             analyses=batches[0],
             word_limit_instruction=word_limit_instruction,
         )
-        response = await client.messages.create(
+        async with client.messages.stream(
             model=model,
             max_tokens=adjusted_max_tokens,
             system=_COMBINE_SYSTEM,
             messages=[{"role": "user", "content": prompt}],
+        ) as stream:
+            message = await stream.get_final_message()
+        return message.content[0].text.strip()
+
+    intermediate: list[str] = []
+    for i, batch in enumerate(batches):
+        prompt = _COMBINE_PROMPT.format(
+            book_name=book_name,
+            analyses=batch,
+            word_limit_instruction=word_limit_instruction,
         )
-        return response.content[0].text.strip()
-
-    semaphore = (
-        _shared_semaphore if _shared_semaphore is not None else asyncio.Semaphore(max_concurrent)
-    )
-
-    async def _bounded_combine(i: int, batch: str) -> str:
-        async with semaphore:
-            prompt = _COMBINE_PROMPT.format(
-                book_name=book_name,
-                analyses=batch,
-                word_limit_instruction=word_limit_instruction,
-            )
-            response = await client.messages.create(
-                model=model,
-                max_tokens=adjusted_max_tokens,
-                system=_COMBINE_SYSTEM,
-                messages=[{"role": "user", "content": prompt}],
-            )
-            result = response.content[0].text.strip()
-            logger.debug(
-                "Intermediate combine done",
-                book=book_name,
-                batch=i + 1,
-                total_batches=len(batches),
-            )
-            return result
-
-    intermediate: list[str] = list(
-        await asyncio.gather(*[_bounded_combine(i, b) for i, b in enumerate(batches)])
-    )
+        async with client.messages.stream(
+            model=model,
+            max_tokens=adjusted_max_tokens,
+            system=_COMBINE_SYSTEM,
+            messages=[{"role": "user", "content": prompt}],
+        ) as stream:
+            msg = await stream.get_final_message()
+        result = msg.content[0].text.strip()
+        logger.debug(
+            "Intermediate combine done",
+            book=book_name,
+            batch=i + 1,
+            total_batches=len(batches),
+        )
+        intermediate.append(result)
 
     final_joined = "\n\n---\n\n".join(f"[Group {i + 1}]\n{s}" for i, s in enumerate(intermediate))
     prompt = _COMBINE_PROMPT.format(
@@ -404,13 +409,14 @@ async def _combine_summaries(
         analyses=final_joined,
         word_limit_instruction=word_limit_instruction,
     )
-    response = await client.messages.create(
+    async with client.messages.stream(
         model=model,
         max_tokens=adjusted_max_tokens,
         system=_COMBINE_SYSTEM,
         messages=[{"role": "user", "content": prompt}],
-    )
-    return response.content[0].text.strip()
+    ) as stream:
+        message = await stream.get_final_message()
+    return message.content[0].text.strip()
 
 
 async def _summarize_chunk(
@@ -440,13 +446,14 @@ async def _summarize_chunk(
         excerpt=excerpt,
         word_limit_instruction=word_limit_instruction,
     )
-    response = await client.messages.create(
+    async with client.messages.stream(
         model=model,
         max_tokens=adjusted_max_tokens,
         system=_CHUNK_SUMMARY_SYSTEM,
         messages=[{"role": "user", "content": prompt}],
-    )
-    return response.content[0].text.strip()
+    ) as stream:
+        message = await stream.get_final_message()
+    return message.content[0].text.strip()
 
 
 async def summarize_pdf_for_syllabus(
@@ -484,7 +491,7 @@ async def summarize_pdf_for_syllabus(
 
     import anthropic
 
-    client = anthropic.AsyncAnthropic(api_key=api_key, timeout=300.0)
+    client = anthropic.AsyncAnthropic(api_key=api_key, timeout=600.0)
 
     use_single_call = chunk_size_chars is None and chunk_max_output_tokens is None
 
@@ -590,34 +597,26 @@ async def summarize_pdf_for_syllabus(
         )
         return summary
 
-    semaphore = (
-        _shared_semaphore if _shared_semaphore is not None else asyncio.Semaphore(max_concurrent)
-    )
-
-    async def _bounded_chunk(i: int, chunk: str) -> str:
-        async with semaphore:
-            result = await _summarize_chunk(
-                client,
-                book_name,
-                chunk,
-                i + 1,
-                total,
-                model=model,
-                max_tokens=chunk_max_tokens,
-                target_words=target_per_chunk_words,
-            )
-            logger.info(
-                "Chunk summarized",
-                book=book_name,
-                chunk=i + 1,
-                total=total,
-                summary_chars=len(result),
-            )
-            return result
-
-    summaries: list[str] = list(
-        await asyncio.gather(*[_bounded_chunk(i, c) for i, c in enumerate(chunks)])
-    )
+    summaries: list[str] = []
+    for i, chunk in enumerate(chunks):
+        result = await _summarize_chunk(
+            client,
+            book_name,
+            chunk,
+            i + 1,
+            total,
+            model=model,
+            max_tokens=chunk_max_tokens,
+            target_words=target_per_chunk_words,
+        )
+        logger.info(
+            "Chunk summarized",
+            book=book_name,
+            chunk=i + 1,
+            total=total,
+            summary_chars=len(result),
+        )
+        summaries.append(result)
 
     combined = await _combine_summaries(
         client,
@@ -627,8 +626,6 @@ async def summarize_pdf_for_syllabus(
         model=model,
         max_tokens=combine_max_tokens,
         target_words=target_words,
-        max_concurrent=max_concurrent,
-        _shared_semaphore=semaphore,
     )
     logger.info(
         "Multi-pass summarization complete",
@@ -683,9 +680,9 @@ def summarize_pdfs_sync(
         )
 
     async def _run_all():
-        shared_semaphore = asyncio.Semaphore(max_concurrent)
-        tasks = [
-            summarize_pdf_for_syllabus(
+        results = []
+        for (name, text, toc), budget in zip(pdf_texts, per_pdf_budgets, strict=True):
+            summary = await summarize_pdf_for_syllabus(
                 name,
                 text,
                 toc,
@@ -695,15 +692,13 @@ def summarize_pdfs_sync(
                 chunk_max_output_tokens=chunk_max_output_tokens,
                 combine_max_output_tokens=combine_max_output_tokens,
                 target_chars=budget,
-                max_concurrent=max_concurrent,
-                _shared_semaphore=shared_semaphore,
                 num_pdfs=len(pdf_texts) if use_dynamic_plan else None,
                 total_pdf_chars=total_chars if use_dynamic_plan else None,
                 context_budget_chars=effective_budget if use_dynamic_plan else None,
             )
-            for (name, text, toc), budget in zip(pdf_texts, per_pdf_budgets, strict=True)
-        ]
-        return await asyncio.gather(*tasks)
+            logger.info("PDF summarized", book=name, summary_chars=len(summary))
+            results.append(summary)
+        return results
 
     return list(asyncio.run(_run_all()))
 

--- a/backend/app/infrastructure/config/platform_defaults.py
+++ b/backend/app/infrastructure/config/platform_defaults.py
@@ -1047,10 +1047,10 @@ SETTING_DEFINITIONS: list[SettingDef] = [
     SettingDef(
         "syllabus-max-concurrent-api-calls",
         "syllabus",
-        5,
+        1,
         "integer",
-        "Max concurrent API calls",
-        "Max parallel Claude API calls during PDF summarization.",
+        "Max concurrent API calls [deprecated — always sequential now]",
+        "Deprecated. PDF summarization is now always sequential (streaming). Value ignored.",
         {"min": 1, "max": 20},
     ),
     SettingDef(

--- a/backend/app/tasks/syllabus_generation.py
+++ b/backend/app/tasks/syllabus_generation.py
@@ -71,7 +71,6 @@ def generate_course_syllabus(
     cache = SettingsCache.instance()
     context_budget = cache.get("syllabus-context-budget-chars", 3_500_000)
     summarizer_model = cache.get("syllabus-summarizer-model", "claude-sonnet-4-6")
-    max_concurrent = cache.get("syllabus-max-concurrent-api-calls", 5)
 
     logger.info(
         "Starting syllabus generation",
@@ -291,7 +290,6 @@ def generate_course_syllabus(
                 pdf_summaries = summarize_pdfs_sync(
                     pdf_full_texts,
                     model=summarizer_model,
-                    max_concurrent=max_concurrent,
                 )
                 pdf_sections = [
                     f"### {name}\n{summary}"

--- a/backend/tests/test_pdf_summarizer.py
+++ b/backend/tests/test_pdf_summarizer.py
@@ -16,6 +16,7 @@ Verifies:
 import asyncio
 import os
 import uuid
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -260,6 +261,39 @@ class TestProportionalBudgets:
         assert sum(r for r in result if r is not None) <= total
 
 
+def _make_stream_client(
+    text: str = "ok",
+    captured_system: list | None = None,
+    captured_user: list | None = None,
+    stream_call_count: list | None = None,
+):
+    """Build a mock client whose .messages.stream() is an async context manager."""
+    final_message = MagicMock()
+    final_message.content = [MagicMock(text=text)]
+
+    @asynccontextmanager
+    async def mock_stream(**kwargs):
+        if captured_system is not None:
+            captured_system.append(kwargs.get("system", ""))
+        if captured_user is not None:
+            captured_user.append(kwargs.get("messages", [{}])[0].get("content", ""))
+        if stream_call_count is not None:
+            stream_call_count.append(1)
+
+        async def _aiter():
+            return
+            yield  # makes it an async generator
+
+        stream = MagicMock()
+        stream.__aiter__ = lambda self: _aiter()
+        stream.get_final_message = AsyncMock(return_value=final_message)
+        yield stream
+
+    mock_client = MagicMock()
+    mock_client.messages.stream = mock_stream
+    return mock_client
+
+
 class TestSummarizePdfForSyllabus:
     def test_no_api_key_returns_toc_fallback(self):
         from app.ai.pdf_summarizer import summarize_pdf_for_syllabus
@@ -280,21 +314,13 @@ class TestSummarizePdfForSyllabus:
         """Without chunk overrides, must use summarize_single_pdf (new enriched prompt)."""
         from app.ai.pdf_summarizer import summarize_pdf_for_syllabus
 
-        mock_response = MagicMock()
-        mock_response.content = [MagicMock(text="Rich structured summary")]
-
-        mock_client = MagicMock()
-        mock_client.messages.create = AsyncMock(return_value=mock_response)
-
-        captured_system = []
-        captured_user = []
-
-        async def capture_create(**kwargs):
-            captured_system.append(kwargs.get("system", ""))
-            captured_user.append(kwargs.get("messages", [{}])[0].get("content", ""))
-            return mock_response
-
-        mock_client.messages.create = capture_create
+        captured_system: list = []
+        captured_user: list = []
+        mock_client = _make_stream_client(
+            text="Rich structured summary",
+            captured_system=captured_system,
+            captured_user=captured_user,
+        )
 
         with (
             patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}),
@@ -308,14 +334,13 @@ class TestSummarizePdfForSyllabus:
         assert any("EXHAUSTIVE" in p for p in captured_user)
 
     def test_single_chunk_legacy_path_when_chunk_size_given(self):
-        """Explicit chunk_size_chars must trigger legacy chunking path."""
+        """Explicit chunk_size_chars must trigger legacy chunking path (streaming)."""
         from app.ai.pdf_summarizer import summarize_pdf_for_syllabus
 
-        mock_response = MagicMock()
-        mock_response.content = [MagicMock(text="Legacy chunk summary")]
-
-        mock_client = MagicMock()
-        mock_client.messages.create = AsyncMock(return_value=mock_response)
+        stream_calls: list = []
+        mock_client = _make_stream_client(
+            text="Legacy chunk summary", stream_call_count=stream_calls
+        )
 
         with (
             patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}),
@@ -328,22 +353,14 @@ class TestSummarizePdfForSyllabus:
             )
 
         assert result == "Legacy chunk summary"
-        assert mock_client.messages.create.call_count == 1
+        assert len(stream_calls) == 1
 
     def test_toc_prepended_to_prompt_in_single_call_mode(self):
         from app.ai.pdf_summarizer import summarize_pdf_for_syllabus
 
         toc = [(1, "Chapter 1", 1), (1, "Chapter 2", 10)]
-        captured_prompts = []
-
-        async def capture_create(**kwargs):
-            captured_prompts.append(kwargs.get("messages", [{}])[0].get("content", ""))
-            resp = MagicMock()
-            resp.content = [MagicMock(text="ok")]
-            return resp
-
-        mock_client = MagicMock()
-        mock_client.messages.create = capture_create
+        captured_user: list = []
+        mock_client = _make_stream_client(text="ok", captured_user=captured_user)
 
         with (
             patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}),
@@ -351,23 +368,15 @@ class TestSummarizePdfForSyllabus:
         ):
             asyncio.run(summarize_pdf_for_syllabus("Book", "content", toc=toc))
 
-        assert any("Chapter 1" in p for p in captured_prompts)
+        assert any("Chapter 1" in p for p in captured_user)
 
 
 class TestSummarizeSinglePdf:
     def test_uses_syllabus_summary_system_prompt(self):
         from app.ai.pdf_summarizer import summarize_single_pdf
 
-        captured_system = []
-
-        async def capture_create(**kwargs):
-            captured_system.append(kwargs.get("system", ""))
-            resp = MagicMock()
-            resp.content = [MagicMock(text="rich summary")]
-            return resp
-
-        mock_client = MagicMock()
-        mock_client.messages.create = capture_create
+        captured_system: list = []
+        mock_client = _make_stream_client(text="rich summary", captured_system=captured_system)
 
         asyncio.run(summarize_single_pdf(mock_client, "MyBook", "text here"))
 
@@ -377,16 +386,8 @@ class TestSummarizeSinglePdf:
     def test_uses_exhaustive_instruction_in_prompt(self):
         from app.ai.pdf_summarizer import summarize_single_pdf
 
-        captured_user = []
-
-        async def capture_create(**kwargs):
-            captured_user.append(kwargs.get("messages", [{}])[0].get("content", ""))
-            resp = MagicMock()
-            resp.content = [MagicMock(text="ok")]
-            return resp
-
-        mock_client = MagicMock()
-        mock_client.messages.create = capture_create
+        captured_user: list = []
+        mock_client = _make_stream_client(text="ok", captured_user=captured_user)
 
         asyncio.run(summarize_single_pdf(mock_client, "TestBook", "some text"))
 
@@ -397,16 +398,8 @@ class TestSummarizeSinglePdf:
         from app.ai.pdf_summarizer import summarize_single_pdf
 
         toc = [(1, "Chapter 1", 1), (2, "Section 1.1", 3)]
-        captured_user = []
-
-        async def capture_create(**kwargs):
-            captured_user.append(kwargs.get("messages", [{}])[0].get("content", ""))
-            resp = MagicMock()
-            resp.content = [MagicMock(text="ok")]
-            return resp
-
-        mock_client = MagicMock()
-        mock_client.messages.create = capture_create
+        captured_user: list = []
+        mock_client = _make_stream_client(text="ok", captured_user=captured_user)
 
         asyncio.run(summarize_single_pdf(mock_client, "Book", "content", toc=toc))
 
@@ -415,13 +408,7 @@ class TestSummarizeSinglePdf:
     def test_returns_stripped_text(self):
         from app.ai.pdf_summarizer import summarize_single_pdf
 
-        async def mock_create(**kwargs):
-            resp = MagicMock()
-            resp.content = [MagicMock(text="  summary with spaces  ")]
-            return resp
-
-        mock_client = MagicMock()
-        mock_client.messages.create = mock_create
+        mock_client = _make_stream_client(text="  summary with spaces  ")
 
         result = asyncio.run(summarize_single_pdf(mock_client, "Book", "text"))
         assert result == "summary with spaces"
@@ -429,22 +416,13 @@ class TestSummarizeSinglePdf:
     def test_single_api_call_regardless_of_text_size(self):
         from app.ai.pdf_summarizer import summarize_single_pdf
 
-        call_count = 0
-
-        async def mock_create(**kwargs):
-            nonlocal call_count
-            call_count += 1
-            resp = MagicMock()
-            resp.content = [MagicMock(text="ok")]
-            return resp
-
-        mock_client = MagicMock()
-        mock_client.messages.create = mock_create
+        stream_calls: list = []
+        mock_client = _make_stream_client(text="ok", stream_call_count=stream_calls)
 
         large_text = "word " * 100_000
         asyncio.run(summarize_single_pdf(mock_client, "BigBook", large_text))
 
-        assert call_count == 1
+        assert len(stream_calls) == 1
 
 
 class TestSummarizePdfsSync:


### PR DESCRIPTION
## Summary
- Switch all Claude API calls in pdf_summarizer.py from `messages.create()` to `messages.stream()` — connections stay alive during long 60K-token generation
- Replace `asyncio.gather()` parallel execution with sequential loop — avoids overwhelming Anthropic rate limits
- Increase client timeout 300s → 600s (streaming applies per-chunk, not total)
- Add progress logging every 5K tokens during streaming

## Changes
- `backend/app/ai/pdf_summarizer.py`: streaming, sequential loop, 600s timeout, progress logs
- `backend/app/tasks/syllabus_generation.py`: remove max_concurrent read
- `backend/app/infrastructure/config/platform_defaults.py`: deprecate max-concurrent setting
- `backend/tests/test_pdf_summarizer.py`: update mocks for streaming API

Fixes #1144

🤖 Generated with [Claude Code](https://claude.ai/code)