### PR TITLE
fix(content): case study generates lesson structure — guard empty cache + add prompt logging

### DIFF
--- a/backend/app/ai/prompts/case_study.py
+++ b/backend/app/ai/prompts/case_study.py
@@ -2,7 +2,11 @@
 
 from typing import Literal
 
+import structlog
+
 from app.ai.prompts.lesson import _apply_settings_template
+
+logger = structlog.get_logger(__name__)
 
 CASE_STUDY_TOPICS = {
     "M01": {
@@ -49,6 +53,14 @@ def get_case_study_system_prompt(
     course_domain: str = "",
 ) -> str:
     """Generate system prompt for case study content generation."""
+    logger.debug(
+        "get_case_study_system_prompt called",
+        setting_key="ai-prompt-case-study-system",
+        language=language,
+        country=country,
+        level=level,
+        bloom_level=bloom_level,
+    )
     return _apply_settings_template(
         "ai-prompt-case-study-system",
         language,

--- a/backend/app/ai/prompts/lesson.py
+++ b/backend/app/ai/prompts/lesson.py
@@ -99,7 +99,7 @@ def _apply_settings_template(
     if defn is None:
         return ""
     current = SettingsCache.instance().get(setting_key)
-    if current is None:
+    if not current:
         current = defn.default
     vars_map = _build_template_vars(
         language,

--- a/backend/app/domain/services/lesson_service.py
+++ b/backend/app/domain/services/lesson_service.py
@@ -864,6 +864,12 @@ class CaseStudyGenerationService:
                 syllabus_json=course.syllabus_json if course else None,
             )
 
+            logger.debug(
+                "Case study system prompt preview",
+                system_prompt_prefix=system_prompt[:200],
+                system_prompt_len=len(system_prompt),
+            )
+
             accumulated_content = ""
             async for chunk in self.claude_service.generate_lesson_content_stream(
                 system_prompt, user_message
@@ -983,6 +989,12 @@ class CaseStudyGenerationService:
             language,
             module_id=module_key,
             syllabus_json=course.syllabus_json if course else None,
+        )
+
+        logger.debug(
+            "Case study system prompt preview (non-streaming)",
+            system_prompt_prefix=system_prompt[:200],
+            system_prompt_len=len(system_prompt),
         )
 
         response = await self.claude_service.generate_lesson_content(system_prompt, user_message)

--- a/backend/tests/test_case_study_service.py
+++ b/backend/tests/test_case_study_service.py
@@ -220,3 +220,17 @@ class TestCaseStudyPromptImports:
 
         assert "Unknown Module" in context
         assert "health challenge" in context
+
+    def test_empty_cache_value_falls_back_to_default_prompt(self):
+        from unittest.mock import patch
+
+        from app.ai.prompts.case_study import get_case_study_system_prompt
+        from app.domain.services.platform_settings_service import SettingsCache
+
+        cache = SettingsCache.instance()
+        with patch.object(cache, "get", return_value=""):
+            prompt = get_case_study_system_prompt("fr", "SN", 1, "remember")
+
+        assert "West African Context" in prompt
+        assert "Guided Questions" in prompt
+        assert "Annotated Correction" in prompt


### PR DESCRIPTION
## Summary

- **Bug 1 fixed**: `_apply_settings_template` used `if current is None` which allowed an empty string from `SettingsCache` to bypass the compiled default, sending an **empty system prompt** to Claude — causing it to produce a lesson-like structure instead of the required 4-section case study.
- **Bug 2 fixed**: No diagnostic logging existed to confirm which prompt was actually sent. Added `logger.debug` in `get_case_study_system_prompt()` and both code paths in `CaseStudyGenerationService`.

## Changes

- `backend/app/ai/prompts/lesson.py`: `if current is None` → `if not current` in `_apply_settings_template` so empty string also falls back to compiled default
- `backend/app/ai/prompts/case_study.py`: added `logger.debug` in `get_case_study_system_prompt` logging the setting key, language, country, level, bloom_level
- `backend/app/domain/services/lesson_service.py`: added `logger.debug` logging first 200 chars of `system_prompt` before both streaming and non-streaming Claude API calls
- `backend/tests/test_case_study_service.py`: added `test_empty_cache_value_falls_back_to_default_prompt` verifying the fix

## Test plan

- [x] 12/12 case study service tests pass
- [x] ruff check passes
- [x] ruff format passes
- [ ] Manually verify in production logs that `system_prompt_prefix` starts with "You are an expert educator in..." (not empty or a lesson prompt)

Closes #1227

Generated with [Claude Code](https://claude.ai/code)