### PR TITLE
fix(migration): create missing module_media table

### DIFF
--- a/backend/migrations/versions/048_create_module_media_table.py
+++ b/backend/migrations/versions/048_create_module_media_table.py
@@ -48,12 +48,8 @@ def upgrade() -> None:
         """
     )
 
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_module_media_module_id ON module_media (module_id)"
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_module_media_status ON module_media (status)"
-    )
+    op.execute("CREATE INDEX IF NOT EXISTS ix_module_media_module_id ON module_media (module_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_module_media_status ON module_media (status)")
     op.execute(
         "CREATE INDEX IF NOT EXISTS ix_module_media_module_language_type ON module_media (module_id, language, media_type)"
     )


### PR DESCRIPTION
## Summary

Creates Alembic migration `048_create_module_media_table.py` to fix the missing `module_media` table on production. Migration `025c` was skipped during a branch merge but the Alembic version stamp advanced to `047`, leaving the table and enum absent from the DB.

## Changes

- `backend/migrations/versions/048_create_module_media_table.py` (new)
  - `down_revision = "047"` — chains correctly from current prod state
  - Creates `media_status_enum` PG type idempotently (`DO $$ ... IF NOT EXISTS`)
  - Creates `module_media` table with `CREATE TABLE IF NOT EXISTS`
  - Matches **current model** at `backend/app/domain/models/module_media.py` exactly:
    - `media_type VARCHAR(50)` (NOT a PG enum — avoids old `mediatype` enum)
    - `status media_status_enum` with server_default `'pending'`
    - `language VARCHAR(10)` (not VARCHAR(2) from old 025c)
    - `script_text`, `created_at`, `media_metadata` columns included
  - All 3 indexes (`IF NOT EXISTS` guards)
  - Unique constraint `uq_module_media_module_type_lang`
  - `downgrade()` drops table and enum

## Test plan

- [ ] `alembic upgrade head` succeeds on production
- [ ] `\d module_media` shows correct schema
- [ ] `POST /api/v1/modules/{id}/media/generate` returns 202 (not 500)
- [ ] Backend tests pass

Closes #1194

Generated with [Claude Code](https://claude.ai/code)