### PR TITLE
Merge dev → main: Sira rebrand (#1215)

### DIFF
--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -32,7 +32,7 @@ test.describe('Dashboard', () => {
   test('renders dashboard page with title and subtitle', async ({ page }) => {
     await page.goto('/en/dashboard');
     await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
-    await expect(page.getByText('Your public health learning platform')).toBeVisible();
+    await expect(page.getByText('Sira Learning Platform')).toBeVisible();
   });
 
   test('displays streak and key stat cards', async ({ page }) => {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -169,7 +169,7 @@
   "Dashboard": {
     "title": "Dashboard",
     "welcome": "Welcome to Sira",
-    "subtitle": "Your public health learning platform",
+    "subtitle": "Sira Learning Platform",
     "streak": "Day streak",
     "nextReview": "Next review",
     "continueModule": "Continue module",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -169,7 +169,7 @@
   "Dashboard": {
     "title": "Tableau de bord",
     "welcome": "Bienvenue sur Sira",
-    "subtitle": "Votre plateforme d'apprentissage en santé publique",
+    "subtitle": "Sira — Plateforme d'apprentissage",
     "streak": "Jours consécutifs",
     "nextReview": "Prochaine révision",
     "continueModule": "Continuer le module",


### PR DESCRIPTION
Rebrand subtitle to Sira Learning Platform. Closes #1215.