### PR TITLE
Merge dev → main: persist settings + init SettingsCache in worker (#1223)

### DIFF
--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -3,8 +3,10 @@
 import structlog
 from celery import Celery
 from celery.schedules import crontab
+from celery.signals import worker_ready
 
 import app.domain.models  # noqa: F401 — register all SQLAlchemy models with the mapper
+from app.domain.services.platform_settings_service import SettingsCache
 from app.infrastructure.config.settings import settings
 
 logger = structlog.get_logger(__name__)
@@ -82,6 +84,15 @@ celery_app.conf.beat_schedule = {
 @celery_app.task(bind=True)
 def debug_task(self):
     logger.info(f"Request: {self.request!r}")
+
+
+@worker_ready.connect
+def _on_worker_ready(**kwargs):
+    try:
+        SettingsCache.instance().refresh()
+        logger.info("settings_cache.loaded_on_worker_start")
+    except Exception as exc:
+        logger.warning("settings_cache.load_skipped_on_worker_start", error=str(exc))
 
 
 if __name__ == "__main__":

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -48,6 +48,7 @@ services:
       SMS_RELAY_API_KEY: ${SMS_RELAY_API_KEY}
       SMS_RELAY_TRUSTED_SENDERS: ${SMS_RELAY_TRUSTED_SENDERS}
     volumes:
+      - ./config:/app/config
       - ./resources:/app/resources
       - uploads:/app/uploads
     depends_on:
@@ -122,6 +123,7 @@ services:
       SMS_RELAY_API_KEY: ${SMS_RELAY_API_KEY}
       SMS_RELAY_TRUSTED_SENDERS: ${SMS_RELAY_TRUSTED_SENDERS}
     volumes:
+      - ./config:/app/config
       - ./resources:/app/resources
       - uploads:/app/uploads
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
+      - ./config:/app/config
       - uploads_data:/app/uploads
     depends_on:
       postgres:


### PR DESCRIPTION
## Summary

- Volume mount `./config:/app/config` on backend + celery-worker so `platform_settings.json` survives deploys
- `@worker_ready` signal to refresh `SettingsCache` on Celery worker startup — fixes empty cache causing wrong prompt/budget fallbacks
- Also fixes case study generating lesson content (wrong prompt due to empty cache)

Closes #1223

🤖 Generated with [Claude Code](https://claude.com/claude-code)