### PR TITLE
feat(ai): adapt quiz user message and media prompt for kids courses + multi-domain

### DIFF
--- a/backend/app/domain/services/media_summary_service.py
+++ b/backend/app/domain/services/media_summary_service.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.ai.claude_service import ClaudeService
+from app.ai.prompts.audience import detect_audience
 from app.ai.rag.embeddings import EmbeddingService
 from app.ai.rag.retriever import SemanticRetriever
 from app.domain.models.module import Module
@@ -21,21 +22,54 @@ from app.infrastructure.storage.s3 import S3StorageService
 
 logger = structlog.get_logger(__name__)
 
-AUDIO_SUMMARY_SYSTEM_PROMPT = """You are an expert in public health for West Africa (ECOWAS region).
+
+def _build_audio_system_prompt(
+    language: str,
+    course_title: str | None = None,
+    is_kids: bool = False,
+    age_range: str = "",
+) -> str:
+    """Build a context-aware audio summary system prompt.
+
+    Args:
+        language: Content language code ("fr" or "en").
+        course_title: Optional course title used as domain descriptor.
+        is_kids: Whether the course targets children.
+        age_range: Age range string (e.g. "6-12") used when is_kids=True.
+
+    Returns:
+        Formatted system prompt string for Claude.
+    """
+    domain = course_title or "public health"
+    if is_kids:
+        audience = f"young learners aged {age_range}"
+        style = f"clear, engaging, and fun narration suitable for children aged {age_range}"
+        west_africa_note = (
+            "Reference concrete examples from West Africa that children can relate to"
+        )
+    else:
+        audience = f"professionals in {domain}"
+        style = f"clear, engaging narration suitable for {audience}"
+        west_africa_note = (
+            "Reference concrete examples from West African health systems where possible"
+        )
+
+    return f"""You are an expert educator in {domain} for West Africa (ECOWAS region).
 Your task is to write a spoken audio summary script for a learning module.
 
 Guidelines:
 - Write in {language} (French or English as specified)
 - Length: approximately 2000 words — about 10-12 minutes of spoken audio
-- Style: clear, engaging narration suitable for public health professionals
+- Style: {style}
 - Structure: brief introduction → core concepts → real West African examples → key takeaways
 - Use simple language accessible on 2G/3G with limited bandwidth
-- Reference concrete examples from West African health systems where possible
+- {west_africa_note}
 - DO NOT include headers, bullet points, or markdown — write plain spoken prose
 - DO NOT include source citations in the script itself (they are tracked separately)
 - End with 3-5 key takeaways the listener should remember
 
 Output only the script text, nothing else."""
+
 
 AUDIO_SUMMARY_USER_TEMPLATE = """Module: {module_title}
 Language: {language}
@@ -138,12 +172,24 @@ class MediaSummaryService:
                 session=session,
             )
 
+            course = module.course
+            audience_ctx = detect_audience(course)
+            course_title = None
+            if course is not None:
+                course_title = course.title_fr if language == "fr" else course.title_en
+            age_range = (
+                f"{audience_ctx.age_min}-{audience_ctx.age_max}" if audience_ctx.is_kids else ""
+            )
+
             script = await self._generate_script(
                 module_title=module_title or f"Module {module.module_number}",
                 language=language,
                 level=module.level,
                 unit_titles=unit_titles,
                 rag_chunks=rag_chunks,
+                course_title=course_title,
+                is_kids=audience_ctx.is_kids,
+                age_range=age_range,
             )
 
             audio_bytes = await self._call_gemini_tts(script, language)
@@ -289,9 +335,17 @@ class MediaSummaryService:
         level: int,
         unit_titles: list[str],
         rag_chunks: list,
+        course_title: str | None = None,
+        is_kids: bool = False,
+        age_range: str = "",
     ) -> str:
         """Call Claude to generate a ~2000-word spoken summary script."""
-        system_prompt = AUDIO_SUMMARY_SYSTEM_PROMPT.format(language=language)
+        system_prompt = _build_audio_system_prompt(
+            language=language,
+            course_title=course_title,
+            is_kids=is_kids,
+            age_range=age_range,
+        )
         unit_list = "\n".join(f"- {t}" for t in unit_titles) if unit_titles else "- (no units)"
         rag_context = _format_rag_context(rag_chunks)
 

--- a/backend/app/domain/services/quiz_service.py
+++ b/backend/app/domain/services/quiz_service.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.ai.claude_service import ClaudeService
+from app.ai.prompts.audience import detect_audience
 from app.ai.prompts.quiz import get_quiz_system_prompt
 from app.ai.rag.retriever import SemanticRetriever
 from app.api.v1.schemas.quiz import QuizContent, QuizResponse
@@ -430,26 +431,42 @@ class QuizService:
             course=course,
         )
 
