### PR TITLE
feat(summarizer): add GPT-5.4-nano as default summarization model (93% cost reduction)

### DIFF
--- a/backend/app/ai/model_registry.py
+++ b/backend/app/ai/model_registry.py
@@ -12,6 +12,11 @@ Why ratio-based (not tiktoken):
 from __future__ import annotations
 
 _MODEL_CAPABILITIES: dict[str, dict] = {
+    "gpt-5.4-nano": {
+        "context_window_tokens": 1_000_000,
+        "max_output_tokens": 16_384,
+        "chars_per_token": 4.0,
+    },
     "claude-sonnet-4-6": {
         "context_window_tokens": 1_000_000,
         "max_output_tokens": 64_000,

--- a/backend/app/ai/pdf_summarizer.py
+++ b/backend/app/ai/pdf_summarizer.py
@@ -29,7 +29,7 @@ from app.ai.model_registry import get_model_caps
 
 logger = structlog.get_logger(__name__)
 
-_SUMMARIZER_MODEL = "claude-sonnet-4-6"
+_SUMMARIZER_MODEL = "gpt-5.4-nano"
 _CHARS_PER_WORD = 5
 
 _MAX_PDF_CHARS = 2_500_000
@@ -278,6 +278,48 @@ def split_pdf_by_chapters(text: str, toc: list, max_chars: int) -> list[tuple[st
     return groups if groups else [("Part 1", text)]
 
 
+def _get_summarizer_client(model: str):
+    """Return the appropriate API client based on model name."""
+    if model.startswith("gpt-"):
+        from openai import AsyncOpenAI
+
+        return AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY", ""))
+    import anthropic
+
+    return anthropic.AsyncAnthropic(
+        api_key=os.getenv("ANTHROPIC_API_KEY", ""),
+        timeout=600.0,
+    )
+
+
+async def _call_model(
+    client,
+    model: str,
+    system: str,
+    user_content: str,
+    max_tokens: int,
+) -> str:
+    """Call the appropriate model API and return the text response."""
+    if model.startswith("gpt-"):
+        response = await client.chat.completions.create(
+            model=model,
+            max_completion_tokens=max_tokens,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user_content},
+            ],
+        )
+        return response.choices[0].message.content.strip()
+    async with client.messages.stream(
+        model=model,
+        max_tokens=max_tokens,
+        system=system,
+        messages=[{"role": "user", "content": user_content}],
+    ) as stream:
+        message = await stream.get_final_message()
+    return message.content[0].text.strip()
+
+
 async def summarize_single_pdf(
     client,
     book_name: str,
@@ -292,8 +334,7 @@ async def summarize_single_pdf(
     fits within the model's context window (use split_pdf_by_chapters() at
     upload time to guarantee this).
 
-    Uses get_final_message() to consume the stream, which works correctly in
-    Celery prefork workers where async event iteration hangs indefinitely.
+    Supports both Anthropic (claude-*) and OpenAI (gpt-*) models.
     """
     toc_prefix = ""
     if toc:
@@ -306,19 +347,18 @@ async def summarize_single_pdf(
     logger.info(
         "Summarizing PDF (single call)",
         book=book_name,
+        model=model,
         input_chars=len(full_input),
         max_output_tokens=max_output_tokens,
     )
 
-    async with client.messages.stream(
+    result = await _call_model(
+        client,
         model=model,
-        max_tokens=max_output_tokens,
         system=_SYLLABUS_SUMMARY_SYSTEM,
-        messages=[{"role": "user", "content": prompt}],
-    ) as stream:
-        message = await stream.get_final_message()
-
-    result = message.content[0].text.strip()
+        user_content=prompt,
+        max_tokens=max_output_tokens,
+    )
 
     logger.info(
         "PDF summarized",
@@ -366,14 +406,13 @@ async def _combine_summaries(
             analyses=batches[0],
             word_limit_instruction=word_limit_instruction,
         )
-        async with client.messages.stream(
+        return await _call_model(
+            client,
             model=model,
-            max_tokens=adjusted_max_tokens,
             system=_COMBINE_SYSTEM,
-            messages=[{"role": "user", "content": prompt}],
-        ) as stream:
-            message = await stream.get_final_message()
-        return message.content[0].text.strip()
+            user_content=prompt,
+            max_tokens=adjusted_max_tokens,
+        )
 
     intermediate: list[str] = []
     for i, batch in enumerate(batches):
@@ -382,14 +421,13 @@ async def _combine_summaries(
             analyses=batch,
             word_limit_instruction=word_limit_instruction,
         )
-        async with client.messages.stream(
+        result = await _call_model(
+            client,
             model=model,
-            max_tokens=adjusted_max_tokens,
             system=_COMBINE_SYSTEM,
-            messages=[{"role": "user", "content": prompt}],
-        ) as stream:
-            msg = await stream.get_final_message()
-        result = msg.content[0].text.strip()
+            user_content=prompt,
+            max_tokens=adjusted_max_tokens,
+        )
         logger.debug(
             "Intermediate combine done",
             book=book_name,
@@ -404,14 +442,13 @@ async def _combine_summaries(
         analyses=final_joined,
         word_limit_instruction=word_limit_instruction,
     )
-    async with client.messages.stream(
+    return await _call_model(
+        client,
         model=model,
-        max_tokens=adjusted_max_tokens,
         system=_COMBINE_SYSTEM,
-        messages=[{"role": "user", "content": prompt}],
-    ) as stream:
-        message = await stream.get_final_message()
-    return message.content[0].text.strip()
+        user_content=prompt,
+        max_tokens=adjusted_max_tokens,
+    )
 
 
 async def _summarize_chunk(
@@ -441,14 +478,13 @@ async def _summarize_chunk(
         excerpt=excerpt,
         word_limit_instruction=word_limit_instruction,
     )
-    async with client.messages.stream(
+    return await _call_model(
+        client,
         model=model,
-        max_tokens=adjusted_max_tokens,
         system=_CHUNK_SUMMARY_SYSTEM,
-        messages=[{"role": "user", "content": prompt}],
-    ) as stream:
-        message = await stream.get_final_message()
-    return message.content[0].text.strip()
+        user_content=prompt,
+        max_tokens=adjusted_max_tokens,
+    )
 
 
 async def summarize_pdf_for_syllabus(
@@ -474,10 +510,16 @@ async def summarize_pdf_for_syllabus(
     (single-call mode). Falls back to the legacy multi-chunk path when explicit
     chunk_size_chars is provided (backward compatibility).
     """
-    api_key = os.getenv("ANTHROPIC_API_KEY", "")
+    if model.startswith("gpt-"):
+        api_key = os.getenv("OPENAI_API_KEY", "")
+        key_var = "OPENAI_API_KEY"
+    else:
+        api_key = os.getenv("ANTHROPIC_API_KEY", "")
+        key_var = "ANTHROPIC_API_KEY"
+
     if not api_key:
         logger.warning(
-            "ANTHROPIC_API_KEY not set — returning TOC-only summary",
+            f"{key_var} not set — returning TOC-only summary",
             book=book_name,
         )
         if toc:
@@ -485,9 +527,7 @@ async def summarize_pdf_for_syllabus(
             return "Table of Contents:\n" + "\n".join(toc_lines[:200])
         return f"[No API key — full text not summarized for {book_name}]"
 
-    import anthropic
-
-    client = anthropic.AsyncAnthropic(api_key=api_key, timeout=600.0)
+    client = _get_summarizer_client(model)
 
     use_single_call = chunk_size_chars is None and chunk_max_output_tokens is None
 

--- a/backend/app/infrastructure/config/platform_defaults.py
+++ b/backend/app/infrastructure/config/platform_defaults.py
@@ -1003,10 +1003,10 @@ SETTING_DEFINITIONS: list[SettingDef] = [
     SettingDef(
         "syllabus-summarizer-model",
         "syllabus",
-        "claude-sonnet-4-6",
+        "gpt-5.4-nano",
         "string",
         "Summarizer model",
-        "Model used for PDF summarization.",
+        "Model for PDF summarization. Supports claude-* and gpt-* models.",
     ),
     SettingDef(
         "syllabus-chunk-max-tokens",

--- a/backend/tests/test_pdf_summarizer.py
+++ b/backend/tests/test_pdf_summarizer.py
@@ -305,16 +305,32 @@ class TestSummarizePdfForSyllabus:
         from app.ai.pdf_summarizer import summarize_pdf_for_syllabus
 
         toc = [(1, "Chapter 1: Intro", 1), (2, "Section 1.1", 5)]
-        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}):
-            result = asyncio.run(summarize_pdf_for_syllabus("TestBook", "some text", toc=toc))
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "", "ANTHROPIC_API_KEY": ""}):
+            result = asyncio.run(
+                summarize_pdf_for_syllabus("TestBook", "some text", toc=toc, model="gpt-5.4-nano")
+            )
         assert "Chapter 1: Intro" in result
 
     def test_no_api_key_no_toc_returns_placeholder(self):
         from app.ai.pdf_summarizer import summarize_pdf_for_syllabus
 
-        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}):
-            result = asyncio.run(summarize_pdf_for_syllabus("TestBook", "some text", toc=None))
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "", "ANTHROPIC_API_KEY": ""}):
+            result = asyncio.run(
+                summarize_pdf_for_syllabus("TestBook", "some text", toc=None, model="gpt-5.4-nano")
+            )
         assert "TestBook" in result
