### PR TITLE
style: remove unused import in course_agent_service

### DIFF
--- a/backend/app/domain/services/course_agent_service.py
+++ b/backend/app/domain/services/course_agent_service.py
@@ -475,8 +475,6 @@ class CourseAgentService:
                 )
 
             # Use tool_use to enforce structured JSON output
-            import json as _json
-
             async with client.messages.stream(
                 model=_model,
                 max_tokens=64000,


### PR DESCRIPTION
## Summary
- Remove unused `import json as _json` that caused ruff F401 lint failure in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)