### PR TITLE
fix(nav): clear sticky curriculum context + profile dashboard link

### DIFF
--- a/frontend/app/[locale]/(app)/courses/page.tsx
+++ b/frontend/app/[locale]/(app)/courses/page.tsx
@@ -14,6 +14,7 @@ import {
   type CourseResponse,
   type TaxonomyItem,
 } from '@/lib/api';
+import { clearCurriculumContext } from '@/lib/curriculum-context';
 
 export default function CoursesPage() {
   const t = useTranslations('Courses');
@@ -21,6 +22,10 @@ export default function CoursesPage() {
   const router = useRouter();
   const pathname = usePathname();
   const locale = (pathname.split('/')[1] || 'fr') as 'fr' | 'en';
+
+  useEffect(() => {
+    clearCurriculumContext();
+  }, []);
 
   const [courses, setCourses] = useState<CourseResponse[]>([]);
   const [loading, setLoading] = useState(true);

--- a/frontend/app/[locale]/(app)/dashboard/page.tsx
+++ b/frontend/app/[locale]/(app)/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { DashboardClient } from "./dashboard-client";
 import { DashboardStats } from "@/components/dashboard/dashboard-stats";
 import { UpcomingReviews } from "@/components/dashboard/upcoming-reviews";
 import { CurriculaSection } from "@/components/shared/curricula-section";
+import { ClearCurriculumContext } from "@/components/shared/clear-curriculum-context";
 
 interface DashboardPageProps {
   searchParams: Promise<{ curriculum?: string }>;
@@ -29,6 +30,7 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
         <DashboardClient curriculumSlug={curriculum} />
       </div>
 
+      {!curriculum && <ClearCurriculumContext />}
       {!curriculum && <CurriculaSection />}
     </div>
   );

--- a/frontend/app/[locale]/(app)/profile/profile-client.tsx
+++ b/frontend/app/[locale]/(app)/profile/profile-client.tsx
@@ -22,7 +22,7 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Link } from "@/i18n/routing";
 import { PlacementResultsHistory } from "@/components/placement/placement-results-history";
-import { Upload, User as UserIcon, AlertTriangle, CheckCircle, ClipboardList, LogOut } from "lucide-react";
+import { Upload, User as UserIcon, AlertTriangle, CheckCircle, ClipboardList, LogOut, ArrowLeft } from "lucide-react";
 import { authClient } from "@/lib/auth";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -208,6 +208,14 @@ export function ProfileClient() {
 
   return (
     <div className="space-y-6">
+      <Link
+        href="/dashboard"
+        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        {t("backToDashboard")}
+      </Link>
+
       {showRecontextAlert && (
         <Alert>
           <AlertTriangle className="h-4 w-4" />

--- a/frontend/components/shared/clear-curriculum-context.tsx
+++ b/frontend/components/shared/clear-curriculum-context.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { useEffect } from 'react';
+import { clearCurriculumContext } from '@/lib/curriculum-context';
+
+export function ClearCurriculumContext() {
+  useEffect(() => {
+    clearCurriculumContext();
+  }, []);
+  return null;
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -844,6 +844,7 @@
     "logout": "Log out",
     "logoutDescription": "Sign out of your account",
     "loggingOut": "Logging out...",
+    "backToDashboard": "Back to Dashboard",
     "languages": {
       "french": "Français",
       "english": "English"

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -844,6 +844,7 @@
     "logout": "Déconnexion",
     "logoutDescription": "Se déconnecter de votre compte",
     "loggingOut": "Déconnexion en cours...",
+    "backToDashboard": "Retour au Tableau de Bord",
     "languages": {
       "french": "Français",
       "english": "English"


### PR DESCRIPTION
## Summary
- Clear the `curriculum_context` cookie when visiting `/dashboard` (without `?curriculum` param) or `/courses`, so navigation reverts from curriculum-scoped links back to normal `/courses`
- Add a "Back to Dashboard" link with arrow icon at the top of the profile page (FR/EN i18n)

## Test plan
- [ ] Visit a curriculum page → sidebar/bottom-nav shows curriculum-scoped links
- [ ] Navigate to `/dashboard` (no param) → nav reverts to `/courses`
- [ ] Navigate to `/courses` directly → nav reverts to `/courses`
- [ ] Visit curriculum, then `/dashboard?curriculum=slug` → nav stays scoped
- [ ] Profile page shows "Back to Dashboard" link that navigates to `/dashboard`
- [ ] Verify FR and EN translations display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)