### PR TITLE
fix(lesson): remove duplicated introduction in lesson viewer

### DIFF
--- a/backend/app/domain/services/lesson_service.py
+++ b/backend/app/domain/services/lesson_service.py
@@ -539,11 +539,11 @@ class LessonGenerationService:
             if source_citation not in sources_cited:
                 sources_cited.append(source_citation)
 
-        # For now, return a basic structure with the full content
-        # In a production system, you would parse the structured sections
+        # Full content is already well-structured by the AI prompt with section headings.
+        # Keep introduction empty — it's already in the content body (concepts).
         return LessonContent(
-            introduction=(content_text[:200] + "..." if len(content_text) > 200 else content_text),
-            concepts=[content_text],  # Simplified - would parse sections in production
+            introduction="",
+            concepts=[content_text],
             aof_example="",
             synthesis="",
             key_points=[],  # Would be parsed


### PR DESCRIPTION
## Summary
- Fixes #1385 — lesson title, introduction, and first paragraph were rendered twice
- Root cause: `_parse_lesson_content` stuffed first 200 chars into `introduction` AND full content into `concepts[0]`; frontend rendered both
- Fix: set `introduction=""` since the AI-generated content already includes it with proper structure

## Test plan
- [ ] Load any lesson page and verify content appears only once
- [ ] Verify audio player and illustration still render correctly between sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)