### PR TITLE
feat(model): extend activation_codes + curricula for orgs

### DIFF
--- a/backend/app/domain/models/activation_code.py
+++ b/backend/app/domain/models/activation_code.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import (
     Boolean,
+    CheckConstraint,
     DateTime,
     ForeignKey,
     Index,
@@ -21,16 +22,38 @@ from app.domain.models.base import Base
 if TYPE_CHECKING:
     from app.domain.models.course import Course
     from app.domain.models.credit import CreditTransaction
+    from app.domain.models.curriculum import Curriculum
+    from app.domain.models.organization import Organization
     from app.domain.models.user import User
 
 
 class ActivationCode(Base):
     __tablename__ = "activation_codes"
+    __table_args__ = (
+        CheckConstraint(
+            "(course_id IS NOT NULL) OR (curriculum_id IS NOT NULL)",
+            name="ck_activation_codes_course_or_curriculum",
+        ),
+        CheckConstraint(
+            "(organization_id IS NULL) OR (created_by IS NULL)",
+            name="ck_activation_codes_org_xor_expert",
+        ),
+        CheckConstraint(
+            "(curriculum_id IS NULL) OR (organization_id IS NOT NULL)",
+            name="ck_activation_codes_curriculum_requires_org",
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     code: Mapped[str] = mapped_column(String(30), unique=True, index=True, nullable=False)
-    course_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("courses.id", ondelete="CASCADE"), index=True
+    course_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("courses.id", ondelete="CASCADE"), nullable=True, index=True
+    )
+    organization_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("organizations.id", ondelete="CASCADE"), nullable=True, index=True
+    )
+    curriculum_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("curricula.id", ondelete="CASCADE"), nullable=True, index=True
     )
     created_by: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("users.id", ondelete="SET NULL"), nullable=True
@@ -40,7 +63,9 @@ class ActivationCode(Base):
     is_active: Mapped[bool] = mapped_column(Boolean, server_default="true", default=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    course: Mapped[Course] = relationship()
+    course: Mapped[Course | None] = relationship()
+    organization: Mapped[Organization | None] = relationship(foreign_keys=[organization_id])
+    curriculum: Mapped[Curriculum | None] = relationship(foreign_keys=[curriculum_id])
     creator: Mapped[User | None] = relationship(foreign_keys=[created_by])
     redemptions: Mapped[list[ActivationCodeRedemption]] = relationship(back_populates="code")
 

--- a/backend/app/domain/models/credit.py
+++ b/backend/app/domain/models/credit.py
@@ -42,6 +42,9 @@ class TransactionType(enum.StrEnum):
     payout = "payout"
     refund = "refund"
     free_trial = "free_trial"
+    org_code_escrow = "org_code_escrow"
+    org_code_refund = "org_code_refund"
+    org_credit_purchase = "org_credit_purchase"
 
 
 class CreditAccount(Base):

--- a/backend/app/domain/models/curriculum.py
+++ b/backend/app/domain/models/curriculum.py
@@ -11,6 +11,7 @@ from app.domain.models.base import Base
 
 if TYPE_CHECKING:
     from app.domain.models.course import Course
+    from app.domain.models.organization import Organization
     from app.domain.models.user import User
 
 
@@ -31,11 +32,15 @@ class Curriculum(Base):
     created_by: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("users.id", ondelete="SET NULL"), nullable=True
     )
+    organization_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("organizations.id", ondelete="CASCADE"), nullable=True, index=True
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     published_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
     courses: Mapped[list[Course]] = relationship(secondary="curriculum_courses", lazy="selectin")
     creator: Mapped[User | None] = relationship(foreign_keys=[created_by])
+    organization: Mapped[Organization | None] = relationship(foreign_keys=[organization_id])
 
 
 class CurriculumCourse(Base):

