### PR TITLE
fix(summarizer): correct gpt-5.4-nano context limit + chunk oversized PDFs + fix event loop

### DIFF
--- a/backend/app/ai/model_registry.py
+++ b/backend/app/ai/model_registry.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 _MODEL_CAPABILITIES: dict[str, dict] = {
     "gpt-5.4-nano": {
-        "context_window_tokens": 1_000_000,
+        "context_window_tokens": 272_000,
         "max_output_tokens": 16_384,
         "chars_per_token": 4.0,
     },

--- a/backend/app/ai/pdf_summarizer.py
+++ b/backend/app/ai/pdf_summarizer.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass
 
 import structlog
 
-from app.ai.model_registry import get_model_caps
+from app.ai.model_registry import get_model_caps, tokens_to_chars
 
 logger = structlog.get_logger(__name__)
 
@@ -328,11 +328,12 @@ async def summarize_single_pdf(
     model: str = _SUMMARIZER_MODEL,
     max_output_tokens: int = 60_000,
 ) -> str:
-    """Summarize a single PDF in one API call using the enriched syllabus prompt.
+    """Summarize a single PDF using the enriched syllabus prompt.
 
-    The text is sent directly — no chunking. The caller must ensure the text
-    fits within the model's context window (use split_pdf_by_chapters() at
-    upload time to guarantee this).
+    If the input fits within the model's context window, sends it in one call.
+    If the input exceeds the model's context window, splits into chunks, summarizes
+    each chunk separately, then combines the results. This allows large PDFs to be
+    processed entirely on the same model without fallback.
 
     Supports both Anthropic (claude-*) and OpenAI (gpt-*) models.
     """
@@ -342,30 +343,91 @@ async def summarize_single_pdf(
         toc_prefix = "TABLE OF CONTENTS:\n" + "\n".join(toc_lines) + "\n\n"
 
     full_input = toc_prefix + full_text
-    prompt = _SYLLABUS_SUMMARY_PROMPT.format(book_name=book_name, text=full_input)
+
+    caps = get_model_caps(model)
+    max_input_chars = tokens_to_chars(
+        caps["context_window_tokens"] - max_output_tokens - 1000, model
+    )
+
+    if len(full_input) <= max_input_chars:
+        prompt = _SYLLABUS_SUMMARY_PROMPT.format(book_name=book_name, text=full_input)
+
+        logger.info(
+            "Summarizing PDF (single call)",
+            book=book_name,
+            model=model,
+            input_chars=len(full_input),
+            max_output_tokens=max_output_tokens,
+        )
+
+        result = await _call_model(
+            client,
+            model=model,
+            system=_SYLLABUS_SUMMARY_SYSTEM,
+            user_content=prompt,
+            max_tokens=max_output_tokens,
+        )
+
+        logger.info(
+            "PDF summarized",
+            book=book_name,
+            summary_chars=len(result),
+        )
+        return result
+
+    chunks = _split_into_chunks(full_input, max_input_chars)
+    total_chunks = len(chunks)
 
     logger.info(
-        "Summarizing PDF (single call)",
+        "Input exceeds model context — splitting into chunks",
         book=book_name,
         model=model,
         input_chars=len(full_input),
-        max_output_tokens=max_output_tokens,
+        max_input_chars=max_input_chars,
+        chunk_count=total_chunks,
+        context_window_tokens=caps["context_window_tokens"],
     )
 
-    result = await _call_model(
+    chunk_max_tokens = min(caps["max_output_tokens"], 16_000)
+    combine_chunk_size = max_input_chars
+
+    chunk_summaries: list[str] = []
+    for i, chunk in enumerate(chunks):
+        summary = await _summarize_chunk(
+            client,
+            book_name,
+            chunk,
+            chunk_num=i + 1,
+            total_chunks=total_chunks,
+            model=model,
+            max_tokens=chunk_max_tokens,
+        )
+        logger.info(
+            "Chunk summarized",
+            book=book_name,
+            chunk=i + 1,
+            total=total_chunks,
+            summary_chars=len(summary),
+        )
+        chunk_summaries.append(summary)
+
+    combined = await _combine_summaries(
         client,
+        book_name,
+        chunk_summaries,
+        combine_chunk_size=combine_chunk_size,
         model=model,
-        system=_SYLLABUS_SUMMARY_SYSTEM,
-        user_content=prompt,
         max_tokens=max_output_tokens,
     )
 
     logger.info(
-        "PDF summarized",
+        "PDF summarized (chunked)",
         book=book_name,
-        summary_chars=len(result),
+        model=model,
+        chunk_count=total_chunks,
+        summary_chars=len(combined),
     )
-    return result
+    return combined
 
 
 async def _combine_summaries(
@@ -740,7 +802,11 @@ def summarize_pdfs_sync(
             results.append(summary)
         return results
 
-    return list(asyncio.run(_run_all()))
+    loop = asyncio.new_event_loop()
+    try:
+        return list(loop.run_until_complete(_run_all()))
+    finally:
+        loop.close()
 
 
 def _proportional_budgets(


### PR DESCRIPTION
## Summary

Fixes three issues in the PDF summarizer pipeline (issue #1171):

1. **Correct gpt-5.4-nano context window** — was `1_000_000`, actual API limit is `272_000` tokens. This caused large PDFs to fail immediately with \`Input tokens exceed the configured limit of 272000 tokens\`.

2. **Auto-chunking for oversized PDFs** — instead of falling back to Claude for large PDFs, `summarize_single_pdf()` now checks if the input exceeds the model's context window and automatically splits into chunks. Each chunk is summarized separately with the same model (gpt-5.4-nano), then combined. Chunk size is derived from the actual context limit using `tokens_to_chars()`:
   - `max_input_chars = tokens_to_chars(context_window_tokens - max_output_tokens - 1000, model)`
   - For nano: `(272_000 - 60_000 - 1000) * 4.0 ≈ 844K chars per chunk`
   - A 2M char PDF → 3 chunks at ~$0.39 vs $2 with Claude fallback

3. **Fix Celery event loop error** — `summarize_pdfs_sync()` now uses `asyncio.new_event_loop()` instead of `asyncio.run()`, preventing `RuntimeError: Event loop is closed` when processing multiple PDFs sequentially in Celery prefork workers.

## Changes

- `backend/app/ai/model_registry.py` — `gpt-5.4-nano` context window: `1_000_000` → `272_000`
- `backend/app/ai/pdf_summarizer.py` — chunking logic in `summarize_single_pdf()` + new event loop in `summarize_pdfs_sync()`

## Test plan

- [x] 52/52 existing tests pass
- [x] Linter passes (`ruff check`)
- [ ] Upload large PDF (>1M chars) → logs show "Input exceeds model context — splitting into chunks"
- [ ] Upload small PDF (<844K chars) → logs show "Summarizing PDF (single call)"
- [ ] Upload 3+ PDFs sequentially → no "Event loop is closed" error

Closes #1171

Generated with [Claude Code](https://claude.ai/code)