### PR TITLE
fix(admin): hide 'Generate structure' button for published courses

### DIFF
--- a/backend/migrations/versions/050_fix_published_course_creation_step.py
+++ b/backend/migrations/versions/050_fix_published_course_creation_step.py
@@ -1,0 +1,34 @@
+"""Fix creation_step for published courses with incorrect state
+
+Revision ID: 050
+Revises: 049
+Create Date: 2026-04-08 17:00:00.000000
+
+Fixes courses where status='published' but creation_step is not 'published',
+which can happen when a user clicks "Generate structure" on an already-published
+course, setting creation_step='generating' and corrupting the wizard state.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "050"
+down_revision: str | None = "049"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE courses
+        SET creation_step = 'published'
+        WHERE status = 'published'
+          AND creation_step != 'published'
+        """
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/frontend/components/admin/courses-client.tsx
+++ b/frontend/components/admin/courses-client.tsx
@@ -521,21 +521,23 @@ function CourseRow({
         </button>
 
         <div className="flex items-center gap-2 shrink-0">
-          <Button
-            variant="outline"
-            size="sm"
-            className="gap-1.5 min-h-11 hidden sm:flex"
-            onClick={() => onGenerateStructure(course)}
-            disabled={isGenerating}
-            aria-label={t('generateStructure')}
-          >
-            {isGenerating ? (
-              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-            ) : (
-              <Sparkles className="h-4 w-4" aria-hidden="true" />
-            )}
-            <span className="hidden md:inline">{t('generateStructure')}</span>
-          </Button>
+          {!isPublished && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-1.5 min-h-11 hidden sm:flex"
+              onClick={() => onGenerateStructure(course)}
+              disabled={isGenerating}
+              aria-label={t('generateStructure')}
+            >
+              {isGenerating ? (
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+              ) : (
+                <Sparkles className="h-4 w-4" aria-hidden="true" />
+              )}
+              <span className="hidden md:inline">{t('generateStructure')}</span>
+            </Button>
+          )}
 
           <DropdownMenu>
             <DropdownMenuTrigger
@@ -555,14 +557,16 @@ function CourseRow({
                 <BookOpen className="mr-2 h-4 w-4" />
                 {t('editCourse')}
               </DropdownMenuItem>
-              <DropdownMenuItem
-                className="sm:hidden"
-                onClick={() => onGenerateStructure(course)}
-                disabled={isGenerating}
-              >
-                <Sparkles className="mr-2 h-4 w-4" />
-                {t('generateStructure')}
-              </DropdownMenuItem>
+              {!isPublished && (
+                <DropdownMenuItem
+                  className="sm:hidden"
+                  onClick={() => onGenerateStructure(course)}
+                  disabled={isGenerating}
+                >
+                  <Sparkles className="mr-2 h-4 w-4" />
+                  {t('generateStructure')}
+                </DropdownMenuItem>
+              )}
               {course.status !== 'published' && (
                 <DropdownMenuItem onClick={() => onPublish(course)}>
                   <Globe className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary

- Hide the **Generate Structure** button (both inline card button and dropdown item) when `course.status === 'published'`, preventing users from accidentally corrupting published course state
- Add **migration 050** to repair existing corrupted rows: sets `creation_step = 'published'` for all courses where `status = 'published'` but `creation_step != 'published'`

## Changes

- `frontend/components/admin/courses-client.tsx` — wrap both "Generate structure" UI elements with `{!isPublished && ...}` guard using the existing `isPublished` variable
- `backend/migrations/versions/050_fix_published_course_creation_step.py` — one-time data fix migration

## Test plan

- [ ] Published course cards no longer show "Generate structure" button
- [ ] Draft course cards still show the button
- [ ] Migration 050 runs cleanly and fixes "Investissement Digital en Santé Publique" row
- [ ] Frontend lint passes (0 errors)

Closes #1212

Generated with [Claude Code](https://claude.ai/code)