### PR TITLE
Release: catalog filter UI redesign

### DIFF
--- a/frontend/app/[locale]/(app)/courses/page.tsx
+++ b/frontend/app/[locale]/(app)/courses/page.tsx
@@ -3,71 +3,17 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
-import { GraduationCap, X } from 'lucide-react';
+import { GraduationCap } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { CourseCard } from '@/components/learning/course-card';
+import { CourseFilterBar } from '@/components/learning/course-filter-bar';
+import { type FilterSection } from '@/components/learning/filter-chips';
 import {
   getCourses,
   getCourseTaxonomy,
   type CourseResponse,
   type TaxonomyItem,
 } from '@/lib/api';
-
-interface FilterSection {
-  key: string;
-  label: string;
-  allLabel: string;
-  items: TaxonomyItem[];
-}
-
-function FilterChips({
-  section,
-  active,
-  locale,
-  onToggle,
-}: {
-  section: FilterSection;
-  active: string | null;
-  locale: 'fr' | 'en';
-  onToggle: (key: string, value: string | null) => void;
-}) {
-  return (
-    <div className="flex flex-col gap-1.5">
-      <span className="text-xs font-medium text-stone-500 uppercase tracking-wide">
-        {section.label}
-      </span>
-      <div className="flex gap-1.5 overflow-x-auto pb-1 scrollbar-hide">
-        <button
-          type="button"
-          onClick={() => onToggle(section.key, null)}
-          className={`shrink-0 rounded-full px-3 py-1.5 text-xs font-medium transition-colors min-h-[36px] ${
-            !active
-              ? 'bg-teal-600 text-white'
-              : 'bg-stone-100 text-stone-600 hover:bg-stone-200 border border-stone-200'
-          }`}
-        >
-          {section.allLabel}
-        </button>
-        {section.items.map((item) => (
-          <button
-            key={item.value}
-            type="button"
-            onClick={() =>
-              onToggle(section.key, active === item.value ? null : item.value)
-            }
-            className={`shrink-0 rounded-full px-3 py-1.5 text-xs font-medium transition-colors min-h-[36px] ${
-              active === item.value
-                ? 'bg-teal-600 text-white'
-                : 'bg-stone-100 text-stone-600 hover:bg-stone-200 border border-stone-200'
-            }`}
-          >
-            {locale === 'fr' ? item.label_fr : item.label_en}
-          </button>
-        ))}
-      </div>
-    </div>
-  );
-}
 
 export default function CoursesPage() {
   const t = useTranslations('Courses');
@@ -89,8 +35,7 @@ export default function CoursesPage() {
   const activeDomain = searchParams.get('domain');
   const activeLevel = searchParams.get('level');
   const activeAudience = searchParams.get('audience');
-  const activeFilterCount =
-    (activeDomain ? 1 : 0) + (activeLevel ? 1 : 0) + (activeAudience ? 1 : 0);
+  const activeSearch = searchParams.get('search');
 
   const updateFilter = useCallback(
     (key: string, value: string | null) => {
@@ -129,6 +74,7 @@ export default function CoursesPage() {
           course_domain: activeDomain ?? undefined,
           course_level: activeLevel ?? undefined,
           audience_type: activeAudience ?? undefined,
+          search: activeSearch ?? undefined,
         });
         if (!cancelled) {
           setCourses(data);
@@ -146,7 +92,7 @@ export default function CoursesPage() {
     return () => {
       cancelled = true;
     };
-  }, [activeDomain, activeLevel, activeAudience]);
+  }, [activeDomain, activeLevel, activeAudience, activeSearch]);
 
   const handleRetry = () => {
     setError(false);
@@ -155,6 +101,7 @@ export default function CoursesPage() {
       course_domain: activeDomain ?? undefined,
       course_level: activeLevel ?? undefined,
       audience_type: activeAudience ?? undefined,
+      search: activeSearch ?? undefined,
     })
       .then((data) => {
         setCourses(data);
@@ -171,19 +118,16 @@ export default function CoursesPage() {
         {
           key: 'domain',
           label: t('domain'),
-          allLabel: t('allDomains'),
           items: taxonomy.domains,
         },
         {
           key: 'level',
           label: t('level'),
-          allLabel: t('allLevels'),
           items: taxonomy.levels,
         },
         {
           key: 'audience',
           label: t('audience'),
-          allLabel: t('allAudiences'),
           items: taxonomy.audience_types,
         },
       ]
@@ -204,32 +148,16 @@ export default function CoursesPage() {
 
       {/* Filter bar */}
       {taxonomy && (
-        <div className="mb-6 space-y-3 bg-stone-50 rounded-xl p-4 border border-stone-200">
-          {filterSections.map((section) => (
-            <FilterChips
-              key={section.key}
-              section={section}
-              active={activeValues[section.key]}
-              locale={locale}
-              onToggle={updateFilter}
-            />
-          ))}
-          {activeFilterCount > 0 && (
-            <div className="flex items-center justify-between pt-1">
-              <span className="text-xs text-stone-500">
-                {t('activeFilters', { count: activeFilterCount })}
-              </span>
-              <button
-                type="button"
-                onClick={clearFilters}
-                className="inline-flex items-center gap-1 text-xs text-teal-600 hover:text-teal-700 font-medium"
-              >
-                <X className="h-3 w-3" />
-                {t('clearFilters')}
-              </button>
-            </div>
-          )}
-        </div>
+        <CourseFilterBar
+          filterSections={filterSections}
+          activeValues={activeValues}
+          activeSearch={activeSearch}
+          courseCount={courses.length}
+          loading={loading}
+          locale={locale}
+          onUpdateFilter={updateFilter}
+          onClearFilters={clearFilters}
+        />
       )}
 
       {loading && (
@@ -253,10 +181,12 @@ export default function CoursesPage() {
             <GraduationCap className="h-12 w-12 text-teal-600" aria-hidden="true" />
           </div>
           <h2 className="text-lg font-semibold text-stone-900">
-            {activeFilterCount > 0 ? t('noCoursesMatchFilter') : t('noCourses')}
+            {activeValues.domain || activeValues.level || activeValues.audience || activeSearch
+              ? t('noCoursesMatchFilter')
+              : t('noCourses')}
           </h2>
           <p className="text-stone-500 text-sm max-w-sm">
-            {activeFilterCount > 0 ? (
+            {activeValues.domain || activeValues.level || activeValues.audience || activeSearch ? (
               <button
                 type="button"
                 onClick={clearFilters}

--- a/frontend/app/[locale]/(app)/curricula/[slug]/page.tsx
+++ b/frontend/app/[locale]/(app)/curricula/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { GraduationCap, BookOpen, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { CourseCard } from '@/components/learning/course-card';
 import { ShareButton } from '@/components/shared/share-button';
+import { FilterChips, type FilterSection } from '@/components/learning/filter-chips';
 import {
   getCurriculumBySlug,
   getCourses,
@@ -16,60 +17,6 @@ import {
   type TaxonomyItem,
 } from '@/lib/api';
 import { setCurriculumContext } from '@/lib/curriculum-context';
-
-interface FilterSection {
-  key: string;
-  label: string;
-  allLabel: string;
-  items: TaxonomyItem[];
-}
-
-function FilterChips({
-  section,
-  active,
-  locale,
-  onToggle,
-}: {
-  section: FilterSection;
-  active: string | null;
-  locale: 'fr' | 'en';
-  onToggle: (key: string, value: string | null) => void;
-}) {
-  return (
-    <div className="flex flex-col gap-1.5">
-      <span className="text-xs font-medium text-stone-500 uppercase tracking-wide">
-        {section.label}
-      </span>
-      <div className="flex gap-1.5 overflow-x-auto pb-1 scrollbar-hide">
-        <button
-          type="button"
-          onClick={() => onToggle(section.key, null)}
-          className={`shrink-0 rounded-full px-3 py-1.5 text-xs font-medium transition-colors min-h-[36px] ${
-            !active
-              ? 'bg-teal-600 text-white'
-              : 'bg-stone-100 text-stone-600 hover:bg-stone-200 border border-stone-200'
-          }`}
-        >
-          {section.allLabel}
-        </button>
-        {section.items.map((item) => (
-          <button
-            key={item.value}
-            type="button"
-            onClick={() => onToggle(section.key, active === item.value ? null : item.value)}
-            className={`shrink-0 rounded-full px-3 py-1.5 text-xs font-medium transition-colors min-h-[36px] ${
-              active === item.value
-                ? 'bg-teal-600 text-white'
-                : 'bg-stone-100 text-stone-600 hover:bg-stone-200 border border-stone-200'
-            }`}
-          >
-            {locale === 'fr' ? item.label_fr : item.label_en}
-          </button>
-        ))}
-      </div>
-    </div>
-  );
-}
 
 export default function CurriculumPage() {
   const t = useTranslations('Curricula');
@@ -186,19 +133,16 @@ export default function CurriculumPage() {
         {
           key: 'domain',
           label: tCourses('domain'),
-          allLabel: tCourses('allDomains'),
           items: taxonomy.domains,
         },
         {
           key: 'level',
           label: tCourses('level'),
-          allLabel: tCourses('allLevels'),
           items: taxonomy.levels,
         },
         {
           key: 'audience',
           label: tCourses('audience'),
-          allLabel: tCourses('allAudiences'),
           items: taxonomy.audience_types,
         },
       ]

--- a/frontend/components/learning/course-filter-bar.tsx
+++ b/frontend/components/learning/course-filter-bar.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useTranslations } from 'next-intl';
+import { Search, X, ChevronDown, ChevronUp, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { FilterChips, type FilterSection } from './filter-chips';
+import { useDebounce } from '@/lib/hooks/use-debounce';
+
+interface CourseFilterBarProps {
+  filterSections: FilterSection[];
+  activeValues: Record<string, string | null>;
+  activeSearch: string | null;
+  courseCount: number;
+  loading: boolean;
+  locale: 'fr' | 'en';
+  onUpdateFilter: (key: string, value: string | null) => void;
+  onClearFilters: () => void;
+}
+
+export function CourseFilterBar({
+  filterSections,
+  activeValues,
+  activeSearch,
+  courseCount,
+  loading,
+  locale,
+  onUpdateFilter,
+  onClearFilters,
+}: CourseFilterBarProps) {
+  const t = useTranslations('Courses');
+  const [filtersExpanded, setFiltersExpanded] = useState(false);
+  // Use activeSearch as key to reset input when URL clears (e.g. clearFilters)
+  const searchKey = activeSearch ?? '';
+  const [searchInput, setSearchInput] = useState(searchKey);
+  const debouncedSearch = useDebounce(searchInput, 300);
+
+  // Reset local input when activeSearch is cleared externally (e.g. clearFilters)
+  const [prevSearchKey, setPrevSearchKey] = useState(searchKey);
+  if (searchKey !== prevSearchKey) {
+    setPrevSearchKey(searchKey);
+    if (searchKey === '' && searchInput !== '') {
+      setSearchInput('');
+    }
+  }
+
+  // Sync debounced search to URL
+  useEffect(() => {
+    const current = activeSearch ?? '';
+    if (debouncedSearch !== current) {
+      onUpdateFilter('search', debouncedSearch || null);
+    }
+  }, [debouncedSearch]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const activeFilterCount = Object.values(activeValues).filter(Boolean).length;
+  const totalActiveCount = activeFilterCount + (activeSearch ? 1 : 0);
+
+  // Build active filter labels for collapsed mobile badges
+  const activeFilterBadges: { key: string; label: string }[] = [];
+  for (const section of filterSections) {
+    const val = activeValues[section.key];
+    if (val) {
+      const item = section.items.find((i) => i.value === val);
+      if (item) {
+        activeFilterBadges.push({
+          key: section.key,
+          label: locale === 'fr' ? item.label_fr : item.label_en,
+        });
+      }
+    }
+  }
+
+  return (
+    <div className="mb-6 space-y-3 bg-stone-50 rounded-xl p-4 border border-stone-200">
+      {/* Search input */}
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-stone-400 pointer-events-none" />
+        <Input
+          type="search"
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          placeholder={t('searchPlaceholder')}
+          aria-label={t('searchPlaceholder')}
+          className="h-11 pl-9 pr-9 rounded-lg"
+        />
+        {searchInput && (
+          <button
+            type="button"
+            onClick={() => setSearchInput('')}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600"
+            aria-label={t('clearFilters')}
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      {/* Mobile: toggle button + result count row */}
+      <div className="flex items-center justify-between md:hidden">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setFiltersExpanded(!filtersExpanded)}
+          className="gap-1.5 min-h-[44px]"
+        >
+          {t('filters')}
+          {activeFilterCount > 0 && (
+            <span className="inline-flex items-center justify-center h-5 w-5 rounded-full bg-teal-600 text-white text-[10px] font-bold">
+              {activeFilterCount}
+            </span>
+          )}
+          {filtersExpanded ? (
+            <ChevronUp className="h-4 w-4" />
+          ) : (
+            <ChevronDown className="h-4 w-4" />
+          )}
+        </Button>
+        <ResultCount loading={loading} count={courseCount} t={t} />
+      </div>
+
+      {/* Mobile: active filter badges when collapsed */}
+      {!filtersExpanded && activeFilterBadges.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 md:hidden">
+          {activeFilterBadges.map(({ key, label }) => (
+            <Badge
+              key={key}
+              variant="secondary"
+              className="gap-1 cursor-pointer hover:bg-stone-200"
+              onClick={() => onUpdateFilter(key, null)}
+            >
+              {label}
+              <X className="h-3 w-3" />
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      {/* Filter sections — always visible on desktop, toggle on mobile */}
+      <div className={`space-y-3 ${filtersExpanded ? 'block' : 'hidden'} md:block`}>
+        {filterSections.map((section) => (
+          <FilterChips
+            key={section.key}
+            section={section}
+            active={activeValues[section.key]}
+            locale={locale}
+            onToggle={onUpdateFilter}
+          />
+        ))}
+      </div>
+
+      {/* Desktop: result count + clear row */}
+      <div className="hidden md:flex items-center justify-between pt-1">
+        <ResultCount loading={loading} count={courseCount} t={t} />
+        {totalActiveCount > 0 && (
+          <button
+            type="button"
+            onClick={onClearFilters}
+            className="inline-flex items-center gap-1 text-xs text-teal-600 hover:text-teal-700 font-medium"
+          >
+            <X className="h-3 w-3" />
+            {t('clearFilters')}
+          </button>
+        )}
+      </div>
+
+      {/* Mobile: clear filters inside expanded panel */}
+      {filtersExpanded && totalActiveCount > 0 && (
+        <div className="flex justify-end md:hidden">
+          <button
+            type="button"
+            onClick={onClearFilters}
+            className="inline-flex items-center gap-1 text-xs text-teal-600 hover:text-teal-700 font-medium"
+          >
+            <X className="h-3 w-3" />
+            {t('clearFilters')}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ResultCount({
+  loading,
+  count,
+  t,
+}: {
+  loading: boolean;
+  count: number;
+  t: ReturnType<typeof useTranslations<'Courses'>>;
+}) {
+  if (loading) {
+    return <Loader2 className="h-4 w-4 animate-spin text-stone-400" />;
+  }
+  return (
+    <span className="text-sm text-stone-500">
+      {t('showingCourses', { count })}
+    </span>
+  );
+}

--- a/frontend/components/learning/filter-chips.tsx
+++ b/frontend/components/learning/filter-chips.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+export interface FilterSection {
+  key: string;
+  label: string;
+  items: { value: string; label_fr: string; label_en: string }[];
+}
+
+export function FilterChips({
+  section,
+  active,
+  locale,
+  onToggle,
+}: {
+  section: FilterSection;
+  active: string | null;
+  locale: 'fr' | 'en';
+  onToggle: (key: string, value: string | null) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-xs font-medium text-stone-500 uppercase tracking-wide">
+        {section.label}
+      </span>
+      <div className="flex flex-wrap gap-1.5">
+        {section.items.map((item) => (
+          <button
+            key={item.value}
+            type="button"
+            onClick={() =>
+              onToggle(section.key, active === item.value ? null : item.value)
+            }
+            className={`shrink-0 rounded-full px-3 py-1.5 text-xs font-medium transition-colors min-h-[44px] ${
+              active === item.value
+                ? 'bg-teal-700 text-white ring-2 ring-teal-300/50 ring-offset-1'
+                : 'bg-stone-100 text-stone-600 hover:bg-stone-200 border border-stone-200'
+            }`}
+          >
+            {locale === 'fr' ? item.label_fr : item.label_en}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/hooks/use-debounce.ts
+++ b/frontend/lib/hooks/use-debounce.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react';
+
+export function useDebounce<T>(value: T, delay = 300): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debounced;
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1231,6 +1231,9 @@
     "allAudiences": "All audiences",
     "clearFilters": "Clear filters",
     "activeFilters": "{count, plural, one {# active filter} other {# active filters}}",
+    "searchPlaceholder": "Search courses...",
+    "showingCourses": "{count, plural, one {Showing # course} other {Showing # courses}}",
+    "filters": "Filters",
     "cancel": "Cancel",
     "manageCodes": "Manage Activation Codes"
   },

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1231,6 +1231,9 @@
     "allAudiences": "Tous les publics",
     "clearFilters": "Effacer les filtres",
     "activeFilters": "{count, plural, one {# filtre actif} other {# filtres actifs}}",
+    "searchPlaceholder": "Rechercher des formations...",
+    "showingCourses": "{count, plural, one {# formation trouvée} other {# formations trouvées}}",
+    "filters": "Filtres",
     "cancel": "Annuler",
     "manageCodes": "Gérer les codes d'activation"
   },


### PR DESCRIPTION
## Summary

Merges the catalog filter UI redesign from dev to main for production deployment.

- Search input with debounced filtering (uses existing backend search param)
- Flex-wrap chips replacing hidden horizontal scroll on desktop
- Collapsible filter panel on mobile with active filter badges
- Result count display
- Shared FilterChips component (DRY refactor)
- WCAG 2.1 AA touch targets (44px) and improved contrast

## Test plan
- [ ] Verify deployment succeeds
- [ ] Test course catalog search + filters on desktop and mobile
- [ ] Test curricula page filters still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)