### PR TITLE
fix(summarizer): use stream.get_final_message() instead of async event iteration

### DIFF
--- a/backend/app/ai/pdf_summarizer.py
+++ b/backend/app/ai/pdf_summarizer.py
@@ -292,9 +292,8 @@ async def summarize_single_pdf(
     fits within the model's context window (use split_pdf_by_chapters() at
     upload time to guarantee this).
 
-    Accumulates text chunks during streaming so partial output is preserved if
-    the stream is interrupted. Raises on failure but the accumulated text up to
-    the failure point is logged for diagnostics.
+    Uses get_final_message() to consume the stream, which works correctly in
+    Celery prefork workers where async event iteration hangs indefinitely.
     """
     toc_prefix = ""
     if toc:
@@ -311,47 +310,20 @@ async def summarize_single_pdf(
         max_output_tokens=max_output_tokens,
     )
 
-    accumulated: list[str] = []
-    token_count = 0
-    stream_error: BaseException | None = None
-    try:
-        async with client.messages.stream(
-            model=model,
-            max_tokens=max_output_tokens,
-            system=_SYLLABUS_SUMMARY_SYSTEM,
-            messages=[{"role": "user", "content": prompt}],
-        ) as stream:
-            async for event in stream:
-                if hasattr(event, "type") and event.type == "content_block_delta":
-                    delta = getattr(event, "delta", None)
-                    if delta is not None and hasattr(delta, "text"):
-                        accumulated.append(delta.text)
-                    token_count += 1
-                    if token_count % 5000 == 0:
-                        logger.info(
-                            "Streaming progress",
-                            book=book_name,
-                            tokens_so_far=token_count,
-                            chars_so_far=sum(len(c) for c in accumulated),
-                        )
-    except Exception as exc:
-        stream_error = exc
-        logger.warning(
-            "Stream interrupted — partial summary captured",
-            book=book_name,
-            chars_accumulated=sum(len(c) for c in accumulated),
-            error=str(exc),
-        )
+    async with client.messages.stream(
+        model=model,
+        max_tokens=max_output_tokens,
+        system=_SYLLABUS_SUMMARY_SYSTEM,
+        messages=[{"role": "user", "content": prompt}],
+    ) as stream:
+        message = await stream.get_final_message()
 
-    result = "".join(accumulated).strip()
-    if stream_error is not None and not result:
-        raise stream_error
+    result = message.content[0].text.strip()
 
     logger.info(
         "PDF summarized",
         book=book_name,
         summary_chars=len(result),
-        partial=stream_error is not None,
     )
     return result
 


### PR DESCRIPTION
## Summary

Fixes `summarize_single_pdf()` hanging indefinitely in Celery prefork workers by replacing `async for event in stream:` iteration with `await stream.get_final_message()`.

The async generator iterator doesn't work correctly when Celery's prefork worker calls `asyncio.run()` — the stream opens successfully (200 OK) but zero events arrive, causing a 20+ minute hang.

## Changes

- `backend/app/ai/pdf_summarizer.py`: Replace event-iteration block in `summarize_single_pdf()` with `stream.get_final_message()` — same pattern already used in `_combine_summaries()` and `_summarize_chunk()`

## Test plan

- [ ] Existing `TestSummarizeSinglePdf` tests pass (mock already supports `get_final_message`)
- [ ] Deploy and trigger syllabus generation with 3 large PDFs
- [ ] Logs show: `Summarizing PDF (single call)` → `PDF summarized summary_chars=X` within ~6 min per PDF
- [ ] No 20+ min hang

Closes #1158

Generated with [Claude Code](https://claude.ai/code)