### PR TITLE
fix(celery): add acks_late=False to prevent duplicate task dispatch

### DIFF
--- a/backend/app/tasks/image_indexation.py
+++ b/backend/app/tasks/image_indexation.py
@@ -29,6 +29,7 @@ class ImageIndexTask(Task):
     time_limit=1800,
     soft_time_limit=1500,
     ignore_result=True,
+    acks_late=False,  # Acknowledge immediately to prevent duplicate dispatch
 )
 def reindex_course_images(self, course_id: str, rag_collection_id: str) -> dict:
     """Re-index images for a course independently from text indexation.

--- a/backend/app/tasks/rag_indexation.py
+++ b/backend/app/tasks/rag_indexation.py
@@ -67,6 +67,7 @@ class RAGTask(Task):
     time_limit=1800,
     soft_time_limit=1500,
     ignore_result=True,
+    acks_late=False,  # Acknowledge immediately to prevent duplicate dispatch
 )
 def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict:
     """Index uploaded PDFs for a course into pgvector.

--- a/backend/app/tasks/syllabus_generation.py
+++ b/backend/app/tasks/syllabus_generation.py
@@ -53,6 +53,7 @@ class SyllabusTask(Task):
     time_limit=3600,  # 60 min hard limit
     soft_time_limit=2700,  # 45 min soft limit
     ignore_result=True,
+    acks_late=False,  # Acknowledge immediately to prevent duplicate dispatch
 )
 def generate_course_syllabus(
     self, course_id: str, estimated_hours: int, cached_resource_text: str | None = None


### PR DESCRIPTION
## Problem

Long-running tasks (syllabus generation, RAG indexation) were being re-dispatched to other workers because the global `acks_late=True` setting caused Celery to treat unacknowledged tasks as abandoned. This wasted API tokens ($5+ per duplicate) and caused race conditions where two workers process the same course.

## Fix

Add `acks_late=False` to all long-running tasks so they acknowledge immediately on receipt. If the worker crashes, the task is lost — but that's acceptable because:
- Tasks can be retried from the UI (stop/restart button from #1115)
- The DB `creation_step` tracks state, not Celery
- Better to lose one task than to duplicate it and burn $10

## Changes

3 files, 1 line each:
- `backend/app/tasks/syllabus_generation.py`
- `backend/app/tasks/rag_indexation.py`
- `backend/app/tasks/image_indexation.py`

🤖 Generated with [Claude Code](https://claude.ai/code)