### PR TITLE
merge dev to main: activation codes link + analytics fix

### DIFF
--- a/backend/app/api/v1/content.py
+++ b/backend/app/api/v1/content.py
@@ -40,6 +40,7 @@ from app.api.v1.schemas.quiz import (
 from app.domain.models.content import GeneratedContent
 from app.domain.models.module import Module
 from app.domain.models.module_unit import ModuleUnit
+from app.domain.services.analytics_service import AnalyticsService
 from app.domain.services.flashcard_service import FlashcardGenerationService
 from app.domain.services.lesson_service import CaseStudyGenerationService, LessonGenerationService
 from app.domain.services.progress_service import ProgressService
@@ -538,6 +539,24 @@ async def get_or_generate_lesson_by_module_and_unit(
                         logger.warning(
                             "Failed to track lesson access (non-fatal)",
                             error=str(track_err),
+                        )
+                    try:
+                        from uuid import UUID as _UUID
+
+                        analytics_svc = AnalyticsService(session)
+                        await analytics_svc.ingest_event(
+                            event_name="lesson_viewed",
+                            properties={
+                                "module_id": str(resolved_module_id),
+                                "unit_id": unit_id,
+                                "language": language,
+                            },
+                            user_id=_UUID(str(current_user.id)),
+                            session_id=None,
+                        )
+                    except Exception as analytics_err:
+                        logger.warning(
+                            "Analytics event failed (non-fatal)", error=str(analytics_err)
                         )
 
                 logger.info(

--- a/backend/app/api/v1/flashcards.py
+++ b/backend/app/api/v1/flashcards.py
@@ -28,6 +28,7 @@ from app.domain.models.content import GeneratedContent
 from app.domain.models.flashcard import FlashcardReview
 from app.domain.models.module import Module
 from app.domain.models.user import User
+from app.domain.services.analytics_service import AnalyticsService
 from app.domain.services.flashcard_service import FlashcardGenerationService
 from app.domain.services.platform_settings_service import SettingsCache
 from app.infrastructure.config.settings import get_settings
@@ -332,6 +333,20 @@ async def submit_flashcard_review(
         review.reviewed_at = review_request.reviewed_at or datetime.utcnow()
 
         await session.commit()
+
+        try:
+            analytics_svc = AnalyticsService(session)
+            await analytics_svc.ingest_event(
+                event_name="flashcard_reviewed",
+                properties={
+                    "card_id": str(review_request.card_id),
+                    "rating": review_request.rating,
+                },
+                user_id=uuid.UUID(str(current_user.id)),
+                session_id=None,
+            )
+        except Exception as analytics_err:
+            logger.warning("Analytics event failed (non-fatal)", error=str(analytics_err))
 
         logger.info(
             "Flashcard review processed successfully",

--- a/backend/app/api/v1/quiz.py
+++ b/backend/app/api/v1/quiz.py
@@ -30,6 +30,7 @@ from app.domain.models.content import GeneratedContent
 from app.domain.models.module import Module
 from app.domain.models.progress import UserModuleProgress
 from app.domain.models.quiz import QuizAttempt, SummativeAssessmentAttempt
+from app.domain.services.analytics_service import AnalyticsService
 from app.domain.services.platform_settings_service import SettingsCache
 from app.domain.services.progress_service import ProgressService
 from app.domain.services.quiz_service import QuizService
@@ -493,6 +494,22 @@ async def submit_quiz_attempt(
                     "Failed to update progress after quiz (non-fatal)",
                     error=str(progress_err),
                 )
+
+        try:
+            analytics_svc = AnalyticsService(session)
+            await analytics_svc.ingest_event(
+                event_name="quiz_completed",
+                properties={
+                    "module_id": str(quiz_content.module_id),
+                    "score": score,
+                    "passed": passed,
+                    "duration_seconds": request.total_time_seconds,
+                },
+                user_id=user_id,
+                session_id=None,
+            )
+        except Exception as analytics_err:
+            logger.warning("Analytics event failed (non-fatal)", error=str(analytics_err))
 
         response = QuizAttemptResponse(
             attempt_id=attempt.id,

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -27,6 +27,7 @@ from app.domain.models.course import Course, UserCourseEnrollment
 from app.domain.models.module import Module
 from app.domain.models.source_image import SourceImage
 from app.domain.models.user import User
+from app.domain.services.analytics_service import AnalyticsService
 from app.domain.services.learner_memory_service import LearnerMemoryService
 from app.domain.services.platform_settings_service import SettingsCache
 from app.domain.services.subscription_service import SubscriptionService
@@ -568,6 +569,20 @@ class TutorService:
                 session.add(subscription)
 
             await session.commit()
+
+            try:
+                analytics_svc = AnalyticsService(session)
+                await analytics_svc.ingest_event(
+                    event_name="tutor_message_sent",
+                    properties={
+                        "module_id": str(module_id) if module_id else None,
+                        "language": effective_language,
+                    },
+                    user_id=uuid.UUID(str(user_id)),
+                    session_id=None,
+                )
+            except Exception as analytics_err:
+                logger.warning("Analytics event failed (non-fatal)", error=str(analytics_err))
 
             if conversation.message_count > COMPACT_TRIGGER:
                 asyncio.ensure_future(

--- a/frontend/app/[locale]/(app)/courses/[courseSlug]/page.tsx
+++ b/frontend/app/[locale]/(app)/courses/[courseSlug]/page.tsx
@@ -17,8 +17,10 @@ import {
   ArrowLeft,
   ClipboardList,
   AlertTriangle,
+  KeyRound,
 } from "lucide-react";
 import { apiFetch, enrollInCourse } from "@/lib/api";
+import { authClient } from "@/lib/auth";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -103,6 +105,12 @@ export default function CourseDetailPage() {
   const [unenrollDialogOpen, setUnenrollDialogOpen] = useState(false);
   const [unenrolling, setUnenrolling] = useState(false);
   const [unenrollError, setUnenrollError] = useState<string | null>(null);
+  const [userRole, setUserRole] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    const user = authClient.getCurrentUser();
+    setUserRole(user?.role);
+  }, []);
 
   useEffect(() => {
     apiFetch<CourseDetail>(`/api/v1/courses/${courseSlug}`)
@@ -410,6 +418,16 @@ export default function CourseDetailPage() {
           </Button>
         )}
       </div>
+
+      {(userRole === "expert" || userRole === "admin") && (
+        <Link
+          href={`/courses/${courseSlug}/codes`}
+          className="flex items-center justify-center gap-2 w-full min-h-11 rounded-md border border-amber-200 bg-amber-50 text-amber-700 hover:bg-amber-100 text-sm font-medium transition-colors"
+        >
+          <KeyRound className="h-4 w-4" />
+          {t("manageCodes")}
+        </Link>
+      )}
 
       <AlertDialog open={unenrollDialogOpen} onOpenChange={setUnenrollDialogOpen}>
         <AlertDialogContent>

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -12,6 +12,7 @@ export interface User {
   preferred_language: string;
   country?: string;
   current_level: number;
+  role?: string;
 }
 
 export interface RegisterRequest {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1221,7 +1221,8 @@
     "allAudiences": "All audiences",
     "clearFilters": "Clear filters",
     "activeFilters": "{count, plural, one {# active filter} other {# active filters}}",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "manageCodes": "Manage Activation Codes"
   },
   "AdminCourses": {
     "pageTitle": "Course Management",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1221,7 +1221,8 @@
     "allAudiences": "Tous les publics",
     "clearFilters": "Effacer les filtres",
     "activeFilters": "{count, plural, one {# filtre actif} other {# filtres actifs}}",
-    "cancel": "Annuler"
+    "cancel": "Annuler",
+    "manageCodes": "Gérer les codes d'activation"
   },
   "AdminCourses": {
     "pageTitle": "Gestion des formations",


### PR DESCRIPTION
## Summary

- feat: Add "Manage Activation Codes" link on course detail page for experts/admins (#1297, #1298)
- fix: Server-side analytics event tracking (#1296)

🤖 Generated with [Claude Code](https://claude.com/claude-code)