### PR TITLE
feat(curricula): private curriculum with user/group access control

### DIFF
--- a/backend/app/api/v1/admin_curricula.py
+++ b/backend/app/api/v1/admin_curricula.py
@@ -13,7 +13,8 @@ from app.api.deps import get_db as get_db_session
 from app.api.deps_local_auth import AuthenticatedUser, require_role
 from app.domain.models.course import Course
 from app.domain.models.curriculum import Curriculum, CurriculumCourse
-from app.domain.models.user import UserRole
+from app.domain.models.user import User, UserRole
+from app.domain.models.user_group import CurriculumAccess, UserGroup
 
 logger = get_logger(__name__)
 router = APIRouter(prefix="/admin/curricula", tags=["Admin - Curricula"])
@@ -35,6 +36,26 @@ class UpdateCurriculumRequest(BaseModel):
     cover_image_url: str | None = None
 
 
+class SetVisibilityRequest(BaseModel):
+    visibility: str
+
+
+class GrantAccessRequest(BaseModel):
+    user_id: str | None = None
+    group_id: str | None = None
+
+
+class AccessEntryResponse(BaseModel):
+    id: str
+    curriculum_id: str
+    user_id: str | None
+    user_email: str | None
+    group_id: str | None
+    group_name: str | None
+    granted_by: str | None
+    granted_at: str
+
+
 class CurriculumResponse(BaseModel):
     id: str
     slug: str
@@ -44,6 +65,7 @@ class CurriculumResponse(BaseModel):
     description_en: str | None
     cover_image_url: str | None
     status: str
+    visibility: str
     created_by: str | None
     course_count: int
     created_at: str
@@ -76,6 +98,7 @@ def _curriculum_to_response(curriculum: Curriculum) -> CurriculumResponse:
         description_en=curriculum.description_en,
         cover_image_url=curriculum.cover_image_url,
         status=curriculum.status,
+        visibility=curriculum.visibility,
         created_by=str(curriculum.created_by) if curriculum.created_by else None,
         course_count=len(curriculum.courses) if curriculum.courses else 0,
         created_at=curriculum.created_at.isoformat(),
