### PR TITLE
feat(admin): show all user fields in profile view + add pagination to user list

### DIFF
--- a/backend/app/api/v1/admin/users.py
+++ b/backend/app/api/v1/admin/users.py
@@ -48,6 +48,8 @@ def _user_to_response(u: User) -> UserProfileResponse:
         created_at=u.created_at.isoformat(),
         role=u.role,
         is_active=u.is_active,
+        phone_number=u.phone_number,
+        analytics_opt_out=u.analytics_opt_out,
     )
 
 
@@ -105,6 +107,7 @@ async def export_users_csv(
             [
                 "id",
                 "email",
+                "phone_number",
                 "name",
                 "country",
                 "professional_role",
@@ -121,7 +124,8 @@ async def export_users_csv(
             writer.writerow(
                 [
                     str(u.id),
-                    u.email,
+                    u.email or "",
+                    u.phone_number or "",
                     u.name,
                     u.country or "",
                     u.professional_role or "",

--- a/frontend/components/admin/user-detail-client.tsx
+++ b/frontend/components/admin/user-detail-client.tsx
@@ -3,7 +3,8 @@
 import { useTranslations, useLocale } from "next-intl";
 import { useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Phone } from "lucide-react";
+import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
@@ -12,7 +13,7 @@ import { apiFetch } from "@/lib/api";
 
 interface AdminUser {
   id: string;
-  email: string;
+  email: string | null;
   name: string;
   preferred_language: string;
   country: string | null;
@@ -24,6 +25,8 @@ interface AdminUser {
   created_at: string;
   role: "user" | "expert" | "admin";
   is_active: boolean;
+  phone_number: string | null;
+  analytics_opt_out: boolean;
 }
 
 interface ModuleProgressItem {
@@ -102,12 +105,34 @@ export function UserDetailClient({ userId }: { userId: string }) {
       </div>
 
       <Card className="p-4 md:p-6">
-        <h2 className="text-base font-semibold mb-4">{t("profile")}</h2>
+        <div className="flex items-start gap-4 mb-4">
+          {user.avatar_url && (
+            <Image
+              src={user.avatar_url}
+              alt={user.name}
+              width={56}
+              height={56}
+              className="rounded-full object-cover shrink-0"
+            />
+          )}
+          <h2 className="text-base font-semibold">{t("profile")}</h2>
+        </div>
         <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
-          <div>
-            <dt className="text-muted-foreground">Email</dt>
-            <dd className="font-medium mt-0.5">{user.email}</dd>
-          </div>
+          {user.email && (
+            <div>
+              <dt className="text-muted-foreground">Email</dt>
+              <dd className="font-medium mt-0.5">{user.email}</dd>
+            </div>
+          )}
+          {user.phone_number && (
+            <div>
+              <dt className="text-muted-foreground flex items-center gap-1">
+                <Phone className="h-3 w-3" aria-hidden="true" />
+                {t("phoneNumber")}
+              </dt>
+              <dd className="font-medium mt-0.5">{user.phone_number}</dd>
+            </div>
+          )}
           <div>
             <dt className="text-muted-foreground">{tUsers("filterRole")}</dt>
             <dd className="mt-0.5">
@@ -115,6 +140,12 @@ export function UserDetailClient({ userId }: { userId: string }) {
               {!user.is_active && (
                 <Badge variant="destructive" className="ml-2">{tUsers("inactive")}</Badge>
               )}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">{t("language")}</dt>
+            <dd className="mt-0.5">
+              <Badge variant="outline" className="uppercase">{user.preferred_language}</Badge>
             </dd>
           </div>
           {user.country && (
@@ -125,7 +156,7 @@ export function UserDetailClient({ userId }: { userId: string }) {
           )}
           {user.professional_role && (
             <div>
-              <dt className="text-muted-foreground">Role</dt>
+              <dt className="text-muted-foreground">{t("professionalRole")}</dt>
               <dd className="font-medium mt-0.5">{user.professional_role}</dd>
             </div>
           )}
@@ -147,6 +178,14 @@ export function UserDetailClient({ userId }: { userId: string }) {
             <dt className="text-muted-foreground">{tUsers("lastActive")}</dt>
             <dd className="font-medium mt-0.5">
               {new Date(user.last_active).toLocaleDateString(locale)}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">{t("analyticsOptOut")}</dt>
+            <dd className="mt-0.5">
+              <Badge variant={user.analytics_opt_out ? "secondary" : "outline"}>
+                {user.analytics_opt_out ? t("yes") : t("no")}
+              </Badge>
             </dd>
           </div>
         </dl>

--- a/frontend/components/admin/user-list-client.tsx
+++ b/frontend/components/admin/user-list-client.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback, useTransition } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import { useRouter } from "next/navigation";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Search, Download, MoreVertical, UserCheck, UserX, ShieldCheck, ShieldOff, Shield } from "lucide-react";
+import { Search, Download, MoreVertical, UserCheck, UserX, ShieldCheck, ShieldOff, Shield, ChevronLeft, ChevronRight } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -28,7 +28,7 @@ import { authClient } from "@/lib/auth";
 
 interface AdminUser {
   id: string;
-  email: string;
+  email: string | null;
   name: string;
   preferred_language: string;
   country: string | null;
@@ -40,12 +40,31 @@ interface AdminUser {
   created_at: string;
   role: "user" | "expert" | "admin";
   is_active: boolean;
+  phone_number: string | null;
 }
 
 type PendingAction =
   | { type: "deactivate"; user: AdminUser }
   | { type: "reactivate"; user: AdminUser }
   | { type: "promote"; user: AdminUser; newRole: "expert" | "admin" | "user" };
+
+const PAGE_SIZE = 50;
+
+function buildFilterQuery(params: {
+  search: string;
+  country: string;
+  level: string;
+  role: string;
+  isActive: string;
+}) {
+  const query = new URLSearchParams();
+  if (params.search) query.set("search", params.search);
+  if (params.country) query.set("country", params.country);
+  if (params.level) query.set("level", params.level);
+  if (params.role) query.set("role", params.role);
+  if (params.isActive) query.set("is_active", params.isActive);
+  return query;
+}
 
 function useAdminUsers(params: {
   search: string;
@@ -55,18 +74,28 @@ function useAdminUsers(params: {
   isActive: string;
   offset: number;
 }) {
-  const query = new URLSearchParams();
-  if (params.search) query.set("search", params.search);
-  if (params.country) query.set("country", params.country);
-  if (params.level) query.set("level", params.level);
-  if (params.role) query.set("role", params.role);
-  if (params.isActive) query.set("is_active", params.isActive);
+  const query = buildFilterQuery(params);
   query.set("offset", String(params.offset));
-  query.set("limit", "50");
+  query.set("limit", String(PAGE_SIZE));
 
   return useQuery<AdminUser[]>({
     queryKey: ["admin", "users", params],
     queryFn: () => apiFetch<AdminUser[]>(`/api/v1/admin/users?${query.toString()}`),
+  });
+}
+
+function useAdminUserCount(params: {
+  search: string;
+  country: string;
+  level: string;
+  role: string;
+  isActive: string;
+}) {
+  const query = buildFilterQuery(params);
+
+  return useQuery<{ count: number }>({
+    queryKey: ["admin", "users", "count", params],
+    queryFn: () => apiFetch<{ count: number }>(`/api/v1/admin/users/count?${query.toString()}`),
   });
 }
 
@@ -84,27 +113,24 @@ export function UserListClient() {
   const [level, setLevel] = useState("");
   const [role, setRole] = useState("");
   const [isActive, setIsActive] = useState("");
-  const [offset] = useState(0);
+  const [offset, setOffset] = useState(0);
   const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
   const searchTimeout = useCallback(
     (value: string) => {
       setSearch(value);
-      const t = setTimeout(() => setDebouncedSearch(value), 400);
-      return () => clearTimeout(t);
+      setOffset(0);
+      const timer = setTimeout(() => setDebouncedSearch(value), 400);
+      return () => clearTimeout(timer);
     },
     []
   );
 
-  const { data: users, isLoading, error } = useAdminUsers({
-    search: debouncedSearch,
-    country,
-    level,
-    role,
-    isActive,
-    offset,
-  });
+  const filterParams = { search: debouncedSearch, country, level, role, isActive };
+
+  const { data: users, isLoading, error } = useAdminUsers({ ...filterParams, offset });
+  const { data: countData } = useAdminUserCount(filterParams);
 
   const statusMutation = useMutation({
     mutationFn: ({ userId, is_active }: { userId: string; is_active: boolean }) =>
@@ -204,7 +230,7 @@ export function UserListClient() {
         <select
           className="min-h-11 rounded-md border border-input bg-background px-3 py-2 text-sm"
           value={country}
-          onChange={(e) => setCountry(e.target.value)}
+          onChange={(e) => { setCountry(e.target.value); setOffset(0); }}
           aria-label={t("filterCountry")}
         >
           <option value="">{t("allCountries")}</option>
@@ -216,7 +242,7 @@ export function UserListClient() {
         <select
           className="min-h-11 rounded-md border border-input bg-background px-3 py-2 text-sm"
           value={level}
-          onChange={(e) => setLevel(e.target.value)}
+          onChange={(e) => { setLevel(e.target.value); setOffset(0); }}
           aria-label={t("filterLevel")}
         >
           <option value="">{t("allLevels")}</option>
@@ -228,7 +254,7 @@ export function UserListClient() {
         <select
           className="min-h-11 rounded-md border border-input bg-background px-3 py-2 text-sm"
           value={role}
-          onChange={(e) => setRole(e.target.value)}
+          onChange={(e) => { setRole(e.target.value); setOffset(0); }}
           aria-label={t("filterRole")}
         >
           <option value="">{t("allRoles")}</option>
@@ -240,7 +266,7 @@ export function UserListClient() {
         <select
           className="min-h-11 rounded-md border border-input bg-background px-3 py-2 text-sm"
           value={isActive}
-          onChange={(e) => setIsActive(e.target.value)}
+          onChange={(e) => { setIsActive(e.target.value); setOffset(0); }}
           aria-label={t("filterStatus")}
         >
           <option value="">{t("allStatuses")}</option>
@@ -280,7 +306,9 @@ export function UserListClient() {
       {users && users.length > 0 && (
         <div className="flex flex-col gap-3">
           <p className="text-sm text-muted-foreground">
-            {t("userCount", { count: users.length })}
+            {countData
+              ? t("userCountTotal", { count: countData.count })
+              : t("userCount", { count: users.length })}
           </p>
           <div className="flex flex-col gap-2">
             {users.map((user) => (
@@ -298,6 +326,38 @@ export function UserListClient() {
               />
             ))}
           </div>
+          {countData && countData.count > PAGE_SIZE && (
+            <div className="flex items-center justify-between gap-3 pt-2">
+              <Button
+                variant="outline"
+                size="sm"
+                className="min-h-11 min-w-11 gap-2"
+                disabled={offset === 0}
+                onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+                aria-label={t("prevPage")}
+              >
+                <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+                <span className="hidden sm:inline">{t("prevPage")}</span>
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                {t("pageIndicator", {
+                  page: Math.floor(offset / PAGE_SIZE) + 1,
+                  total: Math.ceil(countData.count / PAGE_SIZE),
+                })}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                className="min-h-11 min-w-11 gap-2"
+                disabled={offset + PAGE_SIZE >= countData.count}
+                onClick={() => setOffset(offset + PAGE_SIZE)}
+                aria-label={t("nextPage")}
+              >
+                <span className="hidden sm:inline">{t("nextPage")}</span>
+                <ChevronRight className="h-4 w-4" aria-hidden="true" />
+              </Button>
+            </div>
+          )}
         </div>
       )}
 
@@ -355,7 +415,12 @@ function UserCard({
               <Badge variant="destructive">{t("inactive")}</Badge>
             )}
           </div>
-          <span className="text-xs text-muted-foreground truncate">{user.email}</span>
+          {user.email && (
+            <span className="text-xs text-muted-foreground truncate">{user.email}</span>
+          )}
+          {user.phone_number && (
+            <span className="text-xs text-muted-foreground truncate">{user.phone_number}</span>
+          )}
           <div className="flex items-center gap-3 mt-1 flex-wrap">
             {user.country && (
               <span className="text-xs text-muted-foreground">{user.country}</span>

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -965,6 +965,10 @@
       "noUsersFound": "No users found",
       "noUsersDescription": "Try adjusting your search or filters.",
       "userCount": "{count, plural, one {# user} other {# users}}",
+      "userCountTotal": "{count, plural, one {# user total} other {# users total}}",
+      "prevPage": "Previous",
+      "nextPage": "Next",
+      "pageIndicator": "Page {page} of {total}",
       "level": "Level {level}",
       "lastActive": "Last active",
       "memberSince": "Member since",
@@ -1008,7 +1012,13 @@
       "unit": "Unit",
       "quizScore": "Score",
       "moduleProgress": "Progress",
-      "completionPct": "{pct}% complete"
+      "completionPct": "{pct}% complete",
+      "phoneNumber": "Phone number",
+      "language": "Language",
+      "professionalRole": "Professional role",
+      "analyticsOptOut": "Analytics opt-out",
+      "yes": "Yes",
+      "no": "No"
     },
     "analytics": {
       "title": "Analytics",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -965,6 +965,10 @@
       "noUsersFound": "Aucun utilisateur trouvé",
       "noUsersDescription": "Essayez d'ajuster votre recherche ou vos filtres.",
       "userCount": "{count, plural, one {# utilisateur} other {# utilisateurs}}",
+      "userCountTotal": "{count, plural, one {# utilisateur au total} other {# utilisateurs au total}}",
+      "prevPage": "Précédent",
+      "nextPage": "Suivant",
+      "pageIndicator": "Page {page} sur {total}",
       "level": "Niveau {level}",
       "lastActive": "Dernière activité",
       "memberSince": "Membre depuis",
@@ -1008,7 +1012,13 @@
       "unit": "Unité",
       "quizScore": "Score",
       "moduleProgress": "Progression",
-      "completionPct": "{pct}% complété"
+      "completionPct": "{pct}% complété",
+      "phoneNumber": "Numéro de téléphone",
+      "language": "Langue",
+      "professionalRole": "Rôle professionnel",
+      "analyticsOptOut": "Désactivation des analytiques",
+      "yes": "Oui",
+      "no": "Non"
     },
     "analytics": {
       "title": "Analytique",


### PR DESCRIPTION
## Summary

- **Backend**: `phone_number` and `analytics_opt_out` are now included in `_user_to_response()` so the admin detail endpoint returns them. The CSV export now includes a `phone_number` column (critical for phone-only accounts with no email).
- **Frontend user list**: `AdminUser` interface updated with `phone_number: string | null`; phone number shown below email in user cards (as fallback when email is null); prev/next pagination controls with "Page X of Y" indicator using the existing `/admin/users/count` endpoint.
- **Frontend user detail**: Profile card now shows phone number, preferred language badge, avatar (via `next/image`), and analytics opt-out status. Email field is now conditional (hidden if null).
- **i18n**: All new strings added to both `en.json` and `fr.json`.

## Changes

- `backend/app/api/v1/admin/users.py` — add `phone_number` + `analytics_opt_out` to `_user_to_response()`; add `phone_number` column to CSV export
- `frontend/components/admin/user-list-client.tsx` — add `phone_number` to interface, show in card, add `useAdminUserCount` hook and pagination UI
- `frontend/components/admin/user-detail-client.tsx` — display phone, language badge, avatar, analytics opt-out; fix email nullability
- `frontend/messages/en.json` + `frontend/messages/fr.json` — new i18n keys

## Test plan

- [ ] Create a phone-only user (no email) → admin user list shows phone number; detail page shows phone, no email field
- [ ] View a user with all fields populated → all fields display correctly in detail view
- [ ] Export CSV → `phone_number` column present
- [ ] With >50 users → pagination controls appear and work (prev/next + page indicator)
- [ ] Mobile responsive check at 320px width
- [ ] Backend tests pass
- [ ] Frontend lint passes (no errors, only pre-existing warnings)

Closes #1324

Generated with [Claude Code](https://claude.ai/code)