### PR TITLE
feat(content): serve language-matched content instantly, generate country-targeted in background

### DIFF
--- a/backend/app/api/v1/schemas/content.py
+++ b/backend/app/api/v1/schemas/content.py
@@ -70,6 +70,10 @@ class LessonResponse(BaseModel):
     content: LessonContent = Field(..., description="Structured lesson content")
     generated_at: str = Field(..., description="Generation timestamp (ISO format)")
     cached: bool = Field(default=False, description="Whether content was retrieved from cache")
+    country_fallback: bool = Field(
+        default=False,
+        description="True when content is from a different country's cache; country-targeted version generating in background",
+    )
     source_image_refs: list[SourceImageRef] = Field(
         default_factory=list, description="Source images referenced by Claude in this lesson"
     )
@@ -236,6 +240,10 @@ class CaseStudyResponse(BaseModel):
     content: CaseStudyContent = Field(..., description="Structured case study content")
     generated_at: str = Field(..., description="Generation timestamp (ISO format)")
     cached: bool = Field(default=False, description="Whether content was retrieved from cache")
+    country_fallback: bool = Field(
+        default=False,
+        description="True when content is from a different country's cache; country-targeted version generating in background",
+    )
     unit_title: str | None = Field(None, description="Unit title for display")
     unit_description: str | None = Field(None, description="Unit description for display")
 

--- a/backend/app/api/v1/schemas/quiz.py
+++ b/backend/app/api/v1/schemas/quiz.py
@@ -47,6 +47,10 @@ class QuizResponse(BaseModel):
     content: QuizContent = Field(description="Quiz content and questions")
     generated_at: str = Field(description="ISO timestamp when quiz was generated")
     cached: bool = Field(description="True if retrieved from cache")
+    country_fallback: bool = Field(
+        default=False,
+        description="True when content is from a different country's cache; country-targeted version generating in background",
+    )
 
     class Config:
         json_schema_extra = {

--- a/backend/app/domain/services/lesson_service.py
+++ b/backend/app/domain/services/lesson_service.py
@@ -60,6 +60,7 @@ class LessonGenerationService:
         level: int,
         session: AsyncSession,
         force_regenerate: bool = False,
+        user_id: uuid.UUID | None = None,
     ) -> LessonResponse:
         """
         Get cached lesson or generate new one.
@@ -72,13 +73,14 @@ class LessonGenerationService:
             level: User's competency level (1-4)
             session: Database session
             force_regenerate: Force new generation even if cached
+            user_id: Optional user UUID for background task logging
 
         Returns:
             LessonResponse with generated or cached content
         """
         # Check for existing cached content first
         if not force_regenerate:
-            cached_lesson = await self._get_cached_lesson(
+            cached_lesson, is_fallback = await self._get_cached_lesson(
                 module_id, unit_id, language, country, level, session
             )
             if cached_lesson:
@@ -87,7 +89,20 @@ class LessonGenerationService:
                     module_id=str(module_id),
                     unit_id=unit_id,
                     language=language,
+                    country_fallback=is_fallback,
                 )
+                if is_fallback:
+                    from app.tasks.content_generation import generate_country_content_task
+
+                    generate_country_content_task.delay(
+                        module_id=str(module_id),
+                        unit_id=unit_id,
+                        content_type="lesson",
+                        language=language,
+                        level=level,
+                        country=country,
+                        user_id=str(user_id) if user_id else "",
+                    )
                 return cached_lesson
 
         # Get module information (eager-load course for prompt context)
@@ -126,6 +141,7 @@ class LessonGenerationService:
         country: str,
         level: int,
         session: AsyncSession,
+        user_id: uuid.UUID | None = None,
     ) -> AsyncGenerator[StreamingEvent, None]:
         """
         Stream lesson generation in real-time.
@@ -137,17 +153,30 @@ class LessonGenerationService:
             country: User's country code
             level: User's competency level (1-4)
             session: Database session
+            user_id: Optional user UUID for background task logging
 
         Yields:
             StreamingEvent objects for real-time updates
         """
         try:
             # Check cache first
