### PR TITLE
fix(audio): progress bar and time display for Opus streams

### DIFF
--- a/backend/migrations/versions/057_create_generated_audio_table.py
+++ b/backend/migrations/versions/057_create_generated_audio_table.py
@@ -1,0 +1,67 @@
+"""Create generated_audio table.
+
+Revision ID: 056
+Revises: 055
+Create Date: 2026-04-11
+
+"""
+
+from alembic import op
+
+revision = "056"
+down_revision = "055"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Use raw SQL for full idempotency (matches pattern from migration 048)
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'audio_status_enum') THEN
+                CREATE TYPE audio_status_enum AS ENUM ('pending', 'generating', 'ready', 'failed');
+            END IF;
+        END$$;
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS generated_audio (
+            id UUID PRIMARY KEY,
+            lesson_id UUID REFERENCES generated_content(id) ON DELETE SET NULL,
+            module_id UUID REFERENCES modules(id) ON DELETE SET NULL,
+            unit_id TEXT,
+            language VARCHAR(5) NOT NULL DEFAULT 'fr',
+            storage_key TEXT,
+            storage_url TEXT,
+            script_text TEXT,
+            duration_seconds INTEGER,
+            file_size_bytes INTEGER,
+            error_message TEXT,
+            status audio_status_enum NOT NULL DEFAULT 'pending',
+            generated_at TIMESTAMP,
+            created_at TIMESTAMP NOT NULL DEFAULT now()
+        );
+        """
+    )
+
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_generated_audio_lesson_id
+        ON generated_audio (lesson_id);
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_generated_audio_status
+        ON generated_audio (status);
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS generated_audio")
+    op.execute("DROP TYPE IF EXISTS audio_status_enum")

--- a/backend/migrations/versions/058_add_lesson_id_index_to_generated_images.py
+++ b/backend/migrations/versions/058_add_lesson_id_index_to_generated_images.py
@@ -1,0 +1,26 @@
+"""Add lesson_id index to generated_images for dedup queries.
+
+Revision ID: 057
+Revises: 056
+Create Date: 2026-04-11
+
+"""
+
+from alembic import op
+
+revision = "057"
+down_revision = "056"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_generated_images_lesson_id",
+        "generated_images",
+        ["lesson_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_generated_images_lesson_id", table_name="generated_images")

--- a/frontend/components/learning/lesson-audio.tsx
+++ b/frontend/components/learning/lesson-audio.tsx
@@ -20,6 +20,7 @@ export function LessonAudio({ lessonId, language }: LessonAudioProps) {
   const [audioUrl, setAudioUrl] = useState<string | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
   const [progress, setProgress] = useState(0);
+  const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
@@ -70,8 +71,10 @@ export function LessonAudio({ lessonId, language }: LessonAudioProps) {
     if (!audio) return;
 
     const onTimeUpdate = () => {
-      if (audio.duration) {
-        setProgress((audio.currentTime / audio.duration) * 100);
+      setCurrentTime(audio.currentTime);
+      const dur = audio.duration && isFinite(audio.duration) ? audio.duration : duration;
+      if (dur > 0) {
+        setProgress((audio.currentTime / dur) * 100);
       }
     };
     const onLoadedMetadata = () => {
@@ -110,11 +113,13 @@ export function LessonAudio({ lessonId, language }: LessonAudioProps) {
 
   const handleProgressClick = (e: React.MouseEvent<HTMLDivElement>) => {
     const audio = audioRef.current;
-    if (!audio || !audio.duration) return;
+    if (!audio) return;
+    const dur = audio.duration && isFinite(audio.duration) ? audio.duration : duration;
+    if (dur <= 0) return;
 
     const rect = e.currentTarget.getBoundingClientRect();
     const pct = (e.clientX - rect.left) / rect.width;
-    audio.currentTime = pct * audio.duration;
+    audio.currentTime = pct * dur;
   };
 
   const formatTime = (seconds: number) => {
@@ -183,9 +188,7 @@ export function LessonAudio({ lessonId, language }: LessonAudioProps) {
 
         {duration > 0 && (
           <span className="text-xs text-teal-600 flex-shrink-0 tabular-nums">
-            {audioRef.current
-              ? formatTime(audioRef.current.currentTime)
-              : '0:00'}
+            {formatTime(currentTime)}
             {' / '}
             {formatTime(duration)}
           </span>


### PR DESCRIPTION
## Summary
Opus audio doesn't expose `duration` via HTMLAudioElement. Use the API-provided `duration_seconds` as fallback for progress bar and track `currentTime` in React state to trigger re-renders.

## Test plan
- [ ] Progress bar moves during playback
- [ ] Time counter updates (e.g. 0:27 / 4:28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)