### PR TITLE
feat(auth): add sub_admin role — restrict AI/prompt settings access

### DIFF
--- a/backend/app/api/deps_local_auth.py
+++ b/backend/app/api/deps_local_auth.py
@@ -172,7 +172,7 @@ async def require_subscription_or_first_unit(
     from ..domain.services.subscription_service import SubscriptionService
     from ..infrastructure.persistence.database import get_db_session
 
-    if user.role == "admin":
+    if user.role in ("admin", "sub_admin"):
         return user
 
     unit_id = request.path_params.get("unit_id") or request.path_params.get("unitId")
@@ -248,7 +248,7 @@ def require_enrollment(course_id_param: str = "course_id") -> Callable:
             enrollment = result.scalar_one_or_none()
             break
 
-        if not enrollment and user.role != "admin":
+        if not enrollment and user.role not in ("admin", "sub_admin"):
             logger.warning(
                 "Access denied - not enrolled in course",
                 user_id=user.id,

--- a/backend/app/api/v1/admin/syllabus.py
+++ b/backend/app/api/v1/admin/syllabus.py
@@ -35,7 +35,7 @@ logger = structlog.get_logger()
 router = APIRouter(prefix="/admin/syllabus", tags=["admin"])
 
 
-_require_admin = require_role(UserRole.admin)
+_require_admin = require_role(UserRole.admin, UserRole.sub_admin)
 
 
 async def get_syllabus_agent_service() -> SyllabusAgentService:

--- a/backend/app/api/v1/admin/users.py
+++ b/backend/app/api/v1/admin/users.py
@@ -78,7 +78,7 @@ async def export_users_csv(
     level: int | None = Query(None, ge=1, le=4),
     role: UserRole | None = Query(None),
     is_active: bool | None = Query(None),
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> StreamingResponse:
     """Export user list as CSV. Admin only."""
@@ -162,7 +162,7 @@ async def count_users(
     level: int | None = Query(None, ge=1, le=4),
     role: UserRole | None = Query(None),
     is_active: bool | None = Query(None),
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> dict:
     """Count users matching filters. Admin only."""
@@ -200,7 +200,7 @@ async def list_users(
     is_active: bool | None = Query(None),
     offset: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=200),
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> list[UserProfileResponse]:
     """List users with search and filters. Admin only."""
@@ -235,7 +235,7 @@ async def list_users(
 @router.get("/users/{user_id}", response_model=UserProfileResponse)
 async def get_user(
     user_id: UUID,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> UserProfileResponse:
     """Get user detail. Admin only."""
@@ -317,7 +317,7 @@ async def update_user_role(
 async def update_user_status(
     user_id: UUID,
     request: UpdateUserStatusRequest,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> UserProfileResponse:
     """Deactivate or reactivate a user. Admin only."""
@@ -364,7 +364,7 @@ async def list_audit_logs(
     target_user_id: UUID | None = Query(None),
     offset: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=200),
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> list[AuditLogResponse]:
     """List admin audit logs. Admin only."""
@@ -402,7 +402,7 @@ async def list_audit_logs(
 @router.get("/users/{user_id}/progress")
 async def get_user_progress(
     user_id: UUID,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> list[dict]:
     """Get module progress for a user. Admin only."""
@@ -443,7 +443,7 @@ async def get_user_quiz_history(
     user_id: UUID,
     offset: int = Query(0, ge=0),
     limit: int = Query(20, ge=1, le=100),
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> list[dict]:
     """Get quiz attempt history for a user. Admin only."""

--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -133,7 +133,7 @@ def _slugify(text: str) -> str:
 
 @router.get("", response_model=list[CourseResponse])
 async def list_courses_admin(
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> list[CourseResponse]:
     """List all courses (any status). Admin only."""
@@ -159,7 +159,7 @@ async def list_courses_admin(
 @router.post("", response_model=CourseResponse, status_code=status.HTTP_201_CREATED)
 async def create_course(
     request: CreateCourseRequest,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> CourseResponse:
     """Create a new course (draft). Admin only."""
@@ -216,7 +216,7 @@ async def create_course(
 @router.get("/{course_id}", response_model=CourseResponse)
 async def get_course_admin(
     course_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> CourseResponse:
     """Get course detail. Admin only."""
@@ -232,7 +232,7 @@ async def get_course_admin(
 async def update_course(
     course_id: uuid.UUID,
     request: CreateCourseRequest,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> CourseResponse:
     """Update course metadata. Admin only."""
@@ -271,7 +271,7 @@ async def update_course(
 @router.post("/{course_id}/publish", response_model=CourseResponse)
 async def publish_course(
     course_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> CourseResponse:
     """Publish a draft course. Admin only."""
@@ -312,7 +312,7 @@ async def publish_course(
 @router.post("/{course_id}/archive", response_model=CourseResponse)
 async def archive_course(
     course_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> CourseResponse:
     """Archive a course. Admin only."""
@@ -338,7 +338,7 @@ async def generate_course_structure(
     course_id: uuid.UUID,
     request: GenerateStructureRequest,
     force: bool = False,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> dict:
     """
@@ -386,7 +386,7 @@ async def generate_course_structure(
 async def regenerate_course_syllabus(
     course_id: uuid.UUID,
     mode: str = "reuse",
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> dict:
     """Regenerate syllabus for an unpublished course with 0 enrollments.
@@ -465,7 +465,7 @@ async def regenerate_course_syllabus(
 async def get_generate_status(
     course_id: uuid.UUID,
     task_id: str | None = None,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> dict:
     """Get syllabus generation status for a course."""
@@ -519,7 +519,7 @@ class DeleteCourseConfirmation(BaseModel):
 async def delete_course(
     course_id: uuid.UUID,
     body: DeleteCourseConfirmation,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> None:
     """Permanently delete a course and all its related data. Admin only."""
@@ -608,7 +608,7 @@ async def delete_course(
 @router.post("/{course_id}/index-resources")
 async def trigger_rag_indexation(
     course_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> dict:
     """Trigger RAG indexation for course resources. Returns Celery task ID."""
@@ -648,7 +648,7 @@ async def trigger_rag_indexation(
 async def get_rag_index_status(
     course_id: uuid.UUID,
     task_id: str | None = None,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> dict:
     """Get RAG indexation status for a course."""
@@ -704,7 +704,7 @@ async def get_rag_index_status(
 @router.post("/{course_id}/cancel-indexation", response_model=CourseResponse)
 async def cancel_indexation(
     course_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> CourseResponse:
     """Revoke a running RAG indexation task and reset the course back to 'generated'.
@@ -758,7 +758,7 @@ async def cancel_indexation(
 async def trigger_image_reindexation(
     course_id: uuid.UUID,
     clear_old: bool = True,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> dict:
     """Trigger image-only re-indexation for course resources.
@@ -807,7 +807,7 @@ MAX_RESOURCE_SIZE = 100 * 1024 * 1024  # 100 MB
 @router.get("/{course_id}/resources")
 async def list_course_resources(
     course_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> dict:
     """List uploaded resource files for a course."""
@@ -838,7 +838,7 @@ async def list_course_resources(
 async def upload_course_resource(
     course_id: uuid.UUID,
     file: UploadFile = File(...),
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> dict:
     """Upload a PDF resource for a course.
@@ -995,7 +995,7 @@ async def upload_course_resource(
 async def delete_course_resource(
     course_id: uuid.UUID,
     filename: str,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> None:
     """Delete an uploaded resource file from a course."""
@@ -1034,7 +1034,7 @@ async def admin_generate_module_content(
     course_id: uuid.UUID,
     module_id: uuid.UUID,
     request: GenerateContentRequest,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> dict:
     """Trigger lesson content generation for all units in a module. Admin only.
@@ -1109,7 +1109,7 @@ class GeneratePreAssessmentRequest(BaseModel):
 async def trigger_preassessment_generation(
     course_id: uuid.UUID,
     request: GeneratePreAssessmentRequest,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> dict:
     """Dispatch a Celery task to generate a 20-question pre-assessment via Claude + RAG.
@@ -1189,7 +1189,7 @@ async def trigger_preassessment_generation(
 @router.post("/{course_id}/validate-preassessment")
 async def validate_preassessment(
     course_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> dict:
     """Mark all pre-assessments for a course as validated. Admin only."""
@@ -1225,7 +1225,7 @@ async def validate_preassessment(
 async def get_preassessment_status(
     course_id: uuid.UUID,
     task_id: str | None = None,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> dict:
     """Get pre-assessment generation status and existing pre-assessment metadata.

--- a/backend/app/api/v1/admin_curricula.py
+++ b/backend/app/api/v1/admin_curricula.py
@@ -126,7 +126,7 @@ def _curriculum_to_detail_response(curriculum: Curriculum) -> CurriculumDetailRe
 
 @router.get("", response_model=list[CurriculumResponse])
 async def list_curricula_admin(
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> list[CurriculumResponse]:
     """List all curricula (any status). Admin only."""
@@ -138,7 +138,7 @@ async def list_curricula_admin(
 @router.post("", response_model=CurriculumDetailResponse, status_code=status.HTTP_201_CREATED)
 async def create_curriculum(
     request: CreateCurriculumRequest,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> CurriculumDetailResponse:
     """Create a new curriculum (draft). Admin only."""
@@ -174,7 +174,7 @@ async def create_curriculum(
 @router.get("/{curriculum_id}", response_model=CurriculumDetailResponse)
 async def get_curriculum_admin(
     curriculum_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> CurriculumDetailResponse:
     """Get curriculum detail with courses. Admin only."""
@@ -189,7 +189,7 @@ async def get_curriculum_admin(
 async def update_curriculum(
     curriculum_id: uuid.UUID,
     request: UpdateCurriculumRequest,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> CurriculumDetailResponse:
     """Update curriculum metadata. Admin only."""
@@ -210,7 +210,7 @@ async def update_curriculum(
 @router.post("/{curriculum_id}/publish", response_model=CurriculumDetailResponse)
 async def publish_curriculum(
     curriculum_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> CurriculumDetailResponse:
     """Publish a draft curriculum. Admin only."""
@@ -234,7 +234,7 @@ async def publish_curriculum(
 @router.post("/{curriculum_id}/archive", response_model=CurriculumDetailResponse)
 async def archive_curriculum(
     curriculum_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> CurriculumDetailResponse:
     """Archive a curriculum. Admin only."""
@@ -253,7 +253,7 @@ async def archive_curriculum(
 @router.delete("/{curriculum_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_curriculum(
     curriculum_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> None:
     """Delete a curriculum. Admin only. Cannot delete published curricula."""
@@ -276,7 +276,7 @@ async def delete_curriculum(
 async def assign_courses(
     curriculum_id: uuid.UUID,
     request: AssignCoursesRequest,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> CurriculumDetailResponse:
     """Replace courses assigned to a curriculum. Admin only."""
@@ -321,7 +321,7 @@ async def assign_courses(
 async def add_course_to_curriculum(
     curriculum_id: uuid.UUID,
     course_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> CurriculumDetailResponse:
     """Add a single course to a curriculum. Admin only."""
@@ -356,7 +356,7 @@ async def add_course_to_curriculum(
 async def remove_course_from_curriculum(
     curriculum_id: uuid.UUID,
     course_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> CurriculumDetailResponse:
     """Remove a single course from a curriculum. Admin only."""
@@ -384,7 +384,7 @@ async def remove_course_from_curriculum(
 async def set_curriculum_visibility(
     curriculum_id: uuid.UUID,
     request: SetVisibilityRequest,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> CurriculumDetailResponse:
     """Set curriculum visibility to 'public' or 'private'. Admin only."""
@@ -413,7 +413,7 @@ async def set_curriculum_visibility(
 @router.get("/{curriculum_id}/access", response_model=list[AccessEntryResponse])
 async def list_curriculum_access(
     curriculum_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> list[AccessEntryResponse]:
     """List all access entries for a curriculum. Admin only."""
@@ -462,7 +462,7 @@ async def list_curriculum_access(
 async def grant_curriculum_access(
     curriculum_id: uuid.UUID,
     request: GrantAccessRequest,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> AccessEntryResponse:
     """Grant access to a private curriculum for a user or group. Admin only."""
@@ -566,7 +566,7 @@ async def grant_curriculum_access(
 async def revoke_curriculum_access(
     curriculum_id: uuid.UUID,
     access_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> None:
     """Revoke access to a private curriculum. Admin only."""

--- a/backend/app/api/v1/admin_groups.py
+++ b/backend/app/api/v1/admin_groups.py
@@ -80,7 +80,7 @@ def _group_to_detail_response(group: UserGroup) -> GroupDetailResponse:
 
 @router.get("", response_model=list[GroupResponse])
 async def list_groups(
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> list[GroupResponse]:
     """List all user groups. Admin only."""
@@ -96,7 +96,7 @@ async def list_groups(
 @router.post("", response_model=GroupDetailResponse, status_code=status.HTTP_201_CREATED)
 async def create_group(
     request: CreateGroupRequest,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> GroupDetailResponse:
     """Create a user group. Admin only."""
@@ -128,7 +128,7 @@ async def create_group(
 @router.get("/{group_id}", response_model=GroupDetailResponse)
 async def get_group(
     group_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> GroupDetailResponse:
     """Get group detail with members. Admin only."""
@@ -147,7 +147,7 @@ async def get_group(
 async def update_group(
     group_id: uuid.UUID,
     request: UpdateGroupRequest,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> GroupDetailResponse:
     """Update group name or description. Admin only."""
@@ -184,7 +184,7 @@ async def update_group(
 @router.delete("/{group_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_group(
     group_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> None:
     """Delete a user group. Admin only."""
@@ -208,7 +208,7 @@ async def delete_group(
 async def add_member(
     group_id: uuid.UUID,
     request: AddMemberRequest,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> GroupDetailResponse:
     """Add a user to a group. Admin only."""
@@ -261,7 +261,7 @@ async def add_member(
 async def remove_member(
     group_id: uuid.UUID,
     user_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> None:
     """Remove a user from a group. Admin only."""

--- a/backend/app/api/v1/admin_taxonomy.py
+++ b/backend/app/api/v1/admin_taxonomy.py
@@ -67,7 +67,7 @@ VALID_TYPES = {"domain", "level", "audience"}
 
 @router.get("", response_model=dict)
 async def list_taxonomy(
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> dict:
     """List all taxonomy categories grouped by type. Admin only."""
@@ -94,7 +94,7 @@ async def list_taxonomy(
 @router.post("", response_model=TaxonomyCategoryResponse, status_code=201)
 async def create_taxonomy_category(
     request: TaxonomyCategoryCreate,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> TaxonomyCategoryResponse:
     """Create a new taxonomy category. Admin only."""
@@ -143,7 +143,7 @@ async def create_taxonomy_category(
 async def update_taxonomy_category(
     category_id: uuid.UUID,
     request: TaxonomyCategoryUpdate,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> TaxonomyCategoryResponse:
     """Update a taxonomy category. Admin only."""
@@ -172,7 +172,7 @@ async def update_taxonomy_category(
 @router.delete("/{category_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_taxonomy_category(
     category_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> None:
     """Delete a taxonomy category. Fails if referenced by courses. Admin only."""

--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -119,7 +119,9 @@ async def ingest_batch(
 )
 async def get_summary(
     db: Annotated[AsyncSession, Depends(get_db)],
-    current_user: Annotated[AuthenticatedUser, Depends(require_role(UserRole.admin))],
+    current_user: Annotated[
+        AuthenticatedUser, Depends(require_role(UserRole.admin, UserRole.sub_admin))
+    ],
     period: Annotated[int, Query(description="Period in days: 7, 30, or 90")] = 7,
 ) -> dict[str, Any]:
     """Admin-only: return aggregated analytics summary for the given period."""

--- a/backend/app/api/v1/module_media.py
+++ b/backend/app/api/v1/module_media.py
@@ -167,7 +167,7 @@ async def generate_module_media(
 async def delete_module_media(
     module_id: uuid.UUID,
     media_id: uuid.UUID,
-    _current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    _current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db: AsyncSession = Depends(get_db_session),
 ) -> None:
     """Delete a module media record and its S3 object."""

--- a/backend/app/api/v1/quiz.py
+++ b/backend/app/api/v1/quiz.py
@@ -55,7 +55,7 @@ async def _check_subscription_or_first_unit(user: AuthenticatedUser, unit_id: st
     from app.domain.services.subscription_service import SubscriptionService
     from app.infrastructure.persistence.database import get_db_session
 
-    if user.role == "admin":
+    if user.role in ("admin", "sub_admin"):
         return
 
     free_count = SettingsCache.instance().get("subscription-free-units-count", 2)

--- a/backend/app/api/v1/source_images.py
+++ b/backend/app/api/v1/source_images.py
@@ -27,7 +27,7 @@ async def list_images_by_source(
     source: str,
     page: int = Query(1, ge=1),
     limit: int = Query(20, ge=1, le=100),
-    _current_user: AuthenticatedUser = Depends(require_role(UserRole.admin)),
+    _current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db: AsyncSession = Depends(get_db),
 ) -> SourceImageListResponse:
     """List all source images for a given book/collection (admin only, paginated)."""

--- a/backend/app/domain/models/user.py
+++ b/backend/app/domain/models/user.py
@@ -14,6 +14,7 @@ from app.domain.models.base import Base
 class UserRole(enum.StrEnum):
     user = "user"
     expert = "expert"
+    sub_admin = "sub_admin"
     admin = "admin"
 
 

--- a/backend/migrations/versions/056_add_sub_admin_role.py
+++ b/backend/migrations/versions/056_add_sub_admin_role.py
@@ -1,0 +1,22 @@
+"""Add sub_admin value to userrole enum.
+
+Revision ID: 056
+Revises: 055
+Create Date: 2026-04-11
+
+"""
+
+from alembic import op
+
+revision = "056"
+down_revision = "055"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE userrole ADD VALUE IF NOT EXISTS 'sub_admin' BEFORE 'admin'")
+
+
+def downgrade() -> None:
+    pass

--- a/backend/tests/test_rbac.py
+++ b/backend/tests/test_rbac.py
@@ -106,6 +106,41 @@ async def test_require_role_expert_or_admin_allows_admin():
     assert result.role == UserRole.admin.value
 
 
+@pytest.mark.asyncio
+async def test_require_role_admin_sub_admin_allows_sub_admin():
+    """require_role(admin, sub_admin) must pass for a 'sub_admin' role."""
+    checker = require_role(UserRole.admin, UserRole.sub_admin)
+    user = _make_user(UserRole.sub_admin.value)
+    result = await checker(user=user)
+    assert result.role == UserRole.sub_admin.value
+
+
+@pytest.mark.asyncio
+async def test_require_role_admin_blocks_sub_admin():
+    """require_role(admin) must raise 403 for a 'sub_admin' role (settings routes)."""
+    from fastapi import HTTPException
+
+    checker = require_role(UserRole.admin)
+    user = _make_user(UserRole.sub_admin.value)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await checker(user=user)
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_sub_admin_jwt_includes_role_claim():
+    """Access token with sub_admin role must contain correct 'role' claim."""
+    jwt_service = JWTAuthService()
+    token = jwt_service.create_access_token(
+        user_id="test-uuid",
+        email="subadmin@example.com",
+        role=UserRole.sub_admin.value,
+    )
+    payload = jwt_service.verify_access_token(token)
+    assert payload["role"] == "sub_admin"
+
+
 # ---------------------------------------------------------------------------
 # Admin endpoint integration tests (no DB required — auth layer only)
 # ---------------------------------------------------------------------------
@@ -133,6 +168,17 @@ def admin_auth_headers():
     return {"Authorization": f"Bearer {token}"}
 
 
+@pytest.fixture
+def sub_admin_auth_headers():
+    jwt_service = JWTAuthService()
+    token = jwt_service.create_access_token(
+        user_id="subadmin-uuid",
+        email="subadmin@example.com",
+        role=UserRole.sub_admin.value,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
 @pytest.mark.asyncio
 async def test_admin_users_endpoint_blocks_user_role(user_auth_headers):
     """GET /api/v1/admin/users must return 403 for user role."""
@@ -149,3 +195,21 @@ async def test_admin_users_endpoint_requires_auth():
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         response = await ac.get("/api/v1/admin/users")
     assert response.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_admin_settings_blocks_sub_admin(sub_admin_auth_headers):
+    """GET /api/v1/admin/settings must return 403 for sub_admin role."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.get("/api/v1/admin/settings", headers=sub_admin_auth_headers)
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_admin_users_allows_sub_admin(sub_admin_auth_headers):
+    """GET /api/v1/admin/users must return non-403 for sub_admin role (DB may fail, but auth passes)."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.get("/api/v1/admin/users", headers=sub_admin_auth_headers)
+    assert response.status_code != 403

--- a/frontend/app/[locale]/admin/settings/page.tsx
+++ b/frontend/app/[locale]/admin/settings/page.tsx
@@ -1,5 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useLocale } from "next-intl";
 import { SettingsClient } from "@/components/admin/settings-client";
 
+function getRole(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const token = localStorage.getItem("access_token");
+    if (!token) return null;
+    const base64Url = token.split(".")[1];
+    if (!base64Url) return null;
+    const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+    const payload = JSON.parse(atob(base64));
+    return (payload?.role as string) ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export default function AdminSettingsPage() {
+  const router = useRouter();
+  const locale = useLocale();
+  const [allowed, setAllowed] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const role = getRole();
+    if (role === "admin") {
+      setAllowed(true);
+    } else {
+      setAllowed(false);
+      router.replace(`/${locale}/admin`);
+    }
+  }, [locale, router]);
+
+  if (allowed === null) return null;
+  if (!allowed) return null;
+
   return <SettingsClient />;
 }

--- a/frontend/components/admin/admin-guard.tsx
+++ b/frontend/components/admin/admin-guard.tsx
@@ -34,7 +34,7 @@ export function AdminGuard({ children }: { children: React.ReactNode }) {
     }
     const payload = parseJwtPayload(token);
     const role = payload?.role as string | undefined;
-    if (role === "admin" || role === "expert") {
+    if (role === "admin" || role === "sub_admin" || role === "expert") {
       startTransition(() => setAuthorized(true));
     } else {
       router.replace(`/${locale}/dashboard`);

--- a/frontend/components/admin/admin-nav.tsx
+++ b/frontend/components/admin/admin-nav.tsx
@@ -3,25 +3,48 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useTranslations, useLocale } from "next-intl";
+import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
+
+function getRole(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const token = localStorage.getItem("access_token");
+    if (!token) return null;
+    const base64Url = token.split(".")[1];
+    if (!base64Url) return null;
+    const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+    const payload = JSON.parse(atob(base64));
+    return (payload?.role as string) ?? null;
+  } catch {
+    return null;
+  }
+}
 
 export function AdminNav() {
   const t = useTranslations("Admin");
   const locale = useLocale();
   const pathname = usePathname();
+  const [role, setRole] = useState<string | null>(null);
 
-  const items = [
-    { href: `/${locale}/admin/users`, label: t("users.title") },
-    { href: `/${locale}/admin/courses`, label: t("courses.title") },
-    { href: `/${locale}/admin/curricula`, label: t("curricula.title") },
-    { href: `/${locale}/admin/groups`, label: t("groups.title") },
-    { href: `/${locale}/admin/taxonomy`, label: t("taxonomy.title") },
-    { href: `/${locale}/admin/syllabus`, label: t("syllabus.title") },
-    { href: `/${locale}/admin/settings`, label: t("settings.title") },
-    { href: `/${locale}/admin/analytics`, label: t("analytics.title") },
-    { href: `/${locale}/admin/audit-logs`, label: t("auditLog.title") },
-    { href: `/${locale}/admin/payments`, label: t("payments.title") },
+  useEffect(() => {
+    setRole(getRole());
+  }, []);
+
+  const allItems = [
+    { href: `/${locale}/admin/users`, label: t("users.title"), adminOnly: false },
+    { href: `/${locale}/admin/courses`, label: t("courses.title"), adminOnly: false },
+    { href: `/${locale}/admin/curricula`, label: t("curricula.title"), adminOnly: false },
+    { href: `/${locale}/admin/groups`, label: t("groups.title"), adminOnly: false },
+    { href: `/${locale}/admin/taxonomy`, label: t("taxonomy.title"), adminOnly: false },
+    { href: `/${locale}/admin/syllabus`, label: t("syllabus.title"), adminOnly: false },
+    { href: `/${locale}/admin/settings`, label: t("settings.title"), adminOnly: true },
+    { href: `/${locale}/admin/analytics`, label: t("analytics.title"), adminOnly: false },
+    { href: `/${locale}/admin/audit-logs`, label: t("auditLog.title"), adminOnly: false },
+    { href: `/${locale}/admin/payments`, label: t("payments.title"), adminOnly: false },
   ];
+
+  const items = allItems.filter((item) => !item.adminOnly || role === "admin");
 
   return (
     <nav className="flex gap-1 border-b px-4 md:px-6 overflow-x-auto" aria-label="Admin navigation">


### PR DESCRIPTION
## Summary

- Adds `sub_admin` role to the role hierarchy: `admin > sub_admin > expert > user`
- `sub_admin` has all admin privileges **except** access to AI/prompt settings (`/admin/settings`)
- Enables SaaS reseller model where tenant admins control AI config but can delegate org management

## Changes

**Backend:**
- `backend/app/domain/models/user.py` — add `sub_admin` to `UserRole` enum
- `backend/migrations/versions/056_add_sub_admin_role.py` — Alembic migration (`ALTER TYPE userrole ADD VALUE`)
- `backend/app/api/v1/admin/users.py` — allow `sub_admin` on all user management endpoints (except role-change, which stays `admin`-only to prevent privilege escalation)
- `backend/app/api/v1/admin/syllabus.py` — allow `sub_admin`
- `backend/app/api/v1/admin_courses.py`, `admin_curricula.py`, `admin_groups.py`, `admin_taxonomy.py`, `analytics.py` — allow `sub_admin`
- `backend/app/api/v1/module_media.py`, `source_images.py` — allow `sub_admin`
- `backend/app/api/v1/admin_settings.py` — unchanged, remains `admin`-only
- `backend/app/api/deps_local_auth.py` — update subscription bypass checks for `sub_admin`
- `backend/app/api/v1/quiz.py` — update subscription bypass for `sub_admin`
- `backend/tests/test_rbac.py` — add 4 new RBAC tests for `sub_admin` (all 774 tests pass)

**Frontend:**
- `frontend/components/admin/admin-guard.tsx` — allow `sub_admin` into admin panel
- `frontend/components/admin/admin-nav.tsx` — hide "Settings" nav link for `sub_admin`
- `frontend/app/[locale]/admin/settings/page.tsx` — redirect `sub_admin` to `/admin`

## Test plan

- [x] All 774 backend tests pass
- [x] `require_role(admin, sub_admin)` passes for `sub_admin`
- [x] `require_role(admin)` (settings routes) returns 403 for `sub_admin`
- [x] `GET /api/v1/admin/settings` returns 403 for `sub_admin`
- [x] `GET /api/v1/admin/users` returns non-403 for `sub_admin`
- [ ] Manually verify frontend hides Settings nav for `sub_admin`
- [ ] Manually verify settings page redirects `sub_admin`
- [ ] Run `alembic upgrade head` in staging

Closes #1365

🤖 Generated with [Claude Code](https://claude.ai/code)