### PR TITLE
fix(audio): enum create_type, migration idempotency, tests, datetime (#1373)

### DIFF
--- a/backend/app/domain/services/lesson_audio_service.py
+++ b/backend/app/domain/services/lesson_audio_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 
 import structlog
 from sqlalchemy import select
@@ -103,7 +103,7 @@ class LessonAudioService:
             record.storage_url = storage_url
             record.duration_seconds = _estimate_duration(len(audio_bytes))
             record.file_size_bytes = len(audio_bytes)
-            record.generated_at = datetime.utcnow()
+            record.generated_at = datetime.now(UTC)
             await session.commit()
 
             logger.info(

--- a/backend/migrations/versions/056_create_generated_audio_table.py
+++ b/backend/migrations/versions/056_create_generated_audio_table.py
@@ -16,13 +16,23 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Create enum type only if it doesn't already exist (idempotent)
-    conn = op.get_bind()
-    row = conn.execute(sa.text("SELECT 1 FROM pg_type WHERE typname = 'audio_status_enum'"))
-    if not row.scalar():
-        sa.Enum("pending", "generating", "ready", "failed", name="audio_status_enum").create(conn)
+    # Create enum type (idempotent — safe for asyncpg and partial re-runs)
+    op.execute(
+        sa.text(
+            "DO $$ BEGIN "
+            "CREATE TYPE audio_status_enum AS ENUM "
+            "('pending', 'generating', 'ready', 'failed'); "
+            "EXCEPTION WHEN duplicate_object THEN NULL; "
+            "END $$"
+        )
+    )
     audio_status_enum = sa.Enum(
-        "pending", "generating", "ready", "failed", name="audio_status_enum", create_type=False
+        "pending",
+        "generating",
+        "ready",
+        "failed",
+        name="audio_status_enum",
+        create_type=False,
     )
 
     op.create_table(

--- a/backend/migrations/versions/056_create_generated_audio_table.py
+++ b/backend/migrations/versions/056_create_generated_audio_table.py
@@ -16,15 +16,16 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Create enum type (idempotent — safe for asyncpg and partial re-runs)
+    # Create enum type (idempotent — matches pattern from migration 048)
     op.execute(
-        sa.text(
-            "DO $$ BEGIN "
-            "CREATE TYPE audio_status_enum AS ENUM "
-            "('pending', 'generating', 'ready', 'failed'); "
-            "EXCEPTION WHEN duplicate_object THEN NULL; "
-            "END $$"
-        )
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'audio_status_enum') THEN
+                CREATE TYPE audio_status_enum AS ENUM ('pending', 'generating', 'ready', 'failed');
+            END IF;
+        END$$;
+        """
     )
     audio_status_enum = sa.Enum(
         "pending",

--- a/backend/tests/test_lesson_audio_api.py
+++ b/backend/tests/test_lesson_audio_api.py
@@ -1,0 +1,105 @@
+"""Unit tests for lesson audio API endpoints."""
+
+import uuid
+
+from httpx import AsyncClient
+
+from app.domain.models.generated_audio import GeneratedAudio
+
+
+class TestGetLessonAudio:
+    async def test_returns_audio_for_lesson(self, authenticated_client: AsyncClient, db_session):
+        audio = GeneratedAudio(
+            id=uuid.uuid4(),
+            lesson_id=uuid.uuid4(),
+            module_id=uuid.uuid4(),
+            unit_id="M01-U01",
+            language="en",
+            status="ready",
+            storage_key="audio/lessons/test/en/summary.mp3",
+            storage_url="https://minio.example.com/audio/test.mp3",
+            duration_seconds=180,
+            file_size_bytes=2880000,
+        )
+        db_session.add(audio)
+        await db_session.commit()
+        resp = await authenticated_client.get(f"/api/v1/audio/lesson/{audio.lesson_id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["audio"][0]["status"] == "ready"
+        assert data["audio"][0]["audio_url"] is not None
+
+    async def test_returns_404_for_unknown_lesson(self, authenticated_client: AsyncClient):
+        resp = await authenticated_client.get(f"/api/v1/audio/lesson/{uuid.uuid4()}")
+        assert resp.status_code == 404
+
+    async def test_pending_audio_has_no_url(self, authenticated_client: AsyncClient, db_session):
+        audio = GeneratedAudio(
+            id=uuid.uuid4(),
+            lesson_id=uuid.uuid4(),
+            module_id=uuid.uuid4(),
+            unit_id="M01-U02",
+            language="fr",
+            status="pending",
+        )
+        db_session.add(audio)
+        await db_session.commit()
+        resp = await authenticated_client.get(f"/api/v1/audio/lesson/{audio.lesson_id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["audio"][0]["status"] == "pending"
+        assert data["audio"][0]["audio_url"] is None
+
+
+class TestGetAudioStatus:
+    async def test_returns_status_for_audio(self, authenticated_client: AsyncClient, db_session):
+        audio = GeneratedAudio(
+            id=uuid.uuid4(),
+            lesson_id=uuid.uuid4(),
+            module_id=uuid.uuid4(),
+            unit_id="M01-U01",
+            language="en",
+            status="ready",
+            storage_key="audio/lessons/test/en/summary.mp3",
+            storage_url="https://minio.example.com/audio/test.mp3",
+            duration_seconds=180,
+            file_size_bytes=2880000,
+        )
+        db_session.add(audio)
+        await db_session.commit()
+        resp = await authenticated_client.get(f"/api/v1/audio/{audio.id}/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ready"
+        assert data["audio_url"] is not None
+
+    async def test_returns_404_for_unknown_audio(self, authenticated_client: AsyncClient):
+        resp = await authenticated_client.get(f"/api/v1/audio/{uuid.uuid4()}/status")
+        assert resp.status_code == 404
+
+
+class TestGetAudioData:
+    async def test_returns_404_when_not_ready(self, authenticated_client: AsyncClient, db_session):
+        audio = GeneratedAudio(
+            id=uuid.uuid4(),
+            lesson_id=uuid.uuid4(),
+            module_id=uuid.uuid4(),
+            unit_id="M01-U02",
+            language="fr",
+            status="pending",
+        )
+        db_session.add(audio)
+        await db_session.commit()
+        resp = await authenticated_client.get(
+            f"/api/v1/audio/{audio.id}/data",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 404
+
+    async def test_returns_404_for_unknown_audio(self, authenticated_client: AsyncClient):
+        resp = await authenticated_client.get(
+            f"/api/v1/audio/{uuid.uuid4()}/data",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- **Model**: `create_type=False` on `audio_status_enum` — prevents duplicate enum when Alembic imports metadata
- **Migration 056**: raw SQL `DO $$ BEGIN CREATE TYPE ... EXCEPTION` for asyncpg-safe idempotent enum creation
- **Tests**: `authenticated_client` instead of `client` — fixes "attached to a different loop" (DB session mismatch)
- **Service**: `datetime.utcnow()` → `datetime.now(UTC)` (deprecated in 3.12)

Closes #1373

## Test plan
- [ ] `uv run ruff check .` passes
- [ ] `uv run ruff format --check .` passes  
- [ ] `uv run pytest` — all 8 audio tests pass (were all failing before)
- [ ] Deploy succeeds (migration 056 runs without DuplicateObjectError)

🤖 Generated with [Claude Code](https://claude.com/claude-code)