### PR TITLE
Deploy: module_media migration + admin audio button

### DIFF
--- a/frontend/components/admin/module-card.tsx
+++ b/frontend/components/admin/module-card.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Clock, BookOpen, Layers, Edit2, Plus } from 'lucide-react';
+import { Clock, BookOpen, Layers, Edit2, Plus, Mic, Loader2, CheckCircle2, AlertCircle } from 'lucide-react';
+import { generateModuleMedia, type MediaStatus } from '@/lib/api';
 
 export interface AdminModuleCardData {
   id: string;
@@ -29,6 +31,8 @@ interface AdminModuleCardProps {
   onEdit: (module: AdminModuleCardData) => void;
 }
 
+type AudioState = { status: MediaStatus } | null;
+
 const LEVEL_LABELS: Record<number, { fr: string; en: string; color: string }> = {
   1: { fr: 'Débutant', en: 'Beginner', color: 'bg-green-100 text-green-800' },
   2: { fr: 'Intermédiaire', en: 'Intermediate', color: 'bg-blue-100 text-blue-800' },
@@ -39,13 +43,53 @@ const LEVEL_LABELS: Record<number, { fr: string; en: string; color: string }> = 
 export function AdminModuleCard({ module, onEdit }: AdminModuleCardProps) {
   const t = useTranslations('AdminSyllabus');
   const locale = useLocale() as 'fr' | 'en';
+  const [audioState, setAudioState] = useState<AudioState>(null);
+  const [generating, setGenerating] = useState(false);
+  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
+
+  useEffect(() => {
+    if (!toast) return;
+    const id = setTimeout(() => setToast(null), 4000);
+    return () => clearTimeout(id);
+  }, [toast]);
+
+  async function handleGenerateAudio() {
+    setGenerating(true);
+    try {
+      const result = await generateModuleMedia(module.id, 'audio', locale);
+      setAudioState({ status: result.status });
+      setToast({ message: t('audioGenerateSuccess'), type: 'success' });
+    } catch (err: unknown) {
+      const status = (err as { status?: number })?.status;
+      if (status === 409) {
+        setToast({ message: t('audioAlreadyExists'), type: 'error' });
+      } else {
+        setToast({ message: t('audioGenerateError'), type: 'error' });
+      }
+    } finally {
+      setGenerating(false);
+    }
+  }
 
   const title = locale === 'fr' ? module.title_fr : module.title_en;
   const description = locale === 'fr' ? module.description_fr : module.description_en;
   const levelLabel = LEVEL_LABELS[module.level] ?? LEVEL_LABELS[1];
 
   return (
-    <Card className="flex flex-col hover:shadow-md transition-shadow min-h-[200px]">
+    <Card className="relative flex flex-col hover:shadow-md transition-shadow min-h-[200px]">
+      {toast && (
+        <div
+          role="status"
+          aria-live="polite"
+          className={`absolute top-2 right-2 z-10 flex items-center gap-1.5 rounded px-3 py-1.5 text-xs font-medium shadow ${
+            toast.type === 'success'
+              ? 'bg-green-100 text-green-800'
+              : 'bg-red-100 text-red-800'
+          }`}
+        >
+          {toast.message}
+        </div>
+      )}
       <CardHeader className="pb-2">
         <div className="flex items-start justify-between gap-2">
           <div className="flex items-center gap-2 flex-1 min-w-0">
@@ -64,15 +108,37 @@ export function AdminModuleCard({ module, onEdit }: AdminModuleCardProps) {
               </Badge>
             )}
           </div>
-          <Button
-            size="icon"
-            variant="ghost"
-            className="h-8 w-8 shrink-0"
-            onClick={() => onEdit(module)}
-            aria-label={t('editModule')}
-          >
-            <Edit2 className="h-4 w-4" />
-          </Button>
+          <div className="flex items-center gap-1 shrink-0">
+            {audioState && audioState.status === 'ready' ? (
+              <CheckCircle2 className="h-4 w-4 text-green-600" aria-label={t('audioStatus.ready')} />
+            ) : audioState && (audioState.status === 'generating' || audioState.status === 'pending') ? (
+              <Loader2 className="h-4 w-4 animate-spin text-blue-500" aria-label={t(`audioStatus.${audioState.status}`)} />
+            ) : (
+              <Button
+                size="icon"
+                variant="ghost"
+                className="h-8 w-8"
+                onClick={handleGenerateAudio}
+                disabled={generating}
+                aria-label={t('generateAudio')}
+              >
+                {generating ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Mic className="h-4 w-4" />
+                )}
+              </Button>
+            )}
+            <Button
+              size="icon"
+              variant="ghost"
+              className="h-8 w-8"
+              onClick={() => onEdit(module)}
+              aria-label={t('editModule')}
+            >
+              <Edit2 className="h-4 w-4" />
+            </Button>
+          </div>
         </div>
         <CardTitle className="text-base leading-snug mt-1 line-clamp-2">{title}</CardTitle>
       </CardHeader>

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1430,7 +1430,17 @@
     "moduleNumber": "Module number",
     "untitledCourse": "Untitled course",
     "unlinkedModules": "Unlinked modules",
-    "noModules": "No modules found. Create a course first."
+    "noModules": "No modules found. Create a course first.",
+    "generateAudio": "Generate audio summary",
+    "audioGenerateSuccess": "Audio generation started",
+    "audioGenerateError": "Failed to start audio generation",
+    "audioAlreadyExists": "Audio already exists for this module",
+    "audioStatus": {
+      "pending": "Audio pending",
+      "generating": "Audio generating",
+      "ready": "Audio ready",
+      "failed": "Audio generation failed"
+    }
   },
   "AuthGuard": {
     "loading": "Loading..."

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1430,7 +1430,17 @@
     "moduleNumber": "Numéro de module",
     "untitledCourse": "Cours sans titre",
     "unlinkedModules": "Modules non rattachés",
-    "noModules": "Aucun module trouvé. Créez un cours d'abord."
+    "noModules": "Aucun module trouvé. Créez un cours d'abord.",
+    "generateAudio": "Générer le résumé audio",
+    "audioGenerateSuccess": "Génération audio démarrée",
+    "audioGenerateError": "Échec du démarrage de la génération audio",
+    "audioAlreadyExists": "Un audio existe déjà pour ce module",
+    "audioStatus": {
+      "pending": "Audio en attente",
+      "generating": "Audio en cours de génération",
+      "ready": "Audio prêt",
+      "failed": "Échec de la génération audio"
+    }
   },
   "AuthGuard": {
     "loading": "Chargement..."


### PR DESCRIPTION
## Summary
- #1197 — Create missing `module_media` table (migration 048)
- #1198 — Add audio generation button to admin module cards

## Review fixes applied
- Fixed ruff format on migration file
- Removed N+1 API calls from module cards (was fetching media status for every card on mount)
- Added retry capability for failed audio generation