### PR TITLE
refactor(audio): one audio per (module, unit, language) — ignore country

### DIFF
--- a/backend/app/api/v1/lesson_audio.py
+++ b/backend/app/api/v1/lesson_audio.py
@@ -62,18 +62,10 @@ async def get_lesson_audio(
     lesson_id: UUID,
     db: AsyncSession = Depends(get_db_session),
 ) -> LessonAudioListResponse:
-    """Return audio for a lesson, falling back to same lesson/language from another country."""
-    # 1. Try exact match by lesson_id
-    result = await db.execute(select(GeneratedAudio).where(GeneratedAudio.lesson_id == lesson_id))
-    db_audio = result.scalars().all()
-
-    if db_audio:
-        return _build_response(lesson_id, db_audio, fallback=False)
-
-    # 2. Fallback: find ready audio for same (module_id, unit_id, language)
-    #    from a different country's lesson
+    """Return audio for a lesson by (module_id, unit_id, language) — shared across countries."""
     from app.domain.models.content import GeneratedContent
 
+    # Look up lesson metadata to get module_id, unit_id, language
     lesson_row = await db.execute(
         select(
             GeneratedContent.module_id,
@@ -83,40 +75,37 @@ async def get_lesson_audio(
     )
     lesson_meta = lesson_row.first()
 
-    if lesson_meta:
-        fallback_result = await db.execute(
-            select(GeneratedAudio)
-            .where(
-                GeneratedAudio.module_id == lesson_meta.module_id,
-                GeneratedAudio.unit_id == lesson_meta.unit_id,
-                GeneratedAudio.language == lesson_meta.language,
-                GeneratedAudio.status == "ready",
-            )
-            .limit(1)
+    if not lesson_meta:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "lesson_not_found", "message": f"Lesson {lesson_id} not found"},
         )
-        fallback_audio = fallback_result.scalars().all()
 
-        if fallback_audio:
-            logger.info(
-                "Serving cross-country audio fallback",
-                lesson_id=str(lesson_id),
-                fallback_audio_id=str(fallback_audio[0].id),
-            )
-            return _build_response(lesson_id, fallback_audio, fallback=True)
-
-    raise HTTPException(
-        status_code=status.HTTP_404_NOT_FOUND,
-        detail={
-            "error": "lesson_audio_not_found",
-            "message": f"No audio found for lesson {lesson_id}",
-        },
+    # Query audio by (module_id, unit_id, language) — shared across all countries
+    result = await db.execute(
+        select(GeneratedAudio).where(
+            GeneratedAudio.module_id == lesson_meta.module_id,
+            GeneratedAudio.unit_id == lesson_meta.unit_id,
+            GeneratedAudio.language == lesson_meta.language,
+        )
     )
+    db_audio = result.scalars().all()
+
+    if not db_audio:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "error": "lesson_audio_not_found",
+                "message": f"No audio for lesson {lesson_id}",
+            },
+        )
+
+    return _build_response(lesson_id, db_audio)
 
 
 def _build_response(
     lesson_id: UUID,
     db_audio: list[GeneratedAudio],
-    fallback: bool = False,
 ) -> LessonAudioListResponse:
     audio_responses = []
     for aud in db_audio:
@@ -136,14 +125,12 @@ def _build_response(
         "Lesson audio fetched",
         lesson_id=str(lesson_id),
         count=len(audio_responses),
-        fallback=fallback,
     )
 
     return LessonAudioListResponse(
         lesson_id=lesson_id,
         audio=audio_responses,
         total=len(audio_responses),
-        fallback=fallback,
     )
 
 

--- a/backend/app/api/v1/schemas/audio.py
+++ b/backend/app/api/v1/schemas/audio.py
@@ -28,7 +28,6 @@ class LessonAudioListResponse(BaseModel):
     lesson_id: UUID = Field(..., description="Lesson ID")
     audio: list[LessonAudioResponse] = Field(..., description="Audio files for the lesson")
     total: int = Field(..., description="Total number of audio files")
-    fallback: bool = Field(False, description="True if audio is from a different country context")
 
 
 class AudioStatusResponse(BaseModel):

