### PR TITLE
feat(rag): idempotent image reindex + bulk refresh

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -757,6 +757,7 @@ async def cancel_indexation(
 @router.post("/{course_id}/reindex-images")
 async def trigger_image_reindexation(
     course_id: uuid.UUID,
+    clear_old: bool = True,
     current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
     db=Depends(get_db_session),
 ) -> dict:
@@ -765,6 +766,10 @@ async def trigger_image_reindexation(
     Allowed at any creation_step (indexed, published, etc.) since it only touches images.
     Does not re-embed text — no OpenAI cost. Only needs MinIO credentials.
     Returns task_id for polling via the existing index-status endpoint.
+
+    Args:
+        clear_old: If True (default), deletes existing images before re-extracting.
+            Set to False to append without clearing.
     """
     result = await db.execute(select(Course).where(Course.id == course_id))
     course = result.scalar_one_or_none()
@@ -777,7 +782,7 @@ async def trigger_image_reindexation(
             detail="Course has no rag_collection_id",
         )
 
-    task = reindex_course_images.delay(str(course_id), course.rag_collection_id)
+    task = reindex_course_images.delay(str(course_id), course.rag_collection_id, clear_old)
 
     course.indexation_task_id = task.id
     await db.commit()

--- a/backend/app/tasks/image_indexation.py
+++ b/backend/app/tasks/image_indexation.py
@@ -31,7 +31,7 @@ class ImageIndexTask(Task):
     ignore_result=True,
     acks_late=False,  # Acknowledge immediately to prevent duplicate dispatch
 )
-def reindex_course_images(self, course_id: str, rag_collection_id: str) -> dict:
+def reindex_course_images(self, course_id: str, rag_collection_id: str, clear_old: bool = True) -> dict:
     """Re-index images for a course independently from text indexation.
 
     Iterates over PDFs in uploads/course_resources/{course_id}/ and calls
@@ -106,6 +106,26 @@ def reindex_course_images(self, course_id: str, rag_collection_id: str) -> dict:
             pipeline = RAGPipeline(_ES(api_key=""))
 
         total_images = 0
+
+        if clear_old:
+            self.update_state(
+                state="CLEARING_OLD_IMAGES",
+                meta={
+                    "step": "clearing_old_images",
+                    "step_label": "Suppression des anciennes illustrations",
+                    "progress": 3,
+                    "files_total": len(pdf_files),
+                    "files_processed": 0,
+                    "images_processed": 0,
+                },
+            )
+            cleared = await pipeline.clear_source_images(source=rag_collection_id)
+            logger.info(
+                "Cleared old images before re-indexation",
+                count=cleared,
+                course_id=course_id,
+                rag_collection_id=rag_collection_id,
+            )
 
         for i, pdf_path in enumerate(pdf_files):
             extract_progress = 5 + int(((i + 0.5) / len(pdf_files)) * 90)

--- a/backend/app/tasks/image_indexation.py
+++ b/backend/app/tasks/image_indexation.py
@@ -31,7 +31,9 @@ class ImageIndexTask(Task):
     ignore_result=True,
     acks_late=False,  # Acknowledge immediately to prevent duplicate dispatch
 )
-def reindex_course_images(self, course_id: str, rag_collection_id: str, clear_old: bool = True) -> dict:
+def reindex_course_images(
+    self, course_id: str, rag_collection_id: str, clear_old: bool = True
+) -> dict:
     """Re-index images for a course independently from text indexation.
 
     Iterates over PDFs in uploads/course_resources/{course_id}/ and calls

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -300,6 +300,7 @@ export async function apiFetch<T>(
     }
     throw new ApiError(message, res.status, code);
   }
+  if (res.status === 204) return undefined as T;
   return res.json();
 }
 

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -415,6 +415,7 @@ class AuthClient {
             );
           }
 
+          if (retryResponse.status === 204) return undefined as T;
           return retryResponse.json();
         } else {
           const errorData = await response.json().catch(() => ({}));
@@ -425,6 +426,7 @@ class AuthClient {
         }
       }
 
+      if (response.status === 204) return undefined as T;
       return response.json();
     } catch (error) {
       if (error instanceof AuthError && error.status === 401) {


### PR DESCRIPTION
## Summary
- Adds `clear_old` param (default `True`) to `reindex_course_images` task — clears old `source_images` + MinIO objects before re-extracting, preventing duplicates
- Exposes `clear_old` query param on `POST /admin/courses/{id}/reindex-images` endpoint

## Why
9 courses were indexed before the improved image extraction algorithm (PR #1301). Re-running the reindex task without clearing creates duplicate image records. This makes the task idempotent.

## Test plan
- [ ] Deploy to production
- [ ] Trigger reindex for Digital Health course, verify old images cleared + new images extracted
- [ ] Trigger remaining 8 courses
- [ ] Verify no duplicate `source_images` records

🤖 Generated with [Claude Code](https://claude.com/claude-code)