### PR TITLE
fix(image): migrate DALL-E 2 → gpt-image-1 before May 12 shutdown

### DIFF
--- a/backend/app/domain/services/image_service.py
+++ b/backend/app/domain/services/image_service.py
@@ -1,4 +1,4 @@
-"""Service for AI-generated lesson illustrations using DALL-E 2 with semantic reuse."""
+"""Service for AI-generated lesson illustrations using gpt-image-1 with semantic reuse."""
 
 from __future__ import annotations
 
@@ -31,7 +31,7 @@ def _jaccard_similarity(tags_a: list[str], tags_b: list[str]) -> float:
 
 
 class ImageGenerationService:
-    """Pipeline: concept extraction → semantic reuse → DALL-E 2 → WebP → bilingual alt-text."""
+    """Pipeline: concept extraction → semantic reuse → gpt-image-1 → WebP → bilingual alt-text."""
 
     async def generate_for_lesson(
         self,
@@ -153,7 +153,7 @@ class ImageGenerationService:
             "You are an expert in public health education for West Africa. "
             "Given lesson content, extract: "
             "1) A short key concept (5 words max), "
-            "2) A vivid DALL-E 3 illustration prompt that follows these STRICT rules:\n"
+            "2) A vivid image generation prompt that follows these STRICT rules:\n"
             "   - NEVER include any text, words, labels, numbers, letters, captions, or titles in the image\n"
             "   - Focus on visual metaphors, diagrams without text, people, scenes, objects\n"
             "   - Style: clean flat illustration, infographic style, vibrant colors, educational\n"
@@ -164,7 +164,7 @@ class ImageGenerationService:
             "3) A JSON array of 5-8 lowercase semantic tags. "
             "Reply ONLY in this exact format:\n"
             "CONCEPT: <concept>\n"
-            "PROMPT: <dalle_prompt>\n"
+            "PROMPT: <image_prompt>\n"
             "TAGS: <json_array>"
         )
 
@@ -233,8 +233,9 @@ class ImageGenerationService:
         return None
 
     async def _call_dalle(self, prompt: str) -> tuple[bytes, str]:
-        """Call OpenAI DALL-E 2 API and return (image_bytes, image_url)."""
-        import httpx
+        """Call OpenAI gpt-image-1 API and return (image_bytes, image_url)."""
+        import base64
+
         from openai import AsyncOpenAI
 
         client = AsyncOpenAI(api_key=settings.openai_api_key)
@@ -243,18 +244,14 @@ class ImageGenerationService:
         final_prompt = prompt + no_text_suffix
 
         response = await client.images.generate(
-            model="dall-e-2",
+            model="gpt-image-1",
             prompt=final_prompt,
-            n=1,
-            size="512x512",
-            response_format="url",
+            size="1024x1024",
+            quality="low",
         )
 
-        image_url = response.data[0].url
-        async with httpx.AsyncClient(timeout=30) as http_client:
-            img_response = await http_client.get(image_url)
-            img_response.raise_for_status()
-            image_bytes = img_response.content
+        image_bytes = base64.b64decode(response.data[0].b64_json)
+        image_url = f"gpt-image-1://{id(response)}"
 
         return image_bytes, image_url
 

--- a/backend/tests/test_image_generation.py
+++ b/backend/tests/test_image_generation.py
@@ -1,4 +1,4 @@
-"""Tests for DALL-E 2 async image generation pipeline (issue #223, US-025)."""
+"""Tests for gpt-image-1 async image generation pipeline (issue #223, US-025)."""
 
 from __future__ import annotations
 
@@ -202,15 +202,16 @@ class TestImageGenerationService:
     async def test_new_generation_calls_dalle(
         self, service, mock_session, mock_claude_response, mock_alt_text_response
     ):
-        """When no matching image, DALL-E 2 must be called and image saved."""
+        """When no matching image, gpt-image-1 must be called and image saved."""
+        import base64
+
         mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = []
         mock_session.execute = AsyncMock(return_value=mock_result)
 
-        dalle_response = MagicMock()
-        dalle_response.data = [
-            MagicMock(url="https://oaidalleapiprodscus.blob.core.windows.net/img.png")
-        ]
+        fake_b64 = base64.b64encode(b"FAKE_PNG_DATA").decode()
+        image_api_response = MagicMock()
+        image_api_response.data = [MagicMock(b64_json=fake_b64)]
 
         with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
             mock_client = AsyncMock()
@@ -222,36 +223,25 @@ class TestImageGenerationService:
             with patch("openai.AsyncOpenAI") as mock_openai_cls:
                 mock_openai = AsyncMock()
                 mock_openai_cls.return_value = mock_openai
-                mock_openai.images.generate = AsyncMock(return_value=dalle_response)
+                mock_openai.images.generate = AsyncMock(return_value=image_api_response)
 
