### PR TITLE
feat(model): Organizations + members tables + migration

### DIFF
--- a/backend/app/domain/models/__init__.py
+++ b/backend/app/domain/models/__init__.py
@@ -17,6 +17,7 @@ from app.domain.models.lesson_reading import LessonReading
 from app.domain.models.module import Module
 from app.domain.models.module_media import MediaStatus, MediaType, ModuleMedia
 from app.domain.models.module_unit import ModuleUnit
+from app.domain.models.organization import Organization, OrganizationMember, OrgMemberRole
 from app.domain.models.preassessment import CoursePreAssessment
 from app.domain.models.progress import UserModuleProgress
 from app.domain.models.quiz import PlacementTestAttempt, QuizAttempt, SummativeAssessmentAttempt
@@ -64,6 +65,9 @@ __all__ = [
     "Module",
     "ModuleMedia",
     "ModuleUnit",
+    "OrgMemberRole",
+    "Organization",
+    "OrganizationMember",
     "PlacementTestAttempt",
     "QuizAttempt",
     "RefreshToken",

--- a/backend/app/domain/models/credit.py
+++ b/backend/app/domain/models/credit.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     String,
     Text,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -24,6 +25,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.domain.models.base import Base
 
 if TYPE_CHECKING:
+    from app.domain.models.organization import Organization
     from app.domain.models.user import User
 
 
@@ -44,10 +46,27 @@ class TransactionType(enum.StrEnum):
 
 class CreditAccount(Base):
     __tablename__ = "credit_accounts"
+    __table_args__ = (
+        Index(
+            "ix_credit_accounts_user_id_unique",
+            "user_id",
+            unique=True,
+            postgresql_where=text("user_id IS NOT NULL"),
+        ),
+        Index(
+            "ix_credit_accounts_organization_id_unique",
+            "organization_id",
+            unique=True,
+            postgresql_where=text("organization_id IS NOT NULL"),
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
-    user_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("users.id", ondelete="CASCADE"), unique=True, index=True
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=True, index=True
+    )
+    organization_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("organizations.id", ondelete="CASCADE"), nullable=True, index=True
     )
     balance: Mapped[int] = mapped_column(BIGINT, server_default="0", default=0)
     total_purchased: Mapped[int] = mapped_column(BIGINT, server_default="0", default=0)
@@ -59,7 +78,8 @@ class CreditAccount(Base):
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
 
-    user: Mapped[User] = relationship(back_populates="credit_account")
+    user: Mapped[User | None] = relationship(back_populates="credit_account")
+    organization: Mapped[Organization | None] = relationship(foreign_keys=[organization_id])
     transactions: Mapped[list[CreditTransaction]] = relationship(
         back_populates="account", order_by="CreditTransaction.created_at.desc()"
     )

--- a/backend/app/domain/models/organization.py
+++ b/backend/app/domain/models/organization.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.domain.models.base import Base
+
+if TYPE_CHECKING:
+    from app.domain.models.credit import CreditAccount
+    from app.domain.models.user import User
+    from app.domain.models.user_group import UserGroup
+
+
+class OrgMemberRole(enum.StrEnum):
+    owner = "owner"
+    admin = "admin"
+    viewer = "viewer"
+
+
+class Organization(Base):
+    __tablename__ = "organizations"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    slug: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    logo_url: Mapped[str | None] = mapped_column(String, nullable=True)
+    contact_email: Mapped[str | None] = mapped_column(String, nullable=True)
+    credit_account_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("credit_accounts.id", ondelete="SET NULL"), nullable=True
+    )
+    user_group_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("user_groups.id", ondelete="SET NULL"), nullable=True
+    )
+    is_active: Mapped[bool] = mapped_column(Boolean, server_default="true", default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    credit_account: Mapped[CreditAccount | None] = relationship(foreign_keys=[credit_account_id])
+    user_group: Mapped[UserGroup | None] = relationship(foreign_keys=[user_group_id])
+    members: Mapped[list[OrganizationMember]] = relationship(
+        back_populates="organization", cascade="all, delete-orphan"
+    )
+
+
+class OrganizationMember(Base):
+    __tablename__ = "organization_members"
+    __table_args__ = (
+        UniqueConstraint("organization_id", "user_id", name="uq_org_member"),
+        Index("ix_org_members_user_id", "user_id"),
+    )
+
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("organizations.id", ondelete="CASCADE"), primary_key=True
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    role: Mapped[OrgMemberRole] = mapped_column(
+        Enum(OrgMemberRole, name="orgmemberrole"), nullable=False
+    )
+    invited_by: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    joined_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    organization: Mapped[Organization] = relationship(back_populates="members")
+    user: Mapped[User] = relationship(foreign_keys=[user_id])
+    inviter: Mapped[User | None] = relationship(foreign_keys=[invited_by])

--- a/backend/migrations/versions/060_create_organizations_tables.py
+++ b/backend/migrations/versions/060_create_organizations_tables.py
@@ -1,0 +1,162 @@
+"""Create organizations and organization_members tables, extend credit_accounts.
+
+Revision ID: 060
+Revises: 059
+Create Date: 2026-04-13
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "060"
+down_revision = "059"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # --- Create orgmemberrole enum ---
+    orgmemberrole = sa.Enum("owner", "admin", "viewer", name="orgmemberrole")
+    orgmemberrole.create(op.get_bind(), checkfirst=True)
+
+    # --- Create organizations table ---
+    op.create_table(
+        "organizations",
+        sa.Column("id", sa.Uuid(), nullable=False, default=sa.text("gen_random_uuid()")),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("slug", sa.String(255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("logo_url", sa.String(), nullable=True),
+        sa.Column("contact_email", sa.String(), nullable=True),
+        sa.Column("credit_account_id", sa.Uuid(), nullable=True),
+        sa.Column("user_group_id", sa.Uuid(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), server_default="true", nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("slug"),
+        sa.ForeignKeyConstraint(
+            ["credit_account_id"],
+            ["credit_accounts.id"],
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_group_id"],
+            ["user_groups.id"],
+            ondelete="SET NULL",
+        ),
+    )
+    op.create_index("ix_organizations_slug", "organizations", ["slug"])
+
+    # --- Create organization_members table ---
+    op.create_table(
+        "organization_members",
+        sa.Column("organization_id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("role", orgmemberrole, nullable=False),
+        sa.Column("invited_by", sa.Uuid(), nullable=True),
+        sa.Column(
+            "joined_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("organization_id", "user_id"),
+        sa.ForeignKeyConstraint(
+            ["organization_id"],
+            ["organizations.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["invited_by"],
+            ["users.id"],
+            ondelete="SET NULL",
+        ),
+        sa.UniqueConstraint("organization_id", "user_id", name="uq_org_member"),
+    )
+    op.create_index("ix_org_members_user_id", "organization_members", ["user_id"])
+
+    # --- Extend credit_accounts: add organization_id, make user_id nullable ---
+    # Drop the existing unique constraint on user_id
+    op.drop_constraint("credit_accounts_user_id_key", "credit_accounts", type_="unique")
+
+    # Make user_id nullable
+    op.alter_column("credit_accounts", "user_id", existing_type=sa.Uuid(), nullable=True)
+
+    # Add organization_id column
+    op.add_column(
+        "credit_accounts",
+        sa.Column("organization_id", sa.Uuid(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_credit_accounts_organization_id",
+        "credit_accounts",
+        "organizations",
+        ["organization_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_index(
+        "ix_credit_accounts_organization_id",
+        "credit_accounts",
+        ["organization_id"],
+    )
+
+    # Add partial unique indexes (replacing the old simple unique)
+    op.execute(
+        "CREATE UNIQUE INDEX ix_credit_accounts_user_id_unique "
+        "ON credit_accounts (user_id) WHERE user_id IS NOT NULL"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX ix_credit_accounts_organization_id_unique "
+        "ON credit_accounts (organization_id) WHERE organization_id IS NOT NULL"
+    )
+
+    # Add CHECK: exactly one of user_id or organization_id must be set
+    op.execute(
+        "ALTER TABLE credit_accounts ADD CONSTRAINT ck_credit_accounts_owner_xor "
+        "CHECK ((user_id IS NOT NULL) != (organization_id IS NOT NULL))"
+    )
+
+
+def downgrade() -> None:
+    # Remove CHECK constraint
+    op.execute("ALTER TABLE credit_accounts DROP CONSTRAINT IF EXISTS ck_credit_accounts_owner_xor")
+
+    # Remove partial unique indexes
+    op.execute("DROP INDEX IF EXISTS ix_credit_accounts_organization_id_unique")
+    op.execute("DROP INDEX IF EXISTS ix_credit_accounts_user_id_unique")
+
+    # Remove organization_id column
+    op.drop_index("ix_credit_accounts_organization_id", "credit_accounts")
+    op.drop_constraint("fk_credit_accounts_organization_id", "credit_accounts", type_="foreignkey")
+    op.drop_column("credit_accounts", "organization_id")
+
+    # Make user_id non-nullable again
+    op.alter_column("credit_accounts", "user_id", existing_type=sa.Uuid(), nullable=False)
+
+    # Restore unique constraint on user_id
+    op.create_unique_constraint("credit_accounts_user_id_key", "credit_accounts", ["user_id"])
+
+    # Drop tables
+    op.drop_table("organization_members")
+    op.drop_table("organizations")
+
+    # Drop enum
+    sa.Enum(name="orgmemberrole").drop(op.get_bind(), checkfirst=True)


### PR DESCRIPTION
## Summary
- Create `Organization` and `OrganizationMember` models with `OrgMemberRole` enum (owner/admin/viewer)
- Extend `CreditAccount` with nullable `organization_id` FK (partial unique indexes for user vs org accounts)
- Migration 060: creates `organizations` + `organization_members` tables, alters `credit_accounts` with XOR CHECK constraint
- Foundation for Epic 17 — Organizations & Curricula Distribution (B2B2C)

## Files Changed
- `backend/app/domain/models/organization.py` — NEW: Organization, OrganizationMember, OrgMemberRole
- `backend/app/domain/models/credit.py` — Extended CreditAccount with organization_id
- `backend/app/domain/models/__init__.py` — Added new model exports
- `backend/migrations/versions/060_create_organizations_tables.py` — NEW migration

## Test plan
- [ ] Run `alembic upgrade head` — verify migration applies cleanly
- [ ] Run `alembic downgrade 059` — verify rollback works
- [ ] Verify existing credit account queries still work (user accounts unaffected)
- [ ] Verify no regressions in existing activation code or curricula features

Closes #975

🤖 Generated with [Claude Code](https://claude.com/claude-code)