### PR TITLE
Merge dev → main: register image_indexation Celery task

### DIFF
--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -18,6 +18,7 @@ celery_app = Celery(
         "app.tasks.content_generation",
         "app.tasks.data_etl",
         "app.tasks.file_cleanup",
+        "app.tasks.image_indexation",
         "app.tasks.preassessment_generation",
         "app.tasks.rag_indexation",
         "app.tasks.syllabus_generation",


### PR DESCRIPTION
## Summary

- Register `app.tasks.image_indexation` in Celery worker `include` list so the `reindex_course_images` task is available

Without this, `POST /admin/courses/{id}/reindex-images` dispatches a task that the worker doesn't know about, causing silent FAILURE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)