### PR TITLE
feat(audio): cross-country audio fallback for instant playback

### DIFF
--- a/backend/app/api/v1/lesson_audio.py
+++ b/backend/app/api/v1/lesson_audio.py
@@ -62,19 +62,62 @@ async def get_lesson_audio(
     lesson_id: UUID,
     db: AsyncSession = Depends(get_db_session),
 ) -> LessonAudioListResponse:
-    """Return all audio files for a lesson with their generation status."""
+    """Return audio for a lesson, falling back to same lesson/language from another country."""
+    # 1. Try exact match by lesson_id
     result = await db.execute(select(GeneratedAudio).where(GeneratedAudio.lesson_id == lesson_id))
     db_audio = result.scalars().all()
 
-    if not db_audio:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "error": "lesson_audio_not_found",
-                "message": f"No audio found for lesson {lesson_id}",
-            },
-        )
+    if db_audio:
+        return _build_response(lesson_id, db_audio, fallback=False)
 
+    # 2. Fallback: find ready audio for same (module_id, unit_id, language)
+    #    from a different country's lesson
+    from app.domain.models.content import GeneratedContent
+
+    lesson_row = await db.execute(
+        select(
+            GeneratedContent.module_id,
+            GeneratedContent.language,
+            GeneratedContent.content["unit_id"].as_string().label("unit_id"),
+        ).where(GeneratedContent.id == lesson_id)
+    )
+    lesson_meta = lesson_row.first()
+
+    if lesson_meta:
+        fallback_result = await db.execute(
+            select(GeneratedAudio)
+            .where(
+                GeneratedAudio.module_id == lesson_meta.module_id,
+                GeneratedAudio.unit_id == lesson_meta.unit_id,
+                GeneratedAudio.language == lesson_meta.language,
+                GeneratedAudio.status == "ready",
+            )
+            .limit(1)
+        )
+        fallback_audio = fallback_result.scalars().all()
+
+        if fallback_audio:
+            logger.info(
+                "Serving cross-country audio fallback",
+                lesson_id=str(lesson_id),
+                fallback_audio_id=str(fallback_audio[0].id),
+            )
+            return _build_response(lesson_id, fallback_audio, fallback=True)
+
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail={
+            "error": "lesson_audio_not_found",
+            "message": f"No audio found for lesson {lesson_id}",
+        },
+    )
+
+
+def _build_response(
+    lesson_id: UUID,
+    db_audio: list[GeneratedAudio],
+    fallback: bool = False,
+) -> LessonAudioListResponse:
     audio_responses = []
     for aud in db_audio:
         aud_status: AudioStatus = aud.status
@@ -93,12 +136,14 @@ async def get_lesson_audio(
         "Lesson audio fetched",
         lesson_id=str(lesson_id),
         count=len(audio_responses),
+        fallback=fallback,
     )
 
     return LessonAudioListResponse(
         lesson_id=lesson_id,
         audio=audio_responses,
         total=len(audio_responses),
+        fallback=fallback,
     )
 
 

--- a/backend/app/api/v1/schemas/audio.py
+++ b/backend/app/api/v1/schemas/audio.py
@@ -28,6 +28,7 @@ class LessonAudioListResponse(BaseModel):
     lesson_id: UUID = Field(..., description="Lesson ID")
     audio: list[LessonAudioResponse] = Field(..., description="Audio files for the lesson")
     total: int = Field(..., description="Total number of audio files")
+    fallback: bool = Field(False, description="True if audio is from a different country context")
 
 
 class AudioStatusResponse(BaseModel):


### PR DESCRIPTION
## Summary
When no audio exists for the user's exact lesson, fall back to ready audio from the same (module, unit, language) but different country context. Eliminates the ~45s wait.

Closes #1413

## How it works
1. Query by exact `lesson_id` — if found, return it
2. If not found, look up lesson metadata (module_id, unit_id, language)
3. Query `generated_audio` for any `ready` audio matching that (module, unit, language)
4. Return with `fallback: true` flag

## Test plan
- [ ] User with no audio for their country gets instant playback from another country's audio
- [ ] Response includes `fallback: true`
- [ ] User with existing audio still gets their own (no fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)