@@ -355,3 +378,213 @@ async def remove_course_from_curriculum(
 
     await db.refresh(curriculum)
     return _curriculum_to_detail_response(curriculum)
+
+
+@router.post("/{curriculum_id}/visibility", response_model=CurriculumDetailResponse)
+async def set_curriculum_visibility(
+    curriculum_id: uuid.UUID,
+    request: SetVisibilityRequest,
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    db=Depends(get_db_session),
+) -> CurriculumDetailResponse:
+    """Set curriculum visibility to 'public' or 'private'. Admin only."""
+    if request.visibility not in ("public", "private"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="visibility must be 'public' or 'private'",
+        )
+    result = await db.execute(select(Curriculum).where(Curriculum.id == curriculum_id))
+    curriculum = result.scalar_one_or_none()
+    if not curriculum:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Curriculum not found")
+
+    curriculum.visibility = request.visibility
+    await db.commit()
+    await db.refresh(curriculum)
+    logger.info(
+        "Curriculum visibility updated",
+        curriculum_id=str(curriculum_id),
+        visibility=request.visibility,
+        admin_id=current_user.id,
+    )
+    return _curriculum_to_detail_response(curriculum)
+
+
+@router.get("/{curriculum_id}/access", response_model=list[AccessEntryResponse])
+async def list_curriculum_access(
+    curriculum_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    db=Depends(get_db_session),
+) -> list[AccessEntryResponse]:
+    """List all access entries for a curriculum. Admin only."""
+    result = await db.execute(select(Curriculum).where(Curriculum.id == curriculum_id))
+    if not result.scalar_one_or_none():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Curriculum not found")
+
+    access_result = await db.execute(
+        select(CurriculumAccess).where(CurriculumAccess.curriculum_id == curriculum_id)
+    )
+    entries = access_result.scalars().all()
+
+    response = []
+    for entry in entries:
+        user_email = None
+        group_name = None
+        if entry.user_id:
+            user_result = await db.execute(select(User).where(User.id == entry.user_id))
+            user = user_result.scalar_one_or_none()
+            user_email = user.email if user else None
+        if entry.group_id:
+            group_result = await db.execute(select(UserGroup).where(UserGroup.id == entry.group_id))
+            group = group_result.scalar_one_or_none()
+            group_name = group.name if group else None
+
+        response.append(
+            AccessEntryResponse(
+                id=str(entry.id),
+                curriculum_id=str(entry.curriculum_id),
+                user_id=str(entry.user_id) if entry.user_id else None,
+                user_email=user_email,
+                group_id=str(entry.group_id) if entry.group_id else None,
+                group_name=group_name,
+                granted_by=str(entry.granted_by) if entry.granted_by else None,
+                granted_at=entry.granted_at.isoformat(),
+            )
+        )
+    return response
+
+
+@router.post(
+    "/{curriculum_id}/access",
+    response_model=AccessEntryResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def grant_curriculum_access(
+    curriculum_id: uuid.UUID,
+    request: GrantAccessRequest,
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    db=Depends(get_db_session),
+) -> AccessEntryResponse:
+    """Grant access to a private curriculum for a user or group. Admin only."""
+    if not request.user_id and not request.group_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Either user_id or group_id must be provided",
+        )
+    if request.user_id and request.group_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only one of user_id or group_id can be provided",
+        )
+
+    curriculum_result = await db.execute(select(Curriculum).where(Curriculum.id == curriculum_id))
+    if not curriculum_result.scalar_one_or_none():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Curriculum not found")
+
+    user_id: uuid.UUID | None = None
+    group_id: uuid.UUID | None = None
+    user_email = None
+    group_name = None
+
+    if request.user_id:
+        try:
+            user_id = uuid.UUID(request.user_id)
+        except ValueError:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid user_id")
+        user_result = await db.execute(select(User).where(User.id == user_id))
+        user = user_result.scalar_one_or_none()
+        if not user:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+        user_email = user.email
+
+        existing = await db.execute(
+            select(CurriculumAccess).where(
+                CurriculumAccess.curriculum_id == curriculum_id,
+                CurriculumAccess.user_id == user_id,
+            )
+        )
+        if existing.scalar_one_or_none():
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="User already has access to this curriculum",
+            )
+
+    if request.group_id:
+        try:
+            group_id = uuid.UUID(request.group_id)
+        except ValueError:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid group_id")
+        group_result = await db.execute(select(UserGroup).where(UserGroup.id == group_id))
+        group = group_result.scalar_one_or_none()
+        if not group:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+        group_name = group.name
+
+        existing = await db.execute(
+            select(CurriculumAccess).where(
+                CurriculumAccess.curriculum_id == curriculum_id,
+                CurriculumAccess.group_id == group_id,
+            )
+        )
+        if existing.scalar_one_or_none():
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Group already has access to this curriculum",
+            )
+
+    entry = CurriculumAccess(
+        id=uuid.uuid4(),
+        curriculum_id=curriculum_id,
+        user_id=user_id,
+        group_id=group_id,
+        granted_by=uuid.UUID(current_user.id),
+    )
+    db.add(entry)
+    await db.commit()
+    await db.refresh(entry)
+
+    logger.info(
+        "Curriculum access granted",
+        curriculum_id=str(curriculum_id),
+        user_id=str(user_id) if user_id else None,
+        group_id=str(group_id) if group_id else None,
+        admin_id=current_user.id,
+    )
+    return AccessEntryResponse(
+        id=str(entry.id),
+        curriculum_id=str(entry.curriculum_id),
+        user_id=str(entry.user_id) if entry.user_id else None,
+        user_email=user_email,
+        group_id=str(entry.group_id) if entry.group_id else None,
+        group_name=group_name,
+        granted_by=str(entry.granted_by) if entry.granted_by else None,
+        granted_at=entry.granted_at.isoformat(),
+    )
+
+
+@router.delete("/{curriculum_id}/access/{access_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def revoke_curriculum_access(
+    curriculum_id: uuid.UUID,
+    access_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    db=Depends(get_db_session),
+) -> None:
+    """Revoke access to a private curriculum. Admin only."""
+    result = await db.execute(
+        select(CurriculumAccess).where(
+            CurriculumAccess.id == access_id,
+            CurriculumAccess.curriculum_id == curriculum_id,
+        )
+    )
+    entry = result.scalar_one_or_none()
+    if not entry:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Access entry not found")
+
+    await db.delete(entry)
+    await db.commit()
+    logger.info(
+        "Curriculum access revoked",
+        curriculum_id=str(curriculum_id),
+        access_id=str(access_id),
+        admin_id=current_user.id,
+    )

