### PR TITLE
feat(audio): enrich lesson audio prompt with course/module context

### DIFF
--- a/backend/app/domain/services/lesson_audio_service.py
+++ b/backend/app/domain/services/lesson_audio_service.py
@@ -254,7 +254,7 @@ class LessonAudioService:
         voice_name = "Aoede" if language == "fr" else "Charon"
 
         response = await client.aio.models.generate_content(
-            model="gemini-2.5-flash-tts",
+            model="gemini-2.5-flash-preview-tts",
             contents=script,
             config=types.GenerateContentConfig(
                 response_modalities=["AUDIO"],

--- a/backend/app/domain/services/lesson_audio_service.py
+++ b/backend/app/domain/services/lesson_audio_service.py
@@ -8,34 +8,56 @@ from datetime import datetime
 import structlog
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.ai.claude_service import ClaudeService
+from app.ai.prompts.audience import detect_audience
 from app.domain.models.generated_audio import GeneratedAudio
+from app.domain.models.module import Module
 from app.infrastructure.config.settings import settings
 from app.infrastructure.storage.s3 import S3StorageService
 
 logger = structlog.get_logger(__name__)
 
 
-def _build_lesson_audio_system_prompt(language: str) -> str:
+def _build_lesson_audio_system_prompt(
+    language: str,
+    course_title: str | None = None,
+    is_kids: bool = False,
+    age_range: str = "",
+) -> str:
     lang_label = "French" if language == "fr" else "English"
-    return f"""You are an expert educator for West Africa (ECOWAS region).
+    domain = course_title or "general education"
+    if is_kids:
+        audience = f"young learners aged {age_range}"
+        style = f"clear, engaging, and fun narration suitable for children aged {age_range}"
+        context_note = "Reference concrete examples from West Africa that children can relate to"
+    else:
+        audience = f"learners in {domain}"
+        style = f"clear, engaging narration suitable for {audience}"
+        context_note = "Reference concrete examples from West African contexts where relevant"
+
+    return f"""You are an expert educator in {domain} for West Africa (ECOWAS region).
 Your task is to write a short spoken audio summary script for a single lesson.
 
 Guidelines:
 - Write in {lang_label}
 - Length: approximately 500 words — about 3-4 minutes of spoken audio
-- Style: clear, engaging narration suitable for health professionals
+- Style: {style}
 - Structure: brief intro → key concepts recap → main takeaway
 - Use simple language accessible on 2G/3G with limited bandwidth
-- Reference concrete examples from West African health systems where relevant
+- {context_note}
 - DO NOT include headers, bullet points, or markdown — write plain spoken prose
 - End with 2-3 key takeaways the listener should remember
 
 Output only the script text, nothing else."""
 
 
-LESSON_AUDIO_USER_TEMPLATE = """Lesson content to summarize:
+LESSON_AUDIO_USER_TEMPLATE = """Module: {module_title}
+Unit: {unit_id}
+Language: {language_label}
+
+Lesson content to summarize:
 
 {lesson_content}
 
@@ -86,7 +108,33 @@ class LessonAudioService:
             record.status = "generating"
             await session.flush()
 
-            script = await self._generate_script(lesson_content, language)
+            # Fetch module + course context for prompt enrichment
+            module = await self._fetch_module(module_id, session)
+            module_title = ""
+            course_title = None
+            is_kids = False
+            age_range = ""
+            if module:
+                module_title = (
+                    module.title_fr if language == "fr" else module.title_en
+                ) or f"Module {module.module_number}"
+                course = module.course
+                if course:
+                    course_title = course.title_fr if language == "fr" else course.title_en
+                audience_ctx = detect_audience(course)
+                is_kids = audience_ctx.is_kids
+                if is_kids:
+                    age_range = f"{audience_ctx.age_min}-{audience_ctx.age_max}"
+
+            script = await self._generate_script(
+                lesson_content=lesson_content,
+                language=language,
+                module_title=module_title,
+                unit_id=unit_id,
+                course_title=course_title,
+                is_kids=is_kids,
+                age_range=age_range,
+            )
 
             audio_bytes = await self._call_gemini_tts(script, language)
 
@@ -142,9 +190,33 @@ class LessonAudioService:
         )
         return result.scalar_one_or_none()
 
-    async def _generate_script(self, lesson_content: str, language: str) -> str:
-        system_prompt = _build_lesson_audio_system_prompt(language)
+    async def _fetch_module(self, module_id: uuid.UUID, session: AsyncSession) -> Module | None:
+        result = await session.execute(
+            select(Module).where(Module.id == module_id).options(selectinload(Module.course))
+        )
+        return result.scalar_one_or_none()
+
+    async def _generate_script(
+        self,
+        lesson_content: str,
+        language: str,
+        module_title: str = "",
+        unit_id: str = "",
+        course_title: str | None = None,
+        is_kids: bool = False,
+        age_range: str = "",
+    ) -> str:
+        system_prompt = _build_lesson_audio_system_prompt(
+            language=language,
+            course_title=course_title,
+            is_kids=is_kids,
+            age_range=age_range,
+        )
+        language_label = "French" if language == "fr" else "English"
         user_message = LESSON_AUDIO_USER_TEMPLATE.format(
+            module_title=module_title or "Unknown",
+            unit_id=unit_id or "Unknown",
+            language_label=language_label,
             lesson_content=lesson_content[:4000],
         )
 
@@ -178,10 +250,11 @@ class LessonAudioService:
 
         client = genai.Client(api_key=settings.google_api_key)
 
+        # Use Aoede for French (warm female voice), Charon for English
         voice_name = "Aoede" if language == "fr" else "Charon"
 
         response = await client.aio.models.generate_content(
-            model="gemini-2.5-flash-preview-tts",
+            model="gemini-2.5-flash-tts",
             contents=script,
             config=types.GenerateContentConfig(
                 response_modalities=["AUDIO"],
@@ -200,6 +273,7 @@ class LessonAudioService:
         logger.info(
             "Gemini TTS audio generated for lesson",
             language=language,
+            voice=voice_name,
             audio_size_bytes=len(audio_bytes),
         )
         return audio_bytes

--- a/backend/app/domain/services/media_summary_service.py
+++ b/backend/app/domain/services/media_summary_service.py
@@ -395,7 +395,7 @@ class MediaSummaryService:
         voice_name = "Aoede" if language == "fr" else "Charon"
 
         response = await client.aio.models.generate_content(
-            model="gemini-2.5-flash-tts",
+            model="gemini-2.5-flash-preview-tts",
             contents=script,
             config=types.GenerateContentConfig(
                 response_modalities=["AUDIO"],

--- a/backend/app/domain/services/media_summary_service.py
+++ b/backend/app/domain/services/media_summary_service.py
@@ -395,7 +395,7 @@ class MediaSummaryService:
         voice_name = "Aoede" if language == "fr" else "Charon"
 
         response = await client.aio.models.generate_content(
-            model="gemini-2.5-flash-preview-tts",
+            model="gemini-2.5-flash-tts",
             contents=script,
             config=types.GenerateContentConfig(
                 response_modalities=["AUDIO"],


### PR DESCRIPTION
## Summary
- Script prompt now uses course domain and audience (kids/adult) instead of hardcoded "health professionals"
- Module title and unit ID included in Claude prompt for better context
- Fetches module + course from DB using existing `detect_audience()` pattern

## Review
- **No regressions**: all new params have backward-compatible defaults
- **No useless refactoring**: every change serves prompt enrichment
- Only `lesson_audio_service.py` modified (82 insertions, 8 deletions)

## Test plan
- [ ] Deploy succeeds
- [ ] Lesson audio generates with course-aware prompt
- [ ] Kids courses get age-appropriate narration style

🤖 Generated with [Claude Code](https://claude.com/claude-code)