-            cached_lesson = await self._get_cached_lesson(
+            cached_lesson, is_fallback = await self._get_cached_lesson(
                 module_id, unit_id, language, country, level, session
             )
 
             if cached_lesson:
+                if is_fallback:
+                    from app.tasks.content_generation import generate_country_content_task
+
+                    generate_country_content_task.delay(
+                        module_id=str(module_id),
+                        unit_id=unit_id,
+                        content_type="lesson",
+                        language=language,
+                        level=level,
+                        country=country,
+                        user_id=str(user_id) if user_id else "",
+                    )
                 yield StreamingEvent(event="complete", data=cached_lesson.model_dump())
                 return
 
@@ -293,8 +322,13 @@ class LessonGenerationService:
         country: str,
         level: int,
         session: AsyncSession,
-    ) -> LessonResponse | None:
-        """Check for existing cached lesson content."""
+    ) -> tuple[LessonResponse | None, bool]:
+        """Check for existing cached lesson content.
+
+        Returns:
+            Tuple of (LessonResponse | None, country_fallback: bool).
+            country_fallback is True when content is from a different country's cache.
+        """
         query = (
             select(GeneratedContent)
             .where(GeneratedContent.module_id == module_id)
@@ -308,6 +342,22 @@ class LessonGenerationService:
 
         result = await session.execute(query)
         cached_content = result.scalars().first()
+
+        if not cached_content:
+            fallback_query = (
+                select(GeneratedContent)
+                .where(GeneratedContent.module_id == module_id)
+                .where(GeneratedContent.content_type == "lesson")
+                .where(GeneratedContent.language == language)
+                .where(GeneratedContent.level == level)
+                .where(GeneratedContent.content["unit_id"].astext == unit_id)
+                .order_by(GeneratedContent.generated_at.desc())
+            )
+            fallback_result = await session.execute(fallback_query)
+            cached_content = fallback_result.scalars().first()
+            is_fallback = cached_content is not None
+        else:
+            is_fallback = False
 
         if cached_content:
             raw_refs = cached_content.content.get("source_image_refs", [])
@@ -343,10 +393,11 @@ class LessonGenerationService:
                 content=LessonContent(**cached_content.content),
                 generated_at=cached_content.generated_at.isoformat(),
                 cached=True,
+                country_fallback=is_fallback,
                 source_image_refs=source_image_refs,
-            )
+            ), is_fallback
 
-        return None
+        return None, False
 
     async def _generate_lesson_content(
         self,
@@ -777,6 +828,7 @@ class CaseStudyGenerationService:
         level: int,
         session: AsyncSession,
         force_regenerate: bool = False,
+        user_id: uuid.UUID | None = None,
     ) -> CaseStudyResponse:
         """
         Get cached case study or generate new one.
@@ -789,6 +841,7 @@ class CaseStudyGenerationService:
             level: User's competency level (1-4)
             session: Database session
             force_regenerate: Force new generation even if cached
+            user_id: Optional user UUID for background task logging
 
         Returns:
             CaseStudyResponse with generated or cached content
@@ -802,7 +855,7 @@ class CaseStudyGenerationService:
             raise ValueError(f"Module {module_id} not found")
 
         if not force_regenerate:
-            cached = await self._get_cached_case_study(
+            cached, is_fallback = await self._get_cached_case_study(
                 module_id, unit_id, language, country, level, session
             )
             if cached:
@@ -811,7 +864,20 @@ class CaseStudyGenerationService:
                     module_id=str(module_id),
                     unit_id=unit_id,
                     language=language,
+                    country_fallback=is_fallback,
                 )
+                if is_fallback:
+                    from app.tasks.content_generation import generate_country_content_task
+
+                    generate_country_content_task.delay(
+                        module_id=str(module_id),
+                        unit_id=unit_id,
+                        content_type="case",
+                        language=language,
+                        level=level,
+                        country=country,
+                        user_id=str(user_id) if user_id else "",
+                    )
                 unit = await self._resolve_unit(module, unit_id, session)
                 if unit:
                     cached.unit_title = unit.title_fr if language == "fr" else unit.title_en
@@ -845,6 +911,7 @@ class CaseStudyGenerationService:
         country: str,
         level: int,
         session: AsyncSession,
+        user_id: uuid.UUID | None = None,
     ) -> AsyncGenerator[StreamingEvent, None]:
         """
         Stream case study generation in real-time.
