### PR TITLE
fix(middleware): bypass intl middleware for /api/* rewrite routes

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -36,6 +36,12 @@ function getToken(request: NextRequest): string | null {
 export default function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
+  // Let API routes pass through directly — they are proxied to the backend via
+  // Next.js rewrites in next.config.ts and must not be locale-prefixed.
+  if (pathname.startsWith("/api/")) {
+    return NextResponse.next();
+  }
+
   if (pathname === "/settings") {
     return NextResponse.redirect(new URL("/profile", request.url));
   }


### PR DESCRIPTION
## Summary
- Fix API rewrite regression: intl middleware was intercepting `/api/*` requests and adding locale prefixes
- `/api/*` routes now bypass middleware entirely via `NextResponse.next()` so they reach the Next.js rewrite that proxies to the backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)