### PR TITLE
fix(nav): remove Settings menu item that redirected to Profile

### DIFF
--- a/frontend/components/layout/bottom-nav.tsx
+++ b/frontend/components/layout/bottom-nav.tsx
@@ -11,7 +11,6 @@ import {
   MoreHorizontal,
   BookOpen,
   User,
-  Settings,
   X,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -84,12 +83,6 @@ export function BottomNav() {
       label: t("profile"),
       icon: User,
       description: t("profileDescription"),
-    },
-    {
-      href: `/${locale}/settings`,
-      label: t("settings"),
-      icon: Settings,
-      description: t("settingsDescription"),
     },
   ];
 

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -10,7 +10,6 @@ import {
   GraduationCap,
   CreditCard,
   Bot,
-  Settings,
   User,
   ChevronLeft,
   ChevronRight,
@@ -111,12 +110,6 @@ export function Sidebar() {
       label: t("profile"),
       icon: User,
       description: t("profileDescription")
-    },
-    {
-      href: `/${locale}/settings`,
-      label: t("settings"),
-      icon: Settings,
-      description: t("settingsDescription")
     },
     {
       href: `/${locale}/subscribe`,


### PR DESCRIPTION
## Summary

Removes the \"Settings\" entry from the navigation menu (desktop sidebar and mobile bottom nav) that was confusingly redirecting users to the Profile page.

## Changes

- `frontend/components/layout/sidebar.tsx` — removed Settings nav item and unused `Settings` icon import
- `frontend/components/layout/bottom-nav.tsx` — removed Settings entry from the \"More\" menu and unused `Settings` icon import

The middleware redirect (`/settings` → `/profile`) is kept as a safety net for any bookmarked links.

## Test plan

- [ ] Settings no longer appears in desktop sidebar
- [ ] Settings no longer appears in mobile bottom nav "More" menu
- [ ] Profile page remains accessible via its own menu item
- [ ] No lint errors introduced
- [ ] Frontend lint passes ✅

Closes #1265

Generated with [Claude Code](https://claude.ai/code)