### PR TITLE
fix(pwa): offline fallback page for SW navigation (#1363)

### DIFF
--- a/frontend/public/offline.html
+++ b/frontend/public/offline.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#22c55e" />
+  <title>Sira — Hors-ligne</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #fafaf9;
+      color: #1c1917;
+      min-height: 100dvh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 1.5rem;
+      text-align: center;
+    }
+    .logo {
+      width: 64px; height: 64px;
+      background: #22c55e;
+      border-radius: 16px;
+      display: flex; align-items: center; justify-content: center;
+      margin-bottom: 1.5rem;
+      font-size: 28px; font-weight: 700; color: white;
+    }
+    h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: 0.5rem; }
+    .subtitle { color: #78716c; font-size: 0.95rem; margin-bottom: 2rem; max-width: 360px; line-height: 1.5; }
+    .icon-offline {
+      width: 80px; height: 80px;
+      background: #fef3c7;
+      border-radius: 50%;
+      display: flex; align-items: center; justify-content: center;
+      margin-bottom: 1.5rem;
+    }
+    .icon-offline svg { width: 40px; height: 40px; color: #d97706; }
+    .btn {
+      display: inline-flex; align-items: center; gap: 0.5rem;
+      padding: 0.75rem 1.5rem;
+      background: #22c55e; color: white;
+      border: none; border-radius: 8px;
+      font-size: 0.95rem; font-weight: 600;
+      cursor: pointer;
+      min-height: 44px; min-width: 44px;
+      transition: background 0.15s;
+    }
+    .btn:hover { background: #16a34a; }
+    .btn:active { background: #15803d; }
+    .btn svg { width: 18px; height: 18px; }
+    .hint {
+      margin-top: 2rem;
+      color: #a8a29e;
+      font-size: 0.8rem;
+      max-width: 320px;
+      line-height: 1.4;
+    }
+    #lang-toggle {
+      position: absolute; top: 1rem; right: 1rem;
+      background: #f5f5f4; border: 1px solid #e7e5e4;
+      border-radius: 6px; padding: 0.4rem 0.75rem;
+      font-size: 0.8rem; font-weight: 600; color: #57534e;
+      cursor: pointer; min-height: 44px;
+    }
+    [data-lang="en"] .fr { display: none; }
+    [data-lang="fr"] .en { display: none; }
+  </style>
+</head>
+<body data-lang="fr">
+  <button id="lang-toggle" onclick="toggleLang()">
+    <span class="fr">EN</span><span class="en">FR</span>
+  </button>
+
+  <div class="logo">S</div>
+
+  <div class="icon-offline">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M8.288 15.038a5.25 5.25 0 0 1 7.424 0M5.106 11.856c3.807-3.808 9.98-3.808 13.788 0M1.924 8.674c5.565-5.565 14.587-5.565 20.152 0M12 18h.008v.008H12V18Z" />
+      <line x1="3" y1="3" x2="21" y2="21" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+    </svg>
+  </div>
+
+  <h1>
+    <span class="fr">Vous êtes hors-ligne</span>
+    <span class="en">You are offline</span>
+  </h1>
+
+  <p class="subtitle">
+    <span class="fr">Cette page n'est pas disponible sans connexion internet. Vérifiez votre connexion et réessayez.</span>
+    <span class="en">This page is not available without an internet connection. Check your connection and try again.</span>
+  </p>
+
+  <button class="btn" onclick="location.reload()">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182" />
+    </svg>
+    <span class="fr">Réessayer</span>
+    <span class="en">Retry</span>
+  </button>
+
+  <p class="hint">
+    <span class="fr">Astuce : téléchargez un module depuis sa page pour y accéder hors-ligne.</span>
+    <span class="en">Tip: download a module from its page to access it offline.</span>
+  </p>
+
+  <script>
+    function toggleLang() {
+      const body = document.body;
+      body.dataset.lang = body.dataset.lang === 'fr' ? 'en' : 'fr';
+    }
+    // Auto-detect language from URL or browser
+    try {
+      const path = new URL(document.referrer || location.href).pathname;
+      if (path.startsWith('/en')) document.body.dataset.lang = 'en';
+    } catch {}
+  </script>
+</body>
+</html>

--- a/frontend/sw.ts
+++ b/frontend/sw.ts
@@ -17,11 +17,24 @@ declare const self: ServiceWorkerGlobalScope;
 
 const DAY_IN_SECONDS = 24 * 60 * 60;
 
+const OFFLINE_FALLBACK_URL = "/offline.html";
+
 const serwist = new Serwist({
-  precacheEntries: self.__SW_MANIFEST,
+  precacheEntries: [
+    ...(self.__SW_MANIFEST || []),
+    { url: OFFLINE_FALLBACK_URL, revision: "1" },
+  ],
   skipWaiting: true,
   clientsClaim: true,
   navigationPreload: false,
+  fallbacks: {
+    entries: [
+      {
+        url: OFFLINE_FALLBACK_URL,
+        matcher: ({ request }: { request: Request }) => request.mode === "navigate",
+      },
+    ],
+  },
   runtimeCaching: [
     {
       matcher: /^https:\/\/fonts\.(googleapis|gstatic)\.com\/.*/i,


### PR DESCRIPTION
## Summary
- Add `/offline.html` — static fallback page with Sira branding, FR/EN toggle, retry button
- Update `sw.ts` — precache offline page + Serwist `fallbacks` config for navigation requests
- When offline + uncached route: shows branded offline page instead of browser error

Closes #1363

## Test plan
- [ ] Visit app online → go offline → navigate to uncached route → see offline fallback page (not browser error)
- [ ] Previously visited pages still load from SW cache
- [ ] Offline page shows FR by default, toggles to EN
- [ ] Retry button reloads the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)