### PR TITLE
merge dev to main: kids-adaptive tutor + quiz user msg + media multi-domain

### DIFF
--- a/backend/app/ai/prompts/tutor.py
+++ b/backend/app/ai/prompts/tutor.py
@@ -3,6 +3,8 @@
 from dataclasses import dataclass
 from typing import Any
 
+from app.ai.prompts.audience import AudienceContext, get_audience_guidance
+
 
 @dataclass
 class TutorContext:
@@ -19,6 +21,9 @@ class TutorContext:
     course_title: str | None = None  # Human-readable course title (fr or en)
     course_domain: str | None = None  # e.g. "Santé Publique", "Marketing", ...
     learner_memory: str | None = None  # Pre-formatted memory text for system prompt
+    is_kids: bool = False
+    age_min: int | None = None
+    age_max: int | None = None
     previous_session_context: str | None = None  # Compacted context from prior session
     progress_snapshot: str | None = None  # Short learner progress summary
     tutor_mode: str = "socratic"  # "socratic" (guided questions) or "explanatory" (direct answers)
@@ -48,15 +53,39 @@ def get_socratic_system_prompt(context: TutorContext, rag_chunks: list[dict[str,
         System prompt string for Claude API
     """
     language_instruction = _get_language_instruction(context.user_language)
-    level_instruction = _get_level_instruction(context.user_level)
-    country_context = _get_country_context(context.user_country)
+    level_instruction = _get_level_instruction(context.user_level, context.is_kids)
+    country_context = _get_country_context(context.user_country, context.course_domain)
     sources_context = _format_sources_context(rag_chunks)
 
-    pedagogical_section = _get_pedagogical_rules(context.tutor_mode)
+    pedagogical_section = _get_pedagogical_rules(context.tutor_mode, context.is_kids)
 
     course_label = context.course_title or "santé publique"
-    prompt = f"""Tu es un tuteur IA spécialisé en {course_label} pour l'Afrique de l'Ouest.
-{_get_mode_intro(context.tutor_mode)}
+
+    if context.is_kids:
+        audience_ctx = AudienceContext(
+            is_kids=True,
+            age_min=context.age_min,
+            age_max=context.age_max,
+        )
+        audience_guidance = get_audience_guidance(audience_ctx, context.user_language)
+        age_range = _format_age_range(context.age_min, context.age_max, context.user_language)
+        if context.user_language == "fr":
+            persona_line = f"Tu es un tuteur ami et encourageant pour les jeunes apprenants de {age_range}, spécialisé en {course_label} pour l'Afrique de l'Ouest."
+        else:
+            persona_line = f"You are a friendly and encouraging tutor for young learners aged {age_range}, specializing in {course_label} for West Africa."
+        concision_rule = _get_kids_concision_rule(
+            context.age_min, context.age_max, context.user_language
+        )
+        kids_section = (
+            f"\n## ADAPTATION JEUNE PUBLIC\n{audience_guidance}" if audience_guidance else ""
+        )
+    else:
+        persona_line = f"Tu es un tuteur IA spécialisé en {course_label} pour l'Afrique de l'Ouest."
+        concision_rule = "3-5 phrases" if context.user_language == "fr" else "3-5 sentences"
+        kids_section = ""
+
+    prompt = f"""{persona_line}
+{_get_mode_intro(context.tutor_mode, context.is_kids)}
 
 ## LANGUE DE RÉPONSE OBLIGATOIRE
 {language_instruction}
@@ -67,7 +96,7 @@ def get_socratic_system_prompt(context: TutorContext, rag_chunks: list[dict[str,
 - Pays: {country_context}
 - Module actuel: {_format_current_module(context)}
 - Mode: {"Socratique (guidage par questions)" if context.tutor_mode == "socratic" else "Explicatif (réponses directes)"}
-{_format_progress_section(context.progress_snapshot)}{_format_memory_section(context.learner_memory)}{_format_previous_session_section(context.previous_session_context)}
+{_format_progress_section(context.progress_snapshot)}{_format_memory_section(context.learner_memory)}{_format_previous_session_section(context.previous_session_context)}{kids_section}
 
 {pedagogical_section}
 
@@ -139,12 +168,12 @@ Lorsqu'un outil retourne un marqueur `{{{{source_image:UUID}}}}`, tu peux l'incl
 ## INSTRUCTIONS SPÉCIALES
 
 ### CONCISION OBLIGATOIRE
-- Chaque réponse fait 3-5 phrases maximum (hors citations de sources)
+- Chaque réponse fait {concision_rule} maximum (hors citations de sources)
 - Ne pose qu'UNE question par message (deux maximum si décomposition nécessaire)
 - Pas de longs préambules ni de résumés après chaque échange
 
 ### RÉPONSES INTERDITES
-- Ne réponds JAMAIS directement à une question
+- {"Évite de donner directement la réponse — guide avec des questions adaptées à leur âge" if context.is_kids else "Ne réponds JAMAIS directement à une question"}
 - N'énumère pas de listes sans questionnement
 - Évite les réponses encyclopédiques
 - Ne donne pas de cours magistral
@@ -179,7 +208,7 @@ BON:
 "Bonne question ! 🎯 Selon toi, quels seraient les premiers signes à observer sur le terrain ?
 (Selon [Source], Ch. X, p. Y)"
 
-Réponds maintenant dans cette approche socratique stricte."""
+{_get_closing_instruction(context.is_kids, context.user_language)}"""
 
     return prompt
 
@@ -216,12 +245,54 @@ def _format_progress_section(progress_snapshot: str | None) -> str:
     return f"\n## PROGRESSION ACTUELLE\n{progress_snapshot}"
 
 
-def _get_mode_intro(tutor_mode: str) -> str:
+def _format_age_range(age_min: int | None, age_max: int | None, language: str) -> str:
+    """Format age range for display in persona line."""
+    if age_min is not None and age_max is not None:
+        if language == "fr":
+            return f"{age_min}-{age_max} ans"
+        return f"{age_min}-{age_max}"
+    if age_min is not None:
+        if language == "fr":
+            return f"{age_min}+ ans"
+        return f"{age_min}+"
+    return "jeunes apprenants" if language == "fr" else "young learners"
+
+
+def _get_kids_concision_rule(age_min: int | None, age_max: int | None, language: str) -> str:
+    """Return concision rule adapted to children's age tier."""
+    effective_max = age_max or 12
+    if effective_max <= 8:
+        return "2-3 phrases" if language == "fr" else "2-3 sentences"
+    if effective_max <= 12:
+        return "3-4 phrases" if language == "fr" else "3-4 sentences"
+    return "3-5 phrases" if language == "fr" else "3-5 sentences"
+
+
+def _get_closing_instruction(is_kids: bool, language: str) -> str:
+    """Return the closing instruction line of the prompt."""
+    if is_kids:
+        if language == "fr":
+            return "Réponds maintenant avec bienveillance, en adaptant ton langage à l'âge de l'apprenant."
+        return "Now respond kindly, adapting your language to the learner's age."
+    return "Réponds maintenant dans cette approche socratique stricte."
+
+
+def _get_mode_intro(tutor_mode: str, is_kids: bool = False) -> str:
     """Return the mission statement based on tutor mode."""
     if tutor_mode == "explanatory":
+        if is_kids:
+            return (
+                "Tu adoptes une approche explicative douce et encourageante. Ta mission est de fournir "
+                "des réponses claires, simples et accessibles aux jeunes apprenants."
+            )
         return (
             "Tu adoptes une approche explicative directe. Ta mission est de fournir "
             "des réponses claires, structurées et complètes aux questions de l'apprenant."
+        )
+    if is_kids:
+        return (
+            "Tu adoptes une approche pédagogique socratique adaptée aux enfants. Ta mission est de guider "
+            "les jeunes apprenants avec bienveillance, en posant des questions adaptées à leur âge."
         )
     return (
         "Tu adoptes une approche pédagogique socratique. Ta mission est de guider "
@@ -229,7 +300,7 @@ def _get_mode_intro(tutor_mode: str) -> str:
     )
 
 
-def _get_pedagogical_rules(tutor_mode: str) -> str:
+def _get_pedagogical_rules(tutor_mode: str, is_kids: bool = False) -> str:
     """Return the pedagogical rules section based on tutor mode."""
     if tutor_mode == "explanatory":
         return """## APPROCHE EXPLICATIVE — RÈGLES
@@ -326,8 +397,16 @@ def _get_language_instruction(language: str) -> str:
         return "English — You MUST respond ENTIRELY in English. Do NOT use French unless the learner explicitly requests it in their message."
 
 
-def _get_level_instruction(level: int) -> str:
+def _get_level_instruction(level: int, is_kids: bool = False) -> str:
     """Get level-specific instruction."""
+    if is_kids:
+        kids_level_map = {
+            1: "Découverte (L1) - Premiers pas",
+            2: "Explorateur (L2) - J'apprends en pratiquant",
+            3: "Champion (L3) - Je comprends et j'applique",
+            4: "Maître (L4) - Je crée et j'invente",
+        }
+        return kids_level_map.get(level, "Non spécifié")
     level_map = {
         1: "Débutant (L1) - Fondamentaux",
         2: "Intermédiaire (L2) - Application et analyse",
@@ -337,9 +416,45 @@ def _get_level_instruction(level: int) -> str:
     return level_map.get(level, "Non spécifié")
 
 
-def _get_country_context(country: str) -> str:
+def _get_country_context(country: str, course_domain: str | None = None) -> str:
     """Get country-specific context for West Africa region."""
-    country_map = {
+    country_names = {
+        "BF": "Burkina Faso",
+        "BJ": "Bénin",
+        "CI": "Côte d'Ivoire",
+        "GH": "Ghana",
+        "GN": "Guinée",
+        "GW": "Guinée-Bissau",
+        "LR": "Libéria",
+        "ML": "Mali",
+        "NE": "Niger",
+        "NG": "Nigeria",
+        "SL": "Sierra Leone",
+        "SN": "Sénégal",
+        "TG": "Togo",
+        "CV": "Cap-Vert",
+        "GM": "Gambie",
+    }
+    country_name = country_names.get(country, country)
+
+    health_keywords = {
+        "santé",
+        "health",
+        "médecine",
+        "medical",
+        "epidemiology",
+        "épidémiologie",
+        "publique",
+        "public",
+        "clinique",
+        "clinical",
+        "nursing",
+        "infirmi",
+    }
+    if course_domain and not any(kw in course_domain.lower() for kw in health_keywords):
+        return f"{country_name} - Afrique de l'Ouest"
+
+    health_map = {
         "BF": "Burkina Faso - Focus paludisme, méningite, malnutrition",
         "BJ": "Bénin - Focus paludisme, fièvre typhoïde, santé maternelle",
         "CI": "Côte d'Ivoire - Focus paludisme, VIH/SIDA, tuberculose",
@@ -356,7 +471,7 @@ def _get_country_context(country: str) -> str:
         "CV": "Cap-Vert - Focus hypertension, diabète, maladies cardiovasculaires",
         "GM": "Gambie - Focus paludisme, tuberculose, santé maternelle",
     }
-    return country_map.get(country, f"{country} - Contexte Afrique de l'Ouest")
+    return health_map.get(country, f"{country_name} - Contexte Afrique de l'Ouest")
 
 
 def _format_sources_context(rag_chunks: list[dict[str, Any]]) -> str:

--- a/backend/app/domain/services/media_summary_service.py
+++ b/backend/app/domain/services/media_summary_service.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.ai.claude_service import ClaudeService
+from app.ai.prompts.audience import detect_audience
 from app.ai.rag.embeddings import EmbeddingService
 from app.ai.rag.retriever import SemanticRetriever
 from app.domain.models.module import Module
@@ -21,21 +22,54 @@ from app.infrastructure.storage.s3 import S3StorageService
 
 logger = structlog.get_logger(__name__)
 
-AUDIO_SUMMARY_SYSTEM_PROMPT = """You are an expert in public health for West Africa (ECOWAS region).
+
+def _build_audio_system_prompt(
+    language: str,
+    course_title: str | None = None,
+    is_kids: bool = False,
+    age_range: str = "",
+) -> str:
+    """Build a context-aware audio summary system prompt.
+
+    Args:
+        language: Content language code ("fr" or "en").
+        course_title: Optional course title used as domain descriptor.
+        is_kids: Whether the course targets children.
+        age_range: Age range string (e.g. "6-12") used when is_kids=True.
+
+    Returns:
+        Formatted system prompt string for Claude.
+    """
+    domain = course_title or "public health"
+    if is_kids:
+        audience = f"young learners aged {age_range}"
+        style = f"clear, engaging, and fun narration suitable for children aged {age_range}"
+        west_africa_note = (
+            "Reference concrete examples from West Africa that children can relate to"
+        )
+    else:
+        audience = f"professionals in {domain}"
+        style = f"clear, engaging narration suitable for {audience}"
+        west_africa_note = (
+            "Reference concrete examples from West African health systems where possible"
+        )
+
+    return f"""You are an expert educator in {domain} for West Africa (ECOWAS region).
 Your task is to write a spoken audio summary script for a learning module.
 
 Guidelines:
 - Write in {language} (French or English as specified)
 - Length: approximately 2000 words — about 10-12 minutes of spoken audio
-- Style: clear, engaging narration suitable for public health professionals
+- Style: {style}
 - Structure: brief introduction → core concepts → real West African examples → key takeaways
 - Use simple language accessible on 2G/3G with limited bandwidth
-- Reference concrete examples from West African health systems where possible
+- {west_africa_note}
 - DO NOT include headers, bullet points, or markdown — write plain spoken prose
 - DO NOT include source citations in the script itself (they are tracked separately)
 - End with 3-5 key takeaways the listener should remember
 
 Output only the script text, nothing else."""
+
 
 AUDIO_SUMMARY_USER_TEMPLATE = """Module: {module_title}
 Language: {language}
@@ -138,12 +172,24 @@ class MediaSummaryService:
                 session=session,
             )
 
+            course = module.course
+            audience_ctx = detect_audience(course)
+            course_title = None
+            if course is not None:
+                course_title = course.title_fr if language == "fr" else course.title_en
+            age_range = (
+                f"{audience_ctx.age_min}-{audience_ctx.age_max}" if audience_ctx.is_kids else ""
+            )
+
             script = await self._generate_script(
                 module_title=module_title or f"Module {module.module_number}",
                 language=language,
                 level=module.level,
                 unit_titles=unit_titles,
                 rag_chunks=rag_chunks,
+                course_title=course_title,
+                is_kids=audience_ctx.is_kids,
+                age_range=age_range,
             )
 
             audio_bytes = await self._call_gemini_tts(script, language)
@@ -289,9 +335,17 @@ class MediaSummaryService:
         level: int,
         unit_titles: list[str],
         rag_chunks: list,
+        course_title: str | None = None,
+        is_kids: bool = False,
+        age_range: str = "",
     ) -> str:
         """Call Claude to generate a ~2000-word spoken summary script."""
-        system_prompt = AUDIO_SUMMARY_SYSTEM_PROMPT.format(language=language)
+        system_prompt = _build_audio_system_prompt(
+            language=language,
+            course_title=course_title,
+            is_kids=is_kids,
+            age_range=age_range,
+        )
         unit_list = "\n".join(f"- {t}" for t in unit_titles) if unit_titles else "- (no units)"
         rag_context = _format_rag_context(rag_chunks)
 

--- a/backend/app/domain/services/quiz_service.py
+++ b/backend/app/domain/services/quiz_service.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.ai.claude_service import ClaudeService
+from app.ai.prompts.audience import detect_audience
 from app.ai.prompts.quiz import get_quiz_system_prompt
 from app.ai.rag.retriever import SemanticRetriever
 from app.api.v1.schemas.quiz import QuizContent, QuizResponse
@@ -430,26 +431,42 @@ class QuizService:
             course=course,
         )
 
-        audience = (
-            f"professionals in {domain} in {country}"
-            if course_title
-            else f"public health professionals in {country}"
-        )
-        context_note = (
-            f"Use examples relevant to {country} and West African context when possible, adapted to {domain}"
-            if course_title
-            else f"Use examples relevant to {country} and West African context when possible"
-        )
-        practical_note = (
-            f"Focus on practical applications for {domain} work"
-            if course_title
-            else "Focus on practical applications for public health work"
-        )
-        closing_note = (
-            f"Generate the quiz now, ensuring all questions are relevant to {domain} practice in West Africa."
-            if course_title
-            else "Generate the quiz now, ensuring all questions are relevant to public health practice in West Africa."
-        )
+        audience_ctx = detect_audience(course)
+        if audience_ctx.is_kids:
+            age_range = f"{audience_ctx.age_min}-{audience_ctx.age_max}"
+            audience = f"young learners aged {age_range} in {country}"
+            context_note = (
+                f"Use examples from daily life in {country} that children aged {age_range} can relate to "
+                f"(school, market, family, games)"
+            )
+            practical_note = (
+                f"Focus on fun, engaging questions that make {domain} exciting for children"
+            )
+            closing_note = (
+                f"Generate the quiz now. Make it fun and encouraging for children aged {age_range} "
+                f"learning {domain} in West Africa."
+            )
+        else:
+            audience = (
+                f"professionals in {domain} in {country}"
+                if course_title
+                else f"public health professionals in {country}"
+            )
+            context_note = (
+                f"Use examples relevant to {country} and West African context when possible, adapted to {domain}"
+                if course_title
+                else f"Use examples relevant to {country} and West African context when possible"
+            )
+            practical_note = (
+                f"Focus on practical applications for {domain} work"
+                if course_title
+                else "Focus on practical applications for public health work"
+            )
+            closing_note = (
+                f"Generate the quiz now, ensuring all questions are relevant to {domain} practice in West Africa."
+                if course_title
+                else "Generate the quiz now, ensuring all questions are relevant to public health practice in West Africa."
+            )
 
         if unit_title is not None:
             topic_constraint = (

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -14,6 +14,7 @@ from anthropic.types import MessageParam, ToolResultBlockParam, ToolUseBlock
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from app.ai.prompts.audience import detect_audience
 from app.ai.prompts.tutor import (
     TutorContext,
     get_activity_suggestions,
@@ -321,6 +322,8 @@ class TutorService:
                 course_domain = course_domain or course_title
                 rag_collection_id = course.rag_collection_id
 
+            audience = detect_audience(course)
+
             context = TutorContext(
                 user_level=user.current_level,
                 user_language=effective_language,
@@ -336,6 +339,9 @@ class TutorService:
                 learner_memory=session_ctx.learner_memory,
                 previous_session_context=session_ctx.previous_compact,
                 progress_snapshot=session_ctx.progress_snapshot,
+                is_kids=audience.is_kids,
+                age_min=audience.age_min,
+                age_max=audience.age_max,
             )
 
             system_prompt = get_socratic_system_prompt(context, [])

--- a/backend/tests/test_media_summary_service.py
+++ b/backend/tests/test_media_summary_service.py
@@ -1,0 +1,166 @@
+"""Unit tests for media_summary_service — _build_audio_system_prompt and _generate_script."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.domain.services.media_summary_service import (
+    MediaSummaryService,
+    _build_audio_system_prompt,
+)
+
+
+class TestBuildAudioSystemPrompt:
+    def test_no_params_produces_generic_adult_prompt(self):
+        prompt = _build_audio_system_prompt(language="en")
+        assert "public health" in prompt
+        assert "professionals in public health" in prompt
+        assert "young learners" not in prompt
+
+    def test_adult_math_course_says_mathematics_not_public_health(self):
+        prompt = _build_audio_system_prompt(language="en", course_title="Mathematics")
+        assert "Mathematics" in prompt
+        assert "public health" not in prompt
+
+    def test_adult_it_course_says_it(self):
+        prompt = _build_audio_system_prompt(language="en", course_title="Information Technology")
+        assert "Information Technology" in prompt
+        assert "public health" not in prompt
+
+    def test_kids_prompt_uses_age_appropriate_style(self):
+        prompt = _build_audio_system_prompt(
+            language="en",
+            course_title="Village Math",
+            is_kids=True,
+            age_range="6-12",
+        )
+        assert "children aged 6-12" in prompt
+        assert "fun" in prompt
+        assert "professionals" not in prompt
+
+    def test_kids_prompt_includes_children_relate_examples(self):
+        prompt = _build_audio_system_prompt(
+            language="en",
+            course_title="Primary Science",
+            is_kids=True,
+            age_range="6-12",
+        )
+        assert "children can relate to" in prompt
+
+    def test_adult_prompt_mentions_health_systems(self):
+        prompt = _build_audio_system_prompt(language="en")
+        assert "health systems" in prompt
+
+    def test_kids_prompt_does_not_mention_health_systems(self):
+        prompt = _build_audio_system_prompt(
+            language="en",
+            course_title="Village Math",
+            is_kids=True,
+            age_range="6-12",
+        )
+        assert "health systems" not in prompt
+
+    def test_language_appears_in_prompt(self):
+        prompt_fr = _build_audio_system_prompt(language="fr")
+        assert "fr" in prompt_fr
+
+        prompt_en = _build_audio_system_prompt(language="en")
+        assert "en" in prompt_en
+
+    def test_output_format_instructions_always_present(self):
+        for is_kids in [True, False]:
+            prompt = _build_audio_system_prompt(
+                language="en",
+                course_title="Test Course",
+                is_kids=is_kids,
+                age_range="6-12" if is_kids else "",
+            )
+            assert "Output only the script text" in prompt
+            assert "DO NOT include headers" in prompt
+            assert "key takeaways" in prompt
+
+    def test_adult_no_course_title_falls_back_to_public_health(self):
+        prompt = _build_audio_system_prompt(language="fr", course_title=None, is_kids=False)
+        assert "public health" in prompt
+
+
+class TestGenerateScriptUsesAudiencePrompt:
+    @pytest.fixture
+    def mock_claude(self):
+        service = AsyncMock()
+        response = MagicMock()
+        block = MagicMock()
+        block.text = "This is the audio script content."
+        response.content = [block]
+        service.generate_lesson_content = AsyncMock(return_value=response)
+        return service
+
+    @pytest.fixture
+    def media_service(self, mock_claude):
+        return MediaSummaryService(claude_service=mock_claude)
+
+    async def test_generate_script_adult_course_passes_course_title(
+        self, media_service, mock_claude
+    ):
+        await media_service._generate_script(
+            module_title="Module 1",
+            language="en",
+            level=2,
+            unit_titles=["Unit A"],
+            rag_chunks=[],
+            course_title="Tax Policy",
+            is_kids=False,
+            age_range="",
+        )
+        call_args = mock_claude.generate_lesson_content.call_args
+        system_prompt = call_args.kwargs["system_prompt"]
+        assert "Tax Policy" in system_prompt
+        assert "public health" not in system_prompt
+
+    async def test_generate_script_kids_course_uses_kids_prompt(self, media_service, mock_claude):
+        await media_service._generate_script(
+            module_title="Village Math Module 1",
+            language="en",
+            level=1,
+            unit_titles=["Numbers"],
+            rag_chunks=[],
+            course_title="Village Math",
+            is_kids=True,
+            age_range="6-12",
+        )
+        call_args = mock_claude.generate_lesson_content.call_args
+        system_prompt = call_args.kwargs["system_prompt"]
+        assert "children aged 6-12" in system_prompt
+        assert "professionals" not in system_prompt
+
+    async def test_generate_script_no_course_falls_back_to_generic(
+        self, media_service, mock_claude
+    ):
+        await media_service._generate_script(
+            module_title="Module 1",
+            language="en",
+            level=1,
+            unit_titles=[],
+            rag_chunks=[],
+        )
+        call_args = mock_claude.generate_lesson_content.call_args
+        system_prompt = call_args.kwargs["system_prompt"]
+        assert "public health" in system_prompt
+        assert "young learners" not in system_prompt
+
+    async def test_generate_script_raises_on_empty_response(self, mock_claude):
+        response = MagicMock()
+        block = MagicMock()
+        block.text = "   "
+        response.content = [block]
+        mock_claude.generate_lesson_content = AsyncMock(return_value=response)
+        service = MediaSummaryService(claude_service=mock_claude)
+
+        with pytest.raises(ValueError, match="empty script"):
+            await service._generate_script(
+                module_title="Module 1",
+                language="fr",
+                level=1,
+                unit_titles=[],
+                rag_chunks=[],
+            )

--- a/backend/tests/test_quiz_service.py
+++ b/backend/tests/test_quiz_service.py
@@ -416,6 +416,129 @@ class TestBuildQuizPrompt:
         assert "M01-U01" not in user_message
 
 
+class TestBuildQuizPromptKidsAware:
+    def _make_kids_course(self, age_min: int = 6, age_max: int = 12) -> MagicMock:
+        tc = MagicMock()
+        tc.slug = "primary_school"
+        tc.type = "audience"
+        course = MagicMock()
+        course.taxonomy_categories = [tc]
+        course.title_en = f"Village Math (Ages {age_min}-{age_max})"
+        course.title_fr = f"Maths au Village ({age_min}-{age_max} ans)"
+        return course
+
+    def _make_adult_course(self) -> MagicMock:
+        tc = MagicMock()
+        tc.slug = "professionals"
+        tc.type = "audience"
+        course = MagicMock()
+        course.taxonomy_categories = [tc]
+        course.title_en = "Internal Audit"
+        course.title_fr = "Audit Interne"
+        return course
+
+    def test_kids_course_user_message_says_young_learners(self, quiz_service):
+        kids_course = self._make_kids_course()
+        _system, user_message = quiz_service._build_quiz_prompt(
+            context="context",
+            unit_id="M01-U01",
+            language="en",
+            country="senegal",
+            level=1,
+            num_questions=5,
+            course_title="Village Math (Ages 6-12)",
+            course=kids_course,
+        )
+        assert "young learners" in user_message
+        assert "professionals" not in user_message
+
+    def test_kids_course_user_message_includes_age_range(self, quiz_service):
+        kids_course = self._make_kids_course(age_min=6, age_max=12)
+        _system, user_message = quiz_service._build_quiz_prompt(
+            context="context",
+            unit_id="M01-U01",
+            language="en",
+            country="senegal",
+            level=1,
+            num_questions=5,
+            course_title="Village Math (Ages 6-12)",
+            course=kids_course,
+        )
+        assert "6-12" in user_message
+
+    def test_kids_course_closing_note_is_fun_and_encouraging(self, quiz_service):
+        kids_course = self._make_kids_course()
+        _system, user_message = quiz_service._build_quiz_prompt(
+            context="context",
+            unit_id="M01-U01",
+            language="en",
+            country="senegal",
+            level=1,
+            num_questions=5,
+            course_title="Village Math (Ages 6-12)",
+            course=kids_course,
+        )
+        assert "fun" in user_message.lower()
+        assert "encouraging" in user_message.lower()
+
+    def test_adult_course_user_message_says_professionals(self, quiz_service):
+        adult_course = self._make_adult_course()
+        _system, user_message = quiz_service._build_quiz_prompt(
+            context="context",
+            unit_id="M01-U01",
+            language="en",
+            country="ghana",
+            level=2,
+            num_questions=5,
+            course_title="Internal Audit",
+            course=adult_course,
+        )
+        assert "professionals" in user_message
+        assert "young learners" not in user_message
+
+    def test_no_course_produces_adult_public_health_message(self, quiz_service):
+        _system, user_message = quiz_service._build_quiz_prompt(
+            context="context",
+            unit_id="M01-U01",
+            language="en",
+            country="nigeria",
+            level=1,
+            num_questions=5,
+            course=None,
+        )
+        assert "public health professionals" in user_message
+        assert "young learners" not in user_message
+
+    def test_kids_context_note_mentions_daily_life(self, quiz_service):
+        kids_course = self._make_kids_course()
+        _system, user_message = quiz_service._build_quiz_prompt(
+            context="context",
+            unit_id="M01-U01",
+            language="en",
+            country="senegal",
+            level=1,
+            num_questions=5,
+            course_title="Village Math (Ages 6-12)",
+            course=kids_course,
+        )
+        assert "daily life" in user_message.lower()
+
+    def test_kids_practical_note_mentions_exciting_and_fun(self, quiz_service):
+        kids_course = self._make_kids_course()
+        _system, user_message = quiz_service._build_quiz_prompt(
+            context="context",
+            unit_id="M01-U01",
+            language="en",
+            country="senegal",
+            level=1,
+            num_questions=5,
+            course_title="Village Math (Ages 6-12)",
+            course=kids_course,
+        )
+        assert "fun" in user_message.lower()
+        assert "exciting" in user_message.lower()
+
+
 class TestBuildQuizSearchQuery:
     def test_returns_unit_id_when_module_is_none(self, quiz_service):
         result = quiz_service._build_quiz_search_query(None, "M01-U04", "fr")

--- a/backend/tests/test_tutor_kids_adaptation.py
+++ b/backend/tests/test_tutor_kids_adaptation.py
@@ -1,0 +1,189 @@
+"""Unit tests for kids-adaptive AI tutor prompt and multi-domain country context."""
+
+from app.ai.prompts.tutor import (
+    TutorContext,
+    _get_country_context,
+    _get_level_instruction,
+    get_socratic_system_prompt,
+)
+
+
+def _make_adult_context(**kwargs) -> TutorContext:
+    defaults = dict(
+        user_level=2,
+        user_language="fr",
+        user_country="SN",
+        is_kids=False,
+    )
+    defaults.update(kwargs)
+    return TutorContext(**defaults)
+
+
+def _make_kids_context(**kwargs) -> TutorContext:
+    defaults = dict(
+        user_level=2,
+        user_language="fr",
+        user_country="SN",
+        is_kids=True,
+        age_min=6,
+        age_max=12,
+    )
+    defaults.update(kwargs)
+    return TutorContext(**defaults)
+
+
+class TestTutorContextKidsFields:
+    def test_default_is_not_kids(self):
+        ctx = TutorContext(user_level=1, user_language="fr", user_country="SN")
+        assert ctx.is_kids is False
+        assert ctx.age_min is None
+        assert ctx.age_max is None
+
+    def test_kids_fields_set(self):
+        ctx = TutorContext(
+            user_level=1,
+            user_language="fr",
+            user_country="SN",
+            is_kids=True,
+            age_min=6,
+            age_max=12,
+        )
+        assert ctx.is_kids is True
+        assert ctx.age_min == 6
+        assert ctx.age_max == 12
+
+
+class TestGetLevelInstruction:
+    def test_adult_level4_returns_expert(self):
+        result = _get_level_instruction(level=4, is_kids=False)
+        assert "Expert" in result
+        assert "L4" in result
+
+    def test_adult_level4_default_is_not_kids(self):
+        result = _get_level_instruction(level=4)
+        assert "Expert" in result
+
+    def test_kids_level4_returns_maitre_not_expert(self):
+        result = _get_level_instruction(level=4, is_kids=True)
+        assert "Ma\u00eetre" in result
+        assert "Expert" not in result
+
+    def test_kids_level1_returns_decouverte(self):
+        result = _get_level_instruction(level=1, is_kids=True)
+        assert "D\u00e9couverte" in result
+
+    def test_kids_level2_returns_explorateur(self):
+        result = _get_level_instruction(level=2, is_kids=True)
+        assert "Explorateur" in result
+
+    def test_kids_level3_returns_champion(self):
+        result = _get_level_instruction(level=3, is_kids=True)
+        assert "Champion" in result
+
+    def test_adult_level1_returns_debutant(self):
+        result = _get_level_instruction(level=1, is_kids=False)
+        assert "D\u00e9butant" in result
+
+    def test_adult_level3_returns_avance(self):
+        result = _get_level_instruction(level=3, is_kids=False)
+        assert "Avanc\u00e9" in result
+
+
+class TestGetCountryContext:
+    def test_sn_no_domain_returns_health_context(self):
+        result = _get_country_context("SN")
+        assert "paludisme" in result
+        assert "S\u00e9n\u00e9gal" in result
+
+    def test_sn_none_domain_returns_health_context(self):
+        result = _get_country_context("SN", course_domain=None)
+        assert "paludisme" in result
+
+    def test_sn_health_domain_returns_health_context(self):
+        result = _get_country_context("SN", course_domain="Sant\u00e9 publique")
+        assert "paludisme" in result
+
+    def test_sn_math_domain_returns_generic_no_disease(self):
+        result = _get_country_context("SN", course_domain="Mathematics")
+        assert "paludisme" not in result
+        assert "S\u00e9n\u00e9gal" in result
+        assert "Afrique de l'Ouest" in result
+
+    def test_sn_engineering_domain_returns_generic(self):
+        result = _get_country_context("SN", course_domain="Engineering")
+        assert "paludisme" not in result
+
+    def test_ml_no_domain_returns_health_context(self):
+        result = _get_country_context("ML")
+        assert "paludisme" in result or "m\u00e9ningite" in result
+
+    def test_unknown_country_no_domain_returns_west_africa(self):
+        result = _get_country_context("XX")
+        assert "Afrique de l'Ouest" in result
+
+    def test_sn_tax_domain_returns_generic(self):
+        result = _get_country_context("SN", course_domain="Fiscalit\u00e9 et comptabilit\u00e9")
+        assert "paludisme" not in result
+
+
+class TestSocraticPromptKids:
+    def test_adult_prompt_contains_tuteur_ia_specialise(self):
+        ctx = _make_adult_context()
+        prompt = get_socratic_system_prompt(ctx, [])
+        assert "tuteur IA sp\u00e9cialis\u00e9" in prompt
+
+    def test_kids_prompt_contains_tuteur_ami(self):
+        ctx = _make_kids_context()
+        prompt = get_socratic_system_prompt(ctx, [])
+        assert "tuteur ami" in prompt.lower() or "tuteur" in prompt.lower()
+        assert "tuteur IA sp\u00e9cialis\u00e9" not in prompt
+
+    def test_kids_prompt_contains_encouraging_language(self):
+        ctx = _make_kids_context(age_min=6, age_max=10)
+        prompt = get_socratic_system_prompt(ctx, [])
+        assert "encourageant" in prompt or "jeunes apprenants" in prompt
+
+    def test_adult_prompt_not_kids_keyword(self):
+        ctx = _make_adult_context()
+        prompt = get_socratic_system_prompt(ctx, [])
+        assert "jeunes apprenants" not in prompt
+
+    def test_kids_prompt_has_audience_guidance(self):
+        ctx = _make_kids_context(age_min=6, age_max=10)
+        prompt = get_socratic_system_prompt(ctx, [])
+        assert "PÉDAGOGIE" in prompt or "ADAPTATION" in prompt
+
+    def test_kids_prompt_has_softer_forbidden_rule(self):
+        ctx = _make_kids_context()
+        prompt = get_socratic_system_prompt(ctx, [])
+        assert "Ne r\u00e9ponds JAMAIS directement" not in prompt
+
+    def test_adult_prompt_has_strict_forbidden_rule(self):
+        ctx = _make_adult_context()
+        prompt = get_socratic_system_prompt(ctx, [])
+        assert "Ne r\u00e9ponds JAMAIS directement" in prompt
+
+    def test_kids_level_label_in_prompt(self):
+        ctx = _make_kids_context(user_level=4)
+        prompt = get_socratic_system_prompt(ctx, [])
+        assert "Ma\u00eetre" in prompt
+        assert (
+            "Expert" not in prompt.split("## CONTEXTE")[1].split("## LANGUE")[0]
+            if "## CONTEXTE" in prompt
+            else True
+        )
+
+    def test_adult_prompt_word_for_word_unchanged_level(self):
+        ctx = _make_adult_context(user_level=4)
+        prompt = get_socratic_system_prompt(ctx, [])
+        assert "Expert (L4)" in prompt
+
+    def test_kids_early_tier_concision_2_3_phrases(self):
+        ctx = _make_kids_context(age_min=5, age_max=8)
+        prompt = get_socratic_system_prompt(ctx, [])
+        assert "2-3 phrases" in prompt
+
+    def test_adult_concision_3_5_phrases(self):
+        ctx = _make_adult_context()
+        prompt = get_socratic_system_prompt(ctx, [])
+        assert "3-5 phrases" in prompt


### PR DESCRIPTION
## Summary
- feat(ai): kids-adaptive AI tutor prompt + multi-domain country context (#1318)
- feat(ai): adapt quiz user message for kids + multi-domain media summary (#1316)

## What changed
- Tutor: kids persona, age-tiered concision, kids level labels, domain-aware country context
- Quiz: user message says "young learners" for kids courses instead of "professionals"
- Media summary: multi-domain aware (not hardcoded "public health")
- All adult paths unchanged — zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)