--- a/backend/app/api/v1/admin_groups.py
+++ b/backend/app/api/v1/admin_groups.py
@@ -1,0 +1,255 @@
+"""Admin endpoints for user group management (CRUD + member management)."""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import select
+from structlog import get_logger
+
+from app.api.deps import get_db as get_db_session
+from app.api.deps_local_auth import AuthenticatedUser, require_role
+from app.domain.models.user import User, UserRole
+from app.domain.models.user_group import UserGroup, UserGroupMember
+
+logger = get_logger(__name__)
+router = APIRouter(prefix="/admin/groups", tags=["Admin - Groups"])
+
+
+class CreateGroupRequest(BaseModel):
+    name: str
+    description: str | None = None
+
+
+class UpdateGroupRequest(BaseModel):
+    name: str | None = None
+    description: str | None = None
+
+
+class AddMemberRequest(BaseModel):
+    user_id: str
+
+
+class GroupMemberResponse(BaseModel):
+    user_id: str
+    user_email: str | None
+    user_name: str
+    added_at: str
+
+
+class GroupResponse(BaseModel):
+    id: str
+    name: str
+    description: str | None
+    created_by: str | None
+    created_at: str
+    member_count: int
+
+
+class GroupDetailResponse(GroupResponse):
+    members: list[GroupMemberResponse]
+
+
+def _group_to_response(group: UserGroup) -> GroupResponse:
+    return GroupResponse(
+        id=str(group.id),
+        name=group.name,
+        description=group.description,
+        created_by=str(group.created_by) if group.created_by else None,
+        created_at=group.created_at.isoformat(),
+        member_count=len(group.members) if group.members else 0,
+    )
+
+
+def _group_to_detail_response(group: UserGroup) -> GroupDetailResponse:
+    base = _group_to_response(group)
+    members = []
+    for m in group.members or []:
+        user = m.user
+        members.append(
+            GroupMemberResponse(
+                user_id=str(m.user_id),
+                user_email=user.email if user else None,
+                user_name=user.name if user else "",
+                added_at=m.added_at.isoformat(),
+            )
+        )
+    return GroupDetailResponse(**base.model_dump(), members=members)
+
+
+@router.get("", response_model=list[GroupResponse])
+async def list_groups(
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    db=Depends(get_db_session),
+) -> list[GroupResponse]:
+    """List all user groups. Admin only."""
+    result = await db.execute(select(UserGroup).order_by(UserGroup.created_at.desc()))
+    groups = result.scalars().all()
+    return [_group_to_response(g) for g in groups]
+
+
+@router.post("", response_model=GroupDetailResponse, status_code=status.HTTP_201_CREATED)
+async def create_group(
+    request: CreateGroupRequest,
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    db=Depends(get_db_session),
+) -> GroupDetailResponse:
+    """Create a user group. Admin only."""
+    existing = await db.execute(select(UserGroup).where(UserGroup.name == request.name))
+    if existing.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A group with this name already exists",
+        )
+
+    group = UserGroup(
+        id=uuid.uuid4(),
+        name=request.name,
+        description=request.description,
+        created_by=uuid.UUID(current_user.id),
+    )
+    db.add(group)
+    await db.commit()
+    await db.refresh(group)
+    logger.info("User group created", group_id=str(group.id), admin_id=current_user.id)
+    return _group_to_detail_response(group)
+
+
+@router.get("/{group_id}", response_model=GroupDetailResponse)
+async def get_group(
+    group_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    db=Depends(get_db_session),
+) -> GroupDetailResponse:
+    """Get group detail with members. Admin only."""
+    result = await db.execute(select(UserGroup).where(UserGroup.id == group_id))
+    group = result.scalar_one_or_none()
+    if not group:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+    return _group_to_detail_response(group)
+
+
+@router.patch("/{group_id}", response_model=GroupDetailResponse)
+async def update_group(
+    group_id: uuid.UUID,
+    request: UpdateGroupRequest,
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    db=Depends(get_db_session),
+) -> GroupDetailResponse:
+    """Update group name or description. Admin only."""
+    result = await db.execute(select(UserGroup).where(UserGroup.id == group_id))
+    group = result.scalar_one_or_none()
+    if not group:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+
+    if request.name and request.name != group.name:
+        existing = await db.execute(select(UserGroup).where(UserGroup.name == request.name))
+        if existing.scalar_one_or_none():
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="A group with this name already exists",
+            )
+
+    for field, value in request.model_dump(exclude_unset=True).items():
+        setattr(group, field, value)
+
+    await db.commit()
+    await db.refresh(group)
+    logger.info("User group updated", group_id=str(group_id), admin_id=current_user.id)
+    return _group_to_detail_response(group)
+
+
+@router.delete("/{group_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_group(
+    group_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    db=Depends(get_db_session),
+) -> None:
+    """Delete a user group. Admin only."""
+    result = await db.execute(select(UserGroup).where(UserGroup.id == group_id))
+    group = result.scalar_one_or_none()
+    if not group:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+
+    await db.delete(group)
+    await db.commit()
+    logger.info("User group deleted", group_id=str(group_id), admin_id=current_user.id)
+
+
+@router.post(
+    "/{group_id}/members",
+    response_model=GroupDetailResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_member(
+    group_id: uuid.UUID,
+    request: AddMemberRequest,
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    db=Depends(get_db_session),
+) -> GroupDetailResponse:
+    """Add a user to a group. Admin only."""
+    group_result = await db.execute(select(UserGroup).where(UserGroup.id == group_id))
+    group = group_result.scalar_one_or_none()
+    if not group:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+
+    try:
+        user_id = uuid.UUID(request.user_id)
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid user_id")
+
+    user_result = await db.execute(select(User).where(User.id == user_id))
+    if not user_result.scalar_one_or_none():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    existing = await db.execute(
+        select(UserGroupMember).where(
+            UserGroupMember.group_id == group_id,
+            UserGroupMember.user_id == user_id,
+        )
+    )
+    if existing.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="User is already a member of this group"
+        )
+
+    db.add(UserGroupMember(group_id=group_id, user_id=user_id))
+    await db.commit()
+    await db.refresh(group)
+    logger.info(
+        "Member added to group",
+        group_id=str(group_id),
+        user_id=str(user_id),
+        admin_id=current_user.id,
+    )
+    return _group_to_detail_response(group)
+
+
+@router.delete("/{group_id}/members/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_member(
+    group_id: uuid.UUID,
+    user_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    db=Depends(get_db_session),
+) -> None:
+    """Remove a user from a group. Admin only."""
+    result = await db.execute(
+        select(UserGroupMember).where(
+            UserGroupMember.group_id == group_id,
+            UserGroupMember.user_id == user_id,
+        )
+    )
+    member = result.scalar_one_or_none()
+    if not member:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Member not found in group"
+        )
+
+    await db.delete(member)
+    await db.commit()
+    logger.info(
+        "Member removed from group",
+        group_id=str(group_id),
+        user_id=str(user_id),
+        admin_id=current_user.id,
+    )

