### PR TITLE
fix(content): explicit unit_type in API + 404 for missing units

### DIFF
--- a/backend/app/api/v1/content.py
+++ b/backend/app/api/v1/content.py
@@ -433,7 +433,17 @@ async def get_or_generate_lesson_by_module_and_unit(
             )
         )
         unit_type_row = unit_type_result.first()
-        is_case_study = unit_type_row is not None and unit_type_row[0] == "case-study"
+
+        if unit_type_row is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={
+                    "error": "unit_not_found",
+                    "message": f"Unit '{unit_id}' does not exist in this module.",
+                },
+            )
+
+        is_case_study = unit_type_row[0] == "case-study"
 
         if not force_regenerate:
             from sqlalchemy import or_
@@ -688,7 +698,19 @@ async def stream_lesson_by_module_and_unit(
                 )
             )
             unit_type_row = unit_type_result.first()
-            is_case_study = unit_type_row is not None and unit_type_row[0] == "case-study"
+
+            if unit_type_row is None:
+                error_event = StreamingEvent(
+                    event="error",
+                    data={
+                        "error": "unit_not_found",
+                        "message": f"Unit '{unit_id}' not found.",
+                    },
+                )
+                yield error_event.to_sse_format()
+                return
+
+            is_case_study = unit_type_row[0] == "case-study"
 
             if is_case_study:
                 async for event in case_study_service.stream_case_study_generation(
@@ -1368,6 +1390,7 @@ async def get_module_units(
                 description_en=u.description_en,
                 estimated_minutes=u.estimated_minutes,
                 order_index=u.order_index,
+                unit_type=u.unit_type,
             )
             for u in units
         ]

--- a/backend/app/api/v1/schemas/content.py
+++ b/backend/app/api/v1/schemas/content.py
@@ -277,6 +277,7 @@ class PublicUnitDetail(BaseModel):
     description_en: str | None = None
     estimated_minutes: int
     order_index: int
+    unit_type: str | None = None
 
 
 class ModuleUnitsResponse(BaseModel):

--- a/backend/app/domain/services/progress_service.py
+++ b/backend/app/domain/services/progress_service.py
@@ -316,6 +316,7 @@ class ProgressService:
                     "description_en": unit.description_en,
                     "estimated_minutes": unit.estimated_minutes,
                     "order_index": unit.order_index,
+                    "unit_type": unit.unit_type,
                     "status": unit_status,
                 }
             )

--- a/backend/app/tasks/syllabus_generation.py
+++ b/backend/app/tasks/syllabus_generation.py
@@ -549,7 +549,13 @@ def generate_course_syllabus(
                         description_en=u.get("description_en"),
                         estimated_minutes=15,
                         order_index=j,
-                        unit_type=u.get("type"),
+                        unit_type=(
+                            u.get("type")
+                            if u.get("type") in {
+                                "lesson", "quiz", "case-study",
+                            }
+                            else "lesson"
+                        ),
                     )
                     session.add(unit)
 

--- a/frontend/components/learning/lesson-viewer.tsx
+++ b/frontend/components/learning/lesson-viewer.tsx
@@ -14,7 +14,7 @@ import { LessonSkeleton } from './lesson-skeleton';
 import { LessonImage } from './lesson-image';
 import { SourceImage } from './source-image';
 import { SourceCitations } from './source-citations';
-import { apiFetch, checkUnitQuizPassed } from '@/lib/api';
+import { apiFetch, checkUnitQuizPassed, ApiError } from '@/lib/api';
 import type { SourceImageMeta } from '@/lib/api';
 import { SOURCE_IMAGE_RE, splitWithSourceImageMarkers } from '@/lib/source-image-utils';
 import { useCurrentUser } from '@/lib/hooks/use-current-user';
