### PR TITLE
fix: deduplicate lesson image generation to prevent token waste

### DIFF
--- a/backend/app/domain/models/generated_image.py
+++ b/backend/app/domain/models/generated_image.py
@@ -21,6 +21,7 @@ class GeneratedImage(Base):
     __table_args__ = (
         Index("ix_generated_images_semantic_tags_gin", "semantic_tags", postgresql_using="gin"),
         Index("ix_generated_images_status", "status"),
+        Index("ix_generated_images_lesson_id", "lesson_id"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)

--- a/backend/app/domain/services/image_service.py
+++ b/backend/app/domain/services/image_service.py
@@ -45,6 +45,25 @@ class ImageGenerationService:
 
         Status transitions: pending → generating → ready | failed
         """
+        # Dedup: return existing image if one already exists for this lesson
+        existing = await session.execute(
+            select(GeneratedImage)
+            .where(
+                GeneratedImage.lesson_id == lesson_id,
+                GeneratedImage.status.in_(["ready", "generating", "pending"]),
+            )
+            .limit(1)
+        )
+        existing_image = existing.scalar_one_or_none()
+        if existing_image is not None:
+            logger.info(
+                "Image already exists for lesson — skipping generation",
+                lesson_id=str(lesson_id),
+                image_id=str(existing_image.id),
+                status=existing_image.status,
+            )
+            return existing_image
+
         image_record = GeneratedImage(
             id=uuid.uuid4(),
             lesson_id=lesson_id,

--- a/backend/app/domain/services/lesson_service.py
+++ b/backend/app/domain/services/lesson_service.py
@@ -698,18 +698,36 @@ class LessonGenerationService:
             lesson_text = str(content_dict)[:2000]
 
         try:
-            from app.tasks.content_generation import generate_lesson_image
+            from sqlalchemy import select as sa_select
 
-            generate_lesson_image.delay(
-                str(cached_content.id),
-                str(cached_content.module_id),
-                lesson_response.unit_id,
-                lesson_text[:2000],
+            from app.domain.models.generated_image import GeneratedImage
+
+            existing_img = await session.execute(
+                sa_select(GeneratedImage.id)
+                .where(
+                    GeneratedImage.lesson_id == cached_content.id,
+                    GeneratedImage.status.in_(["ready", "generating", "pending"]),
+                )
+                .limit(1)
             )
-            logger.info(
-                "Dispatched image generation task",
-                lesson_id=str(cached_content.id),
-            )
+            if existing_img.scalar_one_or_none() is not None:
+                logger.info(
+                    "Image already exists — skipping dispatch",
+                    lesson_id=str(cached_content.id),
+                )
+            else:
+                from app.tasks.content_generation import generate_lesson_image
+
+                generate_lesson_image.delay(
+                    str(cached_content.id),
+                    str(cached_content.module_id),
+                    lesson_response.unit_id,
+                    lesson_text[:2000],
+                )
+                logger.info(
+                    "Dispatched image generation task",
+                    lesson_id=str(cached_content.id),
+                )
         except Exception as exc:
             logger.warning(
                 "Failed to dispatch image generation task",

--- a/backend/app/tasks/content_generation.py
+++ b/backend/app/tasks/content_generation.py
@@ -598,6 +598,29 @@ def generate_lesson_image(
         session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
         try:
             async with session_factory() as session:
+                # Guard: skip if image already exists for this lesson
+                from sqlalchemy import select as sa_select
+
+                from app.domain.models.generated_image import GeneratedImage
+
+                existing = await session.execute(
+                    sa_select(GeneratedImage)
+                    .where(
+                        GeneratedImage.lesson_id == uuid.UUID(lesson_id),
+                        GeneratedImage.status.in_(["ready", "generating", "pending"]),
+                    )
+                    .limit(1)
+                )
+                existing_image = existing.scalar_one_or_none()
+                if existing_image is not None:
+                    logger.info(
+                        "Image already exists — skipping task",
+                        lesson_id=lesson_id,
+                        image_id=str(existing_image.id),
+                        status=existing_image.status,
+                    )
+                    return {"image_id": str(existing_image.id), "status": existing_image.status}
+
                 service = ImageGenerationService()
                 image = await service.generate_for_lesson(
                     lesson_id=uuid.UUID(lesson_id),

--- a/backend/migrations/versions/057_add_lesson_id_index_to_generated_images.py
+++ b/backend/migrations/versions/057_add_lesson_id_index_to_generated_images.py
@@ -1,0 +1,26 @@
+"""Add lesson_id index to generated_images for dedup queries.
+
+Revision ID: 057
+Revises: 056
+Create Date: 2026-04-11
+
+"""
+
+from alembic import op
+
+revision = "057"
+down_revision = "056"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_generated_images_lesson_id",
+        "generated_images",
+        ["lesson_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_generated_images_lesson_id", table_name="generated_images")


### PR DESCRIPTION
## Summary
- Adds 3-layer dedup guard to prevent duplicate lesson image generation via OpenAI gpt-image-1
- Each duplicate was costing 3 API calls: Claude (concept extraction) + DALL-E (image gen) + Claude (alt-text)
- Adds `lesson_id` index on `generated_images` table for efficient dedup lookups

## Changes
| File | Change |
|------|--------|
| `backend/app/domain/services/image_service.py` | Service-level dedup: checks for existing image before creating new record |
| `backend/app/tasks/content_generation.py` | Celery task guard: queries DB before calling service |
| `backend/app/domain/services/lesson_service.py` | Pre-dispatch check: skips Celery dispatch if image already exists |
| `backend/app/domain/models/generated_image.py` | Adds `ix_generated_images_lesson_id` index |
| `backend/migrations/versions/057_...` | Alembic migration for the new index |

## Test plan
- [ ] Verify lesson loads normally with image generation on first access
- [ ] Verify second access to same lesson does NOT trigger new image generation (check logs for "Image already exists" message)
- [ ] Verify `SELECT count(*), lesson_id FROM generated_images GROUP BY lesson_id HAVING count(*) > 1` returns 0 new duplicates after fix
- [ ] Run Alembic migration `057` successfully

Closes #1388

🤖 Generated with [Claude Code](https://claude.com/claude-code)