### PR TITLE
fix(deploy): validate required secrets before deploying

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,6 +151,17 @@ jobs:
             docker-compose.prod.yml \
             deploy@167.86.115.58:~/etutor/docker-compose.yml
 
+      - name: Validate required secrets
+        run: |
+          missing=""
+          [ -z "${{ secrets.ANTHROPIC_API_KEY }}" ] && missing="$missing ANTHROPIC_API_KEY"
+          [ -z "${{ secrets.OPENAI_API_KEY }}" ] && missing="$missing OPENAI_API_KEY"
+          [ -z "${{ secrets.GOOGLE_API_KEY }}" ] && missing="$missing GOOGLE_API_KEY"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing required secrets:$missing"
+            exit 1
+          fi
+
       - name: Deploy on server
         uses: appleboy/ssh-action@v1
         env:


### PR DESCRIPTION
## Summary
Add a validation step in deploy.yml that fails early if required API keys (ANTHROPIC, OPENAI, GOOGLE) are empty. Prevents silent deployment with missing secrets.

Also re-set GOOGLE_API_KEY secret via stdin pipe (previous `--body` flag didn't store correctly).

## Test plan
- [ ] Deploy succeeds with non-empty GOOGLE_API_KEY
- [ ] Audio generation works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)