### PR TITLE
feat(offline): background sync when back online (#298, closes #46)

### DIFF
--- a/frontend/app/[locale]/(app)/layout.tsx
+++ b/frontend/app/[locale]/(app)/layout.tsx
@@ -4,6 +4,7 @@ import { Sidebar } from "@/components/layout/sidebar";
 import { BreadcrumbNav } from "@/components/layout/breadcrumb-nav";
 import { ChatLayout } from "@/components/chat/chat-layout";
 import { OfflineIndicator } from "@/components/shared/offline-indicator";
+import { SyncStatusIndicator } from "@/components/shared/sync-status-indicator";
 import { AuthGuard } from "@/components/shared/auth-guard";
 import { SubscriptionBanner } from "@/components/shared/subscription-banner";
 
@@ -15,6 +16,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
           <Sidebar />
           <div className="flex flex-1 flex-col min-h-0">
             <OfflineIndicator />
+            <SyncStatusIndicator />
             <SubscriptionBanner />
             <Header />
             <BreadcrumbNav />

--- a/frontend/components/shared/offline-indicator.tsx
+++ b/frontend/components/shared/offline-indicator.tsx
@@ -1,12 +1,26 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { WifiOff, Wifi } from "lucide-react";
 import { useNetworkStatus } from "@/lib/hooks/use-network-status";
+import { SyncManager } from "@/lib/offline/sync-manager";
 
 export function OfflineIndicator() {
   const t = useTranslations("Offline");
   const { isOnline, justReconnected } = useNetworkStatus();
+  const syncTriggered = useRef(false);
+
+  // Trigger background sync when reconnecting
+  useEffect(() => {
+    if (justReconnected && !syncTriggered.current) {
+      syncTriggered.current = true;
+      SyncManager.getInstance().syncNow();
+    }
+    if (!justReconnected) {
+      syncTriggered.current = false;
+    }
+  }, [justReconnected]);
 
   if (isOnline && !justReconnected) return null;
 

--- a/frontend/components/shared/sync-status-indicator.tsx
+++ b/frontend/components/shared/sync-status-indicator.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { RefreshCw, CheckCircle, AlertTriangle, CloudUpload } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useSyncStatus } from '@/lib/hooks/use-sync-status';
+
+export function SyncStatusIndicator() {
+  const t = useTranslations('Offline');
+  const { status, pendingCount, isSyncing, syncNow } = useSyncStatus();
+
+  // Nothing to show when idle with no pending items
+  if (status.state === 'idle' && pendingCount === 0) return null;
+
+  // Syncing
+  if (isSyncing) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex items-center justify-center gap-2 bg-blue-50 border-b border-blue-100 px-4 py-1.5 text-xs font-medium text-blue-700"
+      >
+        <RefreshCw className="h-3.5 w-3.5 animate-spin shrink-0" aria-hidden="true" />
+        <span>{t('syncing')}</span>
+        {status.state === 'syncing' && (
+          <span className="text-blue-500">
+            {status.current}/{status.total}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  // Sync complete
+  if (status.state === 'complete') {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex items-center justify-center gap-2 bg-teal-50 border-b border-teal-100 px-4 py-1.5 text-xs font-medium text-teal-700"
+      >
+        <CheckCircle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span>{t('syncSuccess', { count: status.synced })}</span>
+      </div>
+    );
+  }
+
+  // Sync error
+  if (status.state === 'error') {
+    return (
+      <div
+        role="alert"
+        className="flex items-center justify-center gap-2 bg-red-50 border-b border-red-100 px-4 py-1.5 text-xs font-medium text-red-700"
+      >
+        <AlertTriangle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span>{t('syncFailed')}</span>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={syncNow}
+          className="h-6 px-2 text-xs text-red-700 hover:bg-red-100"
+        >
+          {t('syncRetry')}
+        </Button>
+      </div>
+    );
+  }
+
+  // Idle with pending items
+  if (pendingCount > 0) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex items-center justify-center gap-2 bg-amber-50 border-b border-amber-100 px-4 py-1.5 text-xs font-medium text-amber-700"
+      >
+        <CloudUpload className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span>{t('syncPending', { count: pendingCount })}</span>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/frontend/lib/hooks/use-sync-status.ts
+++ b/frontend/lib/hooks/use-sync-status.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { SyncManager, type SyncStatus } from '@/lib/offline/sync-manager';
+
+export interface UseSyncStatusReturn {
+  /** Current sync status */
+  status: SyncStatus;
+  /** Number of pending offline actions */
+  pendingCount: number;
+  /** Whether sync is currently running */
+  isSyncing: boolean;
+  /** Manually trigger a sync */
+  syncNow: () => void;
+}
+
+export function useSyncStatus(): UseSyncStatusReturn {
+  const [status, setStatus] = useState<SyncStatus>({ state: 'idle' });
+  const [pendingCount, setPendingCount] = useState(0);
+
+  useEffect(() => {
+    const manager = SyncManager.getInstance();
+    manager.start();
+
+    // Load initial pending count
+    manager.getPendingCount().then(setPendingCount);
+
+    // Subscribe to status changes
+    const unsub = manager.onStatusChange((newStatus) => {
+      setStatus(newStatus);
+
+      // Refresh pending count after sync completes or errors
+      if (newStatus.state === 'complete' || newStatus.state === 'error') {
+        manager.getPendingCount().then(setPendingCount);
+
+        // Auto-clear status after 4 seconds
+        setTimeout(() => setStatus({ state: 'idle' }), 4000);
+      }
+    });
+
+    return () => {
+      unsub();
+    };
+  }, []);
+
+  // Refresh pending count periodically (every 30s) to pick up new offline actions
+  useEffect(() => {
+    const interval = setInterval(() => {
+      SyncManager.getInstance().getPendingCount().then(setPendingCount);
+    }, 30_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const syncNow = useCallback(() => {
+    SyncManager.getInstance().syncNow();
+  }, []);
+
+  return {
+    status,
+    pendingCount,
+    isSyncing: status.state === 'syncing',
+    syncNow,
+  };
+}

--- a/frontend/lib/offline/sync-manager.ts
+++ b/frontend/lib/offline/sync-manager.ts
@@ -1,0 +1,235 @@
+/**
+ * Background sync manager.
+ *
+ * Singleton that listens for the `online` event and processes the
+ * `offline_actions` queue in FIFO order, mapping each action to its
+ * corresponding API endpoint.
+ */
+
+import {
+  getPendingOfflineActions,
+  markOfflineActionSynced,
+  clearSyncedActions,
+  type OfflineAction,
+} from './db';
+import { apiFetch } from '@/lib/api';
+
+export type SyncStatus =
+  | { state: 'idle' }
+  | { state: 'syncing'; current: number; total: number }
+  | { state: 'complete'; synced: number }
+  | { state: 'error'; message: string; synced: number; failed: number };
+
+export type SyncStatusListener = (status: SyncStatus) => void;
+
+const MAX_RETRIES = 3;
+const BACKOFF_BASE_MS = 1000;
+const BACKOFF_MAX_MS = 30_000;
+
+class SyncManager {
+  private static instance: SyncManager | null = null;
+  private isSyncing = false;
+  private listeners = new Set<SyncStatusListener>();
+  private onlineHandler: (() => void) | null = null;
+  private started = false;
+
+  static getInstance(): SyncManager {
+    if (!SyncManager.instance) {
+      SyncManager.instance = new SyncManager();
+    }
+    return SyncManager.instance;
+  }
+
+  /** Register the `online` event listener. Call once on app mount. */
+  start(): void {
+    if (this.started || typeof window === 'undefined') return;
+    this.started = true;
+
+    this.onlineHandler = () => {
+      this.syncNow();
+    };
+    window.addEventListener('online', this.onlineHandler);
+  }
+
+  /** Clean up event listener. */
+  stop(): void {
+    if (this.onlineHandler) {
+      window.removeEventListener('online', this.onlineHandler);
+      this.onlineHandler = null;
+    }
+    this.started = false;
+  }
+
+  /** Subscribe to sync status changes. Returns an unsubscribe function. */
+  onStatusChange(listener: SyncStatusListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /** Get count of pending (unsynced) actions. */
+  async getPendingCount(): Promise<number> {
+    const actions = await getPendingOfflineActions();
+    return actions.length;
+  }
+
+  /** Process the pending actions queue. Safe to call multiple times. */
+  async syncNow(): Promise<{ synced: number; failed: number }> {
+    if (this.isSyncing) return { synced: 0, failed: 0 };
+    this.isSyncing = true;
+
+    const actions = await getPendingOfflineActions();
+    if (actions.length === 0) {
+      this.isSyncing = false;
+      return { synced: 0, failed: 0 };
+    }
+
+    let synced = 0;
+    let failed = 0;
+
+    this.emit({ state: 'syncing', current: 0, total: actions.length });
+
+    for (let i = 0; i < actions.length; i++) {
+      const action = actions[i];
+      this.emit({ state: 'syncing', current: i + 1, total: actions.length });
+
+      const success = await this.processAction(action);
+      if (success) {
+        synced++;
+      } else {
+        failed++;
+      }
+    }
+
+    // Clean up synced actions
+    await clearSyncedActions();
+
+    if (failed > 0) {
+      this.emit({ state: 'error', message: `${failed} actions failed`, synced, failed });
+    } else {
+      this.emit({ state: 'complete', synced });
+    }
+
+    this.isSyncing = false;
+    return { synced, failed };
+  }
+
+  // --- Private ---
+
+  private emit(status: SyncStatus): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(status);
+      } catch {
+        // Listener errors are non-fatal
+      }
+    }
+  }
+
+  private async processAction(action: OfflineAction): Promise<boolean> {
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      try {
+        await this.sendAction(action);
+        if (action.id !== undefined) {
+          await markOfflineActionSynced(action.id);
+        }
+        return true;
+      } catch (err: unknown) {
+        // 401: auth expired — stop retrying entirely
+        if (isHttpStatus(err, 401)) {
+          console.warn('Sync: auth expired, skipping action', action.id);
+          return false;
+        }
+
+        // 409: conflict (duplicate) — treat as success
+        if (isHttpStatus(err, 409)) {
+          if (action.id !== undefined) {
+            await markOfflineActionSynced(action.id);
+          }
+          return true;
+        }
+
+        // 4xx (except 401/409): permanent error, don't retry
+        if (isHttpStatus(err, 400) || isHttpStatus(err, 403) || isHttpStatus(err, 404) || isHttpStatus(err, 422)) {
+          console.warn(`Sync: permanent error for action ${action.id}:`, err);
+          return false;
+        }
+
+        // Transient error: exponential backoff
+        if (attempt < MAX_RETRIES - 1) {
+          const delay = Math.min(
+            BACKOFF_BASE_MS * Math.pow(2, attempt),
+            BACKOFF_MAX_MS
+          );
+          await new Promise((r) => setTimeout(r, delay));
+        }
+      }
+    }
+
+    console.warn(`Sync: action ${action.id} failed after ${MAX_RETRIES} retries`);
+    return false;
+  }
+
+  private async sendAction(action: OfflineAction): Promise<void> {
+    const payload = action.payload as Record<string, unknown>;
+
+    switch (action.actionType) {
+      case 'quiz_answer':
+        await apiFetch('/api/v1/quiz/attempt', {
+          method: 'POST',
+          body: JSON.stringify({
+            quiz_id: payload.quiz_id,
+            answers: payload.answers,
+            total_time_seconds: payload.total_time_seconds,
+          }),
+        });
+        break;
+
+      case 'flashcard_review':
+        await apiFetch(`/api/v1/flashcards/${payload.card_id}/review`, {
+          method: 'POST',
+          body: JSON.stringify({
+            rating: payload.rating,
+          }),
+        });
+        break;
+
+      case 'lesson_complete':
+        await apiFetch('/api/v1/progress/lesson-access', {
+          method: 'POST',
+          body: JSON.stringify({
+            module_id: payload.module_id,
+            lesson_id: payload.lesson_id,
+            time_spent_seconds: payload.time_spent_seconds,
+            completion_percentage: payload.completion_percentage,
+          }),
+        });
+        break;
+
+      case 'case_study_complete':
+        await apiFetch('/api/v1/progress/lesson-access', {
+          method: 'POST',
+          body: JSON.stringify({
+            module_id: payload.module_id,
+            lesson_id: payload.lesson_id,
+            time_spent_seconds: payload.time_spent_seconds,
+            completion_percentage: payload.completion_percentage,
+          }),
+        });
+        break;
+
+      default:
+        console.warn(`Sync: unknown action type: ${action.actionType}`);
+    }
+  }
+}
+
+function isHttpStatus(err: unknown, status: number): boolean {
+  return (
+    err !== null &&
+    typeof err === 'object' &&
+    'status' in err &&
+    (err as { status: number }).status === status
+  );
+}
+
+export { SyncManager };

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1683,6 +1683,8 @@
     "redirecting": "Redirecting to course..."
   },
   "Offline": {
+    "offline": "You are offline",
+    "reconnected": "Back online",
     "downloadForOffline": "Download for offline",
     "availableOffline": "Available offline",
     "removeDownload": "Remove download",
@@ -1705,6 +1707,12 @@
     "offlineBadge": "Offline",
     "contentNotAvailable": "Content not available offline",
     "contentNotAvailableHint": "Download this module to access it offline",
-    "quizOfflineNote": "Quiz scored locally — will sync when back online"
+    "quizOfflineNote": "Quiz scored locally — will sync when back online",
+    "syncPending": "{count} pending",
+    "syncing": "Syncing...",
+    "syncComplete": "Sync complete",
+    "syncFailed": "Sync failed",
+    "syncRetry": "Retry sync",
+    "syncSuccess": "{count} items synced"
   }
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1683,6 +1683,8 @@
     "redirecting": "Redirection vers le cours..."
   },
   "Offline": {
+    "offline": "Vous êtes hors-ligne",
+    "reconnected": "Connexion rétablie",
     "downloadForOffline": "Télécharger pour hors-ligne",
     "availableOffline": "Disponible hors-ligne",
     "removeDownload": "Supprimer le téléchargement",
@@ -1705,6 +1707,12 @@
     "offlineBadge": "Hors-ligne",
     "contentNotAvailable": "Contenu non disponible hors-ligne",
     "contentNotAvailableHint": "Téléchargez ce module pour y accéder hors-ligne",
-    "quizOfflineNote": "Quiz noté localement — synchronisation au retour en ligne"
+    "quizOfflineNote": "Quiz noté localement — synchronisation au retour en ligne",
+    "syncPending": "{count} en attente",
+    "syncing": "Synchronisation...",
+    "syncComplete": "Synchronisation terminée",
+    "syncFailed": "Échec de synchronisation",
+    "syncRetry": "Réessayer la synchronisation",
+    "syncSuccess": "{count} éléments synchronisés"
   }
 }


