### PR TITLE
feat(saas): decouple NEXT_PUBLIC_API_URL from build time — use Next.js rewrites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,5 +90,3 @@ jobs:
 
       - name: Build
         run: npm run build
-        env:
-          NEXT_PUBLIC_API_URL: http://localhost:8000

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,8 +63,6 @@ jobs:
           npm ci
           npm run lint
           npm run build
-        env:
-          NEXT_PUBLIC_API_URL: https://api.elearning.portfolio2.kimbetien.com
 
   build-and-push:
     name: Build & Push (${{ matrix.service }})
@@ -126,7 +124,6 @@ jobs:
           cache-from: type=registry,ref=${{ matrix.image }}:buildcache
           cache-to: type=registry,ref=${{ matrix.image }}:buildcache,mode=max
           build-args: |
-            NEXT_PUBLIC_API_URL=https://api.elearning.portfolio2.kimbetien.com
             NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
             SENTRY_ORG=${{ secrets.SENTRY_ORG }}
             SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -80,6 +80,7 @@ services:
     image: ghcr.io/benidrissa/etutor-digital-ph/frontend:latest
     container_name: etutor-frontend
     environment:
+      BACKEND_URL: http://backend:8000
       HOSTNAME: "0.0.0.0"
       PORT: "3000"
       NEXT_PUBLIC_SENTRY_DSN: ${NEXT_PUBLIC_SENTRY_DSN}
@@ -89,6 +90,7 @@ services:
       backend:
         condition: service_healthy
     networks:
+      - etutor-data
       - proxy
     labels:
       traefik.enable: "true"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,7 +13,6 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN mkdir -p public
 
-ARG NEXT_PUBLIC_API_URL
 ARG NEXT_PUBLIC_SENTRY_DSN
 ARG SENTRY_ORG
 ARG SENTRY_PROJECT

