### PR TITLE
fix(syllabus): increase max_tokens to 35K and save all generated fields to DB

### DIFF
--- a/backend/app/domain/models/module.py
+++ b/backend/app/domain/models/module.py
@@ -4,7 +4,7 @@ import uuid
 from typing import TYPE_CHECKING
 
 from sqlalchemy import ARRAY, ForeignKey, Integer, String, Text
-from sqlalchemy.dialects.postgresql import JSON, UUID
+from sqlalchemy.dialects.postgresql import JSON, JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.domain.models.base import Base
@@ -35,6 +35,14 @@ class Module(Base):
         ARRAY(UUID(as_uuid=True)), server_default="{}"
     )
     books_sources: Mapped[dict | None] = mapped_column(JSON)
+    learning_objectives_fr: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    learning_objectives_en: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    quiz_topics_fr: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    quiz_topics_en: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    flashcard_categories_fr: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    flashcard_categories_en: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    case_study_fr: Mapped[str | None] = mapped_column(Text, nullable=True)
+    case_study_en: Mapped[str | None] = mapped_column(Text, nullable=True)
     course_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("courses.id", ondelete="CASCADE"),
         nullable=True,

--- a/backend/app/domain/models/module_unit.py
+++ b/backend/app/domain/models/module_unit.py
@@ -33,6 +33,7 @@ class ModuleUnit(Base):
     description_en: Mapped[str | None] = mapped_column(Text, nullable=True)
     estimated_minutes: Mapped[int] = mapped_column(Integer, server_default="45")
     order_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    unit_type: Mapped[str | None] = mapped_column(String(20), nullable=True)
     created_at: Mapped[datetime] = mapped_column(default=func.now())
 
     module: Mapped[Module] = relationship(back_populates="units")

--- a/backend/app/domain/services/course_agent_service.py
+++ b/backend/app/domain/services/course_agent_service.py
@@ -232,7 +232,7 @@ class CourseAgentService:
             # Use streaming to avoid timeout with large max_tokens
             async with client.messages.stream(
                 model=_model,
-                max_tokens=20000,
+                max_tokens=35000,
                 messages=[{"role": "user", "content": prompt}],
             ) as stream:
                 message = await stream.get_final_message()
@@ -245,7 +245,7 @@ class CourseAgentService:
                 )
                 async with client.messages.stream(
                     model=_model,
-                    max_tokens=20000,
+                    max_tokens=35000,
                     messages=[
                         {"role": "user", "content": prompt},
                         {"role": "assistant", "content": message.content[0].text},

--- a/backend/app/tasks/syllabus_generation.py
+++ b/backend/app/tasks/syllabus_generation.py
@@ -521,6 +521,14 @@ def generate_course_syllabus(
                     bloom_level=m.get("bloom_level"),
                     course_id=uuid.UUID(course_id),
                     books_sources=books_sources,
+                    learning_objectives_fr=m.get("learning_objectives_fr"),
+                    learning_objectives_en=m.get("learning_objectives_en"),
+                    quiz_topics_fr=m.get("quiz_topics_fr"),
+                    quiz_topics_en=m.get("quiz_topics_en"),
+                    flashcard_categories_fr=m.get("flashcard_categories_fr"),
+                    flashcard_categories_en=m.get("flashcard_categories_en"),
+                    case_study_fr=m.get("case_study_fr"),
+                    case_study_en=m.get("case_study_en"),
                 )
                 session.add(module)
 
@@ -535,6 +543,7 @@ def generate_course_syllabus(
                         description_en=u.get("description_en"),
                         estimated_minutes=15,
                         order_index=j,
+                        unit_type=u.get("type"),
                     )
                     session.add(unit)
 

--- a/backend/migrations/versions/047_add_module_syllabus_fields.py
+++ b/backend/migrations/versions/047_add_module_syllabus_fields.py
@@ -1,0 +1,40 @@
+"""Add syllabus fields to modules and unit_type to module_units.
+
+Revision ID: 047
+Revises: 046
+Create Date: 2026-04-08
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "047"
+down_revision = "046"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("modules", sa.Column("learning_objectives_fr", JSONB(), nullable=True))
+    op.add_column("modules", sa.Column("learning_objectives_en", JSONB(), nullable=True))
+    op.add_column("modules", sa.Column("quiz_topics_fr", JSONB(), nullable=True))
+    op.add_column("modules", sa.Column("quiz_topics_en", JSONB(), nullable=True))
+    op.add_column("modules", sa.Column("flashcard_categories_fr", JSONB(), nullable=True))
+    op.add_column("modules", sa.Column("flashcard_categories_en", JSONB(), nullable=True))
+    op.add_column("modules", sa.Column("case_study_fr", sa.Text(), nullable=True))
+    op.add_column("modules", sa.Column("case_study_en", sa.Text(), nullable=True))
+    op.add_column("module_units", sa.Column("unit_type", sa.String(20), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("module_units", "unit_type")
+    op.drop_column("modules", "case_study_en")
+    op.drop_column("modules", "case_study_fr")
+    op.drop_column("modules", "flashcard_categories_en")
+    op.drop_column("modules", "flashcard_categories_fr")
+    op.drop_column("modules", "quiz_topics_en")
+    op.drop_column("modules", "quiz_topics_fr")
+    op.drop_column("modules", "learning_objectives_en")
+    op.drop_column("modules", "learning_objectives_fr")


### PR DESCRIPTION
## Summary

- Increase `max_tokens` from 20K → 35K in both streaming calls (main + retry) in `CourseAgentService` to prevent truncation for 15+ bilingual modules (~$0.53 output per syllabus)
- Add 8 new columns to `modules` table: `learning_objectives_fr/en`, `quiz_topics_fr/en`, `flashcard_categories_fr/en` (JSONB), `case_study_fr/en` (Text)
- Add `unit_type` column (String 20) to `module_units` table
- Update `syllabus_generation` Celery task to persist all newly parsed fields when creating Module and ModuleUnit records
- New Alembic migration `047` adds all new columns

## Changes

- `backend/app/domain/services/course_agent_service.py` — max_tokens 20K → 35K (both calls)
- `backend/app/domain/models/module.py` — add 8 JSONB/Text syllabus fields
- `backend/app/domain/models/module_unit.py` — add `unit_type` column
- `backend/app/tasks/syllabus_generation.py` — save all fields in module/unit creation loop
- `backend/migrations/versions/047_add_module_syllabus_fields.py` — new migration

## Test plan

- [x] Backend tests: 607 passed, 7 skipped
- [x] Ruff lint: all checks passed
- [ ] Generate syllabus for "Contemporary Mathematics" → 10+ modules, all fields populated
- [ ] Check `modules` table → `learning_objectives_fr`, `quiz_topics_fr`, etc. populated
- [ ] Check `module_units` table → `unit_type` populated

Closes #1184

Generated with [Claude Code](https://claude.ai/code)