### PR TITLE
fix(catalog): compact dropdown filters replacing oversized chip grid

### DIFF
--- a/frontend/components/learning/course-filter-bar.tsx
+++ b/frontend/components/learning/course-filter-bar.tsx
@@ -2,12 +2,19 @@
 
 import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
-import { Search, X, ChevronDown, ChevronUp, Loader2 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
+import { Search, X, Loader2 } from 'lucide-react';
 import { Input } from '@/components/ui/input';
-import { FilterChips, type FilterSection } from './filter-chips';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { type FilterSection } from './filter-chips';
 import { useDebounce } from '@/lib/hooks/use-debounce';
+
+const ALL_VALUE = '__all__';
 
 interface CourseFilterBarProps {
   filterSections: FilterSection[];
@@ -31,17 +38,14 @@ export function CourseFilterBar({
   onClearFilters,
 }: CourseFilterBarProps) {
   const t = useTranslations('Courses');
-  const [filtersExpanded, setFiltersExpanded] = useState(false);
-  // Use activeSearch as key to reset input when URL clears (e.g. clearFilters)
-  const searchKey = activeSearch ?? '';
-  const [searchInput, setSearchInput] = useState(searchKey);
+  const [searchInput, setSearchInput] = useState(activeSearch ?? '');
   const debouncedSearch = useDebounce(searchInput, 300);
 
   // Reset local input when activeSearch is cleared externally (e.g. clearFilters)
-  const [prevSearchKey, setPrevSearchKey] = useState(searchKey);
-  if (searchKey !== prevSearchKey) {
-    setPrevSearchKey(searchKey);
-    if (searchKey === '' && searchInput !== '') {
+  const [prevSearchKey, setPrevSearchKey] = useState(activeSearch ?? '');
+  if ((activeSearch ?? '') !== prevSearchKey) {
+    setPrevSearchKey(activeSearch ?? '');
+    if ((activeSearch ?? '') === '' && searchInput !== '') {
       setSearchInput('');
     }
   }
@@ -57,102 +61,70 @@ export function CourseFilterBar({
   const activeFilterCount = Object.values(activeValues).filter(Boolean).length;
   const totalActiveCount = activeFilterCount + (activeSearch ? 1 : 0);
 
-  // Build active filter labels for collapsed mobile badges
-  const activeFilterBadges: { key: string; label: string }[] = [];
-  for (const section of filterSections) {
-    const val = activeValues[section.key];
-    if (val) {
-      const item = section.items.find((i) => i.value === val);
-      if (item) {
-        activeFilterBadges.push({
-          key: section.key,
-          label: locale === 'fr' ? item.label_fr : item.label_en,
-        });
-      }
-    }
-  }
-
   return (
     <div className="mb-6 space-y-3 bg-stone-50 rounded-xl p-4 border border-stone-200">
-      {/* Search input */}
-      <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-stone-400 pointer-events-none" />
-        <Input
-          type="search"
-          value={searchInput}
-          onChange={(e) => setSearchInput(e.target.value)}
-          placeholder={t('searchPlaceholder')}
-          aria-label={t('searchPlaceholder')}
-          className="h-11 pl-9 pr-9 rounded-lg"
-        />
-        {searchInput && (
-          <button
-            type="button"
-            onClick={() => setSearchInput('')}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600"
-            aria-label={t('clearFilters')}
-          >
-            <X className="h-4 w-4" />
-          </button>
-        )}
-      </div>
-
-      {/* Mobile: toggle button + result count row */}
-      <div className="flex items-center justify-between md:hidden">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => setFiltersExpanded(!filtersExpanded)}
-          className="gap-1.5 min-h-[44px]"
-        >
-          {t('filters')}
-          {activeFilterCount > 0 && (
-            <span className="inline-flex items-center justify-center h-5 w-5 rounded-full bg-teal-600 text-white text-[10px] font-bold">
-              {activeFilterCount}
-            </span>
-          )}
-          {filtersExpanded ? (
-            <ChevronUp className="h-4 w-4" />
-          ) : (
-            <ChevronDown className="h-4 w-4" />
-          )}
-        </Button>
-        <ResultCount loading={loading} count={courseCount} t={t} />
-      </div>
-
-      {/* Mobile: active filter badges when collapsed */}
-      {!filtersExpanded && activeFilterBadges.length > 0 && (
-        <div className="flex flex-wrap gap-1.5 md:hidden">
-          {activeFilterBadges.map(({ key, label }) => (
-            <Badge
-              key={key}
-              variant="secondary"
-              className="gap-1 cursor-pointer hover:bg-stone-200"
-              onClick={() => onUpdateFilter(key, null)}
+      {/* Row 1: Search + Dropdowns */}
+      <div className="flex flex-col sm:flex-row gap-2">
+        {/* Search input */}
+        <div className="relative flex-1 min-w-0">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-stone-400 pointer-events-none" />
+          <Input
+            type="search"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder={t('searchPlaceholder')}
+            aria-label={t('searchPlaceholder')}
+            className="h-10 pl-9 pr-9 rounded-lg"
+          />
+          {searchInput && (
+            <button
+              type="button"
+              onClick={() => setSearchInput('')}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600"
+              aria-label={t('clearFilters')}
             >
-              {label}
-              <X className="h-3 w-3" />
-            </Badge>
+              <X className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+
+        {/* Filter dropdowns */}
+        <div className="flex gap-2 flex-wrap sm:flex-nowrap">
+          {filterSections.map((section) => (
+            <Select
+              key={section.key}
+              value={activeValues[section.key] ?? ALL_VALUE}
+              onValueChange={(val) =>
+                onUpdateFilter(section.key, val === ALL_VALUE ? null : val)
+              }
+            >
+              <SelectTrigger className="h-10 min-w-[130px] text-xs">
+                <SelectValue placeholder={section.label} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ALL_VALUE}>
+                  {section.label} — {t('all')}
+                </SelectItem>
+                {section.items.map((item) => (
+                  <SelectItem key={item.value} value={item.value}>
+                    {locale === 'fr' ? item.label_fr : item.label_en}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           ))}
         </div>
-      )}
-
-      {/* Filter sections — always visible on desktop, toggle on mobile */}
-      <div className={`space-y-3 ${filtersExpanded ? 'block' : 'hidden'} md:block`}>
-        {filterSections.map((section) => (
-          <FilterChips
-            key={section.key}
-            section={section}
-            active={activeValues[section.key]}
-            locale={locale}
-            onToggle={onUpdateFilter}
-          />
-        ))}
       </div>
 
-      {/* Desktop: result count + clear row */}
-      <div className="hidden md:flex items-center justify-between pt-1">
-        <ResultCount loading={loading} count={courseCount} t={t} />
+      {/* Row 2: Result count + Clear */}
+      <div className="flex items-center justify-between">
+        {loading ? (
+          <Loader2 className="h-4 w-4 animate-spin text-stone-400" />
+        ) : (
+          <span className="text-sm text-stone-500">
+            {t('showingCourses', { count: courseCount })}
+          </span>
+        )}
         {totalActiveCount > 0 && (
           <button
             type="button"
@@ -164,39 +136,6 @@ export function CourseFilterBar({
           </button>
         )}
       </div>
-
-      {/* Mobile: clear filters inside expanded panel */}
-      {filtersExpanded && totalActiveCount > 0 && (
-        <div className="flex justify-end md:hidden">
-          <button
-            type="button"
-            onClick={onClearFilters}
-            className="inline-flex items-center gap-1 text-xs text-teal-600 hover:text-teal-700 font-medium"
-          >
-            <X className="h-3 w-3" />
-            {t('clearFilters')}
-          </button>
-        </div>
-      )}
     </div>
-  );
-}
-
-function ResultCount({
-  loading,
-  count,
-  t,
-}: {
-  loading: boolean;
-  count: number;
-  t: ReturnType<typeof useTranslations<'Courses'>>;
-}) {
-  if (loading) {
-    return <Loader2 className="h-4 w-4 animate-spin text-stone-400" />;
-  }
-  return (
-    <span className="text-sm text-stone-500">
-      {t('showingCourses', { count })}
-    </span>
   );
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1234,6 +1234,7 @@
     "searchPlaceholder": "Search courses...",
     "showingCourses": "{count, plural, one {Showing # course} other {Showing # courses}}",
     "filters": "Filters",
+    "all": "All",
     "cancel": "Cancel",
     "manageCodes": "Manage Activation Codes"
   },

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1234,6 +1234,7 @@
     "searchPlaceholder": "Rechercher des formations...",
     "showingCourses": "{count, plural, one {# formation trouvée} other {# formations trouvées}}",
     "filters": "Filtres",
+    "all": "Tous",
     "cancel": "Annuler",
     "manageCodes": "Gérer les codes d'activation"
   },


### PR DESCRIPTION
## Summary

- Replaces chip-based filter UI (26 chips covering the viewport) with 3 compact dropdown selects
- Search input + Domain/Level/Audience dropdowns on a single row (desktop) or stacked (mobile)
- Filter bar now takes ~80px instead of ~400px, courses visible immediately
- Added "all" i18n key for dropdown reset option

## Test plan
- [ ] Desktop: search + 3 dropdowns fit on one row, selecting filters works
- [ ] Mobile: dropdowns stack below search, still compact
- [ ] Clear filters resets all dropdowns + search
- [ ] Result count updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)