### PR TITLE
feat(tts): switch to OpenAI gpt-4o-mini-tts with Opus output

### DIFF
--- a/backend/app/api/v1/lesson_audio.py
+++ b/backend/app/api/v1/lesson_audio.py
@@ -158,7 +158,7 @@ async def get_audio_status(
     "/{audio_id}/data",
     status_code=status.HTTP_200_OK,
     responses={
-        200: {"content": {"audio/wav": {}}, "description": "WAV audio data"},
+        200: {"content": {"audio/ogg": {}}, "description": "OGG Opus audio data"},
         404: {"description": "Audio not found or not ready"},
     },
 )
@@ -197,7 +197,7 @@ async def get_audio_data(
             audio_bytes = await storage.download_bytes(aud.storage_key)
             return Response(
                 content=audio_bytes,
-                media_type="audio/wav",
+                media_type="audio/ogg",
                 headers={"Cache-Control": "public, max-age=31536000, immutable"},
             )
         except Exception as exc:

--- a/backend/app/domain/services/lesson_audio_service.py
+++ b/backend/app/domain/services/lesson_audio_service.py
@@ -136,9 +136,9 @@ class LessonAudioService:
                 age_range=age_range,
             )
 
-            audio_bytes = await self._call_gemini_tts(script, language)
+            audio_bytes = await self._call_tts(script, language)
 
-            storage_key = f"audio/lessons/{lesson_id}/{language}/summary.ogg"
+            storage_key = f"audio/lessons/{lesson_id}/{language}/summary.opus"
             storage_url = await self._storage.upload_bytes(
                 key=storage_key,
                 data=audio_bytes,
@@ -240,63 +240,37 @@ class LessonAudioService:
         )
         return script_text.strip()
 
-    async def _call_gemini_tts(self, script: str, language: str) -> bytes:
-        """Call Cloud Text-to-Speech API with Gemini TTS model.
+    async def _call_tts(self, script: str, language: str) -> bytes:
+        """Call OpenAI TTS API to convert script to OGG Opus audio.
 
