### PR TITLE
feat(settings): configurable summary max output tokens (default 30K)

### DIFF
--- a/backend/app/ai/pdf_summarizer.py
+++ b/backend/app/ai/pdf_summarizer.py
@@ -471,6 +471,7 @@ async def summarize_pdf_for_syllabus(
     num_pdfs: int | None = None,
     total_pdf_chars: int | None = None,
     context_budget_chars: int | None = None,
+    summary_max_output_tokens: int | None = None,
 ) -> str:
     """Produce a rich educational content map summary of one PDF.
 
@@ -498,14 +499,16 @@ async def summarize_pdf_for_syllabus(
     if use_single_call:
         caps = get_model_caps(model)
         max_out = caps["max_output_tokens"]
-        summary_max_tokens = min(max_out, 60_000)
+        effective_max = (
+            summary_max_output_tokens if summary_max_output_tokens else min(max_out, 60_000)
+        )
         return await summarize_single_pdf(
             client,
             book_name,
             full_text,
             toc=toc,
             model=model,
-            max_output_tokens=summary_max_tokens,
+            max_output_tokens=effective_max,
         )
 
     use_dynamic_plan = (
@@ -648,6 +651,7 @@ def summarize_pdfs_sync(
     total_budget_chars: int | None = None,
     context_budget_chars: int | None = None,
     max_concurrent: int = 5,
+    summary_max_output_tokens: int | None = None,
 ) -> list[str]:
     """Synchronous wrapper — summarize a list of (book_name, full_text, toc) tuples.
 
@@ -695,6 +699,7 @@ def summarize_pdfs_sync(
                 num_pdfs=len(pdf_texts) if use_dynamic_plan else None,
                 total_pdf_chars=total_chars if use_dynamic_plan else None,
                 context_budget_chars=effective_budget if use_dynamic_plan else None,
+                summary_max_output_tokens=summary_max_output_tokens,
             )
             logger.info("PDF summarized", book=name, summary_chars=len(summary))
             results.append(summary)

--- a/backend/app/infrastructure/config/platform_defaults.py
+++ b/backend/app/infrastructure/config/platform_defaults.py
@@ -1045,6 +1045,15 @@ SETTING_DEFINITIONS: list[SettingDef] = [
         {"min": 0, "max": 64_000},
     ),
     SettingDef(
+        "syllabus-summary-max-output-tokens",
+        "syllabus",
+        30_000,
+        "integer",
+        "Summary max output tokens per PDF",
+        "Max output tokens per PDF summary. Controls richness vs cost.",
+        {"min": 4_000, "max": 64_000},
+    ),
+    SettingDef(
         "syllabus-max-concurrent-api-calls",
         "syllabus",
         1,

--- a/backend/app/tasks/syllabus_generation.py
+++ b/backend/app/tasks/syllabus_generation.py
@@ -71,6 +71,7 @@ def generate_course_syllabus(
     cache = SettingsCache.instance()
     context_budget = cache.get("syllabus-context-budget-chars", 3_500_000)
     summarizer_model = cache.get("syllabus-summarizer-model", "claude-sonnet-4-6")
+    summary_max_tokens = cache.get("syllabus-summary-max-output-tokens", 30_000)
 
     logger.info(
         "Starting syllabus generation",
@@ -290,6 +291,7 @@ def generate_course_syllabus(
                 pdf_summaries = summarize_pdfs_sync(
                     pdf_full_texts,
                     model=summarizer_model,
+                    summary_max_output_tokens=summary_max_tokens,
                 )
                 pdf_sections = [
                     f"### {name}\n{summary}"


### PR DESCRIPTION
## Summary
- New admin setting `syllabus-summary-max-output-tokens` (default 30K, range 4K-64K)
- Reduces API cost: 30K tokens ≈ ~105K chars per PDF summary (was hardcoded 60K)
- Configurable via admin platform settings page without code deploy

3-file change: platform_defaults.py (new setting), syllabus_generation.py (read setting), pdf_summarizer.py (use it)

🤖 Generated with [Claude Code](https://claude.ai/code)