@@ -74,7 +74,7 @@ export function LessonViewer({
   const [isGenerating, setIsGenerating] = useState(false);
   const [isSlowGeneration, setIsSlowGeneration] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [errorType, setErrorType] = useState<'load' | 'generation' | 'timeout' | 'no_content' | null>(null);
+  const [errorType, setErrorType] = useState<'load' | 'generation' | 'timeout' | 'no_content' | 'not_found' | null>(null);
   const [isQuizPassed, setIsQuizPassed] = useState(false);
   const [isCheckingQuiz, setIsCheckingQuiz] = useState(false);
   const [forceRegenerate, setForceRegenerate] = useState(false);
@@ -205,8 +205,13 @@ export function LessonViewer({
         }
       } catch (err) {
         console.error('Error loading lesson:', err);
-        setError(t('loadError'));
-        setErrorType('load');
+        if (err instanceof ApiError && err.status === 404) {
+          setError(t('unitNotFound'));
+          setErrorType('not_found');
+        } else {
+          setError(t('loadError'));
+          setErrorType('load');
+        }
         setIsLoading(false);
         setIsRefreshing(false);
       }
@@ -270,14 +275,24 @@ export function LessonViewer({
             {errorType === 'no_content' && (
               <p className="text-gray-500 text-sm mb-4">{t('noContentFallback')}</p>
             )}
-            <Button
-              variant="outline"
-              onClick={handleRetry}
-              className="min-h-11"
-            >
-              <RefreshCw className="w-4 h-4 mr-2" />
-              {t('retry')}
-            </Button>
+            {errorType === 'not_found' ? (
+              <Button
+                variant="outline"
+                onClick={() => router.push(`/${locale}/modules/${moduleId}`)}
+                className="min-h-11"
+              >
+                {t('backToModule')}
+              </Button>
+            ) : (
+              <Button
+                variant="outline"
+                onClick={handleRetry}
+                className="min-h-11"
+              >
+                <RefreshCw className="w-4 h-4 mr-2" />
+                {t('retry')}
+              </Button>
+            )}
           </CardContent>
         </Card>
       </div>

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -685,7 +685,9 @@
     "completed": "Completed",
     "refreshContent": "Refresh content",
     "validateWithQuiz": "Validate with Quiz",
-    "checkingStatus": "Checking..."
+    "checkingStatus": "Checking...",
+    "unitNotFound": "This unit does not exist in this module.",
+    "backToModule": "Back to module"
   },
   "LessonImage": {
     "imagePending": "Generating illustration...",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -685,7 +685,9 @@
     "completed": "Terminé",
     "refreshContent": "Actualiser le contenu",
     "validateWithQuiz": "Valider avec le Quiz",
-    "checkingStatus": "Vérification..."
+    "checkingStatus": "Vérification...",
+    "unitNotFound": "Cette unité n'existe pas dans ce module.",
+    "backToModule": "Retour au module"
   },
   "LessonImage": {
     "imagePending": "Illustration en cours de génération...",


### PR DESCRIPTION
## Summary
- **Root cause**: Syllabus-generated courses (kids math) create quiz/case-study units, but API responses omitted `unit_type`. Frontend guessed from title keywords — "Scénario" wasn't recognized as case-study, so it got a lesson URL → dead link (M01-U06).
- Add `unit_type` to both public (`/modules/{id}/units`) and progress (`/progress/modules/{id}/detail`) API responses
- Return 404 immediately for non-existent units instead of dispatching a doomed Celery task
- Validate `unit_type` during syllabus generation — default to "lesson" if Claude returns unknown/null
- Frontend handles 404 with "Back to module" button instead of useless retry

## Files changed (7)
| File | Change |
|------|--------|
| `backend/app/api/v1/content.py` | `unit_type` in public endpoint + 404 guard (lesson + streaming) |
| `backend/app/api/v1/schemas/content.py` | `unit_type` field on `PublicUnitDetail` |
| `backend/app/domain/services/progress_service.py` | `unit_type` in progress response |
| `backend/app/tasks/syllabus_generation.py` | Validate `unit_type` — default to "lesson" |
| `frontend/components/learning/lesson-viewer.tsx` | 404 → "unit not found" + back button |
| `frontend/messages/en.json` | `unitNotFound` + `backToModule` |
| `frontend/messages/fr.json` | `unitNotFound` + `backToModule` |

## Test plan
- [ ] `GET /api/v1/content/modules/{uuid}/units` returns `unit_type` for each unit
- [ ] `GET /api/v1/content/lessons/{uuid}/INVALID` returns 404 (not 202)
- [ ] Valid lesson URL still loads normally
- [ ] Module overview routes quiz/case-study units correctly (not to /lessons/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)