### PR TITLE
release: offline PWA — download, render, sync (#295, #296, #298, #46)

### DIFF
--- a/frontend/app/[locale]/(app)/layout.tsx
+++ b/frontend/app/[locale]/(app)/layout.tsx
@@ -4,6 +4,7 @@ import { Sidebar } from "@/components/layout/sidebar";
 import { BreadcrumbNav } from "@/components/layout/breadcrumb-nav";
 import { ChatLayout } from "@/components/chat/chat-layout";
 import { OfflineIndicator } from "@/components/shared/offline-indicator";
+import { SyncStatusIndicator } from "@/components/shared/sync-status-indicator";
 import { AuthGuard } from "@/components/shared/auth-guard";
 import { SubscriptionBanner } from "@/components/shared/subscription-banner";
 
@@ -15,6 +16,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
           <Sidebar />
           <div className="flex flex-1 flex-col min-h-0">
             <OfflineIndicator />
+            <SyncStatusIndicator />
             <SubscriptionBanner />
             <Header />
             <BreadcrumbNav />

--- a/frontend/components/learning/case-study-viewer.tsx
+++ b/frontend/components/learning/case-study-viewer.tsx
@@ -17,6 +17,9 @@ import { LessonSkeleton } from './lesson-skeleton';
 import { SourceCitations } from './source-citations';
 import { apiFetch } from '@/lib/api';
 import { useCurrentUser } from '@/lib/hooks/use-current-user';
+import { loadCaseStudy, OfflineContentNotAvailable } from '@/lib/offline/content-loader';
+import { OfflineBadge } from '@/components/shared/offline-badge';
+import { useNetworkStatus } from '@/lib/hooks/use-network-status';
 
 const COUNTRY_NAMES: Record<string, { en: string; fr: string }> = {
   BF: { en: 'Burkina Faso', fr: 'Burkina Faso' },
@@ -102,12 +105,14 @@ export function CaseStudyViewer({
   const [forceRegenerate, setForceRegenerate] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [objectivesOpen, setObjectivesOpen] = useState(false);
+  const [contentSource, setContentSource] = useState<'api' | 'indexeddb'>('api');
 
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pollStartRef = useRef<number>(0);
 
   const currentUser = useCurrentUser();
   const country = countryContext || currentUser?.country || 'CI';
+  const { isOnline } = useNetworkStatus();
 
   const t = useTranslations('CaseStudyViewer');
 
@@ -166,11 +171,13 @@ export function CaseStudyViewer({
         setIsLoading(true);
         setError(null);
 
-        const forceParam = forceRegenerate ? '&force_regenerate=true' : '';
-        const res = await apiFetch<CaseStudyData | GeneratingResponse>(
-          `/api/v1/content/cases/${moduleId}/${unitId}?language=${language}&level=${level}&country=${country}${forceParam}`
+        const result = await loadCaseStudy<CaseStudyData | GeneratingResponse>(
+          moduleId, unitId, language, level, country, forceRegenerate
         );
 
+        setContentSource(result.source);
+
+        const res = result.data;
         if ('status' in res && res.status === 'generating') {
           setIsLoading(false);
           setIsGenerating(true);
@@ -182,8 +189,12 @@ export function CaseStudyViewer({
           setIsRefreshing(false);
           setForceRegenerate(false);
         }
-      } catch {
-        setError(t('loadError'));
+      } catch (err) {
+        if (err instanceof OfflineContentNotAvailable) {
+          setError(t('contentNotAvailableOffline'));
+        } else {
+          setError(t('loadError'));
+        }
         setIsLoading(false);
         setIsRefreshing(false);
       }
@@ -339,13 +350,14 @@ export function CaseStudyViewer({
                 ? t('estimatedTime', { minutes: estimatedMinutes })
                 : t('estimatedTimeFallback')}
             </div>
-            {caseStudyData.cached && <Badge variant="secondary">{t('cached')}</Badge>}
+            {contentSource === 'indexeddb' && <OfflineBadge />}
+            {caseStudyData.cached && contentSource !== 'indexeddb' && <Badge variant="secondary">{t('cached')}</Badge>}
           </div>
           <Button
             variant="ghost"
             size="sm"
             onClick={handleRefresh}
-            disabled={isRefreshing || isLoading || isGenerating}
+            disabled={isRefreshing || isLoading || isGenerating || !isOnline}
             className="min-h-11 gap-1.5 text-gray-500 hover:text-gray-900"
             title={t('refreshContent')}
           >

--- a/frontend/components/learning/download-module-button.tsx
+++ b/frontend/components/learning/download-module-button.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import {
+  Download,
+  CheckCircle,
+  Trash2,
+  XCircle,
+  Loader2,
+  Wifi,
+  AlertTriangle,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { useDownloadManager } from '@/lib/hooks/use-download-manager';
+import { formatBytes } from '@/lib/offline/download-manager';
+
+interface DownloadModuleButtonProps {
+  moduleId: string;
+  locale: 'fr' | 'en';
+  unitCount: number;
+  level?: number;
+  country?: string;
+}
+
+export function DownloadModuleButton({
+  moduleId,
+  locale,
+  unitCount,
+  level = 1,
+  country = 'CI',
+}: DownloadModuleButtonProps) {
+  const t = useTranslations('Offline');
+  const [wifiOnly, setWifiOnly] = useState(true);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const {
+    status,
+    progress,
+    isDownloading,
+    isAvailableOffline,
+    canDownload,
+    estimatedSize,
+    downloadedUnits,
+    totalUnits,
+    error,
+    download,
+    cancel,
+    remove,
+  } = useDownloadManager(moduleId, locale, unitCount);
+
+  const progressPct =
+    totalUnits > 0 ? Math.round((downloadedUnits / totalUnits) * 100) : 0;
+
+  const handleDownload = async () => {
+    setShowConfirm(false);
+    await download({ wifiOnly, level, country });
+  };
+
+  // Available offline — show status + delete button
+  if (isAvailableOffline) {
+    return (
+      <div className="rounded-lg border border-teal-200 bg-teal-50 p-4 space-y-3">
+        <div className="flex items-center gap-2 text-teal-700">
+          <CheckCircle className="w-5 h-5 shrink-0" />
+          <span className="text-sm font-medium">{t('availableOffline')}</span>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full text-red-600 border-red-200 hover:bg-red-50 min-h-11"
+          onClick={remove}
+        >
+          <Trash2 className="w-4 h-4 mr-2" />
+          {t('removeDownload')}
+        </Button>
+      </div>
+    );
+  }
+
+  // Currently downloading — show progress
+  if (isDownloading) {
+    return (
+      <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 space-y-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2 text-amber-700">
+            <Loader2 className="w-4 h-4 animate-spin" />
+            <span className="text-sm font-medium">{t('downloading')}</span>
+          </div>
+          <span className="text-xs text-amber-600">
+            {downloadedUnits}/{totalUnits} {t('units')}
+          </span>
+        </div>
+
+        <div className="space-y-1">
+          <div className="flex justify-between text-xs text-amber-600">
+            <span>{t('downloadProgress')}</span>
+            <span>{progressPct}%</span>
+          </div>
+          <Progress value={progressPct} />
+        </div>
+
+        {progress?.currentUnit && (
+          <p className="text-xs text-amber-600">
+            {progress.currentContentType === 'lesson' && t('downloadingLesson')}
+            {progress.currentContentType === 'quiz' && t('downloadingQuiz')}
+            {progress.currentContentType === 'case_study' && t('downloadingCaseStudy')}
+            {' '}{progress.currentUnit}
+          </p>
+        )}
+
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full min-h-11"
+          onClick={cancel}
+        >
+          <XCircle className="w-4 h-4 mr-2" />
+          {t('cancel')}
+        </Button>
+      </div>
+    );
+  }
+
+  // Error state — show error + retry
+  if (status === 'error') {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 space-y-3">
+        <div className="flex items-center gap-2 text-red-700">
+          <AlertTriangle className="w-5 h-5 shrink-0" />
+          <span className="text-sm font-medium">{error || t('downloadFailed')}</span>
+        </div>
+        {downloadedUnits > 0 && (
+          <p className="text-xs text-red-600">
+            {t('partialDownload', { count: downloadedUnits, total: totalUnits })}
+          </p>
+        )}
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            className="flex-1 min-h-11"
+            onClick={handleDownload}
+          >
+            {t('retry')}
+          </Button>
+          {downloadedUnits > 0 && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="min-h-11 text-red-600 border-red-200"
+              onClick={remove}
+            >
+              <Trash2 className="w-4 h-4" />
+            </Button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // Not downloaded — show download button or limit warning
+  if (!canDownload) {
+    return (
+      <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 space-y-2">
+        <div className="flex items-center gap-2 text-stone-500">
+          <AlertTriangle className="w-4 h-4" />
+          <span className="text-sm">{t('moduleLimitReached')}</span>
+        </div>
+        <p className="text-xs text-stone-400">{t('moduleLimitHint')}</p>
+      </div>
+    );
+  }
+
+  // Show confirm dialog
+  if (showConfirm) {
+    return (
+      <div className="rounded-lg border border-stone-200 bg-white p-4 space-y-3">
+        <p className="text-sm text-stone-700">
+          {t('downloadConfirm', { size: formatBytes(estimatedSize) })}
+        </p>
+
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="wifi-only"
+            checked={wifiOnly}
+            onCheckedChange={(checked) => setWifiOnly(checked === true)}
+          />
+          <Label htmlFor="wifi-only" className="text-sm text-stone-600 flex items-center gap-1">
+            <Wifi className="w-3.5 h-3.5" />
+            {t('wifiOnly')}
+          </Label>
+        </div>
+
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            className="flex-1 min-h-11 bg-teal-600 hover:bg-teal-700"
+            onClick={handleDownload}
+          >
+            <Download className="w-4 h-4 mr-2" />
+            {t('startDownload')}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="min-h-11"
+            onClick={() => setShowConfirm(false)}
+          >
+            {t('cancelAction')}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // Default: download button
+  return (
+    <Button
+      variant="outline"
+      className="w-full min-h-11"
+      onClick={() => setShowConfirm(true)}
+    >
+      <Download className="w-4 h-4 mr-2" />
+      {t('downloadForOffline')}
+      <span className="ml-auto text-xs text-stone-400">
+        ~{formatBytes(estimatedSize)}
+      </span>
+    </Button>
+  );
+}

--- a/frontend/components/learning/lesson-viewer.tsx
+++ b/frontend/components/learning/lesson-viewer.tsx
@@ -21,6 +21,10 @@ import { useCurrentUser } from '@/lib/hooks/use-current-user';
 import { useRouter } from 'next/navigation';
 import { useLocale } from 'next-intl';
 import { track } from '@/lib/analytics';
+import { loadLesson, OfflineContentNotAvailable } from '@/lib/offline/content-loader';
+import { addOfflineAction } from '@/lib/offline/db';
+import { OfflineBadge } from '@/components/shared/offline-badge';
+import { useNetworkStatus } from '@/lib/hooks/use-network-status';
 
 const POLL_INTERVAL_MS = 3000;
 const POLL_TIMEOUT_MS = 3 * 60 * 1000;
@@ -79,6 +83,7 @@ export function LessonViewer({
   const [isCheckingQuiz, setIsCheckingQuiz] = useState(false);
   const [forceRegenerate, setForceRegenerate] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [contentSource, setContentSource] = useState<'api' | 'indexeddb'>('api');
 
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pollStartRef = useRef<number>(0);
@@ -88,6 +93,7 @@ export function LessonViewer({
   const country = countryContext || currentUser?.country || 'CI';
   const router = useRouter();
   const locale = useLocale();
+  const { isOnline } = useNetworkStatus();
 
   const t = useTranslations('LessonViewer');
 
@@ -177,11 +183,13 @@ export function LessonViewer({
         setIsLoading(true);
         setError(null);
 
-        const forceParam = forceRegenerate ? '&force_regenerate=true' : '';
-        const res = await apiFetch<LessonData | GeneratingResponse>(
-          `/api/v1/content/lessons/${moduleId}/${unitId}?language=${language}&level=${level}&country=${country}${forceParam}`
+        const result = await loadLesson<LessonData | GeneratingResponse>(
+          moduleId, unitId, language, level, country, forceRegenerate
         );
 
+        setContentSource(result.source);
+
+        const res = result.data;
         if ('status' in res && res.status === 'generating') {
           setIsLoading(false);
           setIsGenerating(true);
@@ -205,7 +213,10 @@ export function LessonViewer({
         }
       } catch (err) {
         console.error('Error loading lesson:', err);
-        if (err instanceof ApiError && err.status === 404) {
+        if (err instanceof OfflineContentNotAvailable) {
+          setError(t('contentNotAvailableOffline'));
+          setErrorType('load');
+        } else if (err instanceof ApiError && err.status === 404) {
           setError(t('unitNotFound'));
           setErrorType('not_found');
         } else {
@@ -396,7 +407,8 @@ export function LessonViewer({
               <Clock className="w-4 h-4 mr-1" />
               {t('readingTime')}
             </div>
-            {lessonData.cached && (
+            {contentSource === 'indexeddb' && <OfflineBadge />}
+            {lessonData.cached && contentSource !== 'indexeddb' && (
               <Badge variant="secondary">{t('cached')}</Badge>
             )}
           </div>
@@ -404,7 +416,7 @@ export function LessonViewer({
             variant="ghost"
             size="sm"
             onClick={handleRefresh}
-            disabled={isRefreshing || isLoading || isGenerating}
+            disabled={isRefreshing || isLoading || isGenerating || !isOnline}
             className="min-h-11 gap-1.5 text-gray-500 hover:text-gray-900"
             title={t('refreshContent')}
           >

--- a/frontend/components/learning/module-lock-gate.tsx
+++ b/frontend/components/learning/module-lock-gate.tsx
@@ -12,6 +12,7 @@ import { getModuleDetailWithProgress, getModuleUnits, type ModuleDetailWithProgr
 import { track } from '@/lib/analytics';
 import { ModuleProgressOverlay } from '@/components/learning/module-progress-overlay';
 import { ModuleMediaPlayer } from '@/components/learning/module-media-player';
+import { DownloadModuleButton } from '@/components/learning/download-module-button';
 
 interface ModuleLockGateProps {
   moduleId: string;
@@ -212,6 +213,13 @@ export function ModuleLockGate({ moduleId, language }: ModuleLockGateProps) {
               </Button>
             </Link>
           </div>
+
+          <DownloadModuleButton
+            moduleId={moduleId}
+            locale={language}
+            unitCount={moduleData?.units?.length ?? 0}
+            level={moduleData?.level}
+          />
         </div>
       </div>
     </div>

--- a/frontend/components/quiz/quiz-container.tsx
+++ b/frontend/components/quiz/quiz-container.tsx
@@ -14,6 +14,10 @@ import { ApiError, generateQuiz, apiFetch } from '@/lib/api';
 import { useSettings } from '@/lib/settings-context';
 import { track } from '@/lib/analytics';
 import { useCurrentUser } from '@/lib/hooks/use-current-user';
+import { loadQuiz, OfflineContentNotAvailable } from '@/lib/offline/content-loader';
+import { scoreQuizOffline } from '@/lib/offline/offline-quiz-scorer';
+import { OfflineBadge } from '@/components/shared/offline-badge';
+import { useNetworkStatus } from '@/lib/hooks/use-network-status';
 
 const POLL_INTERVAL_MS = 3000;
 const POLL_TIMEOUT_MS = 3 * 60 * 1000;
@@ -57,9 +61,11 @@ export function QuizContainer({
   const [error, setError] = useState<string>('');
   const [retryCount, setRetryCount] = useState(0);
   const [forceRegenerate, setForceRegenerate] = useState(false);
+  const [contentSource, setContentSource] = useState<'api' | 'indexeddb'>('api');
 
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pollStartRef = useRef<number>(0);
+  const { isOnline } = useNetworkStatus();
 
   const pollStatus = (taskId: string, startTime: number) => {
     if (Date.now() - startTime > POLL_TIMEOUT_MS) {
@@ -118,17 +124,23 @@ export function QuizContainer({
       try {
         setState('loading');
         setError('');
-        
-        const rawData = await generateQuiz({
-          module_id: moduleId,
-          unit_id: unitId,
-          language,
-          country: resolvedCountry,
-          level,
-          num_questions: unitQuestionsCount,
-          force_regenerate: forceRegenerate,
-        }) as Quiz | GeneratingResponse;
 
+        const result = await loadQuiz<Quiz | GeneratingResponse>(
+          moduleId, unitId, language, level, resolvedCountry,
+          unitQuestionsCount, forceRegenerate,
+        );
+
+        setContentSource(result.source);
+
+        // If from IndexedDB, it's already a full quiz (no generating state)
+        if (result.source === 'indexeddb') {
+          setQuiz(result.data as Quiz);
+          setForceRegenerate(false);
+          setState('ready');
+          return;
+        }
+
+        const rawData = result.data;
         if ('status' in rawData && rawData.status === 'generating') {
           setState('generating');
           pollStartRef.current = Date.now();
@@ -141,7 +153,9 @@ export function QuizContainer({
       } catch (err) {
         console.error('Failed to load quiz:', err);
         let errorMessage: string;
-        if (err instanceof ApiError) {
+        if (err instanceof OfflineContentNotAvailable) {
+          errorMessage = t('contentNotAvailableOffline');
+        } else if (err instanceof ApiError) {
           if (err.code === 'subscription_required' || err.status === 403) {
             errorMessage = t('subscriptionRequired');
           } else if (err.status === 401) {
@@ -157,7 +171,7 @@ export function QuizContainer({
         onError?.(errorMessage);
       }
     };
-    
+
     fetchQuiz();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [moduleId, unitId, language, resolvedCountry, level, retryCount, forceRegenerate]);
@@ -335,7 +349,8 @@ export function QuizContainer({
               <Badge variant="outline">
                 {t('level')} {level}
               </Badge>
-              {quiz.cached && (
+              {contentSource === 'indexeddb' && <OfflineBadge />}
+              {quiz.cached && contentSource !== 'indexeddb' && (
                 <Badge variant="secondary">
                   {t('cached')}
                 </Badge>
@@ -347,6 +362,7 @@ export function QuizContainer({
                 variant="ghost"
                 size="sm"
                 onClick={handleRefreshContent}
+                disabled={!isOnline}
                 className="min-h-11 gap-1.5 text-stone-500 hover:text-stone-900"
               >
                 <RefreshCw className="w-4 h-4" />

--- a/frontend/components/quiz/quiz-interface.tsx
+++ b/frontend/components/quiz/quiz-interface.tsx
@@ -14,6 +14,7 @@ import { Progress } from '@/components/ui/progress';
 import { Badge } from '@/components/ui/badge';
 import type { Quiz, QuizAnswerSubmission, QuizAttemptResponse } from '@/lib/api';
 import { ApiError, submitQuizAttempt } from '@/lib/api';
+import { scoreQuizOffline } from '@/lib/offline/offline-quiz-scorer';
 
 interface QuizInterfaceProps {
   quiz: Quiz;
@@ -99,23 +100,43 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
     }
     
     setIsSubmitting(true);
-    
+
     try {
       const totalTimeSeconds = Math.floor((Date.now() - startTime) / 1000);
-      
+
       const answers: QuizAnswerSubmission[] = quiz.content.questions.map((question, index) => ({
         question_id: question.id,
         selected_option: questionStates[index].selectedOption!,
         time_taken_seconds: questionStates[index].timeSpentSeconds,
       }));
-      
-      const result = await submitQuizAttempt({
-        quiz_id: quiz.id,
-        answers,
-        total_time_seconds: totalTimeSeconds,
-      });
-      
-      onComplete(result);
+
+      // Try server submission first; fall back to offline scoring
+      if (navigator.onLine) {
+        try {
+          const result = await submitQuizAttempt({
+            quiz_id: quiz.id,
+            answers,
+            total_time_seconds: totalTimeSeconds,
+          });
+          onComplete(result);
+          return;
+        } catch (serverErr) {
+          // If it's an auth/subscription error, don't fall back
+          if (serverErr instanceof ApiError && (serverErr.status === 401 || serverErr.status === 403)) {
+            throw serverErr;
+          }
+          // Network or other error: fall back to offline scoring
+          console.warn('Server quiz submit failed, scoring offline:', serverErr);
+        }
+      }
+
+      // Offline scoring: compute results locally, queue for sync
+      const answersMap: Record<string, number> = {};
+      for (const a of answers) {
+        answersMap[a.question_id] = a.selected_option;
+      }
+      const offlineResult = await scoreQuizOffline(quiz, answersMap, totalTimeSeconds);
+      onComplete(offlineResult);
     } catch (error) {
       console.error('Quiz submission failed:', error);
       if (error instanceof ApiError) {

--- a/frontend/components/shared/offline-badge.tsx
+++ b/frontend/components/shared/offline-badge.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { CloudOff } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+
+export function OfflineBadge() {
+  const t = useTranslations('Offline');
+
+  return (
+    <Badge variant="secondary" className="bg-amber-100 text-amber-700 border-amber-200 gap-1">
+      <CloudOff className="w-3 h-3" />
+      {t('offlineBadge')}
+    </Badge>
+  );
+}

--- a/frontend/components/shared/offline-indicator.tsx
+++ b/frontend/components/shared/offline-indicator.tsx
@@ -1,12 +1,26 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { WifiOff, Wifi } from "lucide-react";
 import { useNetworkStatus } from "@/lib/hooks/use-network-status";
+import { SyncManager } from "@/lib/offline/sync-manager";
 
 export function OfflineIndicator() {
   const t = useTranslations("Offline");
   const { isOnline, justReconnected } = useNetworkStatus();
+  const syncTriggered = useRef(false);
+
+  // Trigger background sync when reconnecting
+  useEffect(() => {
+    if (justReconnected && !syncTriggered.current) {
+      syncTriggered.current = true;
+      SyncManager.getInstance().syncNow();
+    }
+    if (!justReconnected) {
+      syncTriggered.current = false;
+    }
+  }, [justReconnected]);
 
   if (isOnline && !justReconnected) return null;
 

--- a/frontend/components/shared/sync-status-indicator.tsx
+++ b/frontend/components/shared/sync-status-indicator.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { RefreshCw, CheckCircle, AlertTriangle, CloudUpload } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useSyncStatus } from '@/lib/hooks/use-sync-status';
+
+export function SyncStatusIndicator() {
+  const t = useTranslations('Offline');
+  const { status, pendingCount, isSyncing, syncNow } = useSyncStatus();
+
+  // Nothing to show when idle with no pending items
+  if (status.state === 'idle' && pendingCount === 0) return null;
+
+  // Syncing
+  if (isSyncing) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex items-center justify-center gap-2 bg-blue-50 border-b border-blue-100 px-4 py-1.5 text-xs font-medium text-blue-700"
+      >
+        <RefreshCw className="h-3.5 w-3.5 animate-spin shrink-0" aria-hidden="true" />
+        <span>{t('syncing')}</span>
+        {status.state === 'syncing' && (
+          <span className="text-blue-500">
+            {status.current}/{status.total}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  // Sync complete
+  if (status.state === 'complete') {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex items-center justify-center gap-2 bg-teal-50 border-b border-teal-100 px-4 py-1.5 text-xs font-medium text-teal-700"
+      >
+        <CheckCircle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span>{t('syncSuccess', { count: status.synced })}</span>
+      </div>
+    );
+  }
+
+  // Sync error
+  if (status.state === 'error') {
+    return (
+      <div
+        role="alert"
+        className="flex items-center justify-center gap-2 bg-red-50 border-b border-red-100 px-4 py-1.5 text-xs font-medium text-red-700"
+      >
+        <AlertTriangle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span>{t('syncFailed')}</span>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={syncNow}
+          className="h-6 px-2 text-xs text-red-700 hover:bg-red-100"
+        >
+          {t('syncRetry')}
+        </Button>
+      </div>
+    );
+  }
+
+  // Idle with pending items
+  if (pendingCount > 0) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex items-center justify-center gap-2 bg-amber-50 border-b border-amber-100 px-4 py-1.5 text-xs font-medium text-amber-700"
+      >
+        <CloudUpload className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span>{t('syncPending', { count: pendingCount })}</span>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/frontend/lib/hooks/use-download-manager.ts
+++ b/frontend/lib/hooks/use-download-manager.ts
@@ -1,0 +1,153 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  downloadModule,
+  cancelDownload,
+  removeOfflineModule,
+  canDownloadMore,
+  estimateModuleSize,
+  type DownloadProgress,
+  type DownloadPhase,
+} from '@/lib/offline/download-manager';
+import {
+  getOfflineModule,
+  type OfflineModule,
+  type ModuleDownloadStatus,
+} from '@/lib/offline/db';
+
+export interface UseDownloadManagerReturn {
+  /** Current download status of this module */
+  status: ModuleDownloadStatus;
+  /** Download progress details when downloading */
+  progress: DownloadProgress | null;
+  /** Whether a download is currently active */
+  isDownloading: boolean;
+  /** Whether the module is fully available offline */
+  isAvailableOffline: boolean;
+  /** Whether user can download more modules (under 3 limit) */
+  canDownload: boolean;
+  /** Estimated size in bytes */
+  estimatedSize: number;
+  /** Number of downloaded units (for partial downloads) */
+  downloadedUnits: number;
+  /** Total units in the module */
+  totalUnits: number;
+  /** Error message if download failed */
+  error: string | null;
+  /** Start downloading the module */
+  download: (options?: {
+    wifiOnly?: boolean;
+    level?: number;
+    country?: string;
+  }) => Promise<void>;
+  /** Cancel an in-progress download */
+  cancel: () => void;
+  /** Remove the downloaded module and free space */
+  remove: () => Promise<void>;
+}
+
+export function useDownloadManager(
+  moduleId: string,
+  locale: 'fr' | 'en',
+  unitCount?: number
+): UseDownloadManagerReturn {
+  const [status, setStatus] = useState<ModuleDownloadStatus>('not_downloaded');
+  const [progress, setProgress] = useState<DownloadProgress | null>(null);
+  const [canDl, setCanDl] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [downloadedUnits, setDownloadedUnits] = useState(0);
+  const [totalUnits, setTotalUnits] = useState(unitCount ?? 0);
+
+  // Load existing state from IndexedDB on mount
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadState() {
+      const mod = await getOfflineModule(moduleId);
+      if (cancelled) return;
+
+      if (mod) {
+        setStatus(mod.status);
+        setDownloadedUnits(mod.downloadedUnits);
+        setTotalUnits(mod.totalUnits);
+      } else {
+        setStatus('not_downloaded');
+      }
+
+      setCanDl(await canDownloadMore());
+    }
+
+    loadState();
+    return () => { cancelled = true; };
+  }, [moduleId]);
+
+  const download = useCallback(
+    async (options?: { wifiOnly?: boolean; level?: number; country?: string }) => {
+      setError(null);
+      setStatus('downloading');
+
+      try {
+        await downloadModule(moduleId, locale, {
+          ...options,
+          onProgress: (p) => {
+            setProgress(p);
+            setDownloadedUnits(p.downloadedUnits);
+            setTotalUnits(p.totalUnits);
+
+            if (p.phase === 'complete') {
+              setStatus('downloaded');
+            } else if (p.phase === 'error') {
+              setStatus('error');
+              setError(p.error ?? 'Download failed');
+            } else if (p.phase === 'cancelled') {
+              // Keep current status (partial download is functional)
+              getOfflineModule(moduleId).then((mod) => {
+                if (mod) {
+                  setStatus(mod.downloadedUnits > 0 ? mod.status : 'not_downloaded');
+                } else {
+                  setStatus('not_downloaded');
+                }
+              });
+            }
+          },
+        });
+      } catch (err: unknown) {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        setStatus('error');
+        setError(err instanceof Error ? err.message : 'Download failed');
+      }
+
+      setCanDl(await canDownloadMore());
+    },
+    [moduleId, locale]
+  );
+
+  const cancel = useCallback(() => {
+    cancelDownload(moduleId);
+  }, [moduleId]);
+
+  const remove = useCallback(async () => {
+    await removeOfflineModule(moduleId);
+    setStatus('not_downloaded');
+    setProgress(null);
+    setDownloadedUnits(0);
+    setError(null);
+    setCanDl(await canDownloadMore());
+  }, [moduleId]);
+
+  return {
+    status,
+    progress,
+    isDownloading: status === 'downloading',
+    isAvailableOffline: status === 'downloaded',
+    canDownload: canDl || status === 'downloaded',
+    estimatedSize: estimateModuleSize(unitCount ?? totalUnits),
+    downloadedUnits,
+    totalUnits,
+    error,
+    download,
+    cancel,
+    remove,
+  };
+}

--- a/frontend/lib/hooks/use-sync-status.ts
+++ b/frontend/lib/hooks/use-sync-status.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { SyncManager, type SyncStatus } from '@/lib/offline/sync-manager';
+
+export interface UseSyncStatusReturn {
+  /** Current sync status */
+  status: SyncStatus;
+  /** Number of pending offline actions */
+  pendingCount: number;
+  /** Whether sync is currently running */
+  isSyncing: boolean;
+  /** Manually trigger a sync */
+  syncNow: () => void;
+}
+
+export function useSyncStatus(): UseSyncStatusReturn {
+  const [status, setStatus] = useState<SyncStatus>({ state: 'idle' });
+  const [pendingCount, setPendingCount] = useState(0);
+
+  useEffect(() => {
+    const manager = SyncManager.getInstance();
+    manager.start();
+
+    // Load initial pending count
+    manager.getPendingCount().then(setPendingCount);
+
+    // Subscribe to status changes
+    const unsub = manager.onStatusChange((newStatus) => {
+      setStatus(newStatus);
+
+      // Refresh pending count after sync completes or errors
+      if (newStatus.state === 'complete' || newStatus.state === 'error') {
+        manager.getPendingCount().then(setPendingCount);
+
+        // Auto-clear status after 4 seconds
+        setTimeout(() => setStatus({ state: 'idle' }), 4000);
+      }
+    });
+
+    return () => {
+      unsub();
+    };
+  }, []);
+
+  // Refresh pending count periodically (every 30s) to pick up new offline actions
+  useEffect(() => {
+    const interval = setInterval(() => {
+      SyncManager.getInstance().getPendingCount().then(setPendingCount);
+    }, 30_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const syncNow = useCallback(() => {
+    SyncManager.getInstance().syncNow();
+  }, []);
+
+  return {
+    status,
+    pendingCount,
+    isSyncing: status.state === 'syncing',
+    syncNow,
+  };
+}

--- a/frontend/lib/offline/content-loader.ts
+++ b/frontend/lib/offline/content-loader.ts
@@ -1,0 +1,211 @@
+/**
+ * Offline-aware content loader.
+ *
+ * Each load function checks IndexedDB first when offline, falls back to the
+ * API when online (and opportunistically caches the result). Components call
+ * these instead of apiFetch directly.
+ */
+
+import { getOfflineContent, upsertOfflineContent, type ContentType } from './db';
+import { apiFetch } from '@/lib/api';
+
+export interface ContentLoadResult<T> {
+  data: T;
+  /** Where the data came from */
+  source: 'api' | 'indexeddb';
+}
+
+/**
+ * Generic content loader that checks IndexedDB when offline and API when online.
+ * On API success, opportunistically caches the result in IndexedDB.
+ */
+async function loadContent<T>(
+  unitId: string,
+  contentType: ContentType,
+  locale: 'fr' | 'en',
+  moduleId: string,
+  apiUrl: string,
+  apiOptions?: RequestInit,
+): Promise<ContentLoadResult<T>> {
+  const isOnline = typeof navigator !== 'undefined' ? navigator.onLine : true;
+
+  // Offline: only check IndexedDB
+  if (!isOnline) {
+    const cached = await getOfflineContent(unitId, contentType, locale);
+    if (cached) {
+      return { data: cached.content as T, source: 'indexeddb' };
+    }
+    throw new OfflineContentNotAvailable(unitId, contentType);
+  }
+
+  // Online: try API first
+  try {
+    const data = await apiFetch<T>(apiUrl, apiOptions);
+
+    // Opportunistically cache (fire-and-forget)
+    upsertOfflineContent({
+      unitId,
+      moduleId,
+      contentType,
+      locale,
+      content: data,
+      cachedAt: Date.now(),
+    }).catch(() => {/* IndexedDB write failure is non-fatal */});
+
+    return { data, source: 'api' };
+  } catch (err: unknown) {
+    // On network error, fall back to IndexedDB
+    if (isNetworkError(err)) {
+      const cached = await getOfflineContent(unitId, contentType, locale);
+      if (cached) {
+        return { data: cached.content as T, source: 'indexeddb' };
+      }
+    }
+    throw err;
+  }
+}
+
+/**
+ * Load a lesson, checking IndexedDB when offline.
+ */
+export function loadLesson<T>(
+  moduleId: string,
+  unitId: string,
+  locale: 'fr' | 'en',
+  level: number,
+  country: string,
+  forceRegenerate = false,
+): Promise<ContentLoadResult<T>> {
+  const forceParam = forceRegenerate ? '&force_regenerate=true' : '';
+  return loadContent<T>(
+    unitId, 'lesson', locale, moduleId,
+    `/api/v1/content/lessons/${moduleId}/${unitId}?language=${locale}&level=${level}&country=${country}${forceParam}`,
+  );
+}
+
+/**
+ * Load a case study, checking IndexedDB when offline.
+ */
+export function loadCaseStudy<T>(
+  moduleId: string,
+  unitId: string,
+  locale: 'fr' | 'en',
+  level: number,
+  country: string,
+  forceRegenerate = false,
+): Promise<ContentLoadResult<T>> {
+  const forceParam = forceRegenerate ? '&force_regenerate=true' : '';
+  return loadContent<T>(
+    unitId, 'case_study', locale, moduleId,
+    `/api/v1/content/cases/${moduleId}/${unitId}?language=${locale}&level=${level}&country=${country}${forceParam}`,
+  );
+}
+
+/**
+ * Load a quiz, checking IndexedDB when offline.
+ * Note: quiz generation is a POST endpoint, so we handle it differently.
+ */
+export async function loadQuiz<T>(
+  moduleId: string,
+  unitId: string,
+  locale: string,
+  level: number,
+  country: string,
+  numQuestions: number,
+  forceRegenerate = false,
+): Promise<ContentLoadResult<T>> {
+  const isOnline = typeof navigator !== 'undefined' ? navigator.onLine : true;
+  const idbLocale = (locale === 'fr' || locale === 'en') ? locale : 'fr';
+
+  // Offline: only check IndexedDB
+  if (!isOnline) {
+    const cached = await getOfflineContent(unitId, 'quiz', idbLocale);
+    if (cached) {
+      return { data: cached.content as T, source: 'indexeddb' };
+    }
+    throw new OfflineContentNotAvailable(unitId, 'quiz');
+  }
+
+  // Online: call the quiz generate endpoint (POST)
+  try {
+    const data = await apiFetch<T>('/api/v1/quiz/generate', {
+      method: 'POST',
+      body: JSON.stringify({
+        module_id: moduleId,
+        unit_id: unitId,
+        language: locale,
+        country,
+        level,
+        num_questions: numQuestions,
+        force_regenerate: forceRegenerate,
+      }),
+    });
+
+    // Opportunistically cache
+    upsertOfflineContent({
+      unitId,
+      moduleId,
+      contentType: 'quiz',
+      locale: idbLocale,
+      content: data,
+      cachedAt: Date.now(),
+    }).catch(() => {});
+
+    return { data, source: 'api' };
+  } catch (err: unknown) {
+    if (isNetworkError(err)) {
+      const cached = await getOfflineContent(unitId, 'quiz', idbLocale);
+      if (cached) {
+        return { data: cached.content as T, source: 'indexeddb' };
+      }
+    }
+    throw err;
+  }
+}
+
+/**
+ * Load module flashcards, checking IndexedDB when offline.
+ */
+export async function loadFlashcards<T>(
+  moduleId: string,
+  locale: 'fr' | 'en',
+  level: number,
+): Promise<ContentLoadResult<T>> {
+  const unitId = `__module_${moduleId}__`;
+  return loadContent<T>(
+    unitId, 'flashcard', locale, moduleId,
+    `/api/v1/flashcards/modules/${moduleId}?language=${locale}&level=${level}`,
+  );
+}
+
+// --- Error types ---
+
+export class OfflineContentNotAvailable extends Error {
+  unitId: string;
+  contentType: ContentType;
+
+  constructor(unitId: string, contentType: ContentType) {
+    super(`Content not available offline: ${contentType} for ${unitId}`);
+    this.name = 'OfflineContentNotAvailable';
+    this.unitId = unitId;
+    this.contentType = contentType;
+  }
+}
+
+// --- Helpers ---
+
+function isNetworkError(err: unknown): boolean {
+  if (err instanceof TypeError && err.message.includes('fetch')) return true;
+  if (err instanceof DOMException && err.name === 'AbortError') return false;
+  if (err && typeof err === 'object' && 'status' in err) {
+    // API errors (4xx, 5xx) are not network errors
+    return false;
+  }
+  // Generic network failure
+  return err instanceof Error && (
+    err.message.includes('network') ||
+    err.message.includes('Network') ||
+    err.message.includes('Failed to fetch') ||
+    err.message.includes('Load failed')
+  );
+}

--- a/frontend/lib/offline/db.ts
+++ b/frontend/lib/offline/db.ts
@@ -16,6 +16,7 @@ export type ActionType =
 
 export interface OfflineModule {
   moduleId: string;
+  courseId?: string;
   status: ModuleDownloadStatus;
   totalUnits: number;
   downloadedUnits: number;
@@ -39,7 +40,7 @@ export interface OfflineAction {
   actionType: ActionType;
   payload: unknown;
   createdAt: number;
-  synced: boolean;
+  synced: number; // 0 = pending, 1 = synced (number for IndexedDB index compat)
   syncedAt?: number;
 }
 
@@ -50,11 +51,12 @@ interface SantePubliqueDB extends DBSchema {
     indexes: { by_status: ModuleDownloadStatus };
   };
   offline_content: {
-    key: [string, string];
+    key: [string, string, string]; // [unitId, contentType, locale]
     value: OfflineContent;
     indexes: {
       by_module: string;
       by_content_type: ContentType;
+      by_unit: string;
     };
   };
   offline_actions: {
@@ -65,7 +67,7 @@ interface SantePubliqueDB extends DBSchema {
 }
 
 const DB_NAME = "santepublique-offline";
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 
 let dbInstance: IDBPDatabase<SantePubliqueDB> | null = null;
 
@@ -73,7 +75,8 @@ export async function getDB(): Promise<IDBPDatabase<SantePubliqueDB>> {
   if (dbInstance) return dbInstance;
 
   dbInstance = await openDB<SantePubliqueDB>(DB_NAME, DB_VERSION, {
-    upgrade(db, oldVersion) {
+    upgrade(db, oldVersion, _newVersion, transaction) {
+      // V1: create modules + actions stores
       if (oldVersion < 1) {
         const modulesStore = db.createObjectStore("offline_modules", {
           keyPath: "moduleId",
@@ -87,21 +90,39 @@ export async function getDB(): Promise<IDBPDatabase<SantePubliqueDB>> {
         actionsStore.createIndex("by_synced", "synced");
       }
 
-      if (oldVersion < 2) {
+      // V3: recreate offline_content with triple composite key + fix actions synced type
+      if (oldVersion < 3) {
+        // Recreate offline_content with [unitId, contentType, locale] key
         if (db.objectStoreNames.contains("offline_content")) {
           db.deleteObjectStore("offline_content");
         }
         const contentStore = db.createObjectStore("offline_content", {
-          keyPath: ["unitId", "locale"],
+          keyPath: ["unitId", "contentType", "locale"],
         });
         contentStore.createIndex("by_module", "moduleId");
         contentStore.createIndex("by_content_type", "contentType");
+        contentStore.createIndex("by_unit", "unitId");
+
+        // Migrate offline_actions: convert boolean synced to number
+        if (oldVersion >= 1) {
+          const actionsStore = transaction.objectStore("offline_actions");
+          actionsStore.openCursor().then(function migrateCursor(cursor) {
+            if (!cursor) return;
+            const value = cursor.value;
+            if (typeof value.synced === "boolean") {
+              cursor.update({ ...value, synced: value.synced ? 1 : 0 });
+            }
+            cursor.continue().then(migrateCursor);
+          });
+        }
       }
     },
   });
 
   return dbInstance;
 }
+
+// --- Offline Modules ---
 
 export async function getOfflineModule(
   moduleId: string
@@ -129,12 +150,15 @@ export async function getOfflineModulesByStatus(
   return db.getAllFromIndex("offline_modules", "by_status", status);
 }
 
+// --- Offline Content ---
+
 export async function getOfflineContent(
   unitId: string,
+  contentType: ContentType,
   locale: "fr" | "en"
 ): Promise<OfflineContent | undefined> {
   const db = await getDB();
-  return db.get("offline_content", [unitId, locale]);
+  return db.get("offline_content", [unitId, contentType, locale]);
 }
 
 export async function upsertOfflineContent(
@@ -149,6 +173,13 @@ export async function getOfflineContentByModule(
 ): Promise<OfflineContent[]> {
   const db = await getDB();
   return db.getAllFromIndex("offline_content", "by_module", moduleId);
+}
+
+export async function getOfflineContentByUnit(
+  unitId: string
+): Promise<OfflineContent[]> {
+  const db = await getDB();
+  return db.getAllFromIndex("offline_content", "by_unit", unitId);
 }
 
 export async function deleteOfflineModule(moduleId: string): Promise<void> {
@@ -169,6 +200,8 @@ export async function deleteOfflineModule(moduleId: string): Promise<void> {
   await tx.done;
 }
 
+// --- Offline Actions ---
+
 export async function addOfflineAction(
   action: Omit<OfflineAction, "id" | "createdAt" | "synced">
 ): Promise<number> {
@@ -176,7 +209,7 @@ export async function addOfflineAction(
   return db.add("offline_actions", {
     ...action,
     createdAt: Date.now(),
-    synced: false,
+    synced: 0,
   });
 }
 
@@ -191,7 +224,7 @@ export async function markOfflineActionSynced(id: number): Promise<void> {
   if (action) {
     await db.put("offline_actions", {
       ...action,
-      synced: true,
+      synced: 1,
       syncedAt: Date.now(),
     });
   }

--- a/frontend/lib/offline/download-manager.ts
+++ b/frontend/lib/offline/download-manager.ts
@@ -1,0 +1,449 @@
+import {
+  upsertOfflineModule,
+  upsertOfflineContent,
+  getOfflineModule,
+  getAllOfflineModules,
+  deleteOfflineModule,
+  type ContentType,
+} from "./db";
+import { apiFetch } from "@/lib/api";
+import type { ModuleUnitsResponse } from "@/lib/api";
+
+const MAX_OFFLINE_MODULES = 3;
+const POLL_INTERVAL_MS = 3000;
+const POLL_TIMEOUT_MS = 3 * 60 * 1000;
+
+// Average bytes per content type (for size estimation)
+const SIZE_ESTIMATE_PER_UNIT = 50_000; // ~50KB per unit (lesson + quiz + case study)
+const SIZE_ESTIMATE_FLASHCARDS = 30_000; // ~30KB for module flashcards
+
+export type DownloadPhase = "fetching_structure" | "downloading_content" | "complete" | "error" | "cancelled";
+
+export interface DownloadProgress {
+  phase: DownloadPhase;
+  totalUnits: number;
+  downloadedUnits: number;
+  currentUnit?: string;
+  currentContentType?: ContentType;
+  error?: string;
+}
+
+export type DownloadProgressCallback = (progress: DownloadProgress) => void;
+
+interface ContentStatusResponse {
+  status: string;
+  content_id?: string;
+  error?: string;
+}
+
+/**
+ * Estimate download size in bytes for a module based on unit count.
+ */
+export function estimateModuleSize(unitCount: number): number {
+  return unitCount * SIZE_ESTIMATE_PER_UNIT + SIZE_ESTIMATE_FLASHCARDS;
+}
+
+/**
+ * Format bytes as human-readable string.
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// Active downloads tracked for cancellation
+const activeAbortControllers = new Map<string, AbortController>();
+
+/**
+ * Check whether the current connection is WiFi.
+ * Returns true if WiFi, false if cellular, undefined if API not available.
+ */
+function isWifiConnection(): boolean | undefined {
+  const conn = (navigator as unknown as { connection?: { type?: string } }).connection;
+  if (!conn?.type) return undefined;
+  return conn.type === "wifi";
+}
+
+/**
+ * Get count of currently downloaded (or downloading) modules.
+ */
+export async function getDownloadedModuleCount(): Promise<number> {
+  const modules = await getAllOfflineModules();
+  return modules.filter(
+    (m) => m.status === "downloaded" || m.status === "downloading"
+  ).length;
+}
+
+/**
+ * Check if user can download another module (max 3).
+ */
+export async function canDownloadMore(): Promise<boolean> {
+  return (await getDownloadedModuleCount()) < MAX_OFFLINE_MODULES;
+}
+
+/**
+ * Poll a content generation task until complete, failed, or timeout.
+ */
+async function pollContentStatus(
+  taskId: string,
+  signal: AbortSignal
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < POLL_TIMEOUT_MS) {
+    if (signal.aborted) throw new DOMException("Aborted", "AbortError");
+
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+
+    const status = await apiFetch<ContentStatusResponse>(
+      `/api/v1/content/status/${taskId}`,
+      { signal }
+    );
+
+    if (status.status === "complete") return;
+    if (status.status === "failed") {
+      throw new Error(status.error || "Content generation failed");
+    }
+  }
+  throw new Error("Content generation timed out");
+}
+
+/**
+ * Fetch a single content item, handling 202 (generating) responses.
+ * Returns the content data or null if the content type doesn't exist for this unit.
+ */
+async function fetchContentItem<T>(
+  url: string,
+  signal: AbortSignal
+): Promise<T | null> {
+  try {
+    const res = await apiFetch<T | { status: string; task_id: string }>(url, { signal });
+
+    // Handle 202-like generating response
+    if (res && typeof res === "object" && "status" in res && "task_id" in res) {
+      const generating = res as { status: string; task_id: string };
+      if (generating.status === "generating") {
+        await pollContentStatus(generating.task_id, signal);
+        // Re-fetch after generation completes
+        return apiFetch<T>(url, { signal });
+      }
+    }
+
+    return res as T;
+  } catch (err: unknown) {
+    if (err instanceof DOMException && err.name === "AbortError") throw err;
+    // 404 means content doesn't exist for this unit — skip it
+    if (err && typeof err === "object" && "status" in err && (err as { status: number }).status === 404) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Download a module for offline use.
+ *
+ * Fetches all units' lessons, quizzes, and case studies using existing API
+ * endpoints and stores them in IndexedDB. Each unit becomes usable as soon
+ * as its content is downloaded (partial downloads are functional).
+ */
+export async function downloadModule(
+  moduleId: string,
+  locale: "fr" | "en",
+  options: {
+    wifiOnly?: boolean;
+    level?: number;
+    country?: string;
+    onProgress?: DownloadProgressCallback;
+  } = {}
+): Promise<void> {
+  const { wifiOnly = false, level = 1, country = "CI", onProgress } = options;
+
+  // WiFi-only check
+  if (wifiOnly) {
+    const wifi = isWifiConnection();
+    if (wifi === false) {
+      throw new Error("WiFi-only download requested but not on WiFi");
+    }
+  }
+
+  // Check module limit
+  const existing = await getOfflineModule(moduleId);
+  if (!existing || existing.status !== "downloaded") {
+    if (!(await canDownloadMore()) && existing?.status !== "downloading") {
+      throw new Error("Maximum offline module limit reached (3)");
+    }
+  }
+
+  // Set up abort controller
+  const abortController = new AbortController();
+  activeAbortControllers.set(moduleId, abortController);
+  const { signal } = abortController;
+
+  const emit = (progress: DownloadProgress) => onProgress?.(progress);
+
+  try {
+    // Step 1: Fetch module structure
+    emit({ phase: "fetching_structure", totalUnits: 0, downloadedUnits: 0 });
+
+    const moduleInfo = await apiFetch<ModuleUnitsResponse>(
+      `/api/v1/content/modules/${moduleId}/units`,
+      { signal }
+    );
+
+    const units = moduleInfo.units.sort((a, b) => a.order_index - b.order_index);
+    const totalUnits = units.length;
+    const estimatedSize = estimateModuleSize(totalUnits);
+
+    // Initialize module record in IndexedDB
+    await upsertOfflineModule({
+      moduleId,
+      status: "downloading",
+      totalUnits,
+      downloadedUnits: existing?.downloadedUnits ?? 0,
+      sizeBytes: estimatedSize,
+      updatedAt: Date.now(),
+    });
+
+    let downloadedUnits = 0;
+
+    // Step 2: Download each unit's content
+    for (const unit of units) {
+      if (signal.aborted) throw new DOMException("Aborted", "AbortError");
+
+      const unitId = unit.unit_number;
+
+      // Download lesson
+      emit({
+        phase: "downloading_content",
+        totalUnits,
+        downloadedUnits,
+        currentUnit: unitId,
+        currentContentType: "lesson",
+      });
+
+      await downloadUnitContent(
+        moduleId, unitId, "lesson",
+        `/api/v1/content/lessons/${moduleId}/${unitId}?language=${locale}&level=${level}&country=${country}`,
+        locale, signal
+      );
+
+      // Download quiz
+      if (signal.aborted) throw new DOMException("Aborted", "AbortError");
+
+      emit({
+        phase: "downloading_content",
+        totalUnits,
+        downloadedUnits,
+        currentUnit: unitId,
+        currentContentType: "quiz",
+      });
+
+      await downloadUnitQuiz(moduleId, unitId, locale, level, country, signal);
+
+      // Download case study (only for case-study type units, but try for all)
+      if (signal.aborted) throw new DOMException("Aborted", "AbortError");
+
+      emit({
+        phase: "downloading_content",
+        totalUnits,
+        downloadedUnits,
+        currentUnit: unitId,
+        currentContentType: "case_study",
+      });
+
+      await downloadUnitContent(
+        moduleId, unitId, "case_study",
+        `/api/v1/content/cases/${moduleId}/${unitId}?language=${locale}&level=${level}&country=${country}`,
+        locale, signal
+      );
+
+      downloadedUnits++;
+
+      // Update progress in IndexedDB
+      await upsertOfflineModule({
+        moduleId,
+        status: "downloading",
+        totalUnits,
+        downloadedUnits,
+        sizeBytes: estimatedSize,
+        updatedAt: Date.now(),
+      });
+    }
+
+    // Step 3: Download module-level flashcards
+    if (signal.aborted) throw new DOMException("Aborted", "AbortError");
+
+    try {
+      const flashcards = await fetchContentItem<unknown>(
+        `/api/v1/flashcards/modules/${moduleId}?language=${locale}&level=${level}`,
+        signal
+      );
+      if (flashcards) {
+        await upsertOfflineContent({
+          unitId: `__module_${moduleId}__`,
+          moduleId,
+          contentType: "flashcard",
+          locale,
+          content: flashcards,
+          cachedAt: Date.now(),
+        });
+      }
+    } catch {
+      // Flashcard download failure is non-fatal
+    }
+
+    // Step 4: Mark module as downloaded
+    await upsertOfflineModule({
+      moduleId,
+      status: "downloaded",
+      totalUnits,
+      downloadedUnits: totalUnits,
+      sizeBytes: estimatedSize,
+      downloadedAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    emit({ phase: "complete", totalUnits, downloadedUnits: totalUnits });
+  } catch (err: unknown) {
+    if (err instanceof DOMException && err.name === "AbortError") {
+      emit({
+        phase: "cancelled",
+        totalUnits: 0,
+        downloadedUnits: 0,
+      });
+      return;
+    }
+
+    // Mark module as errored (but keep partial content)
+    const mod = await getOfflineModule(moduleId);
+    if (mod) {
+      await upsertOfflineModule({ ...mod, status: "error" });
+    }
+
+    emit({
+      phase: "error",
+      totalUnits: 0,
+      downloadedUnits: 0,
+      error: err instanceof Error ? err.message : "Download failed",
+    });
+
+    throw err;
+  } finally {
+    activeAbortControllers.delete(moduleId);
+  }
+}
+
+/**
+ * Cancel an in-progress download.
+ */
+export function cancelDownload(moduleId: string): void {
+  const controller = activeAbortControllers.get(moduleId);
+  if (controller) {
+    controller.abort();
+    activeAbortControllers.delete(moduleId);
+  }
+}
+
+/**
+ * Remove a downloaded module and all its cached content.
+ */
+export async function removeOfflineModule(moduleId: string): Promise<void> {
+  cancelDownload(moduleId);
+  await deleteOfflineModule(moduleId);
+}
+
+// --- Internal helpers ---
+
+async function downloadUnitContent(
+  moduleId: string,
+  unitId: string,
+  contentType: ContentType,
+  url: string,
+  locale: "fr" | "en",
+  signal: AbortSignal
+): Promise<void> {
+  try {
+    const data = await fetchContentItem<unknown>(url, signal);
+    if (data) {
+      await upsertOfflineContent({
+        unitId,
+        moduleId,
+        contentType,
+        locale,
+        content: data,
+        cachedAt: Date.now(),
+      });
+    }
+  } catch (err: unknown) {
+    if (err instanceof DOMException && err.name === "AbortError") throw err;
+    // Non-fatal: content may not exist yet, continue with other units
+    console.warn(`Failed to download ${contentType} for ${unitId}:`, err);
+  }
+}
+
+async function downloadUnitQuiz(
+  moduleId: string,
+  unitId: string,
+  locale: "fr" | "en",
+  level: number,
+  country: string,
+  signal: AbortSignal
+): Promise<void> {
+  const quizBody = JSON.stringify({
+    module_id: moduleId,
+    unit_id: unitId,
+    language: locale,
+    country,
+    level,
+    num_questions: 10,
+    force_regenerate: false,
+  });
+
+  try {
+    const res = await apiFetch<unknown>("/api/v1/quiz/generate", {
+      method: "POST",
+      signal,
+      body: quizBody,
+    });
+
+    if (!res) return;
+
+    // Handle 202-like generating response
+    if (typeof res === "object" && "status" in (res as Record<string, unknown>) && "task_id" in (res as Record<string, unknown>)) {
+      const gen = res as { status: string; task_id: string };
+      if (gen.status === "generating") {
+        await pollContentStatus(gen.task_id, signal);
+        // Re-fetch cached quiz after generation
+        const finalQuiz = await apiFetch<unknown>("/api/v1/quiz/generate", {
+          method: "POST",
+          signal,
+          body: quizBody,
+        });
+        if (finalQuiz) {
+          await upsertOfflineContent({
+            unitId,
+            moduleId,
+            contentType: "quiz",
+            locale,
+            content: finalQuiz,
+            cachedAt: Date.now(),
+          });
+        }
+        return;
+      }
+    }
+
+    await upsertOfflineContent({
+      unitId,
+      moduleId,
+      contentType: "quiz",
+      locale,
+      content: res,
+      cachedAt: Date.now(),
+    });
+  } catch (err: unknown) {
+    if (err instanceof DOMException && err.name === "AbortError") throw err;
+    console.warn(`Failed to download quiz for ${unitId}:`, err);
+  }
+}

--- a/frontend/lib/offline/offline-quiz-scorer.ts
+++ b/frontend/lib/offline/offline-quiz-scorer.ts
@@ -1,0 +1,76 @@
+/**
+ * Client-side quiz scoring for offline mode.
+ *
+ * Calculates results from stored quiz data (which includes correct_answer
+ * fields) and queues the attempt in the offline_actions store for later sync.
+ */
+
+import { addOfflineAction } from './db';
+import type { Quiz, QuizAttemptResponse, QuizAttemptResult } from '@/lib/api';
+
+interface OfflineQuizAttemptResponse extends QuizAttemptResponse {
+  /** Marks this as scored locally, not by the server */
+  offline: true;
+}
+
+/**
+ * Score a quiz attempt locally using stored correct answers.
+ * Queues the result in IndexedDB for background sync.
+ */
+export async function scoreQuizOffline(
+  quiz: Quiz,
+  answers: Record<string, number>,
+  totalTimeSeconds: number,
+): Promise<OfflineQuizAttemptResponse> {
+  const questions = quiz.content.questions;
+  const results: QuizAttemptResult[] = [];
+  let correctCount = 0;
+
+  for (const question of questions) {
+    const userAnswer = answers[question.id];
+    const isCorrect = userAnswer === question.correct_answer;
+    if (isCorrect) correctCount++;
+
+    results.push({
+      question_id: question.id,
+      user_answer: userAnswer ?? -1,
+      correct_answer: question.correct_answer,
+      is_correct: isCorrect,
+      explanation: question.explanation,
+      time_taken_seconds: 0, // Individual timing not tracked offline
+    });
+  }
+
+  const totalQuestions = questions.length;
+  const score = totalQuestions > 0 ? (correctCount / totalQuestions) * 100 : 0;
+  const passed = score >= (quiz.content.passing_score || 70);
+
+  const response: OfflineQuizAttemptResponse = {
+    attempt_id: `offline-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    quiz_id: quiz.id,
+    score,
+    total_questions: totalQuestions,
+    correct_answers: correctCount,
+    total_time_seconds: totalTimeSeconds,
+    passed,
+    lesson_validated: passed,
+    results,
+    attempted_at: new Date().toISOString(),
+    offline: true,
+  };
+
+  // Queue for background sync
+  await addOfflineAction({
+    actionType: 'quiz_answer',
+    payload: {
+      quiz_id: quiz.id,
+      module_id: quiz.module_id,
+      unit_id: quiz.unit_id,
+      answers,
+      total_time_seconds: totalTimeSeconds,
+      offline_scored_at: response.attempted_at,
+    },
+  });
+
+  return response;
+}

--- a/frontend/lib/offline/sync-manager.ts
+++ b/frontend/lib/offline/sync-manager.ts
@@ -1,0 +1,235 @@
+/**
+ * Background sync manager.
+ *
+ * Singleton that listens for the `online` event and processes the
+ * `offline_actions` queue in FIFO order, mapping each action to its
+ * corresponding API endpoint.
+ */
+
+import {
+  getPendingOfflineActions,
+  markOfflineActionSynced,
+  clearSyncedActions,
+  type OfflineAction,
+} from './db';
+import { apiFetch } from '@/lib/api';
+
+export type SyncStatus =
+  | { state: 'idle' }
+  | { state: 'syncing'; current: number; total: number }
+  | { state: 'complete'; synced: number }
+  | { state: 'error'; message: string; synced: number; failed: number };
+
+export type SyncStatusListener = (status: SyncStatus) => void;
+
+const MAX_RETRIES = 3;
+const BACKOFF_BASE_MS = 1000;
+const BACKOFF_MAX_MS = 30_000;
+
+class SyncManager {
+  private static instance: SyncManager | null = null;
+  private isSyncing = false;
+  private listeners = new Set<SyncStatusListener>();
+  private onlineHandler: (() => void) | null = null;
+  private started = false;
+
+  static getInstance(): SyncManager {
+    if (!SyncManager.instance) {
+      SyncManager.instance = new SyncManager();
+    }
+    return SyncManager.instance;
+  }
+
+  /** Register the `online` event listener. Call once on app mount. */
+  start(): void {
+    if (this.started || typeof window === 'undefined') return;
+    this.started = true;
+
+    this.onlineHandler = () => {
+      this.syncNow();
+    };
+    window.addEventListener('online', this.onlineHandler);
+  }
+
+  /** Clean up event listener. */
+  stop(): void {
+    if (this.onlineHandler) {
+      window.removeEventListener('online', this.onlineHandler);
+      this.onlineHandler = null;
+    }
+    this.started = false;
+  }
+
+  /** Subscribe to sync status changes. Returns an unsubscribe function. */
+  onStatusChange(listener: SyncStatusListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /** Get count of pending (unsynced) actions. */
+  async getPendingCount(): Promise<number> {
+    const actions = await getPendingOfflineActions();
+    return actions.length;
+  }
+
+  /** Process the pending actions queue. Safe to call multiple times. */
+  async syncNow(): Promise<{ synced: number; failed: number }> {
+    if (this.isSyncing) return { synced: 0, failed: 0 };
+    this.isSyncing = true;
+
+    const actions = await getPendingOfflineActions();
+    if (actions.length === 0) {
+      this.isSyncing = false;
+      return { synced: 0, failed: 0 };
+    }
+
+    let synced = 0;
+    let failed = 0;
+
+    this.emit({ state: 'syncing', current: 0, total: actions.length });
+
+    for (let i = 0; i < actions.length; i++) {
+      const action = actions[i];
+      this.emit({ state: 'syncing', current: i + 1, total: actions.length });
+
+      const success = await this.processAction(action);
+      if (success) {
+        synced++;
+      } else {
+        failed++;
+      }
+    }
+
+    // Clean up synced actions
+    await clearSyncedActions();
+
+    if (failed > 0) {
+      this.emit({ state: 'error', message: `${failed} actions failed`, synced, failed });
+    } else {
+      this.emit({ state: 'complete', synced });
+    }
+
+    this.isSyncing = false;
+    return { synced, failed };
+  }
+
+  // --- Private ---
+
+  private emit(status: SyncStatus): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(status);
+      } catch {
+        // Listener errors are non-fatal
+      }
+    }
+  }
+
+  private async processAction(action: OfflineAction): Promise<boolean> {
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      try {
+        await this.sendAction(action);
+        if (action.id !== undefined) {
+          await markOfflineActionSynced(action.id);
+        }
+        return true;
+      } catch (err: unknown) {
+        // 401: auth expired — stop retrying entirely
+        if (isHttpStatus(err, 401)) {
+          console.warn('Sync: auth expired, skipping action', action.id);
+          return false;
+        }
+
+        // 409: conflict (duplicate) — treat as success
+        if (isHttpStatus(err, 409)) {
+          if (action.id !== undefined) {
+            await markOfflineActionSynced(action.id);
+          }
+          return true;
+        }
+
+        // 4xx (except 401/409): permanent error, don't retry
+        if (isHttpStatus(err, 400) || isHttpStatus(err, 403) || isHttpStatus(err, 404) || isHttpStatus(err, 422)) {
+          console.warn(`Sync: permanent error for action ${action.id}:`, err);
+          return false;
+        }
+
+        // Transient error: exponential backoff
+        if (attempt < MAX_RETRIES - 1) {
+          const delay = Math.min(
+            BACKOFF_BASE_MS * Math.pow(2, attempt),
+            BACKOFF_MAX_MS
+          );
+          await new Promise((r) => setTimeout(r, delay));
+        }
+      }
+    }
+
+    console.warn(`Sync: action ${action.id} failed after ${MAX_RETRIES} retries`);
+    return false;
+  }
+
+  private async sendAction(action: OfflineAction): Promise<void> {
+    const payload = action.payload as Record<string, unknown>;
+
+    switch (action.actionType) {
+      case 'quiz_answer':
+        await apiFetch('/api/v1/quiz/attempt', {
+          method: 'POST',
+          body: JSON.stringify({
+            quiz_id: payload.quiz_id,
+            answers: payload.answers,
+            total_time_seconds: payload.total_time_seconds,
+          }),
+        });
+        break;
+
+      case 'flashcard_review':
+        await apiFetch(`/api/v1/flashcards/${payload.card_id}/review`, {
+          method: 'POST',
+          body: JSON.stringify({
+            rating: payload.rating,
+          }),
+        });
+        break;
+
+      case 'lesson_complete':
+        await apiFetch('/api/v1/progress/lesson-access', {
+          method: 'POST',
+          body: JSON.stringify({
+            module_id: payload.module_id,
+            lesson_id: payload.lesson_id,
+            time_spent_seconds: payload.time_spent_seconds,
+            completion_percentage: payload.completion_percentage,
+          }),
+        });
+        break;
+
+      case 'case_study_complete':
+        await apiFetch('/api/v1/progress/lesson-access', {
+          method: 'POST',
+          body: JSON.stringify({
+            module_id: payload.module_id,
+            lesson_id: payload.lesson_id,
+            time_spent_seconds: payload.time_spent_seconds,
+            completion_percentage: payload.completion_percentage,
+          }),
+        });
+        break;
+
+      default:
+        console.warn(`Sync: unknown action type: ${action.actionType}`);
+    }
+  }
+}
+
+function isHttpStatus(err: unknown, status: number): boolean {
+  return (
+    err !== null &&
+    typeof err === 'object' &&
+    'status' in err &&
+    (err as { status: number }).status === status
+  );
+}
+
+export { SyncManager };

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -318,7 +318,8 @@
     "lessonNotValidatedDesc": "You need at least {score}% to validate this lesson. Try again!",
     "refreshContent": "Refresh content",
     "subscriptionRequired": "A subscription is required to access this content. The first unit of each module is free.",
-    "authRequired": "Please sign in to continue."
+    "authRequired": "Please sign in to continue.",
+    "contentNotAvailableOffline": "This quiz is not available offline. Download the module to take quizzes without internet."
   },
   "ChatTutor": {
     "title": "AI Tutor",
@@ -687,7 +688,8 @@
     "validateWithQuiz": "Validate with Quiz",
     "checkingStatus": "Checking...",
     "unitNotFound": "This unit does not exist in this module.",
-    "backToModule": "Back to module"
+    "backToModule": "Back to module",
+    "contentNotAvailableOffline": "This lesson is not available offline. Download the module to access it without internet."
   },
   "LessonImage": {
     "imagePending": "Generating illustration...",
@@ -749,7 +751,8 @@
     "hideObjectives": "Hide objectives",
     "bloomLevel": "Bloom: {level}",
     "generatedOn": "Generated on {date}",
-    "stretchBadge": "Stretch"
+    "stretchBadge": "Stretch",
+    "contentNotAvailableOffline": "This case study is not available offline. Download the module to access it without internet."
   },
   "CaseStudyPage": {
     "backToModule": "Back to {module}",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1683,6 +1683,8 @@
     "redirecting": "Redirecting to course..."
   },
   "Offline": {
+    "offline": "You are offline",
+    "reconnected": "Back online",
     "downloadForOffline": "Download for offline",
     "availableOffline": "Available offline",
     "removeDownload": "Remove download",
@@ -1705,6 +1707,12 @@
     "offlineBadge": "Offline",
     "contentNotAvailable": "Content not available offline",
     "contentNotAvailableHint": "Download this module to access it offline",
-    "quizOfflineNote": "Quiz scored locally — will sync when back online"
+    "quizOfflineNote": "Quiz scored locally — will sync when back online",
+    "syncPending": "{count} pending",
+    "syncing": "Syncing...",
+    "syncComplete": "Sync complete",
+    "syncFailed": "Sync failed",
+    "syncRetry": "Retry sync",
+    "syncSuccess": "{count} items synced"
   }
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1678,5 +1678,30 @@
     "codeRequired": "Please enter an activation code",
     "scanInstructions": "Point your camera at the QR code",
     "redirecting": "Redirecting to course..."
+  },
+  "Offline": {
+    "downloadForOffline": "Download for offline",
+    "availableOffline": "Available offline",
+    "removeDownload": "Remove download",
+    "downloading": "Downloading...",
+    "units": "units",
+    "downloadProgress": "Download progress",
+    "downloadingLesson": "Downloading lesson",
+    "downloadingQuiz": "Downloading quiz",
+    "downloadingCaseStudy": "Downloading case study",
+    "cancel": "Cancel download",
+    "cancelAction": "Cancel",
+    "downloadFailed": "Download failed",
+    "partialDownload": "{count} of {total} units downloaded",
+    "retry": "Retry download",
+    "moduleLimitReached": "Offline module limit reached (3/3)",
+    "moduleLimitHint": "Remove a downloaded module to free a slot",
+    "downloadConfirm": "Download this module for offline use (~{size})?",
+    "wifiOnly": "WiFi only",
+    "startDownload": "Download",
+    "offlineBadge": "Offline",
+    "contentNotAvailable": "Content not available offline",
+    "contentNotAvailableHint": "Download this module to access it offline",
+    "quizOfflineNote": "Quiz scored locally — will sync when back online"
   }
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -318,7 +318,8 @@
     "lessonNotValidatedDesc": "Vous devez obtenir au moins {score}% pour valider cette leçon. Réessayez !",
     "refreshContent": "Actualiser le contenu",
     "subscriptionRequired": "Un abonnement est requis pour accéder à ce contenu. La première unité de chaque module est gratuite.",
-    "authRequired": "Veuillez vous connecter pour continuer."
+    "authRequired": "Veuillez vous connecter pour continuer.",
+    "contentNotAvailableOffline": "Ce quiz n'est pas disponible hors-ligne. Téléchargez le module pour le passer sans internet."
   },
   "ChatTutor": {
     "title": "Tuteur IA",
@@ -687,7 +688,8 @@
     "validateWithQuiz": "Valider avec le Quiz",
     "checkingStatus": "Vérification...",
     "unitNotFound": "Cette unité n'existe pas dans ce module.",
-    "backToModule": "Retour au module"
+    "backToModule": "Retour au module",
+    "contentNotAvailableOffline": "Cette leçon n'est pas disponible hors-ligne. Téléchargez le module pour y accéder sans internet."
   },
   "LessonImage": {
     "imagePending": "Illustration en cours de génération...",
@@ -749,7 +751,8 @@
     "hideObjectives": "Masquer les objectifs",
     "bloomLevel": "Bloom : {level}",
     "generatedOn": "Généré le {date}",
-    "stretchBadge": "Défi"
+    "stretchBadge": "Défi",
+    "contentNotAvailableOffline": "Cette étude de cas n'est pas disponible hors-ligne. Téléchargez le module pour y accéder sans internet."
   },
   "CaseStudyPage": {
     "backToModule": "Retour à {module}",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1683,6 +1683,8 @@
     "redirecting": "Redirection vers le cours..."
   },
   "Offline": {
+    "offline": "Vous êtes hors-ligne",
+    "reconnected": "Connexion rétablie",
     "downloadForOffline": "Télécharger pour hors-ligne",
     "availableOffline": "Disponible hors-ligne",
     "removeDownload": "Supprimer le téléchargement",
@@ -1705,6 +1707,12 @@
     "offlineBadge": "Hors-ligne",
     "contentNotAvailable": "Contenu non disponible hors-ligne",
     "contentNotAvailableHint": "Téléchargez ce module pour y accéder hors-ligne",
-    "quizOfflineNote": "Quiz noté localement — synchronisation au retour en ligne"
+    "quizOfflineNote": "Quiz noté localement — synchronisation au retour en ligne",
+    "syncPending": "{count} en attente",
+    "syncing": "Synchronisation...",
+    "syncComplete": "Synchronisation terminée",
+    "syncFailed": "Échec de synchronisation",
+    "syncRetry": "Réessayer la synchronisation",
+    "syncSuccess": "{count} éléments synchronisés"
   }
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1678,5 +1678,30 @@
     "codeRequired": "Veuillez entrer un code d'activation",
     "scanInstructions": "Pointez votre caméra sur le code QR",
     "redirecting": "Redirection vers le cours..."
+  },
+  "Offline": {
+    "downloadForOffline": "Télécharger pour hors-ligne",
+    "availableOffline": "Disponible hors-ligne",
+    "removeDownload": "Supprimer le téléchargement",
+    "downloading": "Téléchargement en cours...",
+    "units": "unités",
+    "downloadProgress": "Progression du téléchargement",
+    "downloadingLesson": "Téléchargement de la leçon",
+    "downloadingQuiz": "Téléchargement du quiz",
+    "downloadingCaseStudy": "Téléchargement de l'étude de cas",
+    "cancel": "Annuler le téléchargement",
+    "cancelAction": "Annuler",
+    "downloadFailed": "Échec du téléchargement",
+    "partialDownload": "{count} sur {total} unités téléchargées",
+    "retry": "Réessayer le téléchargement",
+    "moduleLimitReached": "Limite de modules hors-ligne atteinte (3/3)",
+    "moduleLimitHint": "Supprimez un module téléchargé pour libérer une place",
+    "downloadConfirm": "Télécharger ce module pour usage hors-ligne (~{size}) ?",
+    "wifiOnly": "WiFi uniquement",
+    "startDownload": "Télécharger",
+    "offlineBadge": "Hors-ligne",
+    "contentNotAvailable": "Contenu non disponible hors-ligne",
+    "contentNotAvailableHint": "Téléchargez ce module pour y accéder hors-ligne",
+    "quizOfflineNote": "Quiz noté localement — synchronisation au retour en ligne"
   }
 }


### PR DESCRIPTION
## Summary

Complete offline PWA story — 3 features merged to dev:

1. **Module download for offline (#295)** — Download up to 3 modules for offline use. Per-unit content fetching, cancellation, progress UI, 3-module limit.
2. **Offline content rendering (#296)** — Lessons, quizzes, and case studies served from IndexedDB when offline. Client-side quiz scoring with action queueing.
3. **Background sync (#298, closes #46)** — SyncManager processes offline_actions queue on reconnection. Exponential backoff, conflict handling, sync status UI.

### Key architectural decisions
- No new backend endpoints — frontend orchestrates fetches to existing APIs
- IndexedDB schema v3: composite key `[unitId, contentType, locale]`, fixed `synced` field type
- App-level sync (online event), not Web Background Sync API (cross-browser)
- Quiz offline scoring is client-side (correct_answer stored in IDB — unavoidable for offline)

## Test plan
- [ ] Download module → verify content in IndexedDB
- [ ] Go offline → open lesson/quiz/case study → verify renders with Offline badge
- [ ] Take quiz offline → verify client-side scoring + action queued
- [ ] Go back online → verify sync indicator → confirm server has the attempt
- [ ] Install PWA on mobile → airplane mode → study → reconnect → verify sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)