### PR DESCRIPTION
## Summary
- **SyncManager** singleton: listens for `online` event, processes `offline_actions` FIFO queue. Maps action types to API endpoints with exponential backoff (3 retries). Treats 409 as success, stops on 401.
- **SyncStatusIndicator**: shows pending count, syncing animation, success toast, error with retry. Mounted in app layout.
- **OfflineIndicator**: triggers `SyncManager.syncNow()` on reconnection.
- **i18n**: added `offline`/`reconnected` keys (were missing) + `sync*` keys (FR/EN).

Closes #298
Closes #46

## Files changed
- `frontend/lib/offline/sync-manager.ts` — new SyncManager class
- `frontend/lib/hooks/use-sync-status.ts` — new React hook
- `frontend/components/shared/sync-status-indicator.tsx` — new UI component
- `frontend/components/shared/offline-indicator.tsx` — trigger sync on reconnect
- `frontend/app/[locale]/(app)/layout.tsx` — mount SyncStatusIndicator
- `frontend/messages/en.json`, `fr.json` — 8 new i18n keys

## Regression check
- OfflineIndicator: added `useEffect` + `SyncManager` import only. Visual output unchanged.
- Layout: added one component below OfflineIndicator. No structural changes.
- All new files are additive, no existing code paths modified.

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Take quiz offline → go back online → verify sync indicator shows pending → syncing → success
- [ ] Check server that quiz attempt was recorded after sync
- [ ] Verify sync retry on transient failure (simulate with DevTools throttling)
- [ ] Verify FR/EN i18n strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)