--- a/backend/migrations/versions/061_extend_activation_codes_curricula_for_orgs.py
+++ b/backend/migrations/versions/061_extend_activation_codes_curricula_for_orgs.py
@@ -1,0 +1,116 @@
+"""Extend activation_codes + curricula with organization support.
+
+Add organization_id and curriculum_id to activation_codes, make course_id nullable.
+Add organization_id to curricula. Extend transactiontype enum with org values.
+
+Revision ID: 061
+Revises: 060
+Create Date: 2026-04-13
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "061"
+down_revision = "060"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # --- Extend transactiontype enum (must be outside transaction) ---
+    op.execute("COMMIT")
+    op.execute("ALTER TYPE transactiontype ADD VALUE IF NOT EXISTS 'org_code_escrow'")
+    op.execute("ALTER TYPE transactiontype ADD VALUE IF NOT EXISTS 'org_code_refund'")
+    op.execute("ALTER TYPE transactiontype ADD VALUE IF NOT EXISTS 'org_credit_purchase'")
+    op.execute("BEGIN")
+
+    # --- Extend activation_codes ---
+    # Make course_id nullable (existing rows all have course_id set)
+    op.alter_column("activation_codes", "course_id", existing_type=sa.Uuid(), nullable=True)
+
+    # Add organization_id
+    op.add_column("activation_codes", sa.Column("organization_id", sa.Uuid(), nullable=True))
+    op.create_foreign_key(
+        "fk_activation_codes_organization_id",
+        "activation_codes",
+        "organizations",
+        ["organization_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_index("ix_activation_codes_organization_id", "activation_codes", ["organization_id"])
+
+    # Add curriculum_id
+    op.add_column("activation_codes", sa.Column("curriculum_id", sa.Uuid(), nullable=True))
+    op.create_foreign_key(
+        "fk_activation_codes_curriculum_id",
+        "activation_codes",
+        "curricula",
+        ["curriculum_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_index("ix_activation_codes_curriculum_id", "activation_codes", ["curriculum_id"])
+
+    # CHECK constraints
+    op.execute(
+        "ALTER TABLE activation_codes ADD CONSTRAINT ck_activation_codes_course_or_curriculum "
+        "CHECK ((course_id IS NOT NULL) OR (curriculum_id IS NOT NULL))"
+    )
+    op.execute(
+        "ALTER TABLE activation_codes ADD CONSTRAINT ck_activation_codes_org_xor_expert "
+        "CHECK ((organization_id IS NULL) OR (created_by IS NULL))"
+    )
+    op.execute(
+        "ALTER TABLE activation_codes "
+        "ADD CONSTRAINT ck_activation_codes_curriculum_requires_org "
+        "CHECK ((curriculum_id IS NULL) OR (organization_id IS NOT NULL))"
+    )
+
+    # --- Extend curricula with organization_id ---
+    op.add_column("curricula", sa.Column("organization_id", sa.Uuid(), nullable=True))
+    op.create_foreign_key(
+        "fk_curricula_organization_id",
+        "curricula",
+        "organizations",
+        ["organization_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_index("ix_curricula_organization_id", "curricula", ["organization_id"])
+
+
+def downgrade() -> None:
+    # --- Revert curricula ---
+    op.drop_index("ix_curricula_organization_id", "curricula")
+    op.drop_constraint("fk_curricula_organization_id", "curricula", type_="foreignkey")
+    op.drop_column("curricula", "organization_id")
+
+    # --- Revert activation_codes ---
+    op.execute(
+        "ALTER TABLE activation_codes "
+        "DROP CONSTRAINT IF EXISTS ck_activation_codes_curriculum_requires_org"
+    )
+    op.execute(
+        "ALTER TABLE activation_codes DROP CONSTRAINT IF EXISTS ck_activation_codes_org_xor_expert"
+    )
+    op.execute(
+        "ALTER TABLE activation_codes "
+        "DROP CONSTRAINT IF EXISTS ck_activation_codes_course_or_curriculum"
+    )
+
+    op.drop_index("ix_activation_codes_curriculum_id", "activation_codes")
+    op.drop_constraint("fk_activation_codes_curriculum_id", "activation_codes", type_="foreignkey")
+    op.drop_column("activation_codes", "curriculum_id")
+
+    op.drop_index("ix_activation_codes_organization_id", "activation_codes")
+    op.drop_constraint(
+        "fk_activation_codes_organization_id", "activation_codes", type_="foreignkey"
+    )
+    op.drop_column("activation_codes", "organization_id")
+
+    op.alter_column("activation_codes", "course_id", existing_type=sa.Uuid(), nullable=False)
+
+    # Note: Postgres enum values cannot be removed in downgrade


### PR DESCRIPTION
## Summary
- Add `organization_id` + `curriculum_id` FKs to `activation_codes` table
- Make `course_id` nullable (curriculum codes don't target a single course)
- Add 3 CHECK constraints: course-or-curriculum, org-xor-expert, curriculum-requires-org
- Add `organization_id` FK to `curricula` for org-scoped curriculum management
- Extend `TransactionType` enum with `org_code_escrow`, `org_code_refund`, `org_credit_purchase`
- Migration 061

## Files Changed
- `backend/app/domain/models/activation_code.py` — Extended with org_id, curriculum_id, CHECK constraints
- `backend/app/domain/models/curriculum.py` — Added organization_id FK
- `backend/app/domain/models/credit.py` — 3 new TransactionType values
- `backend/migrations/versions/061_extend_activation_codes_curricula_for_orgs.py` — NEW

## Test plan
- [ ] Run `alembic upgrade head` — verify migration 061 applies on top of 060
- [ ] Verify existing activation codes (expert codes) still work — course_id is non-null for all existing rows
- [ ] Verify existing curricula queries still work — organization_id is NULL for all existing rows

Closes #977

🤖 Generated with [Claude Code](https://claude.com/claude-code)