### PR TITLE
fix(audio): show disabled state instead of hiding on failure

### DIFF
--- a/frontend/components/learning/lesson-audio.tsx
+++ b/frontend/components/learning/lesson-audio.tsx
@@ -129,7 +129,16 @@ export function LessonAudio({ lessonId, language }: LessonAudioProps) {
   };
 
   if (status === 'failed') {
-    return null;
+    return (
+      <div className="w-full max-w-xl mx-auto my-4">
+        <div className="flex items-center gap-3 bg-gray-50 border border-gray-200 rounded-lg px-4 py-3 opacity-60">
+          <div className="flex-shrink-0 w-10 h-10 flex items-center justify-center rounded-full bg-gray-300 text-gray-500 min-h-11 min-w-11">
+            <Volume2 className="w-4 h-4" />
+          </div>
+          <span className="text-sm text-gray-500">{t('audioUnavailable')}</span>
+        </div>
+      </div>
+    );
   }
 
   if (status !== 'ready' || !audioUrl) {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -695,7 +695,8 @@
     "audioPending": "Generating audio summary...",
     "play": "Play audio summary",
     "pause": "Pause audio summary",
-    "listenToSummary": "Listen to lesson summary"
+    "listenToSummary": "Listen to lesson summary",
+    "audioUnavailable": "Audio summary not available yet"
   },
   "LessonImage": {
     "imagePending": "Generating illustration...",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -695,7 +695,8 @@
     "audioPending": "Génération du résumé audio...",
     "play": "Écouter le résumé audio",
     "pause": "Mettre en pause le résumé audio",
-    "listenToSummary": "Écouter le résumé de la leçon"
+    "listenToSummary": "Écouter le résumé de la leçon",
+    "audioUnavailable": "Résumé audio pas encore disponible"
   },
   "LessonImage": {
     "imagePending": "Illustration en cours de génération...",


### PR DESCRIPTION
## Summary
Replace `return null` on failed audio status with a visible disabled player showing "Audio summary not available yet". The component no longer disappears.

## Test plan
- [ ] Lesson with failed/missing audio shows grayed-out player
- [ ] Lesson with ready audio plays normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)