### PR TITLE
fix(syllabus): add no-truncation rule to prompt

### DIFF
--- a/backend/app/domain/services/course_agent_service.py
+++ b/backend/app/domain/services/course_agent_service.py
@@ -168,6 +168,7 @@ class CourseAgentService:
             "- flashcard_categories: max 5 short category names per module\n"
             "- case_study_fr/en: max 2 sentences (~40 words) — topic outline only, not the full case\n"
             "- Keep total response under 20,000 words\n\n"
+            "- NEVER truncate text with '...' or ellipsis — write complete short text instead\n\n"
             "Return ONLY valid JSON, no markdown fences, "
             "no explanation."
         )


### PR DESCRIPTION
## Summary

Adds a single rule to the syllabus generation prompt to prevent Claude from truncating field values with `'...'` or ellipsis characters.

## Changes

- `backend/app/domain/services/course_agent_service.py`: Added `- NEVER truncate text with '...' or ellipsis — write complete short text instead` before the final `Return ONLY valid JSON` instruction

## Test plan
- [ ] Backend tests pass
- [ ] Manually verified syllabus generation no longer produces truncated values like `"Algebra: Expressions, Equations, and..."`

Closes #1204

Generated with [Claude Code](https://claude.ai/code)