### PR TITLE
fix(syllabus): remove unused fields from prompt to prevent JSON truncation

### DIFF
--- a/backend/app/domain/services/course_agent_service.py
+++ b/backend/app/domain/services/course_agent_service.py
@@ -120,23 +120,21 @@ class CourseAgentService:
             "{\n"
             '  "module_number": int,\n'
             '  "title_fr": str, "title_en": str,\n'
-            '  "description_fr": str, "description_en": str,\n'
+            '  "description_fr": str (1-2 sentences), '
+            '"description_en": str (1-2 sentences),\n'
             '  "estimated_hours": int,\n'
             '  "bloom_level": "remember"|"understand"|"apply"|'
             '"analyze"|"evaluate"|"create",\n'
-            '  "learning_objectives_fr": [str], '
-            '"learning_objectives_en": [str],\n'
             '  "units": [\n'
-            '    {"title_fr": str, "title_en": str, '
-            '"type": "lesson"|"quiz"|"case-study",\n'
-            '     "description_fr": str, "description_en": str}\n'
-            "  ],\n"
-            '  "quiz_topics_fr": [str], '
-            '"quiz_topics_en": [str],\n'
-            '  "flashcard_categories_fr": [str], '
-            '"flashcard_categories_en": [str],\n'
-            '  "case_study_fr": str, "case_study_en": str\n'
+            '    {"title_fr": str, "title_en": str,\n'
+            '     "description_fr": str (1 sentence), '
+            '"description_en": str (1 sentence)}\n'
+            "  ]\n"
             "}\n\n"
+            "Keep descriptions concise (1-2 sentences). "
+            "Do NOT include learning objectives, quiz topics, "
+            "flashcard categories, or case studies — those are "
+            "generated separately.\n\n"
             "Return ONLY valid JSON, no markdown fences, "
             "no explanation."
         )


### PR DESCRIPTION
## Summary

Removes 6 unused field groups from the `_build_prompt()` output format in `CourseAgentService`. These fields (`learning_objectives`, `quiz_topics`, `flashcard_categories`, `case_study`, and unit `type`) were requested from Claude but immediately discarded by the parser — consuming ~55-60% of output tokens and causing JSON truncation at `max_tokens=20000` for courses with 15+ modules.

Also adds a conciseness instruction for descriptions (1-2 sentences).

## Changes

- `backend/app/domain/services/course_agent_service.py`: Stripped unused fields from the `## Output format` section of `_build_prompt()`. Added note instructing Claude not to generate those fields and to keep descriptions concise.

## Impact

- JSON output shrinks from ~40K tokens to ~12-15K tokens
- Fits within 20K `max_tokens` with room to spare
- No more truncation → no more placeholder module fallback
- Faster generation, lower cost

## Test plan

- [ ] Generate syllabus for "Contemporary Mathematics" → should produce 10+ real modules, not 2 placeholders
- [ ] Check JSON size in logs — should be <20K tokens
- [ ] Modules saved with titles, descriptions, bloom levels, units populated
- [ ] No regressions on existing courses

Closes #1182

Generated with [Claude Code](https://claude.ai/code)