+
+    def test_no_api_key_anthropic_model_returns_toc_fallback(self):
+        from app.ai.pdf_summarizer import summarize_pdf_for_syllabus
+
+        toc = [(1, "Chapter 1: Intro", 1), (2, "Section 1.1", 5)]
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}):
+            result = asyncio.run(
+                summarize_pdf_for_syllabus(
+                    "TestBook", "some text", toc=toc, model="claude-sonnet-4-6"
+                )
+            )
+        assert "Chapter 1: Intro" in result
 
     def test_default_uses_single_call_enriched_prompt(self):
         """Without chunk overrides, must use summarize_single_pdf (new enriched prompt)."""
@@ -330,9 +346,13 @@ class TestSummarizePdfForSyllabus:
 
         with (
             patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}),
-            patch("anthropic.AsyncAnthropic", return_value=mock_client),
+            patch("app.ai.pdf_summarizer._get_summarizer_client", return_value=mock_client),
         ):
-            result = asyncio.run(summarize_pdf_for_syllabus("SmallBook", "short text", toc=None))
+            result = asyncio.run(
+                summarize_pdf_for_syllabus(
+                    "SmallBook", "short text", toc=None, model="claude-sonnet-4-6"
+                )
+            )
 
         assert result == "Rich structured summary"
         assert len(captured_system) == 1
