### PR TITLE
Merge dev → main: tutor mode icon-only on mobile (#1220)

### DIFF
--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -438,9 +438,9 @@ export function ChatPanel({
               title={tutorMode === 'socratic' ? t('modeSocraticTooltip') : t('modeExplanatoryTooltip')}
             >
               {tutorMode === 'socratic' ? (
-                <><HelpCircle className="h-3.5 w-3.5" />{t('modeSocratic')}</>
+                <><HelpCircle className="h-3.5 w-3.5" /><span className="hidden sm:inline">{t('modeSocratic')}</span></>
               ) : (
-                <><BookOpen className="h-3.5 w-3.5" />{t('modeExplanatory')}</>
+                <><BookOpen className="h-3.5 w-3.5" /><span className="hidden sm:inline">{t('modeExplanatory')}</span></>
               )}
             </Button>
             <DropdownMenu>


### PR DESCRIPTION
Hides Socratic/Explanatory text on mobile, shows icon only. Closes #1220.