--- a/backend/app/api/v1/courses.py
+++ b/backend/app/api/v1/courses.py
@@ -171,6 +171,34 @@ async def list_published_courses(
             curriculum_obj = result_c.scalar_one_or_none()
 
         if curriculum_obj:
+            if curriculum_obj.visibility == "private":
+                from app.domain.models.user_group import CurriculumAccess, UserGroupMember
+
+                has_access = False
+                if current_user:
+                    uid = uuid.UUID(current_user.id)
+                    direct = await db.execute(
+                        select(CurriculumAccess).where(
+                            CurriculumAccess.curriculum_id == curriculum_obj.id,
+                            CurriculumAccess.user_id == uid,
+                        )
+                    )
+                    has_access = direct.scalar_one_or_none() is not None
+                    if not has_access:
+                        group_q = await db.execute(
+                            select(CurriculumAccess)
+                            .join(
+                                UserGroupMember,
+                                UserGroupMember.group_id == CurriculumAccess.group_id,
+                            )
+                            .where(
+                                CurriculumAccess.curriculum_id == curriculum_obj.id,
+                                UserGroupMember.user_id == uid,
+                            )
+                        )
+                        has_access = group_q.scalar_one_or_none() is not None
+                if not has_access:
+                    return []
             stmt = stmt.where(
                 exists(
                     select(CurriculumCourse.course_id).where(
@@ -181,6 +209,17 @@ async def list_published_courses(
             )
         else:
             return []
+    else:
+        stmt = stmt.where(
+            ~exists(
+                select(CurriculumCourse.course_id)
+                .join(Curriculum, Curriculum.id == CurriculumCourse.curriculum_id)
+                .where(
+                    CurriculumCourse.course_id == Course.id,
+                    Curriculum.visibility == "private",
+                )
+            )
+        )
 
     if course_domain:
         stmt = stmt.where(

--- a/backend/app/api/v1/curricula.py
+++ b/backend/app/api/v1/curricula.py
@@ -4,11 +4,13 @@ import uuid
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import exists, select
 from structlog import get_logger
 
 from app.api.deps import get_db as get_db_session
+from app.api.deps_local_auth import get_optional_user
 from app.domain.models.curriculum import Curriculum
+from app.domain.models.user_group import CurriculumAccess, UserGroupMember
 
 logger = get_logger(__name__)
 router = APIRouter(prefix="/curricula", tags=["Curricula"])
@@ -30,16 +32,61 @@ class CurriculumPublicDetailResponse(CurriculumPublicResponse):
     course_ids: list[str]
 
 
+def _user_has_access(curriculum_id: uuid.UUID, user_id: uuid.UUID):
+    """Subquery: returns True if user has direct or group-based access."""
+    direct = exists(
+        select(CurriculumAccess.id).where(
+            CurriculumAccess.curriculum_id == curriculum_id,
+            CurriculumAccess.user_id == user_id,
+        )
+    )
+    via_group = exists(
+        select(CurriculumAccess.id)
+        .join(
+            UserGroupMember,
+            UserGroupMember.group_id == CurriculumAccess.group_id,
+        )
+        .where(
+            CurriculumAccess.curriculum_id == curriculum_id,
+            UserGroupMember.user_id == user_id,
+        )
+    )
+    return direct | via_group
+
+
 @router.get("", response_model=list[CurriculumPublicResponse])
 async def list_published_curricula(
+    current_user=Depends(get_optional_user),
     db=Depends(get_db_session),
 ) -> list[CurriculumPublicResponse]:
-    """List all published curricula. No auth required."""
-    result = await db.execute(
+    """List published curricula. Private curricula only shown if user has access."""
+    stmt = (
         select(Curriculum)
         .where(Curriculum.status == "published")
         .order_by(Curriculum.published_at.desc())
     )
+
+    if current_user:
+        uid = uuid.UUID(current_user.id)
+        direct_access = exists(
+            select(CurriculumAccess.id).where(
+                CurriculumAccess.curriculum_id == Curriculum.id,
+                CurriculumAccess.user_id == uid,
+            )
+        )
+        group_access = exists(
+            select(CurriculumAccess.id)
+            .join(UserGroupMember, UserGroupMember.group_id == CurriculumAccess.group_id)
+            .where(
+                CurriculumAccess.curriculum_id == Curriculum.id,
+                UserGroupMember.user_id == uid,
+            )
+        )
+        stmt = stmt.where((Curriculum.visibility == "public") | direct_access | group_access)
+    else:
+        stmt = stmt.where(Curriculum.visibility == "public")
+
+    result = await db.execute(stmt)
     curricula = result.scalars().all()
 
     return [
@@ -61,9 +108,10 @@ async def list_published_curricula(
 @router.get("/{slug_or_id}", response_model=CurriculumPublicDetailResponse)
 async def get_curriculum_detail(
     slug_or_id: str,
+    current_user=Depends(get_optional_user),
     db=Depends(get_db_session),
 ) -> CurriculumPublicDetailResponse:
-    """Get published curriculum detail with course IDs. No auth required."""
+    """Get published curriculum detail. Private curricula require access."""
     curriculum: Curriculum | None = None
 
     try:
@@ -85,6 +133,30 @@ async def get_curriculum_detail(
 
     if not curriculum:
         raise HTTPException(status_code=404, detail="Curriculum not found")
+
+    if curriculum.visibility == "private":
+        if not current_user:
+            raise HTTPException(status_code=404, detail="Curriculum not found")
+        uid = uuid.UUID(current_user.id)
+        direct = await db.execute(
+            select(CurriculumAccess).where(
+                CurriculumAccess.curriculum_id == curriculum.id,
+                CurriculumAccess.user_id == uid,
+            )
+        )
+        has_access = direct.scalar_one_or_none() is not None
+        if not has_access:
+            group_q = await db.execute(
+                select(CurriculumAccess)
+                .join(UserGroupMember, UserGroupMember.group_id == CurriculumAccess.group_id)
+                .where(
+                    CurriculumAccess.curriculum_id == curriculum.id,
+                    UserGroupMember.user_id == uid,
+                )
+            )
+            has_access = group_q.scalar_one_or_none() is not None
+        if not has_access:
+            raise HTTPException(status_code=404, detail="Curriculum not found")
 
     return CurriculumPublicDetailResponse(
         id=str(curriculum.id),

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 from app.api.v1.admin import router as admin_router
 from app.api.v1.admin_courses import router as admin_courses_router
 from app.api.v1.admin_curricula import router as admin_curricula_router
+from app.api.v1.admin_groups import router as admin_groups_router
 from app.api.v1.admin_settings import router as admin_settings_router
 from app.api.v1.admin_taxonomy import router as admin_taxonomy_router
 from app.api.v1.analytics import router as analytics_router
@@ -44,6 +45,7 @@ api_v1_router.include_router(admin_router)
 api_v1_router.include_router(admin_settings_router)
 api_v1_router.include_router(admin_courses_router)
 api_v1_router.include_router(admin_curricula_router)
+api_v1_router.include_router(admin_groups_router)
 api_v1_router.include_router(admin_taxonomy_router)
 api_v1_router.include_router(courses_router)
 api_v1_router.include_router(curricula_router)

--- a/backend/app/domain/models/curriculum.py
+++ b/backend/app/domain/models/curriculum.py
@@ -27,6 +27,7 @@ class Curriculum(Base):
     status: Mapped[str] = mapped_column(
         Enum("draft", "published", "archived", name="curriculumstatus"), server_default="draft"
     )
+    visibility: Mapped[str] = mapped_column(String(10), server_default="public")
     created_by: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("users.id", ondelete="SET NULL"), nullable=True
     )

--- a/backend/app/domain/models/user_group.py
+++ b/backend/app/domain/models/user_group.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, String, Text, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.domain.models.base import Base
+
+if TYPE_CHECKING:
+    from app.domain.models.curriculum import Curriculum
+    from app.domain.models.user import User
+
+
+class UserGroup(Base):
+    __tablename__ = "user_groups"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(255), unique=True, index=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_by: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    creator: Mapped[User | None] = relationship(foreign_keys=[created_by])
+    members: Mapped[list[UserGroupMember]] = relationship(
+        back_populates="group", cascade="all, delete-orphan"
+    )
+
+
+class UserGroupMember(Base):
+    __tablename__ = "user_group_members"
+    __table_args__ = (UniqueConstraint("group_id", "user_id", name="uq_group_member"),)
+
+    group_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("user_groups.id", ondelete="CASCADE"), primary_key=True
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    added_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    group: Mapped[UserGroup] = relationship(back_populates="members")
+    user: Mapped[User] = relationship(foreign_keys=[user_id])
+
+
+class CurriculumAccess(Base):
+    __tablename__ = "curriculum_access"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    curriculum_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("curricula.id", ondelete="CASCADE"), index=True
+    )
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=True
+    )
+    group_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("user_groups.id", ondelete="CASCADE"), nullable=True
+    )
+    granted_by: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    granted_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    curriculum: Mapped[Curriculum] = relationship(foreign_keys=[curriculum_id])
+    user: Mapped[User | None] = relationship(foreign_keys=[user_id])
+    group: Mapped[UserGroup | None] = relationship(foreign_keys=[group_id])
+    granter: Mapped[User | None] = relationship(foreign_keys=[granted_by])

--- a/backend/migrations/versions/051_add_curriculum_visibility_and_access.py
+++ b/backend/migrations/versions/051_add_curriculum_visibility_and_access.py
@@ -1,0 +1,86 @@
+"""add curriculum visibility, user_groups, user_group_members, curriculum_access
+
+Revision ID: 051
+Revises: 050
+Create Date: 2026-04-08
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "051"
+down_revision = "050"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "curricula",
+        sa.Column("visibility", sa.String(10), nullable=False, server_default="public"),
+    )
+
+    op.create_table(
+        "user_groups",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("created_by", sa.UUID(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["created_by"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name", name="uq_user_groups_name"),
+    )
+    op.create_index("ix_user_groups_name", "user_groups", ["name"])
+
+    op.create_table(
+        "user_group_members",
+        sa.Column("group_id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "added_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["group_id"], ["user_groups.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("group_id", "user_id"),
+        sa.UniqueConstraint("group_id", "user_id", name="uq_group_member"),
+    )
+
+    op.create_table(
+        "curriculum_access",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("curriculum_id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=True),
+        sa.Column("group_id", sa.UUID(), nullable=True),
+        sa.Column("granted_by", sa.UUID(), nullable=True),
+        sa.Column(
+            "granted_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["curriculum_id"], ["curricula.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["group_id"], ["user_groups.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["granted_by"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_curriculum_access_curriculum_id", "curriculum_access", ["curriculum_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_curriculum_access_curriculum_id", table_name="curriculum_access")
+    op.drop_table("curriculum_access")
+    op.drop_table("user_group_members")
+    op.drop_index("ix_user_groups_name", table_name="user_groups")
+    op.drop_table("user_groups")
+    op.drop_column("curricula", "visibility")


### PR DESCRIPTION
## Summary

Implements private curriculum support so admins can restrict access to specific users or groups, as specified in issue #1218.

## Changes

- **`backend/app/domain/models/curriculum.py`** — added `visibility` field (`"public"` default / `"private"`)
- **`backend/app/domain/models/user_group.py`** (new) — `UserGroup`, `UserGroupMember`, `CurriculumAccess` models
- **`backend/migrations/versions/051_add_curriculum_visibility_and_access.py`** (new) — single migration adding `visibility` column + `user_groups`, `user_group_members`, `curriculum_access` tables
- **`backend/app/api/v1/curricula.py`** — public list/detail now filters private curricula; authenticated users see private ones they have access to
- **`backend/app/api/v1/courses.py`** — public catalog excludes courses belonging to private curricula; `?curriculum=` param checks access for private curricula
- **`backend/app/api/v1/admin_curricula.py`** — added `POST /{id}/visibility`, `GET /{id}/access`, `POST /{id}/access`, `DELETE /{id}/access/{access_id}`; `CurriculumResponse` now includes `visibility`
- **`backend/app/api/v1/admin_groups.py`** (new) — full CRUD for user groups + `POST/DELETE /{id}/members`
- **`backend/app/api/v1/router.py`** — registered `admin_groups_router`

## Test plan

- [ ] Backend tests pass
- [ ] `ruff check` passes (verified locally)
- [ ] Public curricula endpoint hides private curricula for unauthenticated users
- [ ] Authenticated users with access can see private curricula
- [ ] Public courses catalog excludes courses in private curricula
- [ ] Admin can set visibility via `POST /admin/curricula/{id}/visibility`
- [ ] Admin can grant/revoke access via `/admin/curricula/{id}/access`
- [ ] Admin can manage groups via `/admin/groups`
- [ ] Existing public curricula/courses unaffected (default `visibility='public'`)

Closes #1218

Generated with [Claude Code](https://claude.ai/code)