@@ -868,11 +935,23 @@ class CaseStudyGenerationService:
                 )
                 return
 
-            cached = await self._get_cached_case_study(
+            cached, is_fallback = await self._get_cached_case_study(
                 module_id, unit_id, language, country, level, session
             )
 
             if cached:
+                if is_fallback:
+                    from app.tasks.content_generation import generate_country_content_task
+
+                    generate_country_content_task.delay(
+                        module_id=str(module_id),
+                        unit_id=unit_id,
+                        content_type="case",
+                        language=language,
+                        level=level,
+                        country=country,
+                        user_id=str(user_id) if user_id else "",
+                    )
                 unit = await self._resolve_unit(module, unit_id, session)
                 if unit:
                     cached.unit_title = unit.title_fr if language == "fr" else unit.title_en
@@ -1009,8 +1088,13 @@ class CaseStudyGenerationService:
         country: str,
         level: int,
         session: AsyncSession,
-    ) -> CaseStudyResponse | None:
-        """Check for existing cached case study content."""
+    ) -> tuple[CaseStudyResponse | None, bool]:
+        """Check for existing cached case study content.
+
+        Returns:
+            Tuple of (CaseStudyResponse | None, country_fallback: bool).
+            country_fallback is True when content is from a different country's cache.
+        """
         query = (
             select(GeneratedContent)
             .where(GeneratedContent.module_id == module_id)
@@ -1025,6 +1109,22 @@ class CaseStudyGenerationService:
         result = await session.execute(query)
         cached_content = result.scalars().first()
 
+        if not cached_content:
+            fallback_query = (
+                select(GeneratedContent)
+                .where(GeneratedContent.module_id == module_id)
+                .where(GeneratedContent.content_type == "case")
+                .where(GeneratedContent.language == language)
+                .where(GeneratedContent.level == level)
+                .where(GeneratedContent.content["unit_id"].astext == unit_id)
+                .order_by(GeneratedContent.generated_at.desc())
+            )
+            fallback_result = await session.execute(fallback_query)
+            cached_content = fallback_result.scalars().first()
+            is_fallback = cached_content is not None
+        else:
+            is_fallback = False
+
         if cached_content:
             return CaseStudyResponse(
                 id=cached_content.id,
@@ -1036,9 +1136,10 @@ class CaseStudyGenerationService:
                 content=CaseStudyContent(**cached_content.content),
                 generated_at=cached_content.generated_at.isoformat(),
                 cached=True,
-            )
+                country_fallback=is_fallback,
+            ), is_fallback
 
-        return None
+        return None, False
 
     async def _generate_case_study_content(
         self,

--- a/backend/app/domain/services/quiz_service.py
+++ b/backend/app/domain/services/quiz_service.py
@@ -37,9 +37,10 @@ class QuizService:
         language: str,
         country: str,
         level: int,
-        num_questions: int,
-        session: AsyncSession,
+        num_questions: int = 10,
+        session: AsyncSession | None = None,
         force_regenerate: bool = False,
+        user_id: UUID | None = None,
     ) -> QuizResponse:
         """
         Get existing quiz from cache or generate new one using RAG + Claude API.
@@ -52,6 +53,7 @@ class QuizService:
             level: Learning level (1-4)
             num_questions: Number of questions to generate (5-15)
             session: Database session
+            user_id: Optional user UUID for background task logging
 
         Returns:
             QuizResponse with quiz content and metadata
@@ -62,6 +64,7 @@ class QuizService:
         """
         try:
             cached_quiz = None
+            is_fallback = False
             if not force_regenerate:
                 # Cache lookup: match all 6 fields that form the unique index
                 # Use .first() with ORDER BY as safety net for any legacy duplicates
@@ -81,13 +84,43 @@ class QuizService:
                 result = await session.execute(query)
                 cached_quiz = result.scalars().first()
 