-                with patch("httpx.AsyncClient") as mock_http_cls:
-                    mock_http = AsyncMock()
-                    mock_http_cls.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-                    mock_http_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-                    mock_http.get = AsyncMock(
-                        return_value=MagicMock(
-                            content=b"FAKE_PNG_DATA", raise_for_status=MagicMock()
-                        )
-                    )
-
-                    result = await service.generate_for_lesson(
-                        lesson_id=uuid.uuid4(),
-                        module_id=uuid.uuid4(),
-                        unit_id="u01",
-                        lesson_content="Lesson about cholera surveillance.",
-                        session=mock_session,
-                    )
+                result = await service.generate_for_lesson(
+                    lesson_id=uuid.uuid4(),
+                    module_id=uuid.uuid4(),
+                    unit_id="u01",
+                    lesson_content="Lesson about cholera surveillance.",
+                    session=mock_session,
+                )
 
             mock_openai.images.generate.assert_called_once()
             call_kwargs = mock_openai.images.generate.call_args.kwargs
-            assert call_kwargs.get("model") == "dall-e-2"
-            assert call_kwargs.get("size") == "512x512"
+            assert call_kwargs.get("model") == "gpt-image-1"
+            assert call_kwargs.get("size") == "1024x1024"
             prompt_sent = call_kwargs.get("prompt", "")
             assert "NO text" in prompt_sent or "no text" in prompt_sent.lower()
 
         assert result.status == "ready"
         assert result.image_url == f"/api/v1/images/{result.id}/data"
-        assert "oaidalleapiprodscus" not in (result.image_url or "")
         assert result.image_data is not None
         assert len(result.image_data) > 0
 
@@ -280,12 +270,15 @@ class TestImageGenerationService:
         self, service, mock_session, mock_claude_response, mock_alt_text_response
     ):
         """Alt-text must be generated in both FR and EN."""
+        import base64
+
         mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = []
         mock_session.execute = AsyncMock(return_value=mock_result)
 
-        dalle_response = MagicMock()
-        dalle_response.data = [MagicMock(url="https://example.com/img.png")]
+        fake_b64 = base64.b64encode(b"DATA").decode()
+        image_api_response = MagicMock()
+        image_api_response.data = [MagicMock(b64_json=fake_b64)]
 
         with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
             mock_client = AsyncMock()
@@ -297,23 +290,15 @@ class TestImageGenerationService:
             with patch("openai.AsyncOpenAI") as mock_openai_cls:
                 mock_openai = AsyncMock()
                 mock_openai_cls.return_value = mock_openai
-                mock_openai.images.generate = AsyncMock(return_value=dalle_response)
+                mock_openai.images.generate = AsyncMock(return_value=image_api_response)
 
-                with patch("httpx.AsyncClient") as mock_http_cls:
-                    mock_http = AsyncMock()
-                    mock_http_cls.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-                    mock_http_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-                    mock_http.get = AsyncMock(
-                        return_value=MagicMock(content=b"DATA", raise_for_status=MagicMock())
-                    )
-
-                    result = await service.generate_for_lesson(
-                        lesson_id=uuid.uuid4(),
-                        module_id=uuid.uuid4(),
-                        unit_id="u01",
-                        lesson_content="Lesson content.",
-                        session=mock_session,
-                    )
+                result = await service.generate_for_lesson(
+                    lesson_id=uuid.uuid4(),
+                    module_id=uuid.uuid4(),
+                    unit_id="u01",
+                    lesson_content="Lesson content.",
+                    session=mock_session,
+                )
 
         assert result.alt_text_fr is not None and len(result.alt_text_fr) > 0
         assert result.alt_text_en is not None and len(result.alt_text_en) > 0
@@ -391,13 +376,16 @@ class TestImageGenerationService:
     async def test_new_generation_image_data_not_null(
         self, service, mock_session, mock_claude_response, mock_alt_text_response
     ):
-        """image_data must be stored (not NULL) after successful DALL-E generation."""
+        """image_data must be stored (not NULL) after successful gpt-image-1 generation."""
+        import base64
+
         mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = []
         mock_session.execute = AsyncMock(return_value=mock_result)
 
-        dalle_response = MagicMock()
-        dalle_response.data = [MagicMock(url="https://example.com/img.png")]
+        fake_b64 = base64.b64encode(b"FAKE_PNG_BINARY_DATA").decode()
+        image_api_response = MagicMock()
+        image_api_response.data = [MagicMock(b64_json=fake_b64)]
 
         with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
             mock_client = AsyncMock()
@@ -409,27 +397,16 @@ class TestImageGenerationService:
             with patch("openai.AsyncOpenAI") as mock_openai_cls:
                 mock_openai = AsyncMock()
                 mock_openai_cls.return_value = mock_openai
