### PR TITLE
fix(offline): prevent cross-module content collision in IndexedDB

### DIFF
--- a/frontend/lib/offline/content-loader.ts
+++ b/frontend/lib/offline/content-loader.ts
@@ -31,7 +31,7 @@ async function loadContent<T>(
 
   // Offline: only check IndexedDB
   if (!isOnline) {
-    const cached = await getOfflineContentWithFallback(unitId, contentType, locale);
+    const cached = await getOfflineContentWithFallback(moduleId, unitId, contentType, locale);
     if (cached) {
       return { data: cached.content as T, source: 'indexeddb' };
     }
@@ -56,7 +56,7 @@ async function loadContent<T>(
   } catch (err: unknown) {
     // On network error, fall back to IndexedDB
     if (isNetworkError(err)) {
-      const cached = await getOfflineContentWithFallback(unitId, contentType, locale);
+      const cached = await getOfflineContentWithFallback(moduleId, unitId, contentType, locale);
       if (cached) {
         return { data: cached.content as T, source: 'indexeddb' };
       }
@@ -119,7 +119,7 @@ export async function loadQuiz<T>(
 
   // Offline: only check IndexedDB
   if (!isOnline) {
-    const cached = await getOfflineContentWithFallback(unitId, 'quiz', idbLocale);
+    const cached = await getOfflineContentWithFallback(moduleId, unitId, 'quiz', idbLocale);
     if (cached) {
       return { data: cached.content as T, source: 'indexeddb' };
     }
@@ -154,7 +154,7 @@ export async function loadQuiz<T>(
     return { data, source: 'api' };
   } catch (err: unknown) {
     if (isNetworkError(err)) {
-      const cached = await getOfflineContentWithFallback(unitId, 'quiz', idbLocale);
+      const cached = await getOfflineContentWithFallback(moduleId, unitId, 'quiz', idbLocale);
       if (cached) {
         return { data: cached.content as T, source: 'indexeddb' };
       }
@@ -211,16 +211,17 @@ function normalizeUnitId(unitId: string): string | null {
  * format (M01-U05 → 1.5) to handle the URL vs API format mismatch.
  */
 async function getOfflineContentWithFallback(
+  moduleId: string,
   unitId: string,
   contentType: ContentType,
   locale: 'fr' | 'en',
 ) {
-  const cached = await getOfflineContent(unitId, contentType, locale);
+  const cached = await getOfflineContent(moduleId, unitId, contentType, locale);
   if (cached) return cached;
 
   const normalized = normalizeUnitId(unitId);
   if (normalized && normalized !== unitId) {
-    return getOfflineContent(normalized, contentType, locale);
+    return getOfflineContent(moduleId, normalized, contentType, locale);
   }
   return undefined;
 }

--- a/frontend/lib/offline/db.ts
+++ b/frontend/lib/offline/db.ts
@@ -51,7 +51,7 @@ interface SantePubliqueDB extends DBSchema {
     indexes: { by_status: ModuleDownloadStatus };
   };
   offline_content: {
-    key: [string, string, string]; // [unitId, contentType, locale]
+    key: [string, string, string, string]; // [moduleId, unitId, contentType, locale]
     value: OfflineContent;
     indexes: {
       by_module: string;
@@ -67,7 +67,7 @@ interface SantePubliqueDB extends DBSchema {
 }
 
 const DB_NAME = "santepublique-offline";
-const DB_VERSION = 3;
+const DB_VERSION = 4;
 
 let dbInstance: IDBPDatabase<SantePubliqueDB> | null = null;
 
@@ -90,20 +90,8 @@ export async function getDB(): Promise<IDBPDatabase<SantePubliqueDB>> {
         actionsStore.createIndex("by_synced", "synced");
       }
 
-      // V3: recreate offline_content with triple composite key + fix actions synced type
+      // V3: fix actions synced type (boolean → number)
       if (oldVersion < 3) {
-        // Recreate offline_content with [unitId, contentType, locale] key
-        if (db.objectStoreNames.contains("offline_content")) {
-          db.deleteObjectStore("offline_content");
-        }
-        const contentStore = db.createObjectStore("offline_content", {
-          keyPath: ["unitId", "contentType", "locale"],
-        });
-        contentStore.createIndex("by_module", "moduleId");
-        contentStore.createIndex("by_content_type", "contentType");
-        contentStore.createIndex("by_unit", "unitId");
-
-        // Migrate offline_actions: convert boolean synced to number
         if (oldVersion >= 1) {
           const actionsStore = transaction.objectStore("offline_actions");
           actionsStore.openCursor().then(function migrateCursor(cursor) {
@@ -115,6 +103,20 @@ export async function getDB(): Promise<IDBPDatabase<SantePubliqueDB>> {
             cursor.continue().then(migrateCursor);
           });
         }
+      }
+
+      // V4: recreate offline_content with moduleId in key to prevent cross-module collisions
+      // Key: [moduleId, unitId, contentType, locale]
+      if (oldVersion < 4) {
+        if (db.objectStoreNames.contains("offline_content")) {
+          db.deleteObjectStore("offline_content");
+        }
+        const contentStore = db.createObjectStore("offline_content", {
+          keyPath: ["moduleId", "unitId", "contentType", "locale"],
+        });
+        contentStore.createIndex("by_module", "moduleId");
+        contentStore.createIndex("by_content_type", "contentType");
+        contentStore.createIndex("by_unit", "unitId");
       }
     },
   });
@@ -153,12 +155,13 @@ export async function getOfflineModulesByStatus(
 // --- Offline Content ---
 
 export async function getOfflineContent(
+  moduleId: string,
   unitId: string,
   contentType: ContentType,
   locale: "fr" | "en"
 ): Promise<OfflineContent | undefined> {
   const db = await getDB();
-  return db.get("offline_content", [unitId, contentType, locale]);
+  return db.get("offline_content", [moduleId, unitId, contentType, locale]);
 }
 
 export async function upsertOfflineContent(


### PR DESCRIPTION
CRITICAL: units with same unit_number from different modules overwrote each other. Added moduleId to IndexedDB key. DB v3→v4 migration.