### PR TITLE
fix(lint): resolve setState-in-effect errors blocking deploy

### DIFF
--- a/backend/app/domain/services/lesson_audio_service.py
+++ b/backend/app/domain/services/lesson_audio_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 
 import structlog
 from sqlalchemy import select
@@ -151,7 +151,7 @@ class LessonAudioService:
             record.storage_url = storage_url
             record.duration_seconds = _estimate_duration(len(audio_bytes))
             record.file_size_bytes = len(audio_bytes)
-            record.generated_at = datetime.utcnow()
+            record.generated_at = datetime.now(UTC)
             await session.commit()
 
             logger.info(

--- a/frontend/app/[locale]/admin/settings/page.tsx
+++ b/frontend/app/[locale]/admin/settings/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useMemo } from "react";
+import { redirect } from "next/navigation";
 import { useLocale } from "next-intl";
 import { SettingsClient } from "@/components/admin/settings-client";
 
@@ -21,22 +21,12 @@ function getRole(): string | null {
 }
 
 export default function AdminSettingsPage() {
-  const router = useRouter();
   const locale = useLocale();
-  const [allowed, setAllowed] = useState<boolean | null>(null);
+  const role = useMemo(() => getRole(), []);
 
-  useEffect(() => {
-    const role = getRole();
-    if (role === "admin") {
-      setAllowed(true);
-    } else {
-      setAllowed(false);
-      router.replace(`/${locale}/admin`);
-    }
-  }, [locale, router]);
-
-  if (allowed === null) return null;
-  if (!allowed) return null;
+  if (role !== "admin") {
+    redirect(`/${locale}/admin`);
+  }
 
   return <SettingsClient />;
 }

--- a/frontend/components/admin/admin-nav.tsx
+++ b/frontend/components/admin/admin-nav.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useTranslations, useLocale } from "next-intl";
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
 import { cn } from "@/lib/utils";
 
 function getRole(): string | null {
@@ -25,11 +25,7 @@ export function AdminNav() {
   const t = useTranslations("Admin");
   const locale = useLocale();
   const pathname = usePathname();
-  const [role, setRole] = useState<string | null>(null);
-
-  useEffect(() => {
-    setRole(getRole());
-  }, []);
+  const role = useMemo(() => getRole(), []);
 
   const allItems = [
     { href: `/${locale}/admin/users`, label: t("users.title"), adminOnly: false },


### PR DESCRIPTION
## Summary
- Fix 2 lint errors in admin-nav.tsx and settings/page.tsx that blocked the deploy pipeline
- Replace `useEffect` + `setState` with `useMemo` for synchronous role checks
- Use `redirect()` instead of `router.replace()` in settings page guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)