### PR TITLE
fix(ui): hide empty/placeholder lesson sections (#1253)

### DIFF
--- a/backend/migrations/versions/052_invalidate_placeholder_cached_lessons.py
+++ b/backend/migrations/versions/052_invalidate_placeholder_cached_lessons.py
@@ -1,0 +1,30 @@
+"""Invalidate cached lessons containing placeholder text
+
+Deletes generated lesson content that still has the old placeholder
+values injected by the pre-fix _parse_lesson_content() implementation.
+
+Revision ID: 052
+Revises: 051
+Create Date: 2026-04-09
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "052"
+down_revision: str | None = "051"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        DELETE FROM generated_content
+        WHERE content_type = 'lesson'
+          AND content::text LIKE '%Exemple contextuel sera extrait%'
+    """)
+
+
+def downgrade() -> None:
+    pass

--- a/frontend/components/learning/lesson-viewer.tsx
+++ b/frontend/components/learning/lesson-viewer.tsx
@@ -425,34 +425,39 @@ export function LessonViewer({
           </div>
 
           {/* West African Example */}
-          <div className="mb-8 bg-teal-50 border-l-4 border-teal-400 p-6 rounded-r-lg">
-            <div className="prose prose-teal max-w-none">
-              {renderContentWithImages(content.aof_example)}
+          {content.aof_example && (
+            <div className="mb-8 bg-teal-50 border-l-4 border-teal-400 p-6 rounded-r-lg">
+              <div className="prose prose-teal max-w-none">
+                {renderContentWithImages(content.aof_example)}
+              </div>
             </div>
-          </div>
+          )}
 
           {/* Synthesis */}
-          <div className="mb-8">
-            {renderContentWithImages(content.synthesis)}
-          </div>
-
+          {content.synthesis && (
+            <div className="mb-8">
+              {renderContentWithImages(content.synthesis)}
+            </div>
+          )}
 
           {/* Key Points */}
-          <div className="mb-8">
-            <h2 className="text-xl font-semibold text-gray-900 mb-4">
-              {t('keyPoints')}
-            </h2>
-            <ul className="space-y-3">
-              {content.key_points.map((point, index) => (
-                <li key={index} className="flex items-start gap-3">
-                  <div className="w-2 h-2 bg-teal-500 rounded-full mt-3 flex-shrink-0" />
-                  <span className="text-base leading-relaxed text-gray-700">
-                    {point}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </div>
+          {content.key_points.length > 0 && (
+            <div className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">
+                {t('keyPoints')}
+              </h2>
+              <ul className="space-y-3">
+                {content.key_points.map((point, index) => (
+                  <li key={index} className="flex items-start gap-3">
+                    <div className="w-2 h-2 bg-teal-500 rounded-full mt-3 flex-shrink-0" />
+                    <span className="text-base leading-relaxed text-gray-700">
+                      {point}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Summary

- Conditionally render `aof_example` teal box only when `content.aof_example` is truthy
- Conditionally render `synthesis` only when `content.synthesis` is truthy  
- Conditionally render Key Points heading + list only when `content.key_points.length > 0`

## Changes

- `frontend/components/learning/lesson-viewer.tsx` — wrap three sections with conditional guards
- `backend/migrations/versions/052_invalidate_placeholder_cached_lessons.py` — Alembic data migration that deletes cached lessons still containing the old French placeholder text (`%Exemple contextuel sera extrait%`)

## Test plan

- [ ] Lessons with real content in aof_example/synthesis/key_points still display them
- [ ] Lessons with empty/placeholder values no longer show those sections
- [ ] Old cached placeholder lessons cleared from DB by migration 052
- [ ] No visual regression on mobile viewport

Closes #1253

Generated with [Claude Code](https://claude.ai/code)