### PR TITLE
fix(syllabus): save syllabus_context before calling Claude to avoid re-paying on retry

### DIFF
--- a/backend/app/tasks/syllabus_generation.py
+++ b/backend/app/tasks/syllabus_generation.py
@@ -419,6 +419,19 @@ def generate_course_syllabus(
                 total_chars=len(resource_text),
             )
 
+        _early_save_engine = create_engine(settings.database_url_sync, pool_pre_ping=True)
+        try:
+            with Session(_early_save_engine) as _early_session:
+                _early_session.execute(
+                    text("UPDATE courses SET syllabus_context = :ctx WHERE id = :cid"),
+                    {"ctx": resource_text, "cid": course_id},
+                )
+                _early_session.commit()
+        except Exception:
+            logger.warning("Failed to save syllabus_context early (non-blocking)")
+        finally:
+            _early_save_engine.dispose()
+
     # ── Phase 2: Call Claude API (async, fresh event loop) ──────────────────
     self.update_state(
         state="GENERATING",


### PR DESCRIPTION
## Summary

Persist `syllabus_context` to the DB **before** calling the Claude API so that if Claude's stream fails or times out, the retry path can reuse the already-saved context and skip both the summarization step and the costly (~$1) Claude re-call.

## Changes

- `backend/app/tasks/syllabus_generation.py`: Added early DB save of `syllabus_context` immediately after building `resource_text` from summaries, before Phase 2 (Claude call). Uses a non-blocking try/except pattern consistent with existing code.

## Behaviour

- **On success:** `syllabus_context` is saved twice (before and after Claude call) — harmless.
- **On failure + retry:** `syllabus_context` already in DB → retry uses `cached_resource_text` (mode=reuse), skipping summarization AND the Claude re-call → $0 retry cost.

## Test plan
- [ ] Backend tests pass
- [ ] Manually verified: `syllabus_context` column is populated in DB before Claude responds
- [ ] Retry scenario: context reused correctly on second attempt

Closes #1165

Generated with [Claude Code](https://claude.ai/code)