### PR TITLE
fix(courses): GROUP BY compat for last_accessed ordering

### DIFF
--- a/backend/app/api/v1/courses.py
+++ b/backend/app/api/v1/courses.py
@@ -319,7 +319,7 @@ async def my_enrollments(
             .group_by(Course.id)
             .order_by(
                 func.max(UserModuleProgress.last_accessed).desc().nullslast(),
-                UserCourseEnrollment.enrolled_at.desc(),
+                func.max(UserCourseEnrollment.enrolled_at).desc(),
             )
         )
     else:


### PR DESCRIPTION
## Summary
- Wraps `UserCourseEnrollment.enrolled_at` in `func.max()` in the fallback ORDER BY clause
- PostgreSQL strict GROUP BY rejects bare columns not in the GROUP BY — this caused a 500 on `?order_by=last_accessed`

## Test plan
- [ ] `GET /api/v1/courses/my-enrollments?order_by=last_accessed&limit=3` returns 200 with courses
- [ ] Tutor page course dropdown appears when enrolled in 2+ courses

🤖 Generated with [Claude Code](https://claude.com/claude-code)