### PR TITLE
feat(courses): comprehensive last_interacted_at for recent-courses dropdown

### DIFF
--- a/backend/app/api/v1/course_preassessment.py
+++ b/backend/app/api/v1/course_preassessment.py
@@ -226,6 +226,14 @@ async def submit_course_preassessment(
         db.add(attempt)
         await db.commit()
 
+        # Touch course interaction for recent-courses ranking
+        try:
+            from app.domain.services.progress_service import touch_course_interaction
+
+            await touch_course_interaction(db, UUID(str(current_user.id)), course_id)
+        except Exception as touch_err:
+            logger.warning("touch_course_interaction failed (non-fatal)", error=str(touch_err))
+
         logger.info(
             "Course pre-assessment submitted",
             user_id=str(current_user.id),

--- a/backend/app/api/v1/courses.py
+++ b/backend/app/api/v1/courses.py
@@ -5,7 +5,7 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 from sqlalchemy import delete as sa_delete
-from sqlalchemy import exists, func, select
+from sqlalchemy import exists, select
 from structlog import get_logger
 
 from app.api.deps import get_db as get_db_session
@@ -310,17 +310,9 @@ async def my_enrollments(
     )
 
     if order_by == "last_accessed":
-        stmt = (
-            stmt.outerjoin(Module, Module.course_id == Course.id)
-            .outerjoin(
-                UserModuleProgress,
-                (UserModuleProgress.module_id == Module.id) & (UserModuleProgress.user_id == uid),
-            )
-            .group_by(Course.id)
-            .order_by(
-                func.max(UserModuleProgress.last_accessed).desc().nullslast(),
-                func.max(UserCourseEnrollment.enrolled_at).desc(),
-            )
+        stmt = stmt.order_by(
+            UserCourseEnrollment.last_interacted_at.desc().nullslast(),
+            UserCourseEnrollment.enrolled_at.desc(),
         )
     else:
         stmt = stmt.order_by(UserCourseEnrollment.enrolled_at.desc())

--- a/backend/app/api/v1/flashcards.py
+++ b/backend/app/api/v1/flashcards.py
@@ -334,6 +334,22 @@ async def submit_flashcard_review(
 
         await session.commit()
 
+        # Touch course interaction for recent-courses ranking
+        try:
+            from app.domain.models.content import GeneratedContent
+            from app.domain.services.progress_service import touch_course_interaction_by_module
+
+            gc_result = await session.execute(
+                select(GeneratedContent.module_id).where(GeneratedContent.id == review.card_id)
+            )
+            card_module_id = gc_result.scalar_one_or_none()
+            if card_module_id:
+                await touch_course_interaction_by_module(
+                    session, uuid.UUID(str(current_user.id)), card_module_id
+                )
+        except Exception as touch_err:
+            logger.warning("touch_course_interaction failed (non-fatal)", error=str(touch_err))
+
         try:
             analytics_svc = AnalyticsService(session)
             await analytics_svc.ingest_event(

--- a/backend/app/api/v1/quiz.py
+++ b/backend/app/api/v1/quiz.py
@@ -954,6 +954,19 @@ async def submit_summative_assessment_attempt(
         await session.commit()
         await session.refresh(attempt)
 
+        # Touch course interaction for recent-courses ranking
+        if assessment_content.module_id:
+            try:
+                from app.domain.services.progress_service import (
+                    touch_course_interaction_by_module,
+                )
+
+                await touch_course_interaction_by_module(
+                    session, user_id, assessment_content.module_id
+                )
+            except Exception as touch_err:
+                logger.warning("touch_course_interaction failed (non-fatal)", error=str(touch_err))
+
         response = SummativeAssessmentResponse(
             attempt_id=attempt.id,
             assessment_id=request.quiz_id,

--- a/backend/app/domain/models/course.py
+++ b/backend/app/domain/models/course.py
@@ -79,5 +79,8 @@ class UserCourseEnrollment(Base):
         server_default="active",
     )
     completion_pct: Mapped[float] = mapped_column(server_default="0.0")
+    last_interacted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
+    )
 
     course: Mapped[Course] = relationship(back_populates="enrollments")

--- a/backend/app/domain/services/progress_service.py
+++ b/backend/app/domain/services/progress_service.py
@@ -7,9 +7,10 @@ from datetime import datetime
 from uuid import UUID
 
 import structlog
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.domain.models.course import UserCourseEnrollment
 from app.domain.models.lesson_reading import LessonReading
 from app.domain.models.module import Module
 from app.domain.models.module_unit import ModuleUnit
@@ -17,6 +18,33 @@ from app.domain.models.progress import UserModuleProgress
 from app.domain.services.platform_settings_service import SettingsCache
 
 logger = structlog.get_logger()
+
+
+async def touch_course_interaction(db: AsyncSession, user_id: UUID, course_id: UUID) -> None:
+    """Update last_interacted_at on enrollment with 5-min debounce."""
+    await db.execute(
+        update(UserCourseEnrollment)
+        .where(
+            UserCourseEnrollment.user_id == user_id,
+            UserCourseEnrollment.course_id == course_id,
+            UserCourseEnrollment.status == "active",
+            or_(
+                UserCourseEnrollment.last_interacted_at.is_(None),
+                UserCourseEnrollment.last_interacted_at < func.now() - text("INTERVAL '5 minutes'"),
+            ),
+        )
+        .values(last_interacted_at=func.now())
+    )
+
+
+async def touch_course_interaction_by_module(
+    db: AsyncSession, user_id: UUID, module_id: UUID
+) -> None:
+    """Resolve course_id from module, then touch enrollment."""
+    result = await db.execute(select(Module.course_id).where(Module.id == module_id))
+    course_id = result.scalar_one_or_none()
+    if course_id:
+        await touch_course_interaction(db, user_id, course_id)
 
 
 def _unlock_pct():
@@ -88,6 +116,7 @@ class ProgressService:
 
         await self.db.commit()
         await self.db.refresh(progress)
+        await touch_course_interaction_by_module(self.db, user_id, module_id)
 
         logger.info(
             "Lesson access tracked",
@@ -142,6 +171,7 @@ class ProgressService:
 
         await self.db.commit()
         await self.db.refresh(progress)
+        await touch_course_interaction_by_module(self.db, user_id, module_id)
 
         # After commit, check whether N+1 unlock conditions are met
         if (

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -322,6 +322,14 @@ class TutorService:
                 course_domain = course_domain or course_title
                 rag_collection_id = course.rag_collection_id
 
+                # Touch course interaction for recent-courses ranking
+                try:
+                    from app.domain.services.progress_service import touch_course_interaction
+
+                    await touch_course_interaction(session, uuid.UUID(str(user_id)), course.id)
+                except Exception:
+                    pass  # non-fatal
+
             audience = detect_audience(course)
 
             context = TutorContext(

--- a/backend/migrations/versions/055_add_last_interacted_at_to_enrollment.py
+++ b/backend/migrations/versions/055_add_last_interacted_at_to_enrollment.py
@@ -1,0 +1,32 @@
+"""Add last_interacted_at to user_course_enrollment.
+
+Revision ID: 055
+Revises: 054
+Create Date: 2026-04-11
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "055"
+down_revision = "054"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_course_enrollment",
+        sa.Column("last_interacted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_uce_last_interacted",
+        "user_course_enrollment",
+        ["user_id", "last_interacted_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_uce_last_interacted", table_name="user_course_enrollment")
+    op.drop_column("user_course_enrollment", "last_interacted_at")

--- a/backend/scripts/backfill_last_interacted.py
+++ b/backend/scripts/backfill_last_interacted.py
@@ -1,0 +1,56 @@
+"""Backfill last_interacted_at on user_course_enrollment from historical data.
+
+Run once after migration 055:
+    cd backend && python scripts/backfill_last_interacted.py
+"""
+
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+
+async def backfill() -> None:
+    database_url = os.environ.get(
+        "DATABASE_URL",
+        "postgresql+asyncpg://postgres:postgres@localhost:5432/santepublique",
+    )
+    # Ensure async driver
+    if database_url.startswith("postgresql://"):
+        database_url = database_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+
+    engine = create_async_engine(database_url)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        result = await session.execute(
+            text("""
+                UPDATE user_course_enrollment uce
+                SET last_interacted_at = sub.max_ts
+                FROM (
+                    SELECT ump.user_id, m.course_id,
+                           MAX(ump.last_accessed) AS max_ts
+                    FROM user_module_progress ump
+                    JOIN modules m ON m.id = ump.module_id
+                    WHERE ump.last_accessed IS NOT NULL
+                    GROUP BY ump.user_id, m.course_id
+                ) sub
+                WHERE uce.user_id = sub.user_id
+                  AND uce.course_id = sub.course_id
+                  AND (uce.last_interacted_at IS NULL
+                       OR uce.last_interacted_at < sub.max_ts)
+            """)
+        )
+        await session.commit()
+        print(f"Backfilled {result.rowcount} enrollment rows.")
+
+    await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(backfill())


### PR DESCRIPTION
## Summary
- Add `last_interacted_at` column to `user_course_enrollment` with Alembic migration
- Add `touch_course_interaction()` with 5-min debounce + `_by_module()` helper
- Wire into all 6 content interaction codepaths: lesson reads, quiz completions, flashcard reviews, summative assessments, placement tests, tutor chat
- Simplify `my-enrollments?order_by=last_accessed` to use `last_interacted_at` directly (removes complex GROUP BY + outerjoin)
- Include backfill script for historical data

Closes #1352

## Files changed
| File | Change |
|------|--------|
| `backend/app/domain/models/course.py` | Add `last_interacted_at` column |
| `backend/migrations/versions/055_...` | Alembic migration |
| `backend/app/domain/services/progress_service.py` | Add helpers + wire lesson/quiz |
| `backend/app/api/v1/flashcards.py` | Wire flashcard review |
| `backend/app/api/v1/quiz.py` | Wire summative assessment |
| `backend/app/api/v1/course_preassessment.py` | Wire placement test |
| `backend/app/domain/services/tutor_service.py` | Wire tutor chat |
| `backend/app/api/v1/courses.py` | Simplify query |
| `backend/scripts/backfill_last_interacted.py` | Backfill script |

## Test plan
- [ ] Migration runs cleanly (`alembic upgrade head`)
- [ ] Backfill script populates historical data
- [ ] Lesson read → course appears first in tutor dropdown
- [ ] Flashcard review → course appears first
- [ ] Tutor chat → course appears first
- [ ] Dashboard `getMyEnrollments()` (no params) unaffected
- [ ] Debounce: rapid interactions → only 1 UPDATE per 5 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)