-        audience = (
-            f"professionals in {domain} in {country}"
-            if course_title
-            else f"public health professionals in {country}"
-        )
-        context_note = (
-            f"Use examples relevant to {country} and West African context when possible, adapted to {domain}"
-            if course_title
-            else f"Use examples relevant to {country} and West African context when possible"
-        )
-        practical_note = (
-            f"Focus on practical applications for {domain} work"
-            if course_title
-            else "Focus on practical applications for public health work"
-        )
-        closing_note = (
-            f"Generate the quiz now, ensuring all questions are relevant to {domain} practice in West Africa."
-            if course_title
-            else "Generate the quiz now, ensuring all questions are relevant to public health practice in West Africa."
-        )
+        audience_ctx = detect_audience(course)
+        if audience_ctx.is_kids:
+            age_range = f"{audience_ctx.age_min}-{audience_ctx.age_max}"
+            audience = f"young learners aged {age_range} in {country}"
+            context_note = (
+                f"Use examples from daily life in {country} that children aged {age_range} can relate to "
+                f"(school, market, family, games)"
+            )
+            practical_note = (
+                f"Focus on fun, engaging questions that make {domain} exciting for children"
+            )
+            closing_note = (
+                f"Generate the quiz now. Make it fun and encouraging for children aged {age_range} "
+                f"learning {domain} in West Africa."
+            )
+        else:
+            audience = (
+                f"professionals in {domain} in {country}"
+                if course_title
+                else f"public health professionals in {country}"
+            )
+            context_note = (
+                f"Use examples relevant to {country} and West African context when possible, adapted to {domain}"
+                if course_title
+                else f"Use examples relevant to {country} and West African context when possible"
+            )
+            practical_note = (
+                f"Focus on practical applications for {domain} work"
+                if course_title
+                else "Focus on practical applications for public health work"
+            )
+            closing_note = (
+                f"Generate the quiz now, ensuring all questions are relevant to {domain} practice in West Africa."
+                if course_title
+                else "Generate the quiz now, ensuring all questions are relevant to public health practice in West Africa."
+            )
 
         if unit_title is not None:
             topic_constraint = (

--- a/backend/tests/test_media_summary_service.py
+++ b/backend/tests/test_media_summary_service.py
@@ -1,0 +1,166 @@
+"""Unit tests for media_summary_service — _build_audio_system_prompt and _generate_script."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.domain.services.media_summary_service import (
+    MediaSummaryService,
+    _build_audio_system_prompt,
+)
+
+
+class TestBuildAudioSystemPrompt:
+    def test_no_params_produces_generic_adult_prompt(self):
+        prompt = _build_audio_system_prompt(language="en")
+        assert "public health" in prompt
+        assert "professionals in public health" in prompt
+        assert "young learners" not in prompt
+
+    def test_adult_math_course_says_mathematics_not_public_health(self):
+        prompt = _build_audio_system_prompt(language="en", course_title="Mathematics")
+        assert "Mathematics" in prompt
+        assert "public health" not in prompt
+
+    def test_adult_it_course_says_it(self):
+        prompt = _build_audio_system_prompt(language="en", course_title="Information Technology")
+        assert "Information Technology" in prompt
+        assert "public health" not in prompt
+
+    def test_kids_prompt_uses_age_appropriate_style(self):
+        prompt = _build_audio_system_prompt(
+            language="en",
+            course_title="Village Math",
+            is_kids=True,
+            age_range="6-12",
+        )
+        assert "children aged 6-12" in prompt
+        assert "fun" in prompt
+        assert "professionals" not in prompt
+
+    def test_kids_prompt_includes_children_relate_examples(self):
+        prompt = _build_audio_system_prompt(
+            language="en",
+            course_title="Primary Science",
+            is_kids=True,
+            age_range="6-12",
+        )
+        assert "children can relate to" in prompt
+
+    def test_adult_prompt_mentions_health_systems(self):
+        prompt = _build_audio_system_prompt(language="en")
+        assert "health systems" in prompt
+
+    def test_kids_prompt_does_not_mention_health_systems(self):
+        prompt = _build_audio_system_prompt(
+            language="en",
+            course_title="Village Math",
+            is_kids=True,
+            age_range="6-12",
+        )
+        assert "health systems" not in prompt
+
+    def test_language_appears_in_prompt(self):
+        prompt_fr = _build_audio_system_prompt(language="fr")
+        assert "fr" in prompt_fr
+
+        prompt_en = _build_audio_system_prompt(language="en")
+        assert "en" in prompt_en
+
+    def test_output_format_instructions_always_present(self):
+        for is_kids in [True, False]:
+            prompt = _build_audio_system_prompt(
+                language="en",
+                course_title="Test Course",
+                is_kids=is_kids,
+                age_range="6-12" if is_kids else "",
+            )
+            assert "Output only the script text" in prompt
+            assert "DO NOT include headers" in prompt
+            assert "key takeaways" in prompt
+
+    def test_adult_no_course_title_falls_back_to_public_health(self):
+        prompt = _build_audio_system_prompt(language="fr", course_title=None, is_kids=False)
+        assert "public health" in prompt
+
+
+class TestGenerateScriptUsesAudiencePrompt:
+    @pytest.fixture
+    def mock_claude(self):
+        service = AsyncMock()
+        response = MagicMock()
+        block = MagicMock()
+        block.text = "This is the audio script content."
+        response.content = [block]
+        service.generate_lesson_content = AsyncMock(return_value=response)
+        return service
+
+    @pytest.fixture
+    def media_service(self, mock_claude):
+        return MediaSummaryService(claude_service=mock_claude)
+
+    async def test_generate_script_adult_course_passes_course_title(
+        self, media_service, mock_claude
+    ):
+        await media_service._generate_script(
+            module_title="Module 1",
+            language="en",
+            level=2,
+            unit_titles=["Unit A"],
+            rag_chunks=[],
+            course_title="Tax Policy",
+            is_kids=False,
+            age_range="",
+        )
+        call_args = mock_claude.generate_lesson_content.call_args
+        system_prompt = call_args.kwargs["system_prompt"]
+        assert "Tax Policy" in system_prompt
+        assert "public health" not in system_prompt
+
+    async def test_generate_script_kids_course_uses_kids_prompt(self, media_service, mock_claude):
+        await media_service._generate_script(
+            module_title="Village Math Module 1",
+            language="en",
+            level=1,
+            unit_titles=["Numbers"],
+            rag_chunks=[],
+            course_title="Village Math",
+            is_kids=True,
+            age_range="6-12",
+        )
+        call_args = mock_claude.generate_lesson_content.call_args
+        system_prompt = call_args.kwargs["system_prompt"]
+        assert "children aged 6-12" in system_prompt
+        assert "professionals" not in system_prompt
+
+    async def test_generate_script_no_course_falls_back_to_generic(
+        self, media_service, mock_claude
+    ):
+        await media_service._generate_script(
+            module_title="Module 1",
+            language="en",
+            level=1,
+            unit_titles=[],
+            rag_chunks=[],
+        )
+        call_args = mock_claude.generate_lesson_content.call_args
+        system_prompt = call_args.kwargs["system_prompt"]
+        assert "public health" in system_prompt
+        assert "young learners" not in system_prompt
+
+    async def test_generate_script_raises_on_empty_response(self, mock_claude):
+        response = MagicMock()
+        block = MagicMock()
+        block.text = "   "
+        response.content = [block]
+        mock_claude.generate_lesson_content = AsyncMock(return_value=response)
+        service = MediaSummaryService(claude_service=mock_claude)
+
+        with pytest.raises(ValueError, match="empty script"):
+            await service._generate_script(
+                module_title="Module 1",
+                language="fr",
+                level=1,
+                unit_titles=[],
+                rag_chunks=[],
+            )

--- a/backend/tests/test_quiz_service.py
+++ b/backend/tests/test_quiz_service.py
@@ -416,6 +416,129 @@ class TestBuildQuizPrompt:
         assert "M01-U01" not in user_message
 
 
+class TestBuildQuizPromptKidsAware:
+    def _make_kids_course(self, age_min: int = 6, age_max: int = 12) -> MagicMock:
+        tc = MagicMock()
+        tc.slug = "primary_school"
+        tc.type = "audience"
+        course = MagicMock()
+        course.taxonomy_categories = [tc]
+        course.title_en = f"Village Math (Ages {age_min}-{age_max})"
+        course.title_fr = f"Maths au Village ({age_min}-{age_max} ans)"
+        return course
+
+    def _make_adult_course(self) -> MagicMock:
+        tc = MagicMock()
+        tc.slug = "professionals"
+        tc.type = "audience"
+        course = MagicMock()
+        course.taxonomy_categories = [tc]
+        course.title_en = "Internal Audit"
+        course.title_fr = "Audit Interne"
+        return course
+
+    def test_kids_course_user_message_says_young_learners(self, quiz_service):
+        kids_course = self._make_kids_course()
+        _system, user_message = quiz_service._build_quiz_prompt(
+            context="context",
+            unit_id="M01-U01",
+            language="en",
+            country="senegal",
+            level=1,
+            num_questions=5,
+            course_title="Village Math (Ages 6-12)",
+            course=kids_course,
+        )
+        assert "young learners" in user_message
+        assert "professionals" not in user_message
+
+    def test_kids_course_user_message_includes_age_range(self, quiz_service):
+        kids_course = self._make_kids_course(age_min=6, age_max=12)
+        _system, user_message = quiz_service._build_quiz_prompt(
+            context="context",
+            unit_id="M01-U01",
+            language="en",
+            country="senegal",
+            level=1,
+            num_questions=5,
+            course_title="Village Math (Ages 6-12)",
+            course=kids_course,
+        )
+        assert "6-12" in user_message
+
+    def test_kids_course_closing_note_is_fun_and_encouraging(self, quiz_service):
+        kids_course = self._make_kids_course()
+        _system, user_message = quiz_service._build_quiz_prompt(
+            context="context",
+            unit_id="M01-U01",
+            language="en",
+            country="senegal",
+            level=1,
+            num_questions=5,
+            course_title="Village Math (Ages 6-12)",
+            course=kids_course,
+        )
+        assert "fun" in user_message.lower()
+        assert "encouraging" in user_message.lower()
+
+    def test_adult_course_user_message_says_professionals(self, quiz_service):
+        adult_course = self._make_adult_course()
+        _system, user_message = quiz_service._build_quiz_prompt(
+            context="context",
+            unit_id="M01-U01",
+            language="en",
+            country="ghana",
+            level=2,
+            num_questions=5,
+            course_title="Internal Audit",
+            course=adult_course,
+        )
+        assert "professionals" in user_message
+        assert "young learners" not in user_message
+
+    def test_no_course_produces_adult_public_health_message(self, quiz_service):
+        _system, user_message = quiz_service._build_quiz_prompt(
+            context="context",
+            unit_id="M01-U01",
+            language="en",
+            country="nigeria",
+            level=1,
+            num_questions=5,
+            course=None,
+        )
+        assert "public health professionals" in user_message
+        assert "young learners" not in user_message
+
+    def test_kids_context_note_mentions_daily_life(self, quiz_service):
+        kids_course = self._make_kids_course()
+        _system, user_message = quiz_service._build_quiz_prompt(
+            context="context",
+            unit_id="M01-U01",
+            language="en",
+            country="senegal",
+            level=1,
+            num_questions=5,
+            course_title="Village Math (Ages 6-12)",
+            course=kids_course,
+        )
+        assert "daily life" in user_message.lower()
+
+    def test_kids_practical_note_mentions_exciting_and_fun(self, quiz_service):
+        kids_course = self._make_kids_course()
+        _system, user_message = quiz_service._build_quiz_prompt(
+            context="context",
+            unit_id="M01-U01",
+            language="en",
+            country="senegal",
+            level=1,
+            num_questions=5,
+            course_title="Village Math (Ages 6-12)",
+            course=kids_course,
+        )
+        assert "fun" in user_message.lower()
+        assert "exciting" in user_message.lower()
+
+
 class TestBuildQuizSearchQuery:
     def test_returns_unit_id_when_module_is_none(self, quiz_service):
         result = quiz_service._build_quiz_search_query(None, "M01-U04", "fr")


### PR DESCRIPTION
## Summary

- **Part A** — `quiz_service.py`: `_build_quiz_prompt()` now calls `detect_audience(course)` before assembling the user message. Kids courses get "young learners aged X-Y" audience, fun context/practical/closing notes. Adult path is fully unchanged.
- **Part B** — `media_summary_service.py`: replaced the hardcoded `AUDIO_SUMMARY_SYSTEM_PROMPT` constant (which said "public health professionals") with a `_build_audio_system_prompt()` function that uses `course_title` as the domain (multi-domain fix) and produces age-appropriate narration style for kids courses. Course context is threaded from `generate_audio_summary()` → `_generate_script()`.

## Changes

- `backend/app/domain/services/quiz_service.py` — kids-aware user message variables in `_build_quiz_prompt()` (lines 434–469)
- `backend/app/domain/services/media_summary_service.py` — `_build_audio_system_prompt()` function + course context threading through `_generate_script()`
- `backend/tests/test_quiz_service.py` — added `TestBuildQuizPromptKidsAware` (7 new tests)
- `backend/tests/test_media_summary_service.py` — new file with `TestBuildAudioSystemPrompt` (10 tests) + `TestGenerateScriptUsesAudiencePrompt` (4 tests)

## Test plan

- [x] All 64 tests pass (`pytest tests/test_quiz_service.py tests/test_media_summary_service.py`)
- [x] `ruff check` + `ruff format --check` — all files clean
- [ ] Adult course quiz user message still says "professionals in {domain}" — backward compat verified
- [ ] Kids course quiz user message says "young learners aged {range}"
- [ ] `_build_quiz_prompt()` with `course=None` returns adult public health message
- [ ] `_build_audio_system_prompt()` with no args → "public health professionals" (not hardcoded in constant anymore)
- [ ] Kids audio prompt uses age-appropriate narration style
- [ ] Adult non-health course audio prompt uses course title as domain

Closes #1314

Generated with [Claude Code](https://claude.ai/code)