### PR TITLE
fix(analytics): send events to backend DB alongside PostHog

### DIFF
--- a/frontend/lib/analytics.ts
+++ b/frontend/lib/analytics.ts
@@ -43,8 +43,23 @@ export function track<E extends AnalyticsEvent>(
   event: E["event"],
   properties: E["properties"]
 ) {
-  if (typeof window !== "undefined" && process.env.NEXT_PUBLIC_POSTHOG_KEY && !isOptedOut()) {
+  if (typeof window === "undefined") return;
+  if (isOptedOut()) return;
+
+  if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
     posthog.capture(event, properties);
+  }
+
+  const token = localStorage.getItem("access_token");
+  if (token) {
+    fetch("/api/v1/analytics/events", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ event_name: event, properties }),
+    }).catch(() => {});
   }
 }
 


### PR DESCRIPTION
## Summary

The admin analytics dashboard was showing all zeros because the frontend only sent events to PostHog (external), while the dashboard queries the local \`usage_events\` database table (which was always empty).

## Changes

- `frontend/lib/analytics.ts` — After capturing to PostHog, also fire-and-forget POST to \`/api/v1/analytics/events\` with JWT from \`localStorage\`. The call is skipped if no token is present (unauthenticated users) and respects \`analytics_opt_out\`.

## Test plan

- [ ] Log in as a student → view a lesson → verify \`usage_events\` table has a \`lesson_viewed\` row
- [ ] Complete a quiz → verify \`quiz_started\` and \`quiz_completed\` events appear
- [ ] Log in as admin → open analytics dashboard → verify non-zero counts for 7d period
- [ ] Verify PostHog still receives events (browser network tab)
- [ ] Frontend lint passes (0 errors)

Closes #1255

Generated with [Claude Code](https://claude.ai/code)