### PR TITLE
fix: make /courses catalog the public landing page

### DIFF
--- a/frontend/app/[locale]/(app)/courses/[courseSlug]/page.tsx
+++ b/frontend/app/[locale]/(app)/courses/[courseSlug]/page.tsx
@@ -145,6 +145,12 @@ export default function CourseDetailPage() {
 
   const handleEnroll = async () => {
     if (!course) return;
+    // Redirect unauthenticated users to login
+    const token = typeof window !== "undefined" ? localStorage.getItem("access_token") : null;
+    if (!token) {
+      router.push(`/login?redirect=/courses/${courseSlug}`);
+      return;
+    }
     setEnrolling(true);
     try {
       await enrollInCourse(course.id);

--- a/frontend/app/[locale]/page.tsx
+++ b/frontend/app/[locale]/page.tsx
@@ -2,5 +2,5 @@ import { redirect } from '@/i18n/routing';
 
 export default async function RootPage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
-  redirect({ href: '/dashboard', locale });
+  redirect({ href: '/courses', locale });
 }

--- a/frontend/components/shared/auth-guard.tsx
+++ b/frontend/components/shared/auth-guard.tsx
@@ -23,6 +23,16 @@ function isTokenExpired(token: string): boolean {
   }
 }
 
+/** Routes inside the (app) layout that should be accessible without authentication. */
+const PUBLIC_APP_PATHS = [
+  /^\/[a-z]{2}\/courses$/,
+  /^\/[a-z]{2}\/courses\/[^/]+$/,
+];
+
+function isPublicAppPath(pathname: string): boolean {
+  return PUBLIC_APP_PATHS.some((p) => p.test(pathname));
+}
+
 export function AuthGuard({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const locale = useLocale();
@@ -30,6 +40,12 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
   const [authorized, setAuthorized] = useState(false);
 
   useEffect(() => {
+    // Allow public routes through without authentication
+    if (isPublicAppPath(pathname)) {
+      startTransition(() => setAuthorized(true));
+      return;
+    }
+
     const token = getStoredToken();
     if (!token || isTokenExpired(token)) {
       localStorage.removeItem("access_token");

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -36,6 +36,15 @@ function getToken(request: NextRequest): string | null {
 export default function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
+  // Auth-aware root redirect: authenticated → /dashboard, anonymous → /courses
+  const localeRootMatch = pathname.match(/^\/(fr|en)$/);
+  if (localeRootMatch || pathname === "/") {
+    const token = getToken(request);
+    const locale = localeRootMatch ? localeRootMatch[1] : "fr";
+    const dest = token ? `/${locale}/dashboard` : `/${locale}/courses`;
+    return NextResponse.redirect(new URL(dest, request.url));
+  }
+
   if (pathname === "/settings") {
     return NextResponse.redirect(new URL("/profile", request.url));
   }


### PR DESCRIPTION
## Summary
- Unauthenticated visitors now land on `/courses` instead of being bounced to `/login`
- Authenticated users still land on `/dashboard`
- `/courses` and `/courses/[slug]` fully accessible without login
- Enroll button redirects unauthenticated users to `/login` with return URL

Closes #1418

## Test plan
- [ ] Visit `/` in incognito → lands on `/fr/courses`
- [ ] Browse `/fr/courses` without login → catalog loads, no redirect
- [ ] Click a course → detail page loads
- [ ] Click enroll without login → redirected to `/fr/login?redirect=/courses/{slug}`
- [ ] Visit `/` while logged in → lands on `/fr/dashboard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)