### PR TITLE
fix(deploy): idempotent migration 054 + phone-only admin audit log

### DIFF
--- a/backend/app/api/deps_local_auth.py
+++ b/backend/app/api/deps_local_auth.py
@@ -23,7 +23,8 @@ class AuthenticatedUser:
 
     def __init__(self, jwt_payload: dict):
         self.id = jwt_payload["sub"]
-        self.email = jwt_payload["email"]
+        self.email = jwt_payload.get("email")
+        self.phone_number = jwt_payload.get("phone_number")
         self.preferred_language = jwt_payload.get("preferred_language", "fr")
         self.country = jwt_payload.get("country")
         self.current_level = jwt_payload.get("current_level", 1)

--- a/backend/app/api/v1/admin/users.py
+++ b/backend/app/api/v1/admin/users.py
@@ -62,7 +62,7 @@ async def _write_audit_log(
 ) -> None:
     log = AuditLog(
         admin_id=UUID(admin.id),
-        admin_email=admin.email,
+        admin_email=admin.email or admin.phone_number or "unknown",
         target_user_id=target_user.id,
         target_user_email=target_user.email,
         action=action,

--- a/backend/app/api/v1/admin_settings.py
+++ b/backend/app/api/v1/admin_settings.py
@@ -65,7 +65,7 @@ async def update_setting(
         AuditLog(
             id=uuid.uuid4(),
             admin_id=uuid.UUID(admin.id),
-            admin_email=admin.email,
+            admin_email=admin.email or admin.phone_number or "unknown",
             action=AdminAction.update_setting,
             details=json.dumps({"key": key, "old_value": old_value, "new_value": body.value}),
         )
@@ -91,7 +91,7 @@ async def reset_setting(
         AuditLog(
             id=uuid.uuid4(),
             admin_id=uuid.UUID(admin.id),
-            admin_email=admin.email,
+            admin_email=admin.email or admin.phone_number or "unknown",
             action=AdminAction.reset_setting,
             details=json.dumps({"key": key, "old_value": old_value}),
         )
@@ -114,7 +114,7 @@ async def reset_category(
             AuditLog(
                 id=uuid.uuid4(),
                 admin_id=uuid.UUID(admin.id),
-                admin_email=admin.email,
+                admin_email=admin.email or admin.phone_number or "unknown",
                 action=AdminAction.reset_category,
                 details=json.dumps({"category": category, "reset_count": count}),
             )

--- a/backend/app/domain/services/local_auth_service.py
+++ b/backend/app/domain/services/local_auth_service.py
@@ -175,6 +175,7 @@ class LocalAuthService:
             access_token = self.jwt_service.create_access_token(
                 user_id=str(user.id),
                 email=user.email,
+                phone_number=user.phone_number,
                 preferred_language=user.preferred_language,
                 country=user.country,
                 current_level=user.current_level,
@@ -322,6 +323,7 @@ class LocalAuthService:
             access_token = self.jwt_service.create_access_token(
                 user_id=str(user.id),
                 email=user.email,
+                phone_number=user.phone_number,
                 preferred_language=user.preferred_language,
                 country=user.country,
                 current_level=user.current_level,
@@ -539,6 +541,7 @@ class LocalAuthService:
             access_token = self.jwt_service.create_access_token(
                 user_id=str(user.id),
                 email=user.email,
+                phone_number=user.phone_number,
                 preferred_language=user.preferred_language,
                 country=user.country,
                 current_level=user.current_level,
@@ -711,6 +714,7 @@ class LocalAuthService:
             access_token = self.jwt_service.create_access_token(
                 user_id=user["id"],
                 email=user["email"],
+                phone_number=user.get("phone_number"),
                 preferred_language=user["preferred_language"],
                 country=user["country"],
                 current_level=user["current_level"],
@@ -905,6 +909,7 @@ class LocalAuthService:
             access_token = self.jwt_service.create_access_token(
                 user_id=str(user.id),
                 email=email or "",
+                phone_number=user.phone_number,
                 preferred_language=user.preferred_language,
                 country=user.country,
                 current_level=user.current_level,
@@ -1034,6 +1039,7 @@ class LocalAuthService:
             access_token = self.jwt_service.create_access_token(
                 user_id=str(user.id),
                 email=user.email or "",
+                phone_number=user.phone_number,
                 preferred_language=user.preferred_language,
                 country=user.country,
                 current_level=user.current_level,
@@ -1241,6 +1247,7 @@ class LocalAuthService:
             access_token = self.jwt_service.create_access_token(
                 user_id=user["id"],
                 email=user["email"],
+                phone_number=user.get("phone_number"),
                 preferred_language=user["preferred_language"],
                 country=user["country"],
                 current_level=user["current_level"],

--- a/backend/migrations/versions/054_make_audit_log_admin_email_nullable.py
+++ b/backend/migrations/versions/054_make_audit_log_admin_email_nullable.py
@@ -6,6 +6,7 @@ Create Date: 2026-04-10
 
 """
 
+import sqlalchemy as sa
 from alembic import op
 
 revision = "054"
@@ -14,10 +15,29 @@ branch_labels = None
 depends_on = None
 
 
+def _column_exists(table: str, column: str) -> bool:
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = :table AND column_name = :column"
+        ),
+        {"table": table, "column": column},
+    )
+    return result.scalar() is not None
+
+
 def upgrade() -> None:
-    op.alter_column("admin_audit_logs", "admin_email", nullable=True)
+    if _column_exists("admin_audit_logs", "admin_email"):
+        op.alter_column("admin_audit_logs", "admin_email", nullable=True)
+    else:
+        op.add_column(
+            "admin_audit_logs",
+            sa.Column("admin_email", sa.String(), nullable=True),
+        )
 
 
 def downgrade() -> None:
-    op.execute("UPDATE admin_audit_logs SET admin_email = 'unknown' WHERE admin_email IS NULL")
-    op.alter_column("admin_audit_logs", "admin_email", nullable=False)
+    if _column_exists("admin_audit_logs", "admin_email"):
+        op.execute("UPDATE admin_audit_logs SET admin_email = 'unknown' WHERE admin_email IS NULL")
+        op.alter_column("admin_audit_logs", "admin_email", nullable=False)


### PR DESCRIPTION
## Summary
- Make migration 054 idempotent — checks if `admin_email` column exists before altering/adding it
- Include `phone_number` in JWT payload for phone-only admins
- Use `admin.email or admin.phone_number or "unknown"` fallback in audit log entries

Fixes deployment failure caused by missing `admin_email` column in production DB.

## Test plan
- [x] `ruff format --check .` passes
- [x] Migration handles both cases (column exists vs missing)
- [ ] Deploy to production succeeds

🤖 Generated with [Claude Code](https://claude.ai/claude-code)