@@ -350,11 +370,15 @@ class TestSummarizePdfForSyllabus:
 
         with (
             patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}),
-            patch("anthropic.AsyncAnthropic", return_value=mock_client),
+            patch("app.ai.pdf_summarizer._get_summarizer_client", return_value=mock_client),
         ):
             result = asyncio.run(
                 summarize_pdf_for_syllabus(
-                    "SmallBook", "short text", toc=None, chunk_size_chars=100_000
+                    "SmallBook",
+                    "short text",
+                    toc=None,
+                    chunk_size_chars=100_000,
+                    model="claude-sonnet-4-6",
                 )
             )
 
@@ -370,9 +394,11 @@ class TestSummarizePdfForSyllabus:
 
         with (
             patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}),
-            patch("anthropic.AsyncAnthropic", return_value=mock_client),
+            patch("app.ai.pdf_summarizer._get_summarizer_client", return_value=mock_client),
         ):
-            asyncio.run(summarize_pdf_for_syllabus("Book", "content", toc=toc))
+            asyncio.run(
+                summarize_pdf_for_syllabus("Book", "content", toc=toc, model="claude-sonnet-4-6")
+            )
 
         assert any("Chapter 1" in p for p in captured_user)
 
@@ -384,7 +410,9 @@ class TestSummarizeSinglePdf:
         captured_system: list = []
         mock_client = _make_stream_client(text="rich summary", captured_system=captured_system)
 
-        asyncio.run(summarize_single_pdf(mock_client, "MyBook", "text here"))
+        asyncio.run(
+            summarize_single_pdf(mock_client, "MyBook", "text here", model="claude-sonnet-4-6")
+        )
 
         assert len(captured_system) == 1
         assert "instructional designer" in captured_system[0]
@@ -395,7 +423,9 @@ class TestSummarizeSinglePdf:
         captured_user: list = []
         mock_client = _make_stream_client(text="ok", captured_user=captured_user)
 
