### PR TITLE
fix(admin): handle null email for phone-only admins in audit log

### DIFF
--- a/backend/app/api/v1/admin/users.py
+++ b/backend/app/api/v1/admin/users.py
@@ -62,7 +62,7 @@ async def _write_audit_log(
 ) -> None:
     log = AuditLog(
         admin_id=UUID(admin.id),
-        admin_email=admin.email,
+        admin_email=admin.email or f"phone:{getattr(admin, 'phone_number', 'unknown')}",
         target_user_id=target_user.id,
         target_user_email=target_user.email,
         action=action,

--- a/backend/app/domain/models/audit_log.py
+++ b/backend/app/domain/models/audit_log.py
@@ -35,7 +35,7 @@ class AuditLog(Base):
     admin_id: Mapped[uuid.UUID] = mapped_column(
         PG_UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
     )
-    admin_email: Mapped[str] = mapped_column(String, nullable=False)
+    admin_email: Mapped[str | None] = mapped_column(String, nullable=True)
     target_user_id: Mapped[uuid.UUID | None] = mapped_column(
         PG_UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
     )

--- a/backend/migrations/versions/054_make_audit_log_admin_email_nullable.py
+++ b/backend/migrations/versions/054_make_audit_log_admin_email_nullable.py
@@ -1,0 +1,26 @@
+"""Make admin_audit_logs.admin_email nullable to support phone-only admins.
+
+Revision ID: 054
+Revises: 053
+Create Date: 2026-04-10
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "054"
+down_revision = "053"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("admin_audit_logs", "admin_email", nullable=True)
+
+
+def downgrade() -> None:
+    op.execute(
+        "UPDATE admin_audit_logs SET admin_email = 'unknown' WHERE admin_email IS NULL"
+    )
+    op.alter_column("admin_audit_logs", "admin_email", nullable=False)

--- a/frontend/components/admin/user-list-client.tsx
+++ b/frontend/components/admin/user-list-client.tsx
@@ -143,7 +143,10 @@ export function UserListClient() {
       setPendingAction(null);
       setActionError(null);
     },
-    onError: () => setActionError(t("actionError")),
+    onError: (err) => {
+      console.error("Admin status action failed:", err);
+      setActionError(t("actionError"));
+    },
   });
 
   const roleMutation = useMutation({
@@ -157,7 +160,10 @@ export function UserListClient() {
       setPendingAction(null);
       setActionError(null);
     },
-    onError: () => setActionError(t("actionError")),
+    onError: (err) => {
+      console.error("Admin role action failed:", err);
+      setActionError(t("actionError"));
+    },
   });
 
   const handleConfirmAction = () => {


### PR DESCRIPTION
## Summary

- Admin actions (role/status changes) were failing with a generic 500 error for all users when the acting admin had no email (phone-only account)
- `_write_audit_log()` passed `admin.email` directly to the NOT NULL `admin_email` column, causing a PostgreSQL IntegrityError on commit
- Frontend `onError` callbacks swallowed the actual error with no logging

## Changes

- `backend/app/api/v1/admin/users.py`: Add fallback `admin.email or f"phone:{getattr(admin, 'phone_number', 'unknown')}"` in `_write_audit_log()` (line 65)
- `backend/app/domain/models/audit_log.py`: Make `admin_email` nullable (`Mapped[str | None]`, `nullable=True`)
- `backend/migrations/versions/054_make_audit_log_admin_email_nullable.py`: Alembic migration to `ALTER COLUMN admin_email DROP NOT NULL` with safe downgrade
- `frontend/components/admin/user-list-client.tsx`: Add `console.error` in both `onError` callbacks for better debugging

## Test plan

- [ ] Backend tests pass
- [ ] Frontend lint/tests pass
- [ ] Log in as phone-only admin → change a user's role → succeeds
- [ ] Log in as email admin → change a user's status → succeeds
- [ ] Check `admin_audit_logs` → entries written with correct identifier
- [ ] Frontend console shows detailed error on any future failure
- [ ] Manually verified on mobile viewport

Closes #1329

Generated with [Claude Code](https://claude.ai/code)