-        Returns MP3 bytes directly (no PCM conversion needed).
+        Uses gpt-4o-mini-tts model with opus output format.
         """
-        if not settings.google_api_key:
-            raise ValueError("GOOGLE_API_KEY is required for Gemini TTS")
+        from openai import AsyncOpenAI
 
-        import asyncio
+        client = AsyncOpenAI(api_key=settings.openai_api_key)
 
-        from google.api_core import client_options
-        from google.cloud import texttospeech
+        voice = "nova" if language == "fr" else "ash"
+        lang_label = "French" if language == "fr" else "English"
 
-        client = texttospeech.TextToSpeechClient(
-            client_options=client_options.ClientOptions(
-                api_key=settings.google_api_key,
-            ),
+        response = await client.audio.speech.create(
+            model="gpt-4o-mini-tts",
+            voice=voice,
+            input=script,
+            instructions=f"Speak in {lang_label} with a clear, warm, educational tone suitable for a learning platform.",
+            response_format="opus",
         )
 
-        voice_name = "Aoede" if language == "fr" else "Charon"
-        lang_code = "fr-FR" if language == "fr" else "en-US"
-
-        synthesis_input = texttospeech.SynthesisInput(
-            text=script,
-            prompt="Narrate the following in a clear, warm, educational tone",
-        )
-
-        voice = texttospeech.VoiceSelectionParams(
-            language_code=lang_code,
-            name=voice_name,
-            model_name="gemini-2.5-flash-lite-preview-tts",
-        )
-
-        audio_config = texttospeech.AudioConfig(
-            audio_encoding=texttospeech.AudioEncoding.OGG_OPUS,
-        )
-
-        # Cloud TTS client is synchronous — run in executor
-        loop = asyncio.get_running_loop()
-        response = await loop.run_in_executor(
-            None,
-            lambda: client.synthesize_speech(
-                input=synthesis_input, voice=voice, audio_config=audio_config
-            ),
-        )
-
-        ogg_bytes = response.audio_content
-        if not ogg_bytes:
-            raise ValueError("Gemini TTS returned empty audio")
+        audio_bytes = response.content
+        if not audio_bytes:
+            raise ValueError("OpenAI TTS returned empty audio")
 
         logger.info(
-            "Gemini TTS OGG Opus generated for lesson",
+            "OpenAI TTS audio generated for lesson",
             language=language,
-            voice=voice_name,
-            audio_size_bytes=len(ogg_bytes),
+            voice=voice,
+            audio_size_bytes=len(audio_bytes),
         )
-        return ogg_bytes
+        return audio_bytes
 
 
 def _estimate_duration(file_size_bytes: int) -> int:

--- a/backend/app/domain/services/lesson_audio_service.py
+++ b/backend/app/domain/services/lesson_audio_service.py
@@ -138,11 +138,11 @@ class LessonAudioService:
 
             audio_bytes = await self._call_gemini_tts(script, language)
 
-            storage_key = f"audio/lessons/{lesson_id}/{language}/summary.wav"
+            storage_key = f"audio/lessons/{lesson_id}/{language}/summary.ogg"
             storage_url = await self._storage.upload_bytes(
                 key=storage_key,
                 data=audio_bytes,
-                content_type="audio/wav",
+                content_type="audio/ogg",
             )
 
             record.status = "ready"
@@ -241,79 +241,68 @@ class LessonAudioService:
         return script_text.strip()
 
     async def _call_gemini_tts(self, script: str, language: str) -> bytes:
-        """Call Gemini TTS API to convert script to MP3 bytes."""
+        """Call Cloud Text-to-Speech API with Gemini TTS model.
+
+        Returns MP3 bytes directly (no PCM conversion needed).
+        """
         if not settings.google_api_key:
             raise ValueError("GOOGLE_API_KEY is required for Gemini TTS")
 
-        from google import genai  # type: ignore[import-untyped]
-        from google.genai import types  # type: ignore[import-untyped]
+        import asyncio
 
-        client = genai.Client(api_key=settings.google_api_key)
+        from google.api_core import client_options
+        from google.cloud import texttospeech
 
-        # Use Aoede for French (warm female voice), Charon for English
-        voice_name = "Aoede" if language == "fr" else "Charon"
-
-        response = await client.aio.models.generate_content(
-            model="gemini-2.5-flash-preview-tts",
-            contents=script,
-            config=types.GenerateContentConfig(
-                response_modalities=["AUDIO"],
-                speech_config=types.SpeechConfig(
-                    voice_config=types.VoiceConfig(
-                        prebuilt_voice_config=types.PrebuiltVoiceConfig(
-                            voice_name=voice_name,
-                        ),
-                    ),
-                ),
+        client = texttospeech.TextToSpeechClient(
+            client_options=client_options.ClientOptions(
+                api_key=settings.google_api_key,
             ),
         )
 
-        pcm_bytes = _extract_audio_bytes(response)
-        wav_bytes = _pcm_to_wav(pcm_bytes)
+        voice_name = "Aoede" if language == "fr" else "Charon"
+        lang_code = "fr-FR" if language == "fr" else "en-US"
+
+        synthesis_input = texttospeech.SynthesisInput(
+            text=script,
+            prompt="Narrate the following in a clear, warm, educational tone",
+        )
+
+        voice = texttospeech.VoiceSelectionParams(
+            language_code=lang_code,
+            name=voice_name,
+            model_name="gemini-2.5-flash-lite-preview-tts",
+        )
+
+        audio_config = texttospeech.AudioConfig(
+            audio_encoding=texttospeech.AudioEncoding.OGG_OPUS,
+        )
+
+        # Cloud TTS client is synchronous — run in executor
+        loop = asyncio.get_running_loop()
+        response = await loop.run_in_executor(
+            None,
+            lambda: client.synthesize_speech(
+                input=synthesis_input, voice=voice, audio_config=audio_config
+            ),
+        )
+
+        ogg_bytes = response.audio_content
+        if not ogg_bytes:
+            raise ValueError("Gemini TTS returned empty audio")
 
         logger.info(
-            "Gemini TTS audio generated for lesson",
+            "Gemini TTS OGG Opus generated for lesson",
             language=language,
             voice=voice_name,
-            pcm_bytes=len(pcm_bytes),
-            wav_bytes=len(wav_bytes),
+            audio_size_bytes=len(ogg_bytes),
         )
-        return wav_bytes
-
-
-def _extract_audio_bytes(response: object) -> bytes:
-    """Extract raw audio bytes from Gemini TTS response."""
-    try:
-        for part in response.candidates[0].content.parts:  # type: ignore[union-attr]
-            if part.inline_data and part.inline_data.data:
-                return part.inline_data.data
-    except Exception as exc:
-        logger.error("Failed to extract audio bytes from Gemini response", error=str(exc))
-
-    raise ValueError("No audio data found in Gemini TTS response")
-
-
-def _pcm_to_wav(
-    pcm_data: bytes,
-    sample_rate: int = 24000,
-    channels: int = 1,
-    sample_width: int = 2,
-) -> bytes:
-    """Wrap raw PCM bytes in a WAV container."""
-    import io
-    import wave
-
-    buf = io.BytesIO()
-    with wave.open(buf, "wb") as wf:
-        wf.setnchannels(channels)
-        wf.setsampwidth(sample_width)
-        wf.setframerate(sample_rate)
-        wf.writeframes(pcm_data)
-    return buf.getvalue()
+        return ogg_bytes
 
 
 def _estimate_duration(file_size_bytes: int) -> int:
-    """Estimate audio duration from WAV file size (24kHz, 16-bit mono)."""
-    pcm_size = max(0, file_size_bytes - 44)  # 44-byte WAV header
-    bytes_per_second = 24000 * 2  # sample_rate * sample_width
-    return max(1, pcm_size // bytes_per_second)
+    """Estimate audio duration from OGG Opus file size.
+
+    OGG Opus speech is typically ~48kbps = 6 KB/s.
+    """
+    bytes_per_second = 6 * 1024
+    return max(1, file_size_bytes // bytes_per_second)

--- a/backend/app/domain/services/media_summary_service.py
+++ b/backend/app/domain/services/media_summary_service.py
@@ -194,11 +194,11 @@ class MediaSummaryService:
 
             audio_bytes = await self._call_gemini_tts(script, language)
 
-            storage_key = f"audio/{module_id}/{language}/summary.wav"
+            storage_key = f"audio/{module_id}/{language}/summary.ogg"
             storage_url = await self._storage.upload_bytes(
                 key=storage_key,
                 data=audio_bytes,
-                content_type="audio/wav",
+                content_type="audio/ogg",
             )
 
             duration_seconds = self._estimate_duration(len(audio_bytes))
@@ -380,78 +380,63 @@ class MediaSummaryService:
         return script_text.strip()
 
     async def _call_gemini_tts(self, script: str, language: str) -> bytes:
-        """Call Gemini TTS API to convert script to MP3 bytes.
+        """Call Cloud Text-to-Speech API with Gemini TTS model.
 
-        Uses google-generativeai SDK with gemini-2.5-flash-preview-tts model.
+        Returns MP3 bytes directly.
         """
         if not settings.google_api_key:
             raise ValueError("GOOGLE_API_KEY is required for Gemini TTS")
 
