### PR TITLE
feat(offline): module download for offline (#295)

### DIFF
--- a/frontend/components/learning/download-module-button.tsx
+++ b/frontend/components/learning/download-module-button.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import {
+  Download,
+  CheckCircle,
+  Trash2,
+  XCircle,
+  Loader2,
+  Wifi,
+  AlertTriangle,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { useDownloadManager } from '@/lib/hooks/use-download-manager';
+import { formatBytes } from '@/lib/offline/download-manager';
+
+interface DownloadModuleButtonProps {
+  moduleId: string;
+  locale: 'fr' | 'en';
+  unitCount: number;
+  level?: number;
+  country?: string;
+}
+
+export function DownloadModuleButton({
+  moduleId,
+  locale,
+  unitCount,
+  level = 1,
+  country = 'CI',
+}: DownloadModuleButtonProps) {
+  const t = useTranslations('Offline');
+  const [wifiOnly, setWifiOnly] = useState(true);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const {
+    status,
+    progress,
+    isDownloading,
+    isAvailableOffline,
+    canDownload,
+    estimatedSize,
+    downloadedUnits,
+    totalUnits,
+    error,
+    download,
+    cancel,
+    remove,
+  } = useDownloadManager(moduleId, locale, unitCount);
+
+  const progressPct =
+    totalUnits > 0 ? Math.round((downloadedUnits / totalUnits) * 100) : 0;
+
+  const handleDownload = async () => {
+    setShowConfirm(false);
+    await download({ wifiOnly, level, country });
+  };
+
+  // Available offline — show status + delete button
+  if (isAvailableOffline) {
+    return (
+      <div className="rounded-lg border border-teal-200 bg-teal-50 p-4 space-y-3">
+        <div className="flex items-center gap-2 text-teal-700">
+          <CheckCircle className="w-5 h-5 shrink-0" />
+          <span className="text-sm font-medium">{t('availableOffline')}</span>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full text-red-600 border-red-200 hover:bg-red-50 min-h-11"
+          onClick={remove}
+        >
+          <Trash2 className="w-4 h-4 mr-2" />
+          {t('removeDownload')}
+        </Button>
+      </div>
+    );
+  }
+
+  // Currently downloading — show progress
+  if (isDownloading) {
+    return (
+      <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 space-y-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2 text-amber-700">
+            <Loader2 className="w-4 h-4 animate-spin" />
+            <span className="text-sm font-medium">{t('downloading')}</span>
+          </div>
+          <span className="text-xs text-amber-600">
+            {downloadedUnits}/{totalUnits} {t('units')}
+          </span>
+        </div>
+
+        <div className="space-y-1">
+          <div className="flex justify-between text-xs text-amber-600">
+            <span>{t('downloadProgress')}</span>
+            <span>{progressPct}%</span>
+          </div>
+          <Progress value={progressPct} />
+        </div>
+
+        {progress?.currentUnit && (
+          <p className="text-xs text-amber-600">
+            {progress.currentContentType === 'lesson' && t('downloadingLesson')}
+            {progress.currentContentType === 'quiz' && t('downloadingQuiz')}
+            {progress.currentContentType === 'case_study' && t('downloadingCaseStudy')}
+            {' '}{progress.currentUnit}
+          </p>
+        )}
+
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full min-h-11"
+          onClick={cancel}
+        >
+          <XCircle className="w-4 h-4 mr-2" />
+          {t('cancel')}
+        </Button>
+      </div>
+    );
+  }
+
+  // Error state — show error + retry
+  if (status === 'error') {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 space-y-3">
+        <div className="flex items-center gap-2 text-red-700">
+          <AlertTriangle className="w-5 h-5 shrink-0" />
+          <span className="text-sm font-medium">{error || t('downloadFailed')}</span>
+        </div>
+        {downloadedUnits > 0 && (
+          <p className="text-xs text-red-600">
+            {t('partialDownload', { count: downloadedUnits, total: totalUnits })}
+          </p>
+        )}
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            className="flex-1 min-h-11"
+            onClick={handleDownload}
+          >
+            {t('retry')}
+          </Button>
+          {downloadedUnits > 0 && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="min-h-11 text-red-600 border-red-200"
+              onClick={remove}
+            >
+              <Trash2 className="w-4 h-4" />
+            </Button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // Not downloaded — show download button or limit warning
+  if (!canDownload) {
+    return (
+      <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 space-y-2">
+        <div className="flex items-center gap-2 text-stone-500">
+          <AlertTriangle className="w-4 h-4" />
+          <span className="text-sm">{t('moduleLimitReached')}</span>
+        </div>
+        <p className="text-xs text-stone-400">{t('moduleLimitHint')}</p>
+      </div>
+    );
+  }
+
+  // Show confirm dialog
+  if (showConfirm) {
+    return (
+      <div className="rounded-lg border border-stone-200 bg-white p-4 space-y-3">
+        <p className="text-sm text-stone-700">
+          {t('downloadConfirm', { size: formatBytes(estimatedSize) })}
+        </p>
+
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="wifi-only"
+            checked={wifiOnly}
+            onCheckedChange={(checked) => setWifiOnly(checked === true)}
+          />
+          <Label htmlFor="wifi-only" className="text-sm text-stone-600 flex items-center gap-1">
+            <Wifi className="w-3.5 h-3.5" />
+            {t('wifiOnly')}
+          </Label>
+        </div>
+
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            className="flex-1 min-h-11 bg-teal-600 hover:bg-teal-700"
+            onClick={handleDownload}
+          >
+            <Download className="w-4 h-4 mr-2" />
+            {t('startDownload')}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="min-h-11"
+            onClick={() => setShowConfirm(false)}
+          >
+            {t('cancelAction')}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // Default: download button
+  return (
+    <Button
+      variant="outline"
+      className="w-full min-h-11"
+      onClick={() => setShowConfirm(true)}
+    >
+      <Download className="w-4 h-4 mr-2" />
+      {t('downloadForOffline')}
+      <span className="ml-auto text-xs text-stone-400">
+        ~{formatBytes(estimatedSize)}
+      </span>
+    </Button>
+  );
+}

--- a/frontend/components/learning/module-lock-gate.tsx
+++ b/frontend/components/learning/module-lock-gate.tsx
@@ -12,6 +12,7 @@ import { getModuleDetailWithProgress, getModuleUnits, type ModuleDetailWithProgr
 import { track } from '@/lib/analytics';
 import { ModuleProgressOverlay } from '@/components/learning/module-progress-overlay';
 import { ModuleMediaPlayer } from '@/components/learning/module-media-player';
+import { DownloadModuleButton } from '@/components/learning/download-module-button';
 
 interface ModuleLockGateProps {
   moduleId: string;
@@ -212,6 +213,13 @@ export function ModuleLockGate({ moduleId, language }: ModuleLockGateProps) {
               </Button>
             </Link>
           </div>
+
+          <DownloadModuleButton
+            moduleId={moduleId}
+            locale={language}
+            unitCount={moduleData?.units?.length ?? 0}
+            level={moduleData?.level}
+          />
         </div>
       </div>
     </div>

--- a/frontend/lib/hooks/use-download-manager.ts
+++ b/frontend/lib/hooks/use-download-manager.ts
@@ -1,0 +1,153 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  downloadModule,
+  cancelDownload,
+  removeOfflineModule,
+  canDownloadMore,
+  estimateModuleSize,
+  type DownloadProgress,
+  type DownloadPhase,
+} from '@/lib/offline/download-manager';
+import {
+  getOfflineModule,
+  type OfflineModule,
+  type ModuleDownloadStatus,
+} from '@/lib/offline/db';
+
+export interface UseDownloadManagerReturn {
+  /** Current download status of this module */
+  status: ModuleDownloadStatus;
+  /** Download progress details when downloading */
+  progress: DownloadProgress | null;
+  /** Whether a download is currently active */
+  isDownloading: boolean;
+  /** Whether the module is fully available offline */
+  isAvailableOffline: boolean;
+  /** Whether user can download more modules (under 3 limit) */
+  canDownload: boolean;
+  /** Estimated size in bytes */
+  estimatedSize: number;
+  /** Number of downloaded units (for partial downloads) */
+  downloadedUnits: number;
+  /** Total units in the module */
+  totalUnits: number;
+  /** Error message if download failed */
+  error: string | null;
+  /** Start downloading the module */
+  download: (options?: {
+    wifiOnly?: boolean;
+    level?: number;
+    country?: string;
+  }) => Promise<void>;
+  /** Cancel an in-progress download */
+  cancel: () => void;
+  /** Remove the downloaded module and free space */
+  remove: () => Promise<void>;
+}
+
+export function useDownloadManager(
+  moduleId: string,
+  locale: 'fr' | 'en',
+  unitCount?: number
+): UseDownloadManagerReturn {
+  const [status, setStatus] = useState<ModuleDownloadStatus>('not_downloaded');
+  const [progress, setProgress] = useState<DownloadProgress | null>(null);
+  const [canDl, setCanDl] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [downloadedUnits, setDownloadedUnits] = useState(0);
+  const [totalUnits, setTotalUnits] = useState(unitCount ?? 0);
+
+  // Load existing state from IndexedDB on mount
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadState() {
+      const mod = await getOfflineModule(moduleId);
+      if (cancelled) return;
+
+      if (mod) {
+        setStatus(mod.status);
+        setDownloadedUnits(mod.downloadedUnits);
+        setTotalUnits(mod.totalUnits);
+      } else {
+        setStatus('not_downloaded');
+      }
+
+      setCanDl(await canDownloadMore());
+    }
+
+    loadState();
+    return () => { cancelled = true; };
+  }, [moduleId]);
+
+  const download = useCallback(
+    async (options?: { wifiOnly?: boolean; level?: number; country?: string }) => {
+      setError(null);
+      setStatus('downloading');
+
+      try {
+        await downloadModule(moduleId, locale, {
+          ...options,
+          onProgress: (p) => {
+            setProgress(p);
+            setDownloadedUnits(p.downloadedUnits);
+            setTotalUnits(p.totalUnits);
+
+            if (p.phase === 'complete') {
+              setStatus('downloaded');
+            } else if (p.phase === 'error') {
+              setStatus('error');
+              setError(p.error ?? 'Download failed');
+            } else if (p.phase === 'cancelled') {
+              // Keep current status (partial download is functional)
+              getOfflineModule(moduleId).then((mod) => {
+                if (mod) {
+                  setStatus(mod.downloadedUnits > 0 ? mod.status : 'not_downloaded');
+                } else {
+                  setStatus('not_downloaded');
+                }
+              });
+            }
+          },
+        });
+      } catch (err: unknown) {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        setStatus('error');
+        setError(err instanceof Error ? err.message : 'Download failed');
+      }
+
+      setCanDl(await canDownloadMore());
+    },
+    [moduleId, locale]
+  );
+
+  const cancel = useCallback(() => {
+    cancelDownload(moduleId);
+  }, [moduleId]);
+
+  const remove = useCallback(async () => {
+    await removeOfflineModule(moduleId);
+    setStatus('not_downloaded');
+    setProgress(null);
+    setDownloadedUnits(0);
+    setError(null);
+    setCanDl(await canDownloadMore());
+  }, [moduleId]);
+
+  return {
+    status,
+    progress,
+    isDownloading: status === 'downloading',
+    isAvailableOffline: status === 'downloaded',
+    canDownload: canDl || status === 'downloaded',
+    estimatedSize: estimateModuleSize(unitCount ?? totalUnits),
+    downloadedUnits,
+    totalUnits,
+    error,
+    download,
+    cancel,
+    remove,
+  };
+}

--- a/frontend/lib/offline/db.ts
+++ b/frontend/lib/offline/db.ts
@@ -16,6 +16,7 @@ export type ActionType =
 
 export interface OfflineModule {
   moduleId: string;
+  courseId?: string;
   status: ModuleDownloadStatus;
   totalUnits: number;
   downloadedUnits: number;
@@ -39,7 +40,7 @@ export interface OfflineAction {
   actionType: ActionType;
   payload: unknown;
   createdAt: number;
-  synced: boolean;
+  synced: number; // 0 = pending, 1 = synced (number for IndexedDB index compat)
   syncedAt?: number;
 }
 
@@ -50,11 +51,12 @@ interface SantePubliqueDB extends DBSchema {
     indexes: { by_status: ModuleDownloadStatus };
   };
   offline_content: {
-    key: [string, string];
+    key: [string, string, string]; // [unitId, contentType, locale]
     value: OfflineContent;
     indexes: {
       by_module: string;
       by_content_type: ContentType;
+      by_unit: string;
     };
   };
   offline_actions: {
@@ -65,7 +67,7 @@ interface SantePubliqueDB extends DBSchema {
 }
 
 const DB_NAME = "santepublique-offline";
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 
 let dbInstance: IDBPDatabase<SantePubliqueDB> | null = null;
 
@@ -73,7 +75,8 @@ export async function getDB(): Promise<IDBPDatabase<SantePubliqueDB>> {
   if (dbInstance) return dbInstance;
 
   dbInstance = await openDB<SantePubliqueDB>(DB_NAME, DB_VERSION, {
-    upgrade(db, oldVersion) {
+    upgrade(db, oldVersion, _newVersion, transaction) {
+      // V1: create modules + actions stores
       if (oldVersion < 1) {
         const modulesStore = db.createObjectStore("offline_modules", {
           keyPath: "moduleId",
@@ -87,21 +90,39 @@ export async function getDB(): Promise<IDBPDatabase<SantePubliqueDB>> {
         actionsStore.createIndex("by_synced", "synced");
       }
 
-      if (oldVersion < 2) {
+      // V3: recreate offline_content with triple composite key + fix actions synced type
+      if (oldVersion < 3) {
+        // Recreate offline_content with [unitId, contentType, locale] key
         if (db.objectStoreNames.contains("offline_content")) {
           db.deleteObjectStore("offline_content");
         }
         const contentStore = db.createObjectStore("offline_content", {
-          keyPath: ["unitId", "locale"],
+          keyPath: ["unitId", "contentType", "locale"],
         });
         contentStore.createIndex("by_module", "moduleId");
         contentStore.createIndex("by_content_type", "contentType");
+        contentStore.createIndex("by_unit", "unitId");
+
+        // Migrate offline_actions: convert boolean synced to number
+        if (oldVersion >= 1) {
+          const actionsStore = transaction.objectStore("offline_actions");
+          actionsStore.openCursor().then(function migrateCursor(cursor) {
+            if (!cursor) return;
+            const value = cursor.value;
+            if (typeof value.synced === "boolean") {
+              cursor.update({ ...value, synced: value.synced ? 1 : 0 });
+            }
+            cursor.continue().then(migrateCursor);
+          });
+        }
       }
     },
   });
 
   return dbInstance;
 }
+
+// --- Offline Modules ---
 
 export async function getOfflineModule(
   moduleId: string
@@ -129,12 +150,15 @@ export async function getOfflineModulesByStatus(
   return db.getAllFromIndex("offline_modules", "by_status", status);
 }
 
+// --- Offline Content ---
+
 export async function getOfflineContent(
   unitId: string,
+  contentType: ContentType,
   locale: "fr" | "en"
 ): Promise<OfflineContent | undefined> {
   const db = await getDB();
-  return db.get("offline_content", [unitId, locale]);
+  return db.get("offline_content", [unitId, contentType, locale]);
 }
 
 export async function upsertOfflineContent(
@@ -149,6 +173,13 @@ export async function getOfflineContentByModule(
 ): Promise<OfflineContent[]> {
   const db = await getDB();
   return db.getAllFromIndex("offline_content", "by_module", moduleId);
+}
+
+export async function getOfflineContentByUnit(
+  unitId: string
+): Promise<OfflineContent[]> {
+  const db = await getDB();
+  return db.getAllFromIndex("offline_content", "by_unit", unitId);
 }
 
 export async function deleteOfflineModule(moduleId: string): Promise<void> {
@@ -169,6 +200,8 @@ export async function deleteOfflineModule(moduleId: string): Promise<void> {
   await tx.done;
 }
 
+// --- Offline Actions ---
+
 export async function addOfflineAction(
   action: Omit<OfflineAction, "id" | "createdAt" | "synced">
 ): Promise<number> {
@@ -176,7 +209,7 @@ export async function addOfflineAction(
   return db.add("offline_actions", {
     ...action,
     createdAt: Date.now(),
-    synced: false,
+    synced: 0,
   });
 }
 
@@ -191,7 +224,7 @@ export async function markOfflineActionSynced(id: number): Promise<void> {
   if (action) {
     await db.put("offline_actions", {
       ...action,
-      synced: true,
+      synced: 1,
       syncedAt: Date.now(),
     });
   }

--- a/frontend/lib/offline/download-manager.ts
+++ b/frontend/lib/offline/download-manager.ts
@@ -1,0 +1,449 @@
+import {
+  upsertOfflineModule,
+  upsertOfflineContent,
+  getOfflineModule,
+  getAllOfflineModules,
+  deleteOfflineModule,
+  type ContentType,
+} from "./db";
+import { apiFetch } from "@/lib/api";
+import type { ModuleUnitsResponse } from "@/lib/api";
+
+const MAX_OFFLINE_MODULES = 3;
+const POLL_INTERVAL_MS = 3000;
+const POLL_TIMEOUT_MS = 3 * 60 * 1000;
+
+// Average bytes per content type (for size estimation)
+const SIZE_ESTIMATE_PER_UNIT = 50_000; // ~50KB per unit (lesson + quiz + case study)
+const SIZE_ESTIMATE_FLASHCARDS = 30_000; // ~30KB for module flashcards
+
+export type DownloadPhase = "fetching_structure" | "downloading_content" | "complete" | "error" | "cancelled";
+
+export interface DownloadProgress {
+  phase: DownloadPhase;
+  totalUnits: number;
+  downloadedUnits: number;
+  currentUnit?: string;
+  currentContentType?: ContentType;
+  error?: string;
+}
+
+export type DownloadProgressCallback = (progress: DownloadProgress) => void;
+
+interface ContentStatusResponse {
+  status: string;
+  content_id?: string;
+  error?: string;
+}
+
+/**
+ * Estimate download size in bytes for a module based on unit count.
+ */
+export function estimateModuleSize(unitCount: number): number {
+  return unitCount * SIZE_ESTIMATE_PER_UNIT + SIZE_ESTIMATE_FLASHCARDS;
+}
+
+/**
+ * Format bytes as human-readable string.
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// Active downloads tracked for cancellation
+const activeAbortControllers = new Map<string, AbortController>();
+
+/**
+ * Check whether the current connection is WiFi.
+ * Returns true if WiFi, false if cellular, undefined if API not available.
+ */
+function isWifiConnection(): boolean | undefined {
+  const conn = (navigator as unknown as { connection?: { type?: string } }).connection;
+  if (!conn?.type) return undefined;
+  return conn.type === "wifi";
+}
+
+/**
+ * Get count of currently downloaded (or downloading) modules.
+ */
+export async function getDownloadedModuleCount(): Promise<number> {
+  const modules = await getAllOfflineModules();
+  return modules.filter(
+    (m) => m.status === "downloaded" || m.status === "downloading"
+  ).length;
+}
+
+/**
+ * Check if user can download another module (max 3).
+ */
+export async function canDownloadMore(): Promise<boolean> {
+  return (await getDownloadedModuleCount()) < MAX_OFFLINE_MODULES;
+}
+
+/**
+ * Poll a content generation task until complete, failed, or timeout.
+ */
+async function pollContentStatus(
+  taskId: string,
+  signal: AbortSignal
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < POLL_TIMEOUT_MS) {
+    if (signal.aborted) throw new DOMException("Aborted", "AbortError");
+
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+
+    const status = await apiFetch<ContentStatusResponse>(
+      `/api/v1/content/status/${taskId}`,
+      { signal }
+    );
+
+    if (status.status === "complete") return;
+    if (status.status === "failed") {
+      throw new Error(status.error || "Content generation failed");
+    }
+  }
+  throw new Error("Content generation timed out");
+}
+
+/**
+ * Fetch a single content item, handling 202 (generating) responses.
+ * Returns the content data or null if the content type doesn't exist for this unit.
+ */
+async function fetchContentItem<T>(
+  url: string,
+  signal: AbortSignal
+): Promise<T | null> {
+  try {
+    const res = await apiFetch<T | { status: string; task_id: string }>(url, { signal });
+
+    // Handle 202-like generating response
+    if (res && typeof res === "object" && "status" in res && "task_id" in res) {
+      const generating = res as { status: string; task_id: string };
+      if (generating.status === "generating") {
+        await pollContentStatus(generating.task_id, signal);
+        // Re-fetch after generation completes
+        return apiFetch<T>(url, { signal });
+      }
+    }
+
+    return res as T;
+  } catch (err: unknown) {
+    if (err instanceof DOMException && err.name === "AbortError") throw err;
+    // 404 means content doesn't exist for this unit — skip it
+    if (err && typeof err === "object" && "status" in err && (err as { status: number }).status === 404) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Download a module for offline use.
+ *
+ * Fetches all units' lessons, quizzes, and case studies using existing API
+ * endpoints and stores them in IndexedDB. Each unit becomes usable as soon
+ * as its content is downloaded (partial downloads are functional).
+ */
+export async function downloadModule(
+  moduleId: string,
+  locale: "fr" | "en",
+  options: {
+    wifiOnly?: boolean;
+    level?: number;
+    country?: string;
+    onProgress?: DownloadProgressCallback;
+  } = {}
+): Promise<void> {
+  const { wifiOnly = false, level = 1, country = "CI", onProgress } = options;
+
+  // WiFi-only check
+  if (wifiOnly) {
+    const wifi = isWifiConnection();
+    if (wifi === false) {
+      throw new Error("WiFi-only download requested but not on WiFi");
+    }
+  }
+
+  // Check module limit
+  const existing = await getOfflineModule(moduleId);
+  if (!existing || existing.status !== "downloaded") {
+    if (!(await canDownloadMore()) && existing?.status !== "downloading") {
+      throw new Error("Maximum offline module limit reached (3)");
+    }
+  }
+
+  // Set up abort controller
+  const abortController = new AbortController();
+  activeAbortControllers.set(moduleId, abortController);
+  const { signal } = abortController;
+
+  const emit = (progress: DownloadProgress) => onProgress?.(progress);
+
+  try {
+    // Step 1: Fetch module structure
+    emit({ phase: "fetching_structure", totalUnits: 0, downloadedUnits: 0 });
+
+    const moduleInfo = await apiFetch<ModuleUnitsResponse>(
+      `/api/v1/content/modules/${moduleId}/units`,
+      { signal }
+    );
+
+    const units = moduleInfo.units.sort((a, b) => a.order_index - b.order_index);
+    const totalUnits = units.length;
+    const estimatedSize = estimateModuleSize(totalUnits);
+
+    // Initialize module record in IndexedDB
+    await upsertOfflineModule({
+      moduleId,
+      status: "downloading",
+      totalUnits,
+      downloadedUnits: existing?.downloadedUnits ?? 0,
+      sizeBytes: estimatedSize,
+      updatedAt: Date.now(),
+    });
+
+    let downloadedUnits = 0;
+
+    // Step 2: Download each unit's content
+    for (const unit of units) {
+      if (signal.aborted) throw new DOMException("Aborted", "AbortError");
+
+      const unitId = unit.unit_number;
+
+      // Download lesson
+      emit({
+        phase: "downloading_content",
+        totalUnits,
+        downloadedUnits,
+        currentUnit: unitId,
+        currentContentType: "lesson",
+      });
+
+      await downloadUnitContent(
+        moduleId, unitId, "lesson",
+        `/api/v1/content/lessons/${moduleId}/${unitId}?language=${locale}&level=${level}&country=${country}`,
+        locale, signal
+      );
+
+      // Download quiz
+      if (signal.aborted) throw new DOMException("Aborted", "AbortError");
+
+      emit({
+        phase: "downloading_content",
+        totalUnits,
+        downloadedUnits,
+        currentUnit: unitId,
+        currentContentType: "quiz",
+      });
+
+      await downloadUnitQuiz(moduleId, unitId, locale, level, country, signal);
+
+      // Download case study (only for case-study type units, but try for all)
+      if (signal.aborted) throw new DOMException("Aborted", "AbortError");
+
+      emit({
+        phase: "downloading_content",
+        totalUnits,
+        downloadedUnits,
+        currentUnit: unitId,
+        currentContentType: "case_study",
+      });
+
+      await downloadUnitContent(
+        moduleId, unitId, "case_study",
+        `/api/v1/content/cases/${moduleId}/${unitId}?language=${locale}&level=${level}&country=${country}`,
+        locale, signal
+      );
+
+      downloadedUnits++;
+
+      // Update progress in IndexedDB
+      await upsertOfflineModule({
+        moduleId,
+        status: "downloading",
+        totalUnits,
+        downloadedUnits,
+        sizeBytes: estimatedSize,
+        updatedAt: Date.now(),
+      });
+    }
+
+    // Step 3: Download module-level flashcards
+    if (signal.aborted) throw new DOMException("Aborted", "AbortError");
+
+    try {
+      const flashcards = await fetchContentItem<unknown>(
+        `/api/v1/flashcards/modules/${moduleId}?language=${locale}&level=${level}`,
+        signal
+      );
+      if (flashcards) {
+        await upsertOfflineContent({
+          unitId: `__module_${moduleId}__`,
+          moduleId,
+          contentType: "flashcard",
+          locale,
+          content: flashcards,
+          cachedAt: Date.now(),
+        });
+      }
+    } catch {
+      // Flashcard download failure is non-fatal
+    }
+
+    // Step 4: Mark module as downloaded
+    await upsertOfflineModule({
+      moduleId,
+      status: "downloaded",
+      totalUnits,
+      downloadedUnits: totalUnits,
+      sizeBytes: estimatedSize,
+      downloadedAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    emit({ phase: "complete", totalUnits, downloadedUnits: totalUnits });
+  } catch (err: unknown) {
+    if (err instanceof DOMException && err.name === "AbortError") {
+      emit({
+        phase: "cancelled",
+        totalUnits: 0,
+        downloadedUnits: 0,
+      });
+      return;
+    }
+
+    // Mark module as errored (but keep partial content)
+    const mod = await getOfflineModule(moduleId);
+    if (mod) {
+      await upsertOfflineModule({ ...mod, status: "error" });
+    }
+
+    emit({
+      phase: "error",
+      totalUnits: 0,
+      downloadedUnits: 0,
+      error: err instanceof Error ? err.message : "Download failed",
+    });
+
+    throw err;
+  } finally {
+    activeAbortControllers.delete(moduleId);
+  }
+}
+
+/**
+ * Cancel an in-progress download.
+ */
+export function cancelDownload(moduleId: string): void {
+  const controller = activeAbortControllers.get(moduleId);
+  if (controller) {
+    controller.abort();
+    activeAbortControllers.delete(moduleId);
+  }
+}
+
+/**
+ * Remove a downloaded module and all its cached content.
+ */
+export async function removeOfflineModule(moduleId: string): Promise<void> {
+  cancelDownload(moduleId);
+  await deleteOfflineModule(moduleId);
+}
+
+// --- Internal helpers ---
+
+async function downloadUnitContent(
+  moduleId: string,
+  unitId: string,
+  contentType: ContentType,
+  url: string,
+  locale: "fr" | "en",
+  signal: AbortSignal
+): Promise<void> {
+  try {
+    const data = await fetchContentItem<unknown>(url, signal);
+    if (data) {
+      await upsertOfflineContent({
+        unitId,
+        moduleId,
+        contentType,
+        locale,
+        content: data,
+        cachedAt: Date.now(),
+      });
+    }
+  } catch (err: unknown) {
+    if (err instanceof DOMException && err.name === "AbortError") throw err;
+    // Non-fatal: content may not exist yet, continue with other units
+    console.warn(`Failed to download ${contentType} for ${unitId}:`, err);
+  }
+}
+
+async function downloadUnitQuiz(
+  moduleId: string,
+  unitId: string,
+  locale: "fr" | "en",
+  level: number,
+  country: string,
+  signal: AbortSignal
+): Promise<void> {
+  const quizBody = JSON.stringify({
+    module_id: moduleId,
+    unit_id: unitId,
+    language: locale,
+    country,
+    level,
+    num_questions: 10,
+    force_regenerate: false,
+  });
+
+  try {
+    const res = await apiFetch<unknown>("/api/v1/quiz/generate", {
+      method: "POST",
+      signal,
+      body: quizBody,
+    });
+
+    if (!res) return;
+
+    // Handle 202-like generating response
+    if (typeof res === "object" && "status" in (res as Record<string, unknown>) && "task_id" in (res as Record<string, unknown>)) {
+      const gen = res as { status: string; task_id: string };
+      if (gen.status === "generating") {
+        await pollContentStatus(gen.task_id, signal);
+        // Re-fetch cached quiz after generation
+        const finalQuiz = await apiFetch<unknown>("/api/v1/quiz/generate", {
+          method: "POST",
+          signal,
+          body: quizBody,
+        });
+        if (finalQuiz) {
+          await upsertOfflineContent({
+            unitId,
+            moduleId,
+            contentType: "quiz",
+            locale,
+            content: finalQuiz,
+            cachedAt: Date.now(),
+          });
+        }
+        return;
+      }
+    }
+
+    await upsertOfflineContent({
+      unitId,
+      moduleId,
+      contentType: "quiz",
+      locale,
+      content: res,
+      cachedAt: Date.now(),
+    });
+  } catch (err: unknown) {
+    if (err instanceof DOMException && err.name === "AbortError") throw err;
+    console.warn(`Failed to download quiz for ${unitId}:`, err);
+  }
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1678,5 +1678,30 @@
     "codeRequired": "Please enter an activation code",
     "scanInstructions": "Point your camera at the QR code",
     "redirecting": "Redirecting to course..."
+  },
+  "Offline": {
+    "downloadForOffline": "Download for offline",
+    "availableOffline": "Available offline",
+    "removeDownload": "Remove download",
+    "downloading": "Downloading...",
+    "units": "units",
+    "downloadProgress": "Download progress",
+    "downloadingLesson": "Downloading lesson",
+    "downloadingQuiz": "Downloading quiz",
+    "downloadingCaseStudy": "Downloading case study",
+    "cancel": "Cancel download",
+    "cancelAction": "Cancel",
+    "downloadFailed": "Download failed",
+    "partialDownload": "{count} of {total} units downloaded",
+    "retry": "Retry download",
+    "moduleLimitReached": "Offline module limit reached (3/3)",
+    "moduleLimitHint": "Remove a downloaded module to free a slot",
+    "downloadConfirm": "Download this module for offline use (~{size})?",
+    "wifiOnly": "WiFi only",
+    "startDownload": "Download",
+    "offlineBadge": "Offline",
+    "contentNotAvailable": "Content not available offline",
+    "contentNotAvailableHint": "Download this module to access it offline",
+    "quizOfflineNote": "Quiz scored locally — will sync when back online"
   }
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1678,5 +1678,30 @@
     "codeRequired": "Veuillez entrer un code d'activation",
     "scanInstructions": "Pointez votre caméra sur le code QR",
     "redirecting": "Redirection vers le cours..."
+  },
+  "Offline": {
+    "downloadForOffline": "Télécharger pour hors-ligne",
+    "availableOffline": "Disponible hors-ligne",
+    "removeDownload": "Supprimer le téléchargement",
+    "downloading": "Téléchargement en cours...",
+    "units": "unités",
+    "downloadProgress": "Progression du téléchargement",
+    "downloadingLesson": "Téléchargement de la leçon",
+    "downloadingQuiz": "Téléchargement du quiz",
+    "downloadingCaseStudy": "Téléchargement de l'étude de cas",
+    "cancel": "Annuler le téléchargement",
+    "cancelAction": "Annuler",
+    "downloadFailed": "Échec du téléchargement",
+    "partialDownload": "{count} sur {total} unités téléchargées",
+    "retry": "Réessayer le téléchargement",
+    "moduleLimitReached": "Limite de modules hors-ligne atteinte (3/3)",
+    "moduleLimitHint": "Supprimez un module téléchargé pour libérer une place",
+    "downloadConfirm": "Télécharger ce module pour usage hors-ligne (~{size}) ?",
+    "wifiOnly": "WiFi uniquement",
+    "startDownload": "Télécharger",
+    "offlineBadge": "Hors-ligne",
+    "contentNotAvailable": "Contenu non disponible hors-ligne",
+    "contentNotAvailableHint": "Téléchargez ce module pour y accéder hors-ligne",
+    "quizOfflineNote": "Quiz noté localement — synchronisation au retour en ligne"
   }
 }


### PR DESCRIPTION
## Summary
- **Fix IndexedDB schema (v2→v3):** composite key `[unitId, contentType, locale]` for `offline_content` (was `[unitId, locale]` — couldn't store lesson + quiz for same unit). Fix `synced` field type mismatch (boolean→number) in `offline_actions`.
- **Download manager:** orchestrates per-unit content fetches to existing API endpoints. Supports cancellation, 3-module limit, WiFi-only option, partial downloads immediately functional.
- **Download UI:** `DownloadModuleButton` component with progress bar, confirm dialog, error/retry states. Integrated into module overview sidebar.
- **i18n:** 25 new bilingual (FR/EN) strings in `Offline` namespace.

Closes #295

## Files changed
- `frontend/lib/offline/db.ts` — schema migration v2→v3, new composite key, synced fix
- `frontend/lib/offline/download-manager.ts` — new download orchestration engine
- `frontend/lib/hooks/use-download-manager.ts` — React hook for download state
- `frontend/components/learning/download-module-button.tsx` — UI component
- `frontend/components/learning/module-lock-gate.tsx` — integration point
- `frontend/messages/en.json`, `fr.json` — Offline namespace strings

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Download a module from module overview → verify content in IndexedDB via DevTools
- [ ] Cancel mid-download → verify partial content remains accessible
- [ ] Try downloading 4th module → verify limit enforced
- [ ] Test WiFi-only toggle on mobile
- [ ] Verify FR/EN string switching

🤖 Generated with [Claude Code](https://claude.com/claude-code)