+                if not cached_quiz:
+                    fallback_query = (
+                        select(GeneratedContent)
+                        .where(
+                            GeneratedContent.module_id == module_id,
+                            GeneratedContent.content_type == "quiz",
+                            GeneratedContent.language == language,
+                            GeneratedContent.level == level,
+                            GeneratedContent.content["unit_id"].astext == unit_id,
+                        )
+                        .order_by(GeneratedContent.generated_at.desc())
+                    )
+                    fallback_result = await session.execute(fallback_query)
+                    cached_quiz = fallback_result.scalars().first()
+                    is_fallback = cached_quiz is not None
+
             if cached_quiz:
                 logger.info(
                     "Retrieved quiz from cache",
                     quiz_id=str(cached_quiz.id),
                     module_id=str(module_id),
                     unit_id=unit_id,
+                    country_fallback=is_fallback,
                 )
+
+                if is_fallback:
+                    from app.tasks.content_generation import generate_country_content_task
+
+                    generate_country_content_task.delay(
+                        module_id=str(module_id),
+                        unit_id=unit_id,
+                        content_type="quiz",
+                        language=language,
+                        level=level,
+                        country=country,
+                        user_id=str(user_id) if user_id else "",
+                    )
 
                 return QuizResponse(
                     id=cached_quiz.id,
@@ -99,6 +132,7 @@ class QuizService:
                     content=QuizContent(**cached_quiz.content),
                     generated_at=cached_quiz.generated_at.isoformat(),
                     cached=True,
+                    country_fallback=is_fallback,
                 )
 
             # Generate new quiz using RAG + Claude

--- a/backend/app/domain/services/quiz_service.py
+++ b/backend/app/domain/services/quiz_service.py
@@ -38,7 +38,7 @@ class QuizService:
         country: str,
         level: int,
         num_questions: int = 10,
-        session: AsyncSession | None = None,
+        session: AsyncSession,
         force_regenerate: bool = False,
         user_id: UUID | None = None,
     ) -> QuizResponse:

--- a/backend/app/domain/services/quiz_service.py
+++ b/backend/app/domain/services/quiz_service.py
@@ -37,7 +37,7 @@ class QuizService:
         language: str,
         country: str,
         level: int,
-        num_questions: int = 10,
+        num_questions: int,
         session: AsyncSession,
         force_regenerate: bool = False,
         user_id: UUID | None = None,

