### PR TITLE
fix(nav): sync curriculum context via custom event

### DIFF
--- a/frontend/components/layout/bottom-nav.tsx
+++ b/frontend/components/layout/bottom-nav.tsx
@@ -15,7 +15,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { startTransition, useState, useEffect, useRef } from "react";
-import { getCurriculumContext } from "@/lib/curriculum-context";
+import { getCurriculumContext, onCurriculumContextChange } from "@/lib/curriculum-context";
 
 export function BottomNav() {
   const t = useTranslations("Navigation");
@@ -28,6 +28,12 @@ export function BottomNav() {
   useEffect(() => {
     startTransition(() => setCurriculumSlug(getCurriculumContext()));
   }, [pathname]);
+
+  useEffect(() => {
+    return onCurriculumContextChange(() => {
+      startTransition(() => setCurriculumSlug(getCurriculumContext()));
+    });
+  }, []);
 
   useEffect(() => {
     if (!moreOpen) return;

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -23,7 +23,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { authClient } from "@/lib/auth";
 import { useQueryClient } from "@tanstack/react-query";
-import { getCurriculumContext } from "@/lib/curriculum-context";
+import { getCurriculumContext, onCurriculumContextChange } from "@/lib/curriculum-context";
 
 function getUserRole(): string | null {
   if (typeof window === "undefined") return null;
@@ -58,6 +58,14 @@ export function Sidebar() {
       setCurriculumSlug(getCurriculumContext());
     });
   }, [pathname]);
+
+  useEffect(() => {
+    return onCurriculumContextChange(() => {
+      startTransition(() => {
+        setCurriculumSlug(getCurriculumContext());
+      });
+    });
+  }, []);
 
   const handleLogout = async () => {
     setIsLoggingOut(true);

--- a/frontend/lib/curriculum-context.ts
+++ b/frontend/lib/curriculum-context.ts
@@ -1,4 +1,5 @@
 const COOKIE_NAME = 'curriculum_context';
+const CHANGE_EVENT = 'curriculum-context-change';
 
 export function getCurriculumContext(): string | null {
   if (typeof document === 'undefined') return null;
@@ -11,9 +12,16 @@ export function getCurriculumContext(): string | null {
 export function setCurriculumContext(slug: string) {
   if (typeof document === 'undefined') return;
   document.cookie = `${COOKIE_NAME}=${encodeURIComponent(slug)};path=/;max-age=${60 * 60 * 24 * 30};samesite=lax`;
+  window.dispatchEvent(new Event(CHANGE_EVENT));
 }
 
 export function clearCurriculumContext() {
   if (typeof document === 'undefined') return;
   document.cookie = `${COOKIE_NAME}=;path=/;max-age=0`;
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+}
+
+export function onCurriculumContextChange(callback: () => void): () => void {
+  window.addEventListener(CHANGE_EVENT, callback);
+  return () => window.removeEventListener(CHANGE_EVENT, callback);
 }


### PR DESCRIPTION
## Summary
- Fix race condition where sidebar/bottom-nav read the curriculum cookie before ClearCurriculumContext clears it
- `setCurriculumContext` and `clearCurriculumContext` now dispatch a `curriculum-context-change` event
- Sidebar and bottom-nav listen for this event to re-read the cookie immediately

## Test plan
- [ ] Visit curriculum → nav scopes to curriculum
- [ ] Navigate to /dashboard → nav immediately reverts to /courses
- [ ] Navigate to /courses → nav immediately reverts to /courses

🤖 Generated with [Claude Code](https://claude.com/claude-code)