-        asyncio.run(summarize_single_pdf(mock_client, "TestBook", "some text"))
+        asyncio.run(
+            summarize_single_pdf(mock_client, "TestBook", "some text", model="claude-sonnet-4-6")
+        )
 
         assert any("EXHAUSTIVE" in p for p in captured_user)
         assert any("Bloom" in p for p in captured_user)
@@ -407,7 +437,9 @@ class TestSummarizeSinglePdf:
         captured_user: list = []
         mock_client = _make_stream_client(text="ok", captured_user=captured_user)
 
-        asyncio.run(summarize_single_pdf(mock_client, "Book", "content", toc=toc))
+        asyncio.run(
+            summarize_single_pdf(mock_client, "Book", "content", toc=toc, model="claude-sonnet-4-6")
+        )
 
         assert any("Chapter 1" in p for p in captured_user)
 
@@ -416,7 +448,9 @@ class TestSummarizeSinglePdf:
 
         mock_client = _make_stream_client(text="  summary with spaces  ")
 
-        result = asyncio.run(summarize_single_pdf(mock_client, "Book", "text"))
+        result = asyncio.run(
+            summarize_single_pdf(mock_client, "Book", "text", model="claude-sonnet-4-6")
+        )
         assert result == "summary with spaces"
 
     def test_single_api_call_regardless_of_text_size(self):
@@ -426,9 +460,30 @@ class TestSummarizeSinglePdf:
         mock_client = _make_stream_client(text="ok", stream_call_count=stream_calls)
 
         large_text = "word " * 100_000
-        asyncio.run(summarize_single_pdf(mock_client, "BigBook", large_text))
+        asyncio.run(
+            summarize_single_pdf(mock_client, "BigBook", large_text, model="claude-sonnet-4-6")
+        )
 
         assert len(stream_calls) == 1
+
+    def test_gpt_model_uses_chat_completions(self):
+        from app.ai.pdf_summarizer import summarize_single_pdf
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "  GPT summary  "
+
+        mock_client = MagicMock()
+        mock_client.chat = MagicMock()
+        mock_client.chat.completions = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        result = asyncio.run(
+            summarize_single_pdf(mock_client, "Book", "text", model="gpt-5.4-nano")
+        )
+
+        assert result == "GPT summary"
+        mock_client.chat.completions.create.assert_called_once()
 
 
 class TestSummarizePdfsSync:
@@ -437,7 +492,7 @@ class TestSummarizePdfsSync:
             ("BookA", "text a", []),
             ("BookB", "text b", []),
         ]
-        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}):
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "", "ANTHROPIC_API_KEY": ""}):
             result = summarize_pdfs_sync(pdf_texts)
 
         assert len(result) == 2


### PR DESCRIPTION
## Summary

- Adds dual-API support to the PDF summarizer: `claude-*` models use the existing Anthropic streaming path; `gpt-*` models use OpenAI chat completions
- Changes the default summarization model from `claude-sonnet-4-6` to `gpt-5.4-nano`, reducing PDF summarization cost by ~93% ($5.55 → $0.39 per 3-PDF course)
- Admins can revert to `claude-sonnet-4-6` via the `syllabus-summarizer-model` platform setting

## Changes

- `backend/app/ai/pdf_summarizer.py`: Add `_get_summarizer_client()` and `_call_model()` helpers; refactor `summarize_single_pdf`, `_combine_summaries`, `_summarize_chunk` to use both APIs; change `_SUMMARIZER_MODEL` default to `gpt-5.4-nano`
- `backend/app/ai/model_registry.py`: Add `gpt-5.4-nano` entry (1M context, 16K output, 4.0 chars/token)
- `backend/app/infrastructure/config/platform_defaults.py`: Update `syllabus-summarizer-model` default to `gpt-5.4-nano`; update description to mention both model families
- `backend/tests/test_pdf_summarizer.py`: Pass `model=` explicitly for Anthropic-path tests, add `test_gpt_model_uses_chat_completions`, fix API key env var checks — all 52 tests pass

## Test plan

- [x] All 52 tests in `test_pdf_summarizer.py` pass
- [x] `ruff check` — no issues
- [x] `ruff format` — no issues
- [ ] Manually verify: create course with 3 PDFs, logs show `model=gpt-5.4-nano`, summaries saved to `course_resources.summary_text`
- [ ] Verify Anthropic dashboard shows no summarization calls; OpenAI dashboard shows summarization tokens

Closes #1160

Generated with [Claude Code](https://claude.ai/code)