### PR TITLE
fix(tutor): combine mobile headers + limit course dropdown to 3 recent

### DIFF
--- a/backend/app/api/v1/courses.py
+++ b/backend/app/api/v1/courses.py
@@ -5,7 +5,7 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 from sqlalchemy import delete as sa_delete
-from sqlalchemy import exists, select
+from sqlalchemy import exists, func, select
 from structlog import get_logger
 
 from app.api.deps import get_db as get_db_session
@@ -292,18 +292,45 @@ async def list_published_courses(
 async def my_enrollments(
     current_user=Depends(get_current_user),
     db=Depends(get_db_session),
+    order_by: str | None = Query(None),
+    limit: int | None = Query(None, ge=1, le=50),
 ) -> list[CourseListItem]:
-    """Get courses the current user is enrolled in."""
-    result = await db.execute(
-        select(Course)
-        .join(
-            UserCourseEnrollment,
-            (UserCourseEnrollment.course_id == Course.id)
-            & (UserCourseEnrollment.user_id == uuid.UUID(current_user.id))
-            & (UserCourseEnrollment.status == "active"),
-        )
-        .order_by(UserCourseEnrollment.enrolled_at.desc())
+    """Get courses the current user is enrolled in.
+
+    Optional query params:
+    - order_by=last_accessed: sort by most recent module activity
+    - limit: max number of courses to return
+    """
+    uid = uuid.UUID(current_user.id)
+    stmt = select(Course).join(
+        UserCourseEnrollment,
+        (UserCourseEnrollment.course_id == Course.id)
+        & (UserCourseEnrollment.user_id == uid)
+        & (UserCourseEnrollment.status == "active"),
     )
+
+    if order_by == "last_accessed":
+        stmt = (
+            stmt
+            .outerjoin(Module, Module.course_id == Course.id)
+            .outerjoin(
+                UserModuleProgress,
+                (UserModuleProgress.module_id == Module.id)
+                & (UserModuleProgress.user_id == uid),
+            )
+            .group_by(Course.id)
+            .order_by(
+                func.max(UserModuleProgress.last_accessed).desc().nullslast(),
+                UserCourseEnrollment.enrolled_at.desc(),
+            )
+        )
+    else:
+        stmt = stmt.order_by(UserCourseEnrollment.enrolled_at.desc())
+
+    if limit:
+        stmt = stmt.limit(limit)
+
+    result = await db.execute(stmt)
     courses = result.scalars().all()
     return [_course_to_list_item(c, enrolled=True) for c in courses]
 

--- a/frontend/app/[locale]/(app)/tutor/page.tsx
+++ b/frontend/app/[locale]/(app)/tutor/page.tsx
@@ -12,7 +12,7 @@ export async function generateMetadata() {
 
 export default async function TutorPage() {
   return (
-    <div className="fixed inset-0 top-14 bottom-16 md:left-64 md:bottom-0 flex flex-col overflow-hidden bg-background z-10">
+    <div className="fixed inset-0 top-0 bottom-16 md:left-64 md:bottom-0 flex flex-col overflow-hidden bg-background z-10">
       <TutorPageClient />
     </div>
   );

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslations, useLocale } from 'next-intl';
 import { track } from '@/lib/analytics';
 import { Link } from '@/i18n/routing';
-import { X, MoreVertical, Trash2, Menu, HelpCircle, BookOpen, GraduationCap, ChevronDown } from 'lucide-react';
+import { X, MoreVertical, Trash2, Menu, HelpCircle, BookOpen, GraduationCap, ChevronDown, Globe } from 'lucide-react';
 import { getMyEnrollments, type CourseWithEnrollment } from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import {
@@ -31,7 +31,7 @@ import { UsageCounter } from './usage-counter';
 import { ChatSkeleton } from './chat-skeleton';
 import { cn } from '@/lib/utils';
 import { authClient, AuthError } from '@/lib/auth';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import {
   fetchConversation,
   fetchTutorStats,
@@ -69,6 +69,7 @@ export function ChatPanel({
   const t = useTranslations('ChatTutor');
   const locale = useLocale();
   const router = useRouter();
+  const pathname = usePathname();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isHistoryLoading, setIsHistoryLoading] = useState(false);
@@ -122,7 +123,7 @@ export function ChatPanel({
 
   // Fetch enrolled courses for course selector
   useEffect(() => {
-    getMyEnrollments()
+    getMyEnrollments({ orderBy: 'last_accessed', limit: 3 })
       .then((courses) => {
         setEnrolledCourses(courses);
         // Auto-select first course if none set
@@ -470,6 +471,16 @@ export function ChatPanel({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  className="md:hidden"
+                  onClick={() => {
+                    const next = locale === 'fr' ? 'en' : 'fr';
+                    router.push(pathname.replace(/^\/(fr|en)/, '/' + next));
+                  }}
+                >
+                  <Globe className="h-4 w-4 mr-2" />
+                  {locale === 'fr' ? 'English' : 'Français'}
+                </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => setShowClearDialog(true)}>
                   <Trash2 className="h-4 w-4 mr-2" />
                   {t('clearHistory')}

--- a/frontend/components/layout/header.tsx
+++ b/frontend/components/layout/header.tsx
@@ -1,10 +1,15 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import { usePathname } from "next/navigation";
 import { LocaleSwitcher } from "@/components/shared/locale-switcher";
 
 export function Header() {
   const tCommon = useTranslations("Common");
+  const pathname = usePathname();
+
+  // Hide on tutor page — ChatPanel has its own header with locale switcher
+  if (pathname.endsWith("/tutor")) return null;
 
   return (
     <header className="sticky top-0 z-40 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 md:hidden">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -135,10 +135,17 @@ export async function deleteTaxonomyCategory(id: string): Promise<void> {
   );
 }
 
-export async function getMyEnrollments(): Promise<CourseWithEnrollment[]> {
+export async function getMyEnrollments(opts?: {
+  orderBy?: 'last_accessed';
+  limit?: number;
+}): Promise<CourseWithEnrollment[]> {
   const { authClient } = await import("./auth");
+  const params = new URLSearchParams();
+  if (opts?.orderBy) params.set('order_by', opts.orderBy);
+  if (opts?.limit) params.set('limit', String(opts.limit));
+  const qs = params.toString();
   return authClient.authenticatedFetch<CourseWithEnrollment[]>(
-    "/api/v1/courses/my-enrollments"
+    `/api/v1/courses/my-enrollments${qs ? `?${qs}` : ''}`
   );
 }
 


### PR DESCRIPTION
## Summary
- **Hide app header on `/tutor` route** on mobile — reclaims 56px of vertical space for chat messages
- **Move locale switcher** into ChatPanel's 3-dot menu (mobile only) so language switch remains accessible
- **Add `order_by=last_accessed` & `limit` query params** to `GET /api/v1/courses/my-enrollments` endpoint
- **Tutor course dropdown** now shows only the 3 most recently accessed courses (based on module progress `last_accessed`)

## Files changed
| File | Change |
|------|--------|
| `frontend/components/layout/header.tsx` | `usePathname()` check to hide on `/tutor` |
| `frontend/app/[locale]/(app)/tutor/page.tsx` | `top-14` → `top-0` offset fix |
| `frontend/components/chat/chat-panel.tsx` | Globe locale switcher in menu + `getMyEnrollments({ orderBy, limit })` |
| `frontend/lib/api.ts` | `getMyEnrollments()` accepts optional `orderBy`/`limit` params |
| `backend/app/api/v1/courses.py` | `LEFT JOIN` on module progress for `last_accessed` sort + `limit` |

## Test plan
- [ ] Mobile `/tutor`: app header hidden, chat starts at top of screen
- [ ] 3-dot menu shows language switch on mobile, hidden on desktop
- [ ] Course dropdown shows ≤3 courses sorted by recent module activity
- [ ] Dashboard and module-map still show all enrolled courses (no regression)
- [ ] Desktop layout unchanged on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)