### PR TITLE
fix(module-media): graceful error handling for 500 + document CORS for production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,8 @@ EMBEDDING_DIMENSIONS=1536
 
 # App
 APP_ENV=development
+# For production, set CORS_ORIGINS to a comma-separated list of allowed frontend origins.
+# Example: CORS_ORIGINS=https://etutor.elearning.portfolio2.kimbetien.com,https://other.domain.com
 CORS_ORIGINS=http://localhost:3000
 API_V1_PREFIX=/api/v1
 

--- a/backend/app/api/v1/module_media.py
+++ b/backend/app/api/v1/module_media.py
@@ -41,12 +41,17 @@ class GenerateModuleMediaRequest(BaseModel):
 
 
 def _to_response(media: ModuleMedia) -> ModuleMediaResponse:
-    storage = S3StorageService()
-    url = (
-        storage.public_url(media.storage_key)
-        if media.storage_key and media.status == "ready"
-        else None
-    )
+    url: str | None = None
+    if media.storage_key and media.status == "ready":
+        try:
+            storage = S3StorageService()
+            url = storage.public_url(media.storage_key)
+        except Exception as exc:
+            logger.warning(
+                "S3StorageService unavailable — returning url=None",
+                media_id=str(media.id),
+                error=str(exc),
+            )
     return ModuleMediaResponse(
         id=str(media.id),
         module_id=str(media.module_id),
@@ -67,9 +72,28 @@ async def list_module_media(
     db: AsyncSession = Depends(get_db_session),
 ) -> list[ModuleMediaResponse]:
     """List all media for a module."""
-    result = await db.execute(select(ModuleMedia).where(ModuleMedia.module_id == module_id))
-    items = result.scalars().all()
-    return [_to_response(m) for m in items]
+    try:
+        result = await db.execute(select(ModuleMedia).where(ModuleMedia.module_id == module_id))
+        items = result.scalars().all()
+    except Exception as exc:
+        logger.error(
+            "Failed to query module_media table",
+            module_id=str(module_id),
+            error=str(exc),
+        )
+        return []
+
+    responses: list[ModuleMediaResponse] = []
+    for m in items:
+        try:
+            responses.append(_to_response(m))
+        except Exception as exc:
+            logger.warning(
+                "Skipping media item due to serialisation error",
+                media_id=str(m.id),
+                error=str(exc),
+            )
+    return responses
 
 
 @router.post(


### PR DESCRIPTION
## Summary

- Wraps `S3StorageService()` construction in `_to_response()` with `try/except` — a MinIO connectivity failure now logs a warning and returns `url=None` instead of raising a 500
- Adds `try/except` in `list_module_media` to return an empty list when the DB query fails (e.g. missing `module_media` table) and to skip individual items that fail serialisation
- Documents `CORS_ORIGINS` production usage in `.env.example` with a comment showing the comma-separated format

## Changes

- `backend/app/api/v1/module_media.py` — error handling in `_to_response()` and `list_module_media`
- `.env.example` — comment documenting production `CORS_ORIGINS`

## Test plan

- [ ] Backend tests pass (`uv run pytest`)
- [ ] `GET /api/v1/modules/{moduleId}/media` returns `[]` when table is empty or MinIO is unreachable (no 500)
- [ ] Audio player page loads without "Error loading media" when no media exists
- [ ] Production `.env` has `CORS_ORIGINS=https://etutor.elearning.portfolio2.kimbetien.com,...`

Closes #1181

Generated with [Claude Code](https://claude.ai/code)