-        from google import genai  # type: ignore[import-untyped]
-        from google.genai import types  # type: ignore[import-untyped]
+        import asyncio
 
-        client = genai.Client(api_key=settings.google_api_key)
+        from google.api_core import client_options
+        from google.cloud import texttospeech
 
-        voice_name = "Aoede" if language == "fr" else "Charon"
-
-        response = await client.aio.models.generate_content(
-            model="gemini-2.5-flash-preview-tts",
-            contents=script,
-            config=types.GenerateContentConfig(
-                response_modalities=["AUDIO"],
-                speech_config=types.SpeechConfig(
-                    voice_config=types.VoiceConfig(
-                        prebuilt_voice_config=types.PrebuiltVoiceConfig(
-                            voice_name=voice_name,
-                        ),
-                    ),
-                ),
+        client = texttospeech.TextToSpeechClient(
+            client_options=client_options.ClientOptions(
+                api_key=settings.google_api_key,
             ),
         )
 
-        pcm_bytes = self._extract_audio_bytes(response)
-        wav_bytes = self._pcm_to_wav(pcm_bytes)
+        voice_name = "Aoede" if language == "fr" else "Charon"
+        lang_code = "fr-FR" if language == "fr" else "en-US"
+
+        synthesis_input = texttospeech.SynthesisInput(
+            text=script,
+            prompt="Narrate the following in a clear, warm, educational tone",
+        )
+
+        voice = texttospeech.VoiceSelectionParams(
+            language_code=lang_code,
+            name=voice_name,
+            model_name="gemini-2.5-flash-lite-preview-tts",
+        )
+
+        audio_config = texttospeech.AudioConfig(
+            audio_encoding=texttospeech.AudioEncoding.OGG_OPUS,
+        )
+
+        loop = asyncio.get_running_loop()
+        response = await loop.run_in_executor(
+            None,
+            lambda: client.synthesize_speech(
+                input=synthesis_input, voice=voice, audio_config=audio_config
+            ),
+        )
+
+        ogg_bytes = response.audio_content
+        if not ogg_bytes:
+            raise ValueError("Gemini TTS returned empty audio")
 
         logger.info(
-            "Gemini TTS audio generated",
+            "Gemini TTS MP3 generated",
             language=language,
-            pcm_bytes=len(pcm_bytes),
-            wav_bytes=len(wav_bytes),
+            voice=voice_name,
+            audio_size_bytes=len(ogg_bytes),
         )
-        return wav_bytes
-
-    def _extract_audio_bytes(self, response: object) -> bytes:
-        """Extract raw audio bytes from Gemini TTS response."""
-        try:
-            for part in response.candidates[0].content.parts:  # type: ignore[union-attr]
-                if part.inline_data and part.inline_data.data:
-                    return part.inline_data.data
-        except Exception as exc:
-            logger.error("Failed to extract audio bytes from Gemini response", error=str(exc))
-
-        raise ValueError("No audio data found in Gemini TTS response")
-
-    def _pcm_to_wav(
-        self,
-        pcm_data: bytes,
-        sample_rate: int = 24000,
-        channels: int = 1,
-        sample_width: int = 2,
-    ) -> bytes:
-        """Wrap raw PCM bytes in a WAV container."""
-        import io
-        import wave
-
-        buf = io.BytesIO()
-        with wave.open(buf, "wb") as wf:
-            wf.setnchannels(channels)
-            wf.setsampwidth(sample_width)
-            wf.setframerate(sample_rate)
-            wf.writeframes(pcm_data)
-        return buf.getvalue()
+        return ogg_bytes
 
     def _estimate_duration(self, file_size_bytes: int) -> int:
-        """Estimate audio duration from WAV file size (24kHz, 16-bit mono)."""
-        pcm_size = max(0, file_size_bytes - 44)
-        bytes_per_second = 24000 * 2
-        return max(1, pcm_size // bytes_per_second)
+        """Estimate audio duration from OGG Opus file size (~48kbps speech)."""
+        bytes_per_second = 6 * 1024
+        return max(1, file_size_bytes // bytes_per_second)

--- a/backend/app/domain/services/media_summary_service.py
+++ b/backend/app/domain/services/media_summary_service.py
@@ -192,9 +192,9 @@ class MediaSummaryService:
                 age_range=age_range,
             )
 
-            audio_bytes = await self._call_gemini_tts(script, language)
+            audio_bytes = await self._call_tts(script, language)
 
-            storage_key = f"audio/{module_id}/{language}/summary.ogg"
+            storage_key = f"audio/{module_id}/{language}/summary.opus"
             storage_url = await self._storage.upload_bytes(
                 key=storage_key,
                 data=audio_bytes,
@@ -379,62 +379,37 @@ class MediaSummaryService:
         )
         return script_text.strip()
 
-    async def _call_gemini_tts(self, script: str, language: str) -> bytes:
-        """Call Cloud Text-to-Speech API with Gemini TTS model.
+    async def _call_tts(self, script: str, language: str) -> bytes:
+        """Call OpenAI TTS API to convert script to OGG Opus audio.
 
-        Returns MP3 bytes directly.
+        Uses gpt-4o-mini-tts model with opus output format.
         """
-        if not settings.google_api_key:
-            raise ValueError("GOOGLE_API_KEY is required for Gemini TTS")
+        from openai import AsyncOpenAI
 
-        import asyncio
+        client = AsyncOpenAI(api_key=settings.openai_api_key)
 
-        from google.api_core import client_options
-        from google.cloud import texttospeech
+        voice = "nova" if language == "fr" else "ash"
+        lang_label = "French" if language == "fr" else "English"
 
-        client = texttospeech.TextToSpeechClient(
-            client_options=client_options.ClientOptions(
-                api_key=settings.google_api_key,
-            ),
+        response = await client.audio.speech.create(
+            model="gpt-4o-mini-tts",
+            voice=voice,
+            input=script,
+            instructions=f"Speak in {lang_label} with a clear, warm, educational tone suitable for a learning platform.",
+            response_format="opus",
         )
 
-        voice_name = "Aoede" if language == "fr" else "Charon"
-        lang_code = "fr-FR" if language == "fr" else "en-US"
-
-        synthesis_input = texttospeech.SynthesisInput(
-            text=script,
-            prompt="Narrate the following in a clear, warm, educational tone",
-        )
-
-        voice = texttospeech.VoiceSelectionParams(
-            language_code=lang_code,
-            name=voice_name,
-            model_name="gemini-2.5-flash-lite-preview-tts",
-        )
-
-        audio_config = texttospeech.AudioConfig(
-            audio_encoding=texttospeech.AudioEncoding.OGG_OPUS,
-        )
-
-        loop = asyncio.get_running_loop()
-        response = await loop.run_in_executor(
-            None,
-            lambda: client.synthesize_speech(
-                input=synthesis_input, voice=voice, audio_config=audio_config
-            ),
-        )
-
-        ogg_bytes = response.audio_content
-        if not ogg_bytes:
-            raise ValueError("Gemini TTS returned empty audio")
+        audio_bytes = response.content
+        if not audio_bytes:
+            raise ValueError("OpenAI TTS returned empty audio")
 
         logger.info(
-            "Gemini TTS MP3 generated",
+            "OpenAI TTS audio generated",
             language=language,
-            voice=voice_name,
-            audio_size_bytes=len(ogg_bytes),
+            voice=voice,
+            audio_size_bytes=len(audio_bytes),
         )
-        return ogg_bytes
+        return audio_bytes
 
     def _estimate_duration(self, file_size_bytes: int) -> int:
         """Estimate audio duration from OGG Opus file size (~48kbps speech)."""

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "alembic>=1.18.4",
     "anthropic>=0.86.0",
-    "google-genai>=1.0.0",
+    "google-cloud-texttospeech>=2.29.0",
     "aiobotocore>=2.13.0",
     "botocore>=1.35.0",
     "asyncpg>=0.31.0",
@@ -35,6 +35,7 @@ dependencies = [
     "qrcode[pil]>=8.2",
     "resend>=2.26.0",
     "sentry-sdk[fastapi]>=2.19.0",
+    "google-cloud-texttospeech>=2.29.0",
 ]
 
 [dependency-groups]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,7 +6,6 @@ requires-python = ">=3.12"
 dependencies = [
     "alembic>=1.18.4",
     "anthropic>=0.86.0",
-    "google-cloud-texttospeech>=2.29.0",
     "aiobotocore>=2.13.0",
     "botocore>=1.35.0",
     "asyncpg>=0.31.0",

--- a/backend/tests/test_lesson_audio_service.py
+++ b/backend/tests/test_lesson_audio_service.py
@@ -41,10 +41,10 @@ class TestEstimateDuration:
     def test_minimum_duration_is_one(self):
         assert _estimate_duration(0) == 1
 
-    def test_wav_duration_estimate(self):
-        # WAV 24kHz 16-bit mono = 48000 bytes/sec
-        # 1 minute = 2880000 bytes + 44 header = 2880044
-        duration = _estimate_duration(2880044)
+    def test_ogg_opus_duration_estimate(self):
+        # OGG Opus speech ~48kbps = 6144 bytes/sec
+        # 1 minute = 368640 bytes
+        duration = _estimate_duration(368640)
         assert duration == 60
 
     def test_small_file(self):


### PR DESCRIPTION
## Summary
Replace Gemini TTS (requires GCP API activation) with OpenAI TTS (already configured).

- **Model**: `gpt-4o-mini-tts` 
- **Output**: Opus format (~6KB/s, web-optimized for 2G/3G)
- **Voices**: `nova` (FR), `ash` (EN)
- **Style**: via `instructions` param ("clear, warm, educational tone")
- **No new deps**: `openai` SDK already installed, `OPENAI_API_KEY` already deployed
- Removed `google-cloud-texttospeech` dependency

## Test plan
- [ ] Audio generates successfully (no API activation needed)
- [ ] File size ~300-500KB for 3-4 min speech (vs 8MB PCM)
- [ ] Audio plays in browser, time counter updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)