### PR TITLE
fix(tts): migrate to google-genai SDK for Gemini TTS

### DIFF
--- a/backend/app/domain/services/lesson_audio_service.py
+++ b/backend/app/domain/services/lesson_audio_service.py
@@ -173,22 +173,24 @@ class LessonAudioService:
         if not settings.google_api_key:
             raise ValueError("GOOGLE_API_KEY is required for Gemini TTS")
 
-        import google.generativeai as genai  # type: ignore[import-untyped]
+        from google import genai  # type: ignore[import-untyped]
+        from google.genai import types  # type: ignore[import-untyped]
 
-        genai.configure(api_key=settings.google_api_key)
+        client = genai.Client(api_key=settings.google_api_key)
 
         voice_name = "Aoede" if language == "fr" else "Charon"
 
-        model = genai.GenerativeModel("gemini-2.5-flash-preview-tts")
-
-        response = await model.generate_content_async(
-            script,
-            generation_config=genai.GenerationConfig(
+        response = await client.aio.models.generate_content(
+            model="gemini-2.5-flash-preview-tts",
+            contents=script,
+            config=types.GenerateContentConfig(
                 response_modalities=["AUDIO"],
-                speech_config=genai.SpeechConfig(
-                    voice_config=genai.VoiceConfig(
-                        prebuilt_voice_config=genai.PrebuiltVoiceConfig(voice_name=voice_name)
-                    )
+                speech_config=types.SpeechConfig(
+                    voice_config=types.VoiceConfig(
+                        prebuilt_voice_config=types.PrebuiltVoiceConfig(
+                            voice_name=voice_name,
+                        ),
+                    ),
                 ),
             ),
         )
@@ -206,10 +208,9 @@ class LessonAudioService:
 def _extract_audio_bytes(response: object) -> bytes:
     """Extract raw audio bytes from Gemini TTS response."""
     try:
-        for candidate in response.candidates:  # type: ignore[union-attr]
-            for part in candidate.content.parts:
-                if hasattr(part, "inline_data") and part.inline_data:
-                    return part.inline_data.data
+        for part in response.candidates[0].content.parts:  # type: ignore[union-attr]
+            if part.inline_data and part.inline_data.data:
+                return part.inline_data.data
     except Exception as exc:
         logger.error("Failed to extract audio bytes from Gemini response", error=str(exc))
 

--- a/backend/app/domain/services/media_summary_service.py
+++ b/backend/app/domain/services/media_summary_service.py
@@ -387,22 +387,24 @@ class MediaSummaryService:
         if not settings.google_api_key:
             raise ValueError("GOOGLE_API_KEY is required for Gemini TTS")
 
-        import google.generativeai as genai  # type: ignore[import-untyped]
+        from google import genai  # type: ignore[import-untyped]
+        from google.genai import types  # type: ignore[import-untyped]
 
-        genai.configure(api_key=settings.google_api_key)
+        client = genai.Client(api_key=settings.google_api_key)
 
         voice_name = "Aoede" if language == "fr" else "Charon"
 
-        model = genai.GenerativeModel("gemini-2.5-flash-preview-tts")
-
-        response = await model.generate_content_async(
-            script,
-            generation_config=genai.GenerationConfig(
+        response = await client.aio.models.generate_content(
+            model="gemini-2.5-flash-preview-tts",
+            contents=script,
+            config=types.GenerateContentConfig(
                 response_modalities=["AUDIO"],
-                speech_config=genai.SpeechConfig(
-                    voice_config=genai.VoiceConfig(
-                        prebuilt_voice_config=genai.PrebuiltVoiceConfig(voice_name=voice_name)
-                    )
+                speech_config=types.SpeechConfig(
+                    voice_config=types.VoiceConfig(
+                        prebuilt_voice_config=types.PrebuiltVoiceConfig(
+                            voice_name=voice_name,
+                        ),
+                    ),
                 ),
             ),
         )
@@ -419,10 +421,9 @@ class MediaSummaryService:
     def _extract_audio_bytes(self, response: object) -> bytes:
         """Extract raw audio bytes from Gemini TTS response."""
         try:
-            for candidate in response.candidates:  # type: ignore[union-attr]
-                for part in candidate.content.parts:
-                    if hasattr(part, "inline_data") and part.inline_data:
-                        return part.inline_data.data
+            for part in response.candidates[0].content.parts:  # type: ignore[union-attr]
+                if part.inline_data and part.inline_data.data:
+                    return part.inline_data.data
         except Exception as exc:
             logger.error("Failed to extract audio bytes from Gemini response", error=str(exc))
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "alembic>=1.18.4",
     "anthropic>=0.86.0",
-    "google-generativeai>=0.8.0",
+    "google-genai>=1.0.0",
     "aiobotocore>=2.13.0",
     "botocore>=1.35.0",
     "asyncpg>=0.31.0",


### PR DESCRIPTION
## Summary
Migrate from deprecated `google-generativeai` (0.8.x) to `google-genai` (>=1.0) SDK. The old SDK doesn't have `SpeechConfig` needed for TTS.

Updated both `lesson_audio_service.py` and `media_summary_service.py`.

## Test plan
- [ ] Deploy succeeds
- [ ] Lesson audio generates with Gemini TTS

🤖 Generated with [Claude Code](https://claude.com/claude-code)