--- a/frontend/app/[locale]/(app)/profile/profile-client.tsx
+++ b/frontend/app/[locale]/(app)/profile/profile-client.tsx
@@ -24,8 +24,7 @@ import { Link } from "@/i18n/routing";
 import { PlacementResultsHistory } from "@/components/placement/placement-results-history";
 import { Upload, User as UserIcon, AlertTriangle, CheckCircle, ClipboardList, LogOut, ArrowLeft } from "lucide-react";
 import { authClient } from "@/lib/auth";
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+import { API_BASE } from "@/lib/api";
 
 const fetchUserProfile = async () => {
   const response = await fetch(`${API_BASE}/api/v1/users/me`, {

--- a/frontend/app/[locale]/admin/syllabus/syllabus-client.tsx
+++ b/frontend/app/[locale]/admin/syllabus/syllabus-client.tsx
@@ -8,8 +8,7 @@ import { Loader2, AlertCircle, ChevronDown, ChevronRight, BookOpen } from 'lucid
 import { AdminModuleCard, NewModuleCard, type AdminModuleCardData } from '@/components/admin/module-card';
 import { SyllabusEditor } from '@/components/admin/syllabus-editor';
 import { authClient, AuthError } from '@/lib/auth';
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+import { API_BASE } from '@/lib/api';
 
 interface CourseGroup {
   course_id: string | null;

--- a/frontend/components/admin/course-form.tsx
+++ b/frontend/components/admin/course-form.tsx
@@ -7,7 +7,7 @@ import { X, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { apiFetch, getCourseTaxonomy, type TaxonomyItem } from '@/lib/api';
+import { apiFetch, getCourseTaxonomy, type TaxonomyItem, API_BASE } from '@/lib/api';
 import { authClient, AuthError } from '@/lib/auth';
 import type { AdminCourse } from './courses-client';
 
@@ -159,8 +159,6 @@ export function CourseForm({ course, onClose, onSaved }: CourseFormProps) {
         }
         throw err;
       }
-
-      const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
       if (course) {
         await fetch(`${API_BASE}/api/v1/admin/courses/${course.id}`, {

--- a/frontend/components/admin/courses-client.tsx
+++ b/frontend/components/admin/courses-client.tsx
@@ -35,7 +35,7 @@ import {
   AlertDialogAction,
   AlertDialogCancel,
 } from '@/components/ui/alert-dialog';
-import { apiFetch, ApiError } from '@/lib/api';
+import { apiFetch, ApiError, API_BASE } from '@/lib/api';
 import { authClient, AuthError } from '@/lib/auth';
 import { CourseForm } from '@/components/admin/course-form';
 import { CourseWizardClient } from '@/components/admin/course-wizard-client';
@@ -181,7 +181,7 @@ export function CoursesClient() {
           throw err;
         }
         const res = await fetch(
-          `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/v1/admin/courses/${course.id}/generate-structure`,
+          `${API_BASE}/api/v1/admin/courses/${course.id}/generate-structure`,
           {
             method: 'POST',
             headers: {
@@ -219,7 +219,7 @@ export function CoursesClient() {
       try {
         const currentToken = token ?? await authClient.getValidToken();
         const res = await fetch(
-          `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/v1/admin/courses/${generatingId}/generate-status?task_id=${generateTaskId}`,
+          `${API_BASE}/api/v1/admin/courses/${generatingId}/generate-status?task_id=${generateTaskId}`,
           { headers: { Authorization: `Bearer ${currentToken}` } }
         );
         if (!res.ok) {

--- a/frontend/components/admin/syllabus-editor.tsx
+++ b/frontend/components/admin/syllabus-editor.tsx
@@ -12,8 +12,7 @@ import { Send, Save, Download, Loader2, X, Bot, User } from 'lucide-react';
 import { authClient, AuthError } from '@/lib/auth';
 import { useRouter } from 'next/navigation';
 import type { AdminModuleCardData } from './module-card';
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+import { API_BASE } from '@/lib/api';
 
 interface ChatMessage {
   id: string;

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -5,7 +5,7 @@ import { useTranslations, useLocale } from 'next-intl';
 import { track } from '@/lib/analytics';
 import { Link } from '@/i18n/routing';
 import { X, MoreVertical, Trash2, Menu, HelpCircle, BookOpen, GraduationCap, ChevronDown, Globe } from 'lucide-react';
-import { getMyEnrollments, type CourseWithEnrollment } from '@/lib/api';
+import { getMyEnrollments, type CourseWithEnrollment, API_BASE } from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -224,7 +224,6 @@ export function ChatPanel({
     });
 
     try {
-      const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
       let token: string;
       try {
         token = await authClient.getValidToken();

--- a/frontend/components/placement/placement-results-history.tsx
+++ b/frontend/components/placement/placement-results-history.tsx
@@ -10,8 +10,7 @@ import { Progress } from '@/components/ui/progress';
 import { Separator } from '@/components/ui/separator';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { ClipboardList, TrendingUp, TrendingDown, Minus, Calendar, Trophy } from 'lucide-react';
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+import { API_BASE } from '@/lib/api';
 
 interface PlacementAttemptSummary {
   id: string;

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,4 +1,7 @@
-export const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+export const API_BASE =
+  typeof window === "undefined"
+    ? process.env.BACKEND_URL || "http://localhost:8000"
+    : "";
 
 export class ApiError extends Error {
   constructor(message: string, public status: number, public code?: string) {

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -3,7 +3,7 @@
  * Passwordless TOTP MFA + email magic link recovery.
  */
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+import { API_BASE } from "./api";
 
 export interface User {
   id: string;

--- a/frontend/lib/tutor-api.ts
+++ b/frontend/lib/tutor-api.ts
@@ -1,8 +1,7 @@
 'use client';
 
 import { authClient } from '@/lib/auth';
-
-export const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+import { API_BASE } from '@/lib/api';
 
 export interface UploadedFile {
   file_id: string;

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -53,6 +53,16 @@ const nextConfig: NextConfig = {
     ],
   },
 
+  async rewrites() {
+    const backendUrl = process.env.BACKEND_URL || "http://localhost:8000";
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${backendUrl}/api/:path*`,
+      },
+    ];
+  },
+
   async headers() {
     return [
       {


### PR DESCRIPTION
## Summary

- Replace build-time `NEXT_PUBLIC_API_URL` with runtime `BACKEND_URL` + Next.js rewrites
- Browser calls use relative URLs (`/api/...`); SSR calls use `BACKEND_URL` directly (container-to-container)
- One frontend Docker image is now reusable across different tenants/backends

## Changes

- `frontend/lib/api.ts` — `API_BASE` is now runtime-aware (empty on client, `BACKEND_URL` on SSR)
- `frontend/next.config.ts` — added `/api/:path*` rewrite rule to proxy browser requests to backend
- `frontend/lib/auth.ts`, `frontend/lib/tutor-api.ts` — replaced local `API_BASE` const with import from `@/lib/api`
- `frontend/components/placement/placement-results-history.tsx` — same
- `frontend/app/[locale]/(app)/profile/profile-client.tsx` — same
- `frontend/app/[locale]/admin/syllabus/syllabus-client.tsx` — same
- `frontend/components/admin/syllabus-editor.tsx` — same
- `frontend/components/chat/chat-panel.tsx` — added `API_BASE` to existing import, removed inline const
- `frontend/components/admin/course-form.tsx` — same
- `frontend/components/admin/courses-client.tsx` — replaced inline `process.env.NEXT_PUBLIC_API_URL` usages with `API_BASE`
- `frontend/Dockerfile` — removed `ARG NEXT_PUBLIC_API_URL`
- `docker-compose.prod.yml` — added `BACKEND_URL: http://backend:8000` and `etutor-data` network to frontend service
- `.github/workflows/ci.yml` — removed `NEXT_PUBLIC_API_URL` from build env
- `.github/workflows/deploy.yml` — removed `NEXT_PUBLIC_API_URL` from test env and Docker build-args

## Test plan

- [ ] `npm run build` succeeds without `NEXT_PUBLIC_API_URL`
- [ ] Dev: `npm run dev` still works (falls back to `http://localhost:8000`)
- [ ] Prod: Frontend image reusable across different `BACKEND_URL` values
- [ ] SSR pages fetch data correctly via `BACKEND_URL`
- [ ] Client-side API calls use relative URLs (verify in browser Network tab)
- [ ] Backend tests pass
- [ ] Frontend lint/tests pass

Closes #1364

Generated with [Claude Code](https://claude.ai/code)