### PR TITLE
fix(syllabus): reduce max_tokens from 64000 to 10000 in course_agent_service.py

### DIFF
--- a/backend/app/domain/services/course_agent_service.py
+++ b/backend/app/domain/services/course_agent_service.py
@@ -214,7 +214,7 @@ class CourseAgentService:
             # Use streaming to avoid timeout with large max_tokens
             async with client.messages.stream(
                 model=_model,
-                max_tokens=64000,
+                max_tokens=10000,
                 messages=[{"role": "user", "content": prompt}],
             ) as stream:
                 message = await stream.get_final_message()
@@ -227,7 +227,7 @@ class CourseAgentService:
                 )
                 async with client.messages.stream(
                     model=_model,
-                    max_tokens=64000,
+                    max_tokens=10000,
                     messages=[
                         {"role": "user", "content": prompt},
                         {"role": "assistant", "content": message.content[0].text},


### PR DESCRIPTION
## Summary

Reduces `max_tokens` from 64000 to 10000 in both `client.messages.stream()\ calls in the syllabus generation path. A syllabus is structured JSON metadata (module titles, descriptions, unit names, Bloom's levels) — 10K tokens (~35K chars) is more than sufficient for 16 modules × 5 units.

## Changes

- `backend/app/domain/services/course_agent_service.py` — two occurrences updated (primary stream call at line 217, retry path at line 230)

## Impact

- Generation time: ~20+ min → significantly reduced
- Output cost: ~$0.96 → ~$0.15 per syllabus generation

## Test plan
- [ ] Backend tests pass
- [ ] Syllabus generation completes in reasonable time
- [ ] Generated syllabus JSON is complete and valid

Closes #1167

Generated with [Claude Code](https://claude.ai/code)