-                mock_openai.images.generate = AsyncMock(return_value=dalle_response)
+                mock_openai.images.generate = AsyncMock(return_value=image_api_response)
 
-                with patch("httpx.AsyncClient") as mock_http_cls:
-                    mock_http = AsyncMock()
-                    mock_http_cls.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-                    mock_http_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-                    mock_http.get = AsyncMock(
-                        return_value=MagicMock(
-                            content=b"FAKE_PNG_BINARY_DATA", raise_for_status=MagicMock()
-                        )
-                    )
-
-                    result = await service.generate_for_lesson(
-                        lesson_id=uuid.uuid4(),
-                        module_id=uuid.uuid4(),
-                        unit_id="u01",
-                        lesson_content="Lesson about tuberculosis surveillance in Senegal.",
-                        session=mock_session,
-                    )
+                result = await service.generate_for_lesson(
+                    lesson_id=uuid.uuid4(),
+                    module_id=uuid.uuid4(),
+                    unit_id="u01",
+                    lesson_content="Lesson about tuberculosis surveillance in Senegal.",
+                    session=mock_session,
+                )
 
         assert result.image_data is not None, "image_data must not be NULL after generation"
         assert len(result.image_data) > 0
         assert result.image_url == f"/api/v1/images/{result.id}/data"
-        assert "blob.core.windows.net" not in (result.image_url or "")

--- a/backend/tests/test_tutor_source_image.py
+++ b/backend/tests/test_tutor_source_image.py
@@ -1,4 +1,4 @@
-"""Tests for tutor source image tool and DALL-E fallback optimization (issue #743)."""
+"""Tests for tutor source image tool and gpt-image-1 fallback optimization (issue #743)."""
 
 from __future__ import annotations
 
@@ -513,7 +513,8 @@ class TestDallEFallbackOptimization:
     async def test_dalle_called_when_no_source_image(
         self, service, mock_session, mock_claude_response
     ):
-        """When no source image found, DALL-E should proceed normally."""
+        """When no source image found, gpt-image-1 should proceed normally."""
+        import base64
         from unittest.mock import patch
 
         mock_session.get = AsyncMock(return_value=None)
@@ -524,8 +525,9 @@ class TestDallEFallbackOptimization:
         alt_text_msg = MagicMock()
         alt_text_msg.content = [MagicMock(text="FR: Illustration\nEN: Illustration")]
 
-        dalle_response = MagicMock()
-        dalle_response.data = [MagicMock(url="https://example.com/img.png")]
+        fake_b64 = base64.b64encode(b"FAKE_PNG_DATA").decode()
+        image_api_response = MagicMock()
+        image_api_response.data = [MagicMock(b64_json=fake_b64)]
 
         mock_session.execute = AsyncMock(return_value=reuse_result)
 
@@ -539,25 +541,15 @@ class TestDallEFallbackOptimization:
             with patch("openai.AsyncOpenAI") as mock_openai_cls:
                 mock_openai = AsyncMock()
                 mock_openai_cls.return_value = mock_openai
-                mock_openai.images.generate = AsyncMock(return_value=dalle_response)
+                mock_openai.images.generate = AsyncMock(return_value=image_api_response)
 
-                with patch("httpx.AsyncClient") as mock_http_cls:
-                    mock_http = AsyncMock()
-                    mock_http_cls.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-                    mock_http_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-                    mock_http.get = AsyncMock(
-                        return_value=MagicMock(
-                            content=b"FAKE_PNG_DATA", raise_for_status=MagicMock()
-                        )
-                    )
-
-                    result = await service.generate_for_lesson(
-                        lesson_id=uuid.uuid4(),
-                        module_id=uuid.uuid4(),
-                        unit_id="u01",
-                        lesson_content="Lesson about cholera outbreak.",
-                        session=mock_session,
-                    )
+                result = await service.generate_for_lesson(
+                    lesson_id=uuid.uuid4(),
+                    module_id=uuid.uuid4(),
+                    unit_id="u01",
+                    lesson_content="Lesson about cholera outbreak.",
+                    session=mock_session,
+                )
 
             mock_openai.images.generate.assert_called_once()
 


### PR DESCRIPTION
## Summary
- Migrates image generation from deprecated DALL-E 2 to `gpt-image-1` (DALL-E 2/3 shutdown May 12, 2026)
- Switches from URL download (httpx) to base64 decode response format
- Size 512x512 → 1024x1024 (still resized to 512px WebP before storage)
- Adds `quality="low"` for cost control

## Test plan
- [x] 66/66 image tests pass (`test_image_generation.py`, `test_tutor_source_image.py`, `test_images.py`)
- [ ] Verify image generation works in production after deploy

Closes #1256

🤖 Generated with [Claude Code](https://claude.ai/claude-code)