### PR TITLE
fix(api): handle HTTP 204 No Content in fetch wrappers

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -300,6 +300,7 @@ export async function apiFetch<T>(
     }
     throw new ApiError(message, res.status, code);
   }
+  if (res.status === 204) return undefined as T;
   return res.json();
 }
 

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -415,6 +415,7 @@ class AuthClient {
             );
           }
 
+          if (retryResponse.status === 204) return undefined as T;
           return retryResponse.json();
         } else {
           const errorData = await response.json().catch(() => ({}));
@@ -425,6 +426,7 @@ class AuthClient {
         }
       }
 
+      if (response.status === 204) return undefined as T;
       return response.json();
     } catch (error) {
       if (error instanceof AuthError && error.status === 401) {


### PR DESCRIPTION
## Summary
- Unenrollment was failing visually ("La désinscription a échoué") even though the backend successfully deleted all data (HTTP 204)
- Root cause: `apiFetch()` and `authenticatedFetch()` unconditionally call `res.json()`, which throws on a 204 empty body
- Added a `status === 204` guard before `res.json()` in both `frontend/lib/api.ts` and `frontend/lib/auth.ts`

## Test plan
- [ ] Enroll in a course, then unenroll — should succeed without error
- [ ] Verify `deleteModuleMedia` (also returns 204) still works
- [ ] Verify normal JSON-returning endpoints (course list, dashboard, etc.) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)