--- a/backend/app/tasks/content_generation.py
+++ b/backend/app/tasks/content_generation.py
@@ -472,6 +472,185 @@ def generate_quiz_task(
 @celery_app.task(
     bind=True,
     base=CallbackTask,
+    soft_time_limit=360,
+    time_limit=400,
+    rate_limit="5/m",
+    priority=5,
+)
+def generate_country_content_task(
+    self,
+    module_id: str,
+    unit_id: str,
+    content_type: str,
+    language: str,
+    level: int,
+    country: str,
+    user_id: str,
+) -> dict:
+    """Generate country-targeted content in background after a country-fallback was served.
+
+    Args:
+        module_id: UUID of the module
+        unit_id: Unit identifier within the module
+        content_type: One of "lesson", "quiz", "case"
+        language: Content language (fr/en)
+        level: User competency level (1-4)
+        country: Target country code for generation
+        user_id: UUID of the requesting user (for logging)
+
+    Returns:
+        dict with status and content_id (or error)
+    """
+    import asyncio
+
+    from sqlalchemy import select
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+    from app.ai.claude_service import ClaudeService
+    from app.ai.rag.embeddings import EmbeddingService
+    from app.ai.rag.retriever import SemanticRetriever
+    from app.domain.models.content import GeneratedContent
+    from app.infrastructure.config.settings import settings
+
+    logger.info(
+        "Starting country-targeted background generation",
+        module_id=module_id,
+        unit_id=unit_id,
+        content_type=content_type,
+        language=language,
+        level=level,
+        country=country,
+        user_id=user_id,
+        task_id=self.request.id,
+    )
+
+    async def _run() -> dict:
+        engine = create_async_engine(settings.database_url, echo=False, pool_size=5, max_overflow=2)
+        session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        try:
+            async with session_factory() as session:
+                existing = await session.execute(
+                    select(GeneratedContent)
+                    .where(
+                        GeneratedContent.module_id == uuid.UUID(module_id),
+                        GeneratedContent.content_type == content_type,
+                        GeneratedContent.language == language,
+                        GeneratedContent.level == level,
+                        GeneratedContent.country_context == country,
+                        GeneratedContent.content["unit_id"].astext == unit_id,
+                    )
+                    .limit(1)
+                )
+                if existing.scalars().first():
+                    logger.info(
+                        "Country-targeted content already exists, skipping generation",
+                        module_id=module_id,
+                        unit_id=unit_id,
+                        content_type=content_type,
+                        language=language,
+                        level=level,
+                        country=country,
+                    )
+                    return {"status": "skipped", "reason": "already_exists"}
+
+                embedding_service = EmbeddingService(
+                    api_key=settings.openai_api_key, model=settings.embedding_model
+                )
+                retriever = SemanticRetriever(embedding_service)
+
+                if content_type == "lesson":
+                    from app.domain.services.lesson_service import LessonGenerationService
+
+                    service = LessonGenerationService(ClaudeService(), retriever)
+                    result_obj = await service.get_or_generate_lesson(
+                        module_id=uuid.UUID(module_id),
+                        unit_id=unit_id,
+                        language=language,
+                        country=country,
+                        level=level,
+                        session=session,
+                    )
+                    generate_lesson_audio.delay(str(result_obj.id))
+                    logger.info(
+                        "Country-targeted lesson ready",
+                        unit_id=unit_id,
+                        language=language,
+                        country=country,
+                        content_id=str(result_obj.id),
+                    )
+                    return {"status": "complete", "content_id": str(result_obj.id)}
+
+                elif content_type == "quiz":
+                    from app.domain.services.quiz_service import QuizService
+
+                    service = QuizService(ClaudeService(), retriever)
+                    result_obj = await service.get_or_generate_quiz(
+                        module_id=uuid.UUID(module_id),
+                        unit_id=unit_id,
+                        language=language,
+                        country=country,
+                        level=level,
+                        session=session,
+                    )
+                    logger.info(
+                        "Country-targeted quiz ready",
+                        unit_id=unit_id,
+                        language=language,
+                        country=country,
+                        content_id=str(result_obj.id),
+                    )
+                    return {"status": "complete", "content_id": str(result_obj.id)}
+
+                elif content_type == "case":
+                    from app.domain.services.lesson_service import CaseStudyGenerationService
+
+                    service = CaseStudyGenerationService(ClaudeService(), retriever)
+                    result_obj = await service.get_or_generate_case_study(
+                        module_id=uuid.UUID(module_id),
+                        unit_id=unit_id,
+                        language=language,
+                        country=country,
+                        level=level,
+                        session=session,
+                    )
+                    logger.info(
+                        "Country-targeted case study ready",
+                        unit_id=unit_id,
+                        language=language,
+                        country=country,
+                        content_id=str(result_obj.id),
+                    )
+                    return {"status": "complete", "content_id": str(result_obj.id)}
+
+                else:
+                    logger.warning(
+                        "Unknown content_type for country generation",
+                        content_type=content_type,
+                    )
+                    return {"status": "failed", "error": f"unknown content_type: {content_type}"}
+        finally:
+            await engine.dispose()
+
+    try:
+        result = asyncio.run(_run())
+        return result
+    except Exception as exc:
+        logger.error(
+            "Country-targeted background generation failed",
+            module_id=module_id,
+            unit_id=unit_id,
+            content_type=content_type,
+            language=language,
+            country=country,
+            exception=str(exc),
+            task_id=self.request.id,
+        )
+        return {"status": "failed", "error": str(exc)}
+
+
+@celery_app.task(
+    bind=True,
+    base=CallbackTask,
     soft_time_limit=POLL_SOFT_LIMIT,
     time_limit=POLL_HARD_LIMIT,
     rate_limit="5/m",

--- a/backend/app/tasks/content_generation.py
+++ b/backend/app/tasks/content_generation.py
@@ -570,7 +570,16 @@ def generate_country_content_task(
                         level=level,
                         session=session,
                     )
-                    generate_lesson_audio.delay(str(result_obj.id))
+                    lesson_text = ""
+                    if hasattr(result_obj, "content") and result_obj.content is not None:
+                        lesson_text = getattr(result_obj.content, "content", "") or ""
+                    generate_lesson_audio.delay(
+                        str(result_obj.id),
+                        module_id,
+                        unit_id,
+                        language,
+                        lesson_text,
+                    )
                     logger.info(
                         "Country-targeted lesson ready",
                         unit_id=unit_id,

--- a/backend/tests/test_lesson_query_builder.py
+++ b/backend/tests/test_lesson_query_builder.py
@@ -215,7 +215,7 @@ class TestGetCachedLesson:
         mock_result.scalars.return_value = mock_scalars
         session.execute = AsyncMock(return_value=mock_result)
 
-        result = await lesson_service._get_cached_lesson(
+        result, is_fallback = await lesson_service._get_cached_lesson(
             sample_module_id, "M01-U01", "fr", "SN", 1, session
         )
 
@@ -232,7 +232,7 @@ class TestGetCachedLesson:
         mock_result.scalars.return_value = mock_scalars
         session.execute = AsyncMock(return_value=mock_result)
 
-        result = await lesson_service._get_cached_lesson(
+        result, _ = await lesson_service._get_cached_lesson(
             sample_module_id, "M01-U02", "fr", "SN", 1, session
         )
 
@@ -258,10 +258,10 @@ class TestGetCachedLesson:
         session = AsyncMock(spec=AsyncSession)
         session.execute = AsyncMock(side_effect=[mock_result_u01, mock_result_u02])
 
-        result_u01 = await lesson_service._get_cached_lesson(
+        result_u01, _ = await lesson_service._get_cached_lesson(
             sample_module_id, "M01-U01", "fr", "SN", 1, session
         )
-        result_u02 = await lesson_service._get_cached_lesson(
+        result_u02, _ = await lesson_service._get_cached_lesson(
             sample_module_id, "M01-U02", "fr", "SN", 1, session
         )
 
@@ -283,7 +283,7 @@ class TestGetCachedLesson:
         mock_result.scalars.return_value = mock_scalars
         session.execute = AsyncMock(return_value=mock_result)
 
-        result = await lesson_service._get_cached_lesson(
+        result, _ = await lesson_service._get_cached_lesson(
             sample_module_id, "M01-U03", "fr", "SN", 1, session
         )
 
@@ -368,7 +368,7 @@ class TestGetCachedLessonSourceImageRefs:
 
         session.execute = AsyncMock(side_effect=[mock_first_result, mock_db_result])
 
-        result = await lesson_service._get_cached_lesson(
+        result, _ = await lesson_service._get_cached_lesson(
             sample_module_id, "M01-U01", "fr", "SN", 1, session
         )
 
@@ -429,7 +429,7 @@ class TestGetCachedLessonSourceImageRefs:
 
         session.execute = AsyncMock(side_effect=[mock_first_result, mock_db_result])
 
-        result = await lesson_service._get_cached_lesson(
+        result, _ = await lesson_service._get_cached_lesson(
             sample_module_id, "M01-U01", "fr", "SN", 1, session
         )
 

--- a/frontend/components/learning/case-study-viewer.tsx
+++ b/frontend/components/learning/case-study-viewer.tsx
@@ -58,6 +58,7 @@ interface CaseStudyData {
   country_context: string;
   content: CaseStudyContent;
   cached: boolean;
+  country_fallback?: boolean;
   unit_title?: string;
   unit_description?: string;
   generated_at?: string;
@@ -352,6 +353,11 @@ export function CaseStudyViewer({
             </div>
             {contentSource === 'indexeddb' && <OfflineBadge />}
             {caseStudyData.cached && contentSource !== 'indexeddb' && <Badge variant="secondary">{t('cached')}</Badge>}
+            {caseStudyData.country_fallback && (
+              <Badge variant="outline" className="text-amber-600 border-amber-300 bg-amber-50">
+                {t('countryFallback')}
+              </Badge>
+            )}
           </div>
           <Button
             variant="ghost"

--- a/frontend/components/learning/lesson-viewer.tsx
+++ b/frontend/components/learning/lesson-viewer.tsx
@@ -49,6 +49,7 @@ interface LessonData {
   country_context: string;
   content: LessonContent;
   cached: boolean;
+  country_fallback?: boolean;
   source_image_refs?: SourceImageMeta[];
 }
 
@@ -411,6 +412,11 @@ export function LessonViewer({
             {contentSource === 'indexeddb' && <OfflineBadge />}
             {lessonData.cached && contentSource !== 'indexeddb' && (
               <Badge variant="secondary">{t('cached')}</Badge>
+            )}
+            {lessonData.country_fallback && (
+              <Badge variant="outline" className="text-amber-600 border-amber-300 bg-amber-50">
+                {t('countryFallback')}
+              </Badge>
             )}
           </div>
           <Button

--- a/frontend/components/quiz/quiz-container.tsx
+++ b/frontend/components/quiz/quiz-container.tsx
@@ -355,6 +355,11 @@ export function QuizContainer({
                   {t('cached')}
                 </Badge>
               )}
+              {quiz.country_fallback && (
+                <Badge variant="outline" className="text-amber-600 border-amber-300 bg-amber-50">
+                  {t('countryFallback')}
+                </Badge>
+              )}
               <Badge variant="outline">
                 {language.toUpperCase()}
               </Badge>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -495,6 +495,7 @@ export interface Quiz {
   content: QuizContent;
   generated_at: string;
   cached: boolean;
+  country_fallback?: boolean;
 }
 
 export interface QuizAnswerSubmission {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -319,7 +319,8 @@
     "refreshContent": "Refresh content",
     "subscriptionRequired": "A subscription is required to access this content. The first unit of each module is free.",
     "authRequired": "Please sign in to continue.",
-    "contentNotAvailableOffline": "This quiz is not available offline. Download the module to take quizzes without internet."
+    "contentNotAvailableOffline": "This quiz is not available offline. Download the module to take quizzes without internet.",
+    "countryFallback": "Content optimized for your region will be available shortly"
   },
   "ChatTutor": {
     "title": "AI Tutor",
@@ -689,7 +690,8 @@
     "checkingStatus": "Checking...",
     "unitNotFound": "This unit does not exist in this module.",
     "backToModule": "Back to module",
-    "contentNotAvailableOffline": "This lesson is not available offline. Download the module to access it without internet."
+    "contentNotAvailableOffline": "This lesson is not available offline. Download the module to access it without internet.",
+    "countryFallback": "Content optimized for your region will be available shortly"
   },
   "LessonAudio": {
     "audioPending": "Generating audio summary...",
@@ -758,7 +760,8 @@
     "bloomLevel": "Bloom: {level}",
     "generatedOn": "Generated on {date}",
     "stretchBadge": "Stretch",
-    "contentNotAvailableOffline": "This case study is not available offline. Download the module to access it without internet."
+    "contentNotAvailableOffline": "This case study is not available offline. Download the module to access it without internet.",
+    "countryFallback": "Content optimized for your region will be available shortly"
   },
   "CaseStudyPage": {
     "backToModule": "Back to {module}",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -319,7 +319,8 @@
     "refreshContent": "Actualiser le contenu",
     "subscriptionRequired": "Un abonnement est requis pour accéder à ce contenu. La première unité de chaque module est gratuite.",
     "authRequired": "Veuillez vous connecter pour continuer.",
-    "contentNotAvailableOffline": "Ce quiz n'est pas disponible hors-ligne. Téléchargez le module pour le passer sans internet."
+    "contentNotAvailableOffline": "Ce quiz n'est pas disponible hors-ligne. Téléchargez le module pour le passer sans internet.",
+    "countryFallback": "Le contenu adapté à votre région sera disponible prochainement"
   },
   "ChatTutor": {
     "title": "Tuteur IA",
@@ -689,7 +690,8 @@
     "checkingStatus": "Vérification...",
     "unitNotFound": "Cette unité n'existe pas dans ce module.",
     "backToModule": "Retour au module",
-    "contentNotAvailableOffline": "Cette leçon n'est pas disponible hors-ligne. Téléchargez le module pour y accéder sans internet."
+    "contentNotAvailableOffline": "Cette leçon n'est pas disponible hors-ligne. Téléchargez le module pour y accéder sans internet.",
+    "countryFallback": "Le contenu adapté à votre région sera disponible prochainement"
   },
   "LessonAudio": {
     "audioPending": "Génération du résumé audio...",
@@ -758,7 +760,8 @@
     "bloomLevel": "Bloom : {level}",
     "generatedOn": "Généré le {date}",
     "stretchBadge": "Défi",
-    "contentNotAvailableOffline": "Cette étude de cas n'est pas disponible hors-ligne. Téléchargez le module pour y accéder sans internet."
+    "contentNotAvailableOffline": "Cette étude de cas n'est pas disponible hors-ligne. Téléchargez le module pour y accéder sans internet.",
+    "countryFallback": "Le contenu adapté à votre région sera disponible prochainement"
   },
   "CaseStudyPage": {
     "backToModule": "Retour à {module}",


### PR DESCRIPTION
## Summary

Implements the \"Serve Available, Upgrade in Background\" pattern from #1383.

When a learner opens a lesson, quiz, or case study and no exact cache match exists for their `(language, level, country)`, the system now:
1. **Immediately serves** cached content matching their language and level (regardless of country)
2. **Dispatches a background Celery task** to generate their country-targeted version
3. The country-specific content becomes available on the learner's **next navigation** — no auto-refresh

## Changes

- **`backend/app/api/v1/schemas/content.py`** — Added `country_fallback: bool = False` field to `LessonResponse` and `CaseStudyResponse`
- **`backend/app/api/v1/schemas/quiz.py`** — Added `country_fallback: bool = False` field to `QuizResponse`
- **`backend/app/domain/services/lesson_service.py`** — Added language/level fallback query in `_get_cached_lesson()` and `_get_cached_case_study()` (returns tuple `(response, is_fallback)`); dispatch background task on fallback in `get_or_generate_lesson()`, `stream_lesson_generation()`, `get_or_generate_case_study()`, `stream_case_study_generation()`; added optional `user_id` param
- **`backend/app/domain/services/quiz_service.py`** — Added fallback query in cache lookup; dispatch background task on fallback; added optional `user_id` param; `country_fallback` field in returned `QuizResponse`
- **`backend/app/tasks/content_generation.py`** — New `generate_country_content_task` Celery task with race-condition guard (skips if exact-match already exists), routes to lesson/quiz/case service, triggers TTS audio for lessons
- **`frontend/lib/api.ts`** — Added `country_fallback?: boolean` to `Quiz` interface
- **`frontend/components/learning/lesson-viewer.tsx`** — Added `country_fallback` to `LessonData` interface; subtle amber badge indicator (no auto-refresh)
- **`frontend/components/learning/case-study-viewer.tsx`** — Same for case studies
- **`frontend/components/quiz/quiz-container.tsx`** — Same for quizzes
- **`frontend/messages/en.json`** + **`frontend/messages/fr.json`** — Added `countryFallback` i18n keys for LessonViewer, CaseStudyViewer, Quiz namespaces

## Test plan

- [ ] Exact country match still served when available (no behavior change)
- [ ] When no exact match: fallback to same-language/level content from any country; `country_fallback: true` in response
- [ ] Amber indicator badge shown on lesson/quiz/case study when `country_fallback: true`
- [ ] No auto-refresh or polling triggered by fallback flag
- [ ] Background task `generate_country_content_task` generates country-targeted version
- [ ] Background task skips generation if exact-match already exists (race condition guard)
- [ ] If no content exists at all (any country), falls back to synchronous generation (unchanged behavior)
- [ ] Backend lint passes: `ruff check --fix .`
- [ ] Frontend lint passes: `npm run lint`

Closes #1383

Generated with [Claude Code](https://claude.ai/code)