### PR TITLE
fix(ui): tutor mode button — icon only on mobile

### DIFF
--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -438,9 +438,9 @@ export function ChatPanel({
               title={tutorMode === 'socratic' ? t('modeSocraticTooltip') : t('modeExplanatoryTooltip')}
             >
               {tutorMode === 'socratic' ? (
-                <><HelpCircle className="h-3.5 w-3.5" />{t('modeSocratic')}</>
+                <><HelpCircle className="h-3.5 w-3.5" /><span className="hidden sm:inline">{t('modeSocratic')}</span></>
               ) : (
-                <><BookOpen className="h-3.5 w-3.5" />{t('modeExplanatory')}</>
+                <><BookOpen className="h-3.5 w-3.5" /><span className="hidden sm:inline">{t('modeExplanatory')}</span></>
               )}
             </Button>
             <DropdownMenu>


### PR DESCRIPTION
## Summary
- Wrap text labels in `<span className="hidden sm:inline">` so only the icon shows on mobile viewports (<640px)
- On sm+ screens (640px+), text labels (Socratic / Explanatory) are still visible

## Changes
- `frontend/components/chat/chat-panel.tsx` lines 441 and 443: wrapped `{t('modeSocratic')}` and `{t('modeExplanatory')}` in responsive span

## Test plan
- [ ] Frontend lint passes (no errors)
- [ ] Manually verify icon-only on mobile viewport (<640px)
- [ ] Verify text visible on desktop (≥640px)
- [ ] Mode toggle functionality unchanged

Closes #1220

Generated with [Claude Code](https://claude.ai/code)