### PR TITLE
fix(audio): naive datetime for generated_at

### DIFF
--- a/backend/app/domain/services/lesson_audio_service.py
+++ b/backend/app/domain/services/lesson_audio_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import datetime
 
 import structlog
 from sqlalchemy import select
@@ -218,7 +218,7 @@ class LessonAudioService:
             record.storage_url = storage_url
             record.duration_seconds = _estimate_duration(len(audio_bytes))
             record.file_size_bytes = len(audio_bytes)
-            record.generated_at = datetime.now(UTC)
+            record.generated_at = datetime.utcnow()
             await session.commit()
 
             logger.info(


### PR DESCRIPTION
Fix offset-naive/offset-aware datetime mismatch causing all audio generation to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)