### PR TITLE
merge dev to main: kids-adaptive prompt system (content + syllabus)

### DIFF
--- a/backend/app/ai/prompts/audience.py
+++ b/backend/app/ai/prompts/audience.py
@@ -187,6 +187,54 @@ _GUIDANCE_EN: dict[str, str] = {
 }
 
 
+def detect_audience_from_slugs(
+    audience_type: list[str] | None,
+    title_en: str | None = None,
+    title_fr: str | None = None,
+) -> AudienceContext:
+    """Detect kids audience from raw slug list and optional title strings.
+
+    Lightweight variant of detect_audience() for callers that don't have a
+    Course ORM object (e.g. CourseAgentService._build_prompt).
+
+    Args:
+        audience_type: List of taxonomy slugs (e.g. ["primary_school", "mathematics"]).
+        title_en: Optional English course title for age-range extraction.
+        title_fr: Optional French course title for age-range extraction.
+
+    Returns:
+        AudienceContext with is_kids=False when audience_type is None/empty or adult.
+    """
+    if not audience_type:
+        return AudienceContext(is_kids=False)
+
+    kids_slugs = [s for s in audience_type if s in KIDS_AUDIENCE_SLUGS]
+    if not kids_slugs:
+        return AudienceContext(is_kids=False)
+
+    age_range: tuple[int, int] | None = None
+    for title in (title_en, title_fr):
+        if not title:
+            continue
+        for pattern in (_AGE_PATTERN_EN, _AGE_PATTERN_FR):
+            m = pattern.search(title)
+            if m:
+                age_range = (int(m.group(1)), int(m.group(2)))
+                break
+        if age_range:
+            break
+
+    if age_range is None:
+        age_range = _age_from_slugs(kids_slugs)
+
+    return AudienceContext(
+        is_kids=True,
+        age_min=age_range[0],
+        age_max=age_range[1],
+        audience_slugs=kids_slugs,
+    )
+
+
 def get_audience_guidance(audience: AudienceContext, language: str) -> str:
     """Return age-tier-specific pedagogical instructions for prompt injection.
 

--- a/backend/app/domain/services/course_agent_service.py
+++ b/backend/app/domain/services/course_agent_service.py
@@ -58,13 +58,19 @@ def _try_parse_modules(raw: str) -> list[dict] | None:
 class CourseAgentService:
     """Generates course structure using Claude API, with graceful fallback."""
 
-    def _get_admin_prompt(self, **template_vars: str) -> str | None:
+    def _get_admin_prompt(
+        self,
+        audience_type: list[str] | None = None,
+        **template_vars: str,
+    ) -> str | None:
         """Check if admin has customized the syllabus prompt via platform settings."""
         try:
+            from app.ai.prompts.audience import KIDS_AUDIENCE_SLUGS
             from app.domain.services.platform_settings_service import SettingsCache
             from app.infrastructure.config.platform_defaults import DEFAULTS_BY_KEY
 
-            key = "ai-prompt-syllabus-system"
+            is_kids = bool(audience_type and any(s in KIDS_AUDIENCE_SLUGS for s in audience_type))
+            key = "ai-prompt-syllabus-kids-system" if is_kids else "ai-prompt-syllabus-system"
             defn = DEFAULTS_BY_KEY.get(key)
             if defn is None:
                 return None
@@ -90,14 +96,30 @@ class CourseAgentService:
         resource_block: str,
         description_fr: str | None = None,
         description_en: str | None = None,
+        audience_type: list[str] | None = None,
     ) -> str:
         """Build the syllabus generation prompt, using admin override if available."""
+        from app.ai.prompts.audience import (
+            detect_audience_from_slugs,
+            get_audience_guidance,
+        )
+
+        audience_ctx = detect_audience_from_slugs(audience_type, title_en, title_fr)
+
+        age_range = f"{audience_ctx.age_min}-{audience_ctx.age_max}" if audience_ctx.is_kids else ""
+        audience_guidance = (
+            get_audience_guidance(audience_ctx, "en") if audience_ctx.is_kids else ""
+        )
+
         admin = self._get_admin_prompt(
+            audience_type=audience_type,
             course_title=f"{title_fr} / {title_en}",
             course_domain=domains_str,
             level=levels_str,
             estimated_hours=str(estimated_hours),
             resource_text=resource_block,
+            age_range=age_range,
+            audience_guidance=audience_guidance,
         )
         if admin:
             return admin
@@ -109,6 +131,20 @@ class CourseAgentService:
                 description_block += f"- Description (FR): {description_fr}\n"
             if description_en:
                 description_block += f"- Description (EN): {description_en}\n"
+
+        if audience_ctx.is_kids:
+            return self._build_kids_prompt(
+                title_fr=title_fr,
+                title_en=title_en,
+                description_block=description_block,
+                domains_str=domains_str,
+                levels_str=levels_str,
+                audience_str=audience_str,
+                estimated_hours=estimated_hours,
+                resource_block=resource_block,
+                age_range=age_range,
+                audience_guidance=audience_guidance,
+            )
 
         return (
             "You are an expert instructional designer specializing in "
@@ -173,6 +209,87 @@ class CourseAgentService:
             "no explanation."
         )
 
+    def _build_kids_prompt(
+        self,
+        title_fr: str,
+        title_en: str,
+        description_block: str,
+        domains_str: str,
+        levels_str: str,
+        audience_str: str,
+        estimated_hours: int,
+        resource_block: str,
+        age_range: str,
+        audience_guidance: str,
+    ) -> str:
+        """Build kids-adapted syllabus prompt with child-centered pedagogy."""
+        return (
+            "You are a warm, encouraging instructional designer who creates "
+            "bilingual (FR/EN) course syllabi for young learners aged "
+            f"{age_range} in West Africa. You apply child-centered pedagogy, "
+            "Piaget's developmental stages, and play-based learning.\n\n"
+            f"{audience_guidance}\n\n"
+            f"Create a complete course syllabus for:\n"
+            f"- Title FR: {title_fr}\n"
+            f"- Title EN: {title_en}\n"
+            f"{description_block}"
+            f"- Domain(s): {domains_str}\n"
+            f"- Level(s): {levels_str}\n"
+            f"- Target audience: {audience_str} (ages {age_range})\n"
+            f"- Estimated total hours: {estimated_hours}\n\n"
+            f"{resource_block}\n\n"
+            "## Design principles (mandatory)\n"
+            "- Progressive complexity: start with discovery (remember/understand), "
+            "build to exploration (apply), and for older children (ages 13+) "
+            "reach basic analysis (analyze/evaluate)\n"
+            "- Bloom level cap: primary school → apply; secondary school → evaluate\n"
+            "- Each module must be self-contained (5-15h) with child-friendly "
+            "learning objectives\n"
+            "- Units are short learning sessions (5-10 min for ages 5-8, "
+            "10-15 min for ages 9-15), 3-6 units per module\n"
+            "- Every module includes: lessons, a formative quiz per lesson "
+            "(10 questions, 60% pass — fun and encouraging), flashcards "
+            "(10-20 bilingual cards with simple concrete definitions), and "
+            "a story-based scenario from daily life in West Africa relatable "
+            "to children\n"
+            "- Module titles must be playful and adventure-themed to excite children\n"
+            "- Learning objectives must use child-friendly verbs: "
+            "discover, explore, create, play, build, find, learn, share\n"
+            "- Bilingual: all text in both FR and EN\n\n"
+            "## Output format\n"
+            "Return a JSON array of modules. Each module must have:\n"
+            "{\n"
+            '  "module_number": int,\n'
+            '  "title_fr": str, "title_en": str,\n'
+            '  "description_fr": str, "description_en": str,\n'
+            '  "estimated_hours": int,\n'
+            '  "bloom_level": "remember"|"understand"|"apply"|'
+            '"analyze"|"evaluate"|"create",\n'
+            '  "learning_objectives_fr": [str], '
+            '"learning_objectives_en": [str],\n'
+            '  "units": [\n'
+            '    {"title_fr": str, "title_en": str, '
+            '"type": "lesson"|"quiz"|"case-study",\n'
+            '     "description_fr": str, "description_en": str}\n'
+            "  ],\n"
+            '  "quiz_topics_fr": [str], '
+            '"quiz_topics_en": [str],\n'
+            '  "flashcard_categories_fr": [str], '
+            '"flashcard_categories_en": [str],\n'
+            '  "case_study_fr": str, "case_study_en": str\n'
+            "}\n\n"
+            "## Conciseness rules (CRITICAL — this is a syllabus, not the course itself)\n"
+            "- description_fr/en: max 2 short sentences (~20 words each)\n"
+            "- learning_objectives: max 3-4 bullet points per module, each ≤12 words\n"
+            "- unit description_fr/en: max 1 sentence (~15 words)\n"
+            "- quiz_topics: max 5 short topic names per module\n"
+            "- flashcard_categories: max 5 short category names per module\n"
+            "- case_study_fr/en: max 2 sentences (~30 words) — a story prompt, not the full case\n"
+            "- Keep total response under 20,000 words\n\n"
+            "- NEVER truncate text with '...' or ellipsis — write complete short text instead\n\n"
+            "Return ONLY valid JSON, no markdown fences, no explanation."
+        )
+
     async def generate_course_structure(
         self,
         title_fr: str,
@@ -233,6 +350,7 @@ class CourseAgentService:
                 resource_block,
                 description_fr=course_description_fr,
                 description_en=course_description_en,
+                audience_type=audience_type,
             )
 
             _model = "claude-sonnet-4-6"
@@ -257,6 +375,7 @@ class CourseAgentService:
                     resource_block,
                     description_fr=course_description_fr,
                     description_en=course_description_en,
+                    audience_type=audience_type,
                 )
 
             # Use streaming to avoid timeout with large max_tokens

--- a/backend/app/infrastructure/config/platform_defaults.py
+++ b/backend/app/infrastructure/config/platform_defaults.py
@@ -1318,6 +1318,64 @@ SETTING_DEFINITIONS: list[SettingDef] = [
             " {estimated_hours}, {resource_text}"
         ),
     ),
+    SettingDef(
+        "ai-prompt-syllabus-kids-system",
+        "ai_prompts",
+        (
+            "You are a warm, encouraging instructional designer who creates"
+            " bilingual (FR/EN) course syllabi for young learners aged {age_range}"
+            " in West Africa. You apply child-centered pedagogy, Piaget's"
+            " developmental stages, and play-based learning principles.\n\n"
+            "Create a complete course syllabus for:\n"
+            "- Title: {course_title}\n"
+            "- Domain(s): {course_domain}\n"
+            "- Level(s): {level}\n"
+            "- Estimated total hours: {estimated_hours}\n"
+            "- Age range: {age_range}\n\n"
+            "{audience_guidance}\n\n"
+            "{resource_text}\n\n"
+            "## Design principles (mandatory)\n"
+            "- Progressive complexity: start with discovery (remember/understand),"
+            " build to exploration (apply), and for older children (ages 13+)"
+            " reach basic analysis (analyze/evaluate)\n"
+            "- Bloom level cap: primary school → apply; secondary school → evaluate\n"
+            "- Each module must be self-contained (5-15h) with child-friendly"
+            " learning objectives\n"
+            "- Units are short learning sessions (5-10 min for ages 5-8,"
+            " 10-15 min for ages 9-15), 3-6 units per module\n"
+            "- Every module includes: lessons, a formative quiz per lesson"
+            " (10 questions, 60% pass — fun and encouraging), flashcards"
+            " (10-20 bilingual cards with simple concrete definitions), and"
+            " a story-based scenario from daily life in West Africa relatable"
+            " to children\n"
+            "- Module titles must be playful and adventure-themed to excite children\n"
+            "- Learning objectives must use child-friendly verbs:"
+            " discover, explore, create, play, build, find, learn, share\n"
+            "- Bilingual: all text in both FR and EN\n\n"
+            "## Output format\n"
+            "Return a JSON array of modules. Each module must have:\n"
+            "{\n"
+            '  "module_number": int,\n'
+            '  "title_fr": str, "title_en": str,\n'
+            '  "description_fr": str, "description_en": str,\n'
+            '  "estimated_hours": int,\n'
+            '  "bloom_level": "remember"|"understand"|"apply"|"analyze"|"evaluate"|"create",\n'
+            '  "learning_objectives_fr": [str], "learning_objectives_en": [str],\n'
+            '  "units": [{"title_fr": str, "title_en": str, "type": "lesson"|"quiz"|"case-study",\n'
+            '             "description_fr": str, "description_en": str}],\n'
+            '  "quiz_topics_fr": [str], "quiz_topics_en": [str],\n'
+            '  "flashcard_categories_fr": [str], "flashcard_categories_en": [str],\n'
+            '  "case_study_fr": str, "case_study_en": str\n'
+            "}\n\n"
+            "Return ONLY valid JSON, no markdown fences, no explanation."
+        ),
+        "string",
+        "System prompt — syllabus generation (kids)",
+        (
+            "Template vars: {course_title}, {course_domain}, {level},"
+            " {estimated_hours}, {resource_text}, {age_range}, {audience_guidance}"
+        ),
+    ),
     # ── Syllabus & Ingestion ───────────────────────────────
     SettingDef(
         "upload-max-pdf-chars",

--- a/backend/tests/test_audience_detection.py
+++ b/backend/tests/test_audience_detection.py
@@ -6,6 +6,7 @@ from app.ai.prompts.audience import (
     KIDS_AUDIENCE_SLUGS,
     AudienceContext,
     detect_audience,
+    detect_audience_from_slugs,
     get_audience_guidance,
 )
 
@@ -212,3 +213,203 @@ class TestGetAudienceGuidance:
         ctx = AudienceContext(is_kids=True, age_min=6, age_max=15)
         guidance_fr = get_audience_guidance(ctx, "fr")
         assert "13-15 ans" in guidance_fr
+
+
+class TestDetectAudienceFromSlugs:
+    def test_none_returns_adult(self):
+        result = detect_audience_from_slugs(None)
+        assert result.is_kids is False
+
+    def test_empty_list_returns_adult(self):
+        result = detect_audience_from_slugs([])
+        assert result.is_kids is False
+
+    def test_adult_slugs_returns_adult(self):
+        result = detect_audience_from_slugs(["professionals", "public_health"])
+        assert result.is_kids is False
+
+    def test_primary_school_slug_returns_kids(self):
+        result = detect_audience_from_slugs(["primary_school"])
+        assert result.is_kids is True
+        assert "primary_school" in result.audience_slugs
+
+    def test_kindergarten_slug_returns_kids(self):
+        result = detect_audience_from_slugs(["kindergarten"])
+        assert result.is_kids is True
+        assert result.age_min == 3
+        assert result.age_max == 6
+
+    def test_secondary_school_slug_returns_kids(self):
+        result = detect_audience_from_slugs(["secondary_school"])
+        assert result.is_kids is True
+
+    def test_mixed_slugs_with_kids(self):
+        result = detect_audience_from_slugs(["primary_school", "mathematics"])
+        assert result.is_kids is True
+
+    def test_age_extracted_from_title_en(self):
+        result = detect_audience_from_slugs(
+            ["primary_school"],
+            title_en="Village Math Mastery (Ages 6-12)",
+        )
+        assert result.is_kids is True
+        assert result.age_min == 6
+        assert result.age_max == 12
+
+    def test_age_extracted_from_title_fr(self):
+        result = detect_audience_from_slugs(
+            ["primary_school"],
+            title_fr="Maîtriser les marchés (6 à 12 ans)",
+        )
+        assert result.is_kids is True
+        assert result.age_min == 6
+        assert result.age_max == 12
+
+    def test_title_en_preferred_over_title_fr(self):
+        result = detect_audience_from_slugs(
+            ["primary_school"],
+            title_en="Math Mastery (Ages 7-11)",
+            title_fr="Maîtrise des maths (3-6 ans)",
+        )
+        assert result.age_min == 7
+        assert result.age_max == 11
+
+    def test_slug_fallback_when_no_title_age(self):
+        result = detect_audience_from_slugs(
+            ["primary_school"],
+            title_en="Math Mastery",
+        )
+        assert result.age_min == 6
+        assert result.age_max == 12
+
+
+class TestSyllabusPromptRouting:
+    def test_adult_prompt_does_not_use_andragogy_override(self):
+        from app.domain.services.course_agent_service import CourseAgentService
+
+        svc = CourseAgentService()
+        prompt = svc._build_prompt(
+            title_fr="Épidémiologie",
+            title_en="Epidemiology",
+            domains_str="Public Health",
+            levels_str="intermediate",
+            audience_str="Professionals",
+            estimated_hours=40,
+            resource_block="",
+            audience_type=["professionals"],
+        )
+        assert "andragogy" in prompt
+        assert "Piaget" not in prompt
+        assert "play-based" not in prompt
+
+    def test_kids_prompt_uses_child_pedagogy(self):
+        from app.domain.services.course_agent_service import CourseAgentService
+
+        svc = CourseAgentService()
+        prompt = svc._build_prompt(
+            title_fr="Maths au Village (6-12 ans)",
+            title_en="Village Math (Ages 6-12)",
+            domains_str="Mathematics",
+            levels_str="beginner",
+            audience_str="primary_school",
+            estimated_hours=20,
+            resource_block="",
+            audience_type=["primary_school"],
+        )
+        assert "andragogy" not in prompt
+        assert "Piaget" in prompt
+        assert "play-based" in prompt
+        assert "60% pass" in prompt
+        assert "10-20 bilingual cards" in prompt
+
+    def test_no_audience_type_produces_adult_prompt(self):
+        from app.domain.services.course_agent_service import CourseAgentService
+
+        svc = CourseAgentService()
+        prompt = svc._build_prompt(
+            title_fr="Santé publique",
+            title_en="Public Health",
+            domains_str="Health",
+            levels_str="all",
+            audience_str="General",
+            estimated_hours=30,
+            resource_block="",
+            audience_type=None,
+        )
+        assert "andragogy" in prompt
+
+    def test_get_admin_prompt_selects_kids_key_for_kids_audience(self):
+        from unittest.mock import MagicMock, patch
+
+        from app.domain.services.course_agent_service import CourseAgentService
+
+        svc = CourseAgentService()
+        mock_defn = MagicMock()
+        mock_defn.default = "default_value"
+
+        with (
+            patch(
+                "app.domain.services.course_agent_service.CourseAgentService._get_admin_prompt",
+                wraps=svc._get_admin_prompt,
+            ),
+            patch("app.domain.services.platform_settings_service.SettingsCache") as mock_cache_cls,
+            patch(
+                "app.infrastructure.config.platform_defaults.DEFAULTS_BY_KEY",
+                {
+                    "ai-prompt-syllabus-kids-system": mock_defn,
+                    "ai-prompt-syllabus-system": mock_defn,
+                },
+            ),
+        ):
+            mock_cache = MagicMock()
+            mock_cache.get.return_value = "customized kids prompt for {age_range}"
+            mock_cache_cls.instance.return_value = mock_cache
+
+            result = svc._get_admin_prompt(
+                audience_type=["primary_school"],
+                course_title="Test",
+                course_domain="Math",
+                level="beginner",
+                estimated_hours="20",
+                resource_text="",
+                age_range="6-12",
+                audience_guidance="",
+            )
+            mock_cache.get.assert_called_once_with("ai-prompt-syllabus-kids-system")
+            assert result == "customized kids prompt for 6-12"
+
+    def test_get_admin_prompt_selects_adult_key_for_adult_audience(self):
+        from unittest.mock import MagicMock, patch
+
+        from app.domain.services.course_agent_service import CourseAgentService
+
+        svc = CourseAgentService()
+        mock_defn = MagicMock()
+        mock_defn.default = "default_value"
+
+        with (
+            patch("app.domain.services.platform_settings_service.SettingsCache") as mock_cache_cls,
+            patch(
+                "app.infrastructure.config.platform_defaults.DEFAULTS_BY_KEY",
+                {
+                    "ai-prompt-syllabus-kids-system": mock_defn,
+                    "ai-prompt-syllabus-system": mock_defn,
+                },
+            ),
+        ):
+            mock_cache = MagicMock()
+            mock_cache.get.return_value = "customized adult prompt"
+            mock_cache_cls.instance.return_value = mock_cache
+
+            result = svc._get_admin_prompt(
+                audience_type=["professionals"],
+                course_title="Test",
+                course_domain="Health",
+                level="advanced",
+                estimated_hours="40",
+                resource_text="",
+                age_range="",
+                audience_guidance="",
+            )
+            mock_cache.get.assert_called_once_with("ai-prompt-syllabus-system")
+            assert result == "customized adult prompt"


### PR DESCRIPTION
## Summary
- feat(ai): kids-adaptive prompt system for content generation (#1306)
- feat(ai): kids-adaptive syllabus generation prompt routing (#1311)
- fix(auth): include user role in login responses (#1305)

## What changed
- Audience detection via taxonomy_categories (kindergarten, primary_school, secondary_school)
- Age range parsing from course titles
- Kids-specific prompt templates for: lessons, quizzes, flashcards, case studies, preassessments, syllabus
- Same JSON output format — zero schema changes
- Zero impact on adult courses

## Test plan
- [x] All backend tests pass (666+ tests)
- [x] Frontend CI passes
- [x] Security checks pass
- [ ] Clear kids course caches and verify regenerated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)