--- a/backend/app/domain/services/lesson_audio_service.py
+++ b/backend/app/domain/services/lesson_audio_service.py
@@ -19,35 +19,15 @@ from app.infrastructure.storage.s3 import S3StorageService
 
 logger = structlog.get_logger(__name__)
 
-# ECOWAS country codes → accent hints for TTS
-_COUNTRY_ACCENT: dict[str, str] = {
-    "SN": "Senegalese",
-    "CI": "Ivorian",
-    "GH": "Ghanaian",
-    "NG": "Nigerian",
-    "BF": "Burkinabè",
-    "ML": "Malian",
-    "GN": "Guinean",
-    "NE": "Nigerien",
-    "TG": "Togolese",
-    "BJ": "Beninese",
-    "SL": "Sierra Leonean",
-    "LR": "Liberian",
-    "GM": "Gambian",
-    "GW": "Bissau-Guinean",
-    "CV": "Cape Verdean",
-}
-
 
 def _build_tts_instructions(
     language: str,
     course_title: str | None = None,
     is_kids: bool = False,
     age_range: str = "",
-    country: str = "",
     level: int = 1,
 ) -> str:
-    """Build TTS style instructions from course/audience/country/level context."""
+    """Build TTS style instructions from course/audience/level context."""
     lang_label = "French" if language == "fr" else "English"
     domain = course_title or "general education"
 
