### PR TITLE
fix(syllabus): fix inline fallback budget from 3.5M to 400K (#1201)

### DIFF
--- a/backend/app/tasks/syllabus_generation.py
+++ b/backend/app/tasks/syllabus_generation.py
@@ -71,7 +71,7 @@ def generate_course_syllabus(
     from app.infrastructure.config.settings import settings
 
     cache = SettingsCache.instance()
-    context_budget = cache.get("syllabus-context-budget-chars", 3_500_000)
+    context_budget = cache.get("syllabus-context-budget-chars", 400_000)
     summarizer_model = cache.get("syllabus-summarizer-model", "gpt-5.4-nano")
     summary_max_tokens = cache.get("syllabus-summary-max-output-tokens", 30_000)
 


### PR DESCRIPTION
## Summary

The SettingsCache is never populated in Celery workers (0 keys). `cache.get("syllabus-context-budget-chars", 3_500_000)` always returns the inline fallback `3_500_000`, ignoring the compiled default.

Changes `3_500_000` to `400_000` on line 74 of `syllabus_generation.py`.

Closes #1201

🤖 Generated with [Claude Code](https://claude.com/claude-code)