### PR TITLE
fix(admin): groups UI — 401 on group detail + TypeError on members list

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -908,6 +908,16 @@ export interface UserGroupMember {
   joined_at: string;
 }
 
+interface GroupDetailResponse extends UserGroupResponse {
+  created_by?: string | null;
+  members: Array<{
+    user_id: string;
+    user_email: string | null;
+    user_name: string;
+    added_at: string;
+  }>;
+}
+
 export async function getAdminGroups(): Promise<UserGroupResponse[]> {
   const { authClient } = await import("./auth");
   return authClient.authenticatedFetch<UserGroupResponse[]>("/api/v1/admin/groups");
@@ -942,7 +952,13 @@ export async function deleteAdminGroup(id: string): Promise<void> {
 
 export async function getAdminGroupMembers(groupId: string): Promise<UserGroupMember[]> {
   const { authClient } = await import("./auth");
-  return authClient.authenticatedFetch<UserGroupMember[]>(`/api/v1/admin/groups/${groupId}`);
+  const detail = await authClient.authenticatedFetch<GroupDetailResponse>(`/api/v1/admin/groups/${groupId}`);
+  return detail.members.map((m) => ({
+    user_id: m.user_id,
+    email: m.user_email ?? '',
+    name: m.user_name,
+    joined_at: m.added_at,
+  }));
 }
 
 export async function addGroupMember(groupId: string, userId: string): Promise<void> {

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -378,6 +378,11 @@ class AuthClient {
     path: string,
     options: RequestInit = {}
   ): Promise<T> {
+    if (!this.accessToken && typeof window !== 'undefined') {
+      this.accessToken = localStorage.getItem('access_token');
+      this.refreshToken = localStorage.getItem('refresh_token');
+    }
+
     const url = path.startsWith('/') ? `${API_BASE}${path}` : path;
     
     const headers: Record<string, string> = {


### PR DESCRIPTION
## Summary

Fixes two bugs in the admin groups UI:

1. **TypeError: N.map is not a function** — `getAdminGroupMembers` was calling `GET /api/v1/admin/groups/{id}` and casting the response as `UserGroupMember[]`, but the backend returns a `GroupDetailResponse` object with a `.members` array. Added a `GroupDetailResponse` interface and extracted `.members`, mapping backend field names (`user_email`/`user_name`/`added_at`) to the frontend shape (`email`/`name`/`joined_at`).

2. **401 Unauthorized** — `authClient` is a module-level singleton. In Next.js, when the module is first evaluated during SSR, `window` is undefined so the constructor never reads tokens from `localStorage`. Added a lazy token reload at the top of `authenticatedFetch`: if `accessToken` is null and `window` is available, re-read from `localStorage` before building the Authorization header.

## Changes

- `frontend/lib/api.ts` — add `GroupDetailResponse` interface; fix `getAdminGroupMembers` to unwrap and map members
- `frontend/lib/auth.ts` — lazy token reload in `authenticatedFetch` when `accessToken` is null

## Test plan

- [ ] Backend tests pass
- [ ] Frontend lint passes (0 errors)
- [ ] Open admin groups page → click "Manage Members" → list renders without TypeError
- [ ] Hard-refresh as logged-in admin → group detail loads without 401

Closes #1243

Generated with [Claude Code](https://claude.ai/code)