@@ -66,11 +46,7 @@ def _build_tts_instructions(
     else:
         style = f"Speak in {lang_label} with a clear, warm, educational tone for a {domain} learning platform. {pace}"
 
-    # Country accent
-    accent = _COUNTRY_ACCENT.get(country.upper(), "West African") if country else "West African"
-    accent_hint = f"Use a {accent} {lang_label} accent and intonation."
-
-    return f"{style} {accent_hint}"
+    return style
 
 
 def _build_lesson_audio_system_prompt(
@@ -141,7 +117,7 @@ class LessonAudioService:
 
         Status transitions: pending → generating → ready | failed
         """
-        cached = await self._find_cached(lesson_id, language, session)
+        cached = await self._find_cached(module_id, unit_id, language, session)
         if cached is not None:
             logger.info("Returning cached lesson audio", lesson_id=str(lesson_id))
             return cached
@@ -167,7 +143,6 @@ class LessonAudioService:
             course_title = None
             is_kids = False
             age_range = ""
-            country = ""
             level = 1
             if module:
                 level = module.level or 1
@@ -181,9 +156,6 @@ class LessonAudioService:
                 is_kids = audience_ctx.is_kids
                 if is_kids:
                     age_range = f"{audience_ctx.age_min}-{audience_ctx.age_max}"
-
-            # Fetch country from the lesson's generated content
-            country = await self._fetch_lesson_country(lesson_id, session)
 
             script = await self._generate_script(
                 lesson_content=lesson_content,
@@ -201,11 +173,11 @@ class LessonAudioService:
                 course_title=course_title,
                 is_kids=is_kids,
                 age_range=age_range,
-                country=country,
                 level=level,
             )
 
-            storage_key = f"audio/lessons/{lesson_id}/{language}/summary.opus"
+            # Shared key: one audio per (module, unit, language)
+            storage_key = f"audio/{module_id}/{unit_id}/{language}/summary.opus"
             storage_url = await self._storage.upload_bytes(
                 key=storage_key,
                 data=audio_bytes,
@@ -244,27 +216,21 @@ class LessonAudioService:
 
     async def _find_cached(
         self,
-        lesson_id: uuid.UUID,
+        module_id: uuid.UUID,
+        unit_id: str,
         language: str,
         session: AsyncSession,
     ) -> GeneratedAudio | None:
+        """Find existing ready audio by (module, unit, language) — shared across countries."""
         result = await session.execute(
             select(GeneratedAudio).where(
-                GeneratedAudio.lesson_id == lesson_id,
+                GeneratedAudio.module_id == module_id,
+                GeneratedAudio.unit_id == unit_id,
                 GeneratedAudio.language == language,
                 GeneratedAudio.status == "ready",
             )
         )
         return result.scalar_one_or_none()
-
-    async def _fetch_lesson_country(self, lesson_id: uuid.UUID, session: AsyncSession) -> str:
-        """Get country_context from the GeneratedContent record."""
-        from app.domain.models.content import GeneratedContent
-
-        result = await session.execute(
-            select(GeneratedContent.country_context).where(GeneratedContent.id == lesson_id)
-        )
-        return result.scalar_one_or_none() or ""
 
     async def _fetch_module(self, module_id: uuid.UUID, session: AsyncSession) -> Module | None:
         result = await session.execute(
@@ -323,13 +289,12 @@ class LessonAudioService:
         course_title: str | None = None,
         is_kids: bool = False,
         age_range: str = "",
-        country: str = "",
         level: int = 1,
     ) -> bytes:
         """Call OpenAI TTS API to convert script to OGG Opus audio.
 
         Uses gpt-4o-mini-tts model with opus output format.
-        Style instructions adapt to course domain, audience, level, and country accent.
+        Style instructions adapt to course domain, audience, and level.
         """
         from openai import AsyncOpenAI
 
@@ -343,7 +308,6 @@ class LessonAudioService:
             is_kids=is_kids,
             age_range=age_range,
             level=level,
-            country=country,
         )
 
         response = await client.audio.speech.create(
@@ -362,7 +326,6 @@ class LessonAudioService:
             "OpenAI TTS audio generated for lesson",
             language=language,
             voice=voice,
-            country=country,
             audio_size_bytes=len(audio_bytes),
         )
         return audio_bytes

--- a/backend/app/domain/services/lesson_service.py
+++ b/backend/app/domain/services/lesson_service.py
@@ -787,19 +787,39 @@ class LessonGenerationService:
             )
 
         try:
-            from app.tasks.content_generation import generate_lesson_audio
+            # Audio is shared per (module, unit, language) — skip if one already exists
+            from app.domain.models.generated_audio import GeneratedAudio
 
-            generate_lesson_audio.delay(
-                str(cached_content.id),
-                str(cached_content.module_id),
-                lesson_response.unit_id,
-                lesson_response.language,
-                lesson_text[:4000],
+            existing_audio = await session.execute(
+                select(GeneratedAudio)
+                .where(
+                    GeneratedAudio.module_id == cached_content.module_id,
+                    GeneratedAudio.unit_id == lesson_response.unit_id,
+                    GeneratedAudio.language == lesson_response.language,
+                )
+                .limit(1)
             )
-            logger.info(
-                "Dispatched audio generation task",
-                lesson_id=str(cached_content.id),
-            )
+            if existing_audio.scalar_one_or_none() is not None:
+                logger.info(
+                    "Audio already exists for (module, unit, language) — skipping dispatch",
+                    module_id=str(cached_content.module_id),
+                    unit_id=lesson_response.unit_id,
+                    language=lesson_response.language,
+                )
+            else:
+                from app.tasks.content_generation import generate_lesson_audio
+
+                generate_lesson_audio.delay(
+                    str(cached_content.id),
+                    str(cached_content.module_id),
+                    lesson_response.unit_id,
+                    lesson_response.language,
+                    lesson_text[:4000],
+                )
+                logger.info(
+                    "Dispatched audio generation task",
+                    lesson_id=str(cached_content.id),
+                )
         except Exception as exc:
             logger.warning(
                 "Failed to dispatch audio generation task",


### PR DESCRIPTION
## Summary
Audio is now shared across countries for the same lesson/language. Eliminates duplicate generation.

Closes #1415

- Lookup by `(module_id, unit_id, language)` instead of `lesson_id`
- Skip Celery dispatch if audio already exists for `(module, unit, language)`
- Remove country accent from TTS instructions
- Storage key: `audio/{module_id}/{unit_id}/{language}/summary.opus`
- Removed `_COUNTRY_ACCENT` map and `_fetch_lesson_country`

## Test plan
- [ ] First country generates audio, second country reuses it instantly
- [ ] No duplicate Celery tasks dispatched
- [ ] Both EN and FR audio shared across countries

🤖 Generated with [Claude Code](https://claude.com/claude-code)