### PR TITLE
feat(api): organization CRUD, curricula, codes, and reporting endpoints

### DIFF
--- a/backend/app/api/v1/org_codes.py
+++ b/backend/app/api/v1/org_codes.py
@@ -1,0 +1,206 @@
+"""Organization activation code endpoints."""
+
+from __future__ import annotations
+
+import base64
+import io
+import uuid
+
+import qrcode
+from fastapi import APIRouter, Depends, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_db_session
+from app.api.deps_local_auth import AuthenticatedUser, get_current_user
+from app.core.config import settings
+from app.domain.services.activation_code_service import ActivationCodeService
+from app.domain.services.organization_service import OrganizationService
+
+router = APIRouter(
+    prefix="/organizations/{org_id}/codes",
+    tags=["Organization Codes"],
+)
+
+_code_svc = ActivationCodeService()
+_org_svc = OrganizationService()
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class GenerateOrgCodesRequest(BaseModel):
+    curriculum_id: str | None = None
+    course_id: str | None = None
+    count: int = Field(1, ge=1, le=500)
+    max_uses: int | None = Field(None, ge=1)
+
+
+class OrgCodeResponse(BaseModel):
+    id: str
+    code: str
+    course_id: str | None
+    curriculum_id: str | None
+    max_uses: int | None
+    times_used: int
+    is_active: bool
+    created_at: str
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("", status_code=status.HTTP_201_CREATED, response_model=list[OrgCodeResponse])
+async def generate_org_codes(
+    org_id: uuid.UUID,
+    body: GenerateOrgCodesRequest,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> list[OrgCodeResponse]:
+    """Generate activation codes for an organization (with credit escrow)."""
+    codes = await _code_svc.generate_org_codes(
+        db,
+        org_id=org_id,
+        actor_id=uuid.UUID(current_user.id),
+        curriculum_id=uuid.UUID(body.curriculum_id) if body.curriculum_id else None,
+        course_id=uuid.UUID(body.course_id) if body.course_id else None,
+        count=body.count,
+        max_uses=body.max_uses,
+    )
+    return [
+        OrgCodeResponse(
+            id=str(c.id),
+            code=c.code,
+            course_id=str(c.course_id) if c.course_id else None,
+            curriculum_id=str(c.curriculum_id) if c.curriculum_id else None,
+            max_uses=c.max_uses,
+            times_used=c.times_used,
+            is_active=c.is_active,
+            created_at=c.created_at.isoformat(),
+        )
+        for c in codes
+    ]
+
+
+@router.get("", response_model=list[OrgCodeResponse])
+async def list_org_codes(
+    org_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+    curriculum_id: uuid.UUID | None = Query(None),
+    is_active: bool | None = Query(None),
+) -> list[OrgCodeResponse]:
+    """List activation codes for an organization."""
+    await _org_svc.require_org_role(db, org_id, uuid.UUID(current_user.id))
+    codes = await _code_svc.list_org_codes(
+        db,
+        org_id=org_id,
+        curriculum_id=curriculum_id,
+        is_active=is_active,
+    )
+    return [
+        OrgCodeResponse(
+            id=str(c.id),
+            code=c.code,
+            course_id=str(c.course_id) if c.course_id else None,
+            curriculum_id=str(c.curriculum_id) if c.curriculum_id else None,
+            max_uses=c.max_uses,
+            times_used=c.times_used,
+            is_active=c.is_active,
+            created_at=c.created_at.isoformat(),
+        )
+        for c in codes
+    ]
+
+
+@router.get("/{code_id}", response_model=OrgCodeResponse)
+async def get_org_code(
+    org_id: uuid.UUID,
+    code_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> OrgCodeResponse:
+    """Get a single org code with details."""
+    from sqlalchemy import select
+
+    from app.domain.models.activation_code import ActivationCode
+
+    await _org_svc.require_org_role(db, org_id, uuid.UUID(current_user.id))
+
+    result = await db.execute(
+        select(ActivationCode).where(
+            ActivationCode.id == code_id,
+            ActivationCode.organization_id == org_id,
+        )
+    )
+    ac = result.scalar_one_or_none()
+    if ac is None:
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=404, detail="Code not found.")
+
+    return OrgCodeResponse(
+        id=str(ac.id),
+        code=ac.code,
+        course_id=str(ac.course_id) if ac.course_id else None,
+        curriculum_id=str(ac.curriculum_id) if ac.curriculum_id else None,
+        max_uses=ac.max_uses,
+        times_used=ac.times_used,
+        is_active=ac.is_active,
+        created_at=ac.created_at.isoformat(),
+    )
+
+
+@router.post("/{code_id}/revoke", status_code=status.HTTP_204_NO_CONTENT)
+async def revoke_org_code(
+    org_id: uuid.UUID,
+    code_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> None:
+    """Revoke an unused org code and refund escrowed credits."""
+    await _code_svc.revoke_org_code(
+        db,
+        org_id=org_id,
+        code_id=code_id,
+        actor_id=uuid.UUID(current_user.id),
+    )
+
+
+@router.get("/{code_id}/qr")
+async def get_org_code_qr(
+    org_id: uuid.UUID,
+    code_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> dict:
+    """Generate QR code for an org activation code."""
+    from sqlalchemy import select
+
+    from app.domain.models.activation_code import ActivationCode
+
+    await _org_svc.require_org_role(db, org_id, uuid.UUID(current_user.id))
+
+    result = await db.execute(
+        select(ActivationCode).where(
+            ActivationCode.id == code_id,
+            ActivationCode.organization_id == org_id,
+        )
+    )
+    ac = result.scalar_one_or_none()
+    if ac is None:
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=404, detail="Code not found.")
+
+    activation_url = f"{settings.frontend_url}/fr/activate?code={ac.code}"
+    img = qrcode.make(activation_url)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    buf.seek(0)
+    b64 = base64.b64encode(buf.read()).decode()
+    return {"qr_base64": f"data:image/png;base64,{b64}"}

--- a/backend/app/api/v1/org_curricula.py
+++ b/backend/app/api/v1/org_curricula.py
@@ -1,0 +1,371 @@
+"""Organization-scoped curriculum management endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_db_session
+from app.api.deps_local_auth import AuthenticatedUser, get_current_user
+from app.domain.models.course import Course
+from app.domain.models.curriculum import Curriculum, CurriculumCourse
+from app.domain.models.organization import OrgMemberRole
+from app.domain.models.user_group import CurriculumAccess
+from app.domain.services.organization_service import OrganizationService
+
+router = APIRouter(
+    prefix="/organizations/{org_id}/curricula",
+    tags=["Organization Curricula"],
+)
+
+_org_svc = OrganizationService()
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class CreateCurriculumRequest(BaseModel):
+    title_fr: str = Field(..., min_length=1)
+    title_en: str = Field(..., min_length=1)
+    slug: str
+    description_fr: str | None = None
+    description_en: str | None = None
+    cover_image_url: str | None = None
+
+
+class UpdateCurriculumRequest(BaseModel):
+    title_fr: str | None = None
+    title_en: str | None = None
+    description_fr: str | None = None
+    description_en: str | None = None
+    cover_image_url: str | None = None
+
+
+class SetCoursesRequest(BaseModel):
+    course_ids: list[str]
+
+
+class CurriculumResponse(BaseModel):
+    id: str
+    slug: str
+    title_fr: str
+    title_en: str
+    description_fr: str | None = None
+    description_en: str | None = None
+    cover_image_url: str | None = None
+    status: str
+    organization_id: str | None = None
+    course_count: int = 0
+
+
+class CurriculumDetailResponse(CurriculumResponse):
+    courses: list[dict]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _curriculum_response(c: Curriculum, course_count: int = 0) -> CurriculumResponse:
+    return CurriculumResponse(
+        id=str(c.id),
+        slug=c.slug,
+        title_fr=c.title_fr,
+        title_en=c.title_en,
+        description_fr=c.description_fr,
+        description_en=c.description_en,
+        cover_image_url=c.cover_image_url,
+        status=c.status,
+        organization_id=str(c.organization_id) if c.organization_id else None,
+        course_count=course_count,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=list[CurriculumResponse])
+async def list_org_curricula(
+    org_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> list[CurriculumResponse]:
+    """List org-scoped curricula + platform curricula the org has access to."""
+    await _org_svc.require_org_role(db, org_id, uuid.UUID(current_user.id))
+
+    # Org-scoped curricula
+    result = await db.execute(select(Curriculum).where(Curriculum.organization_id == org_id))
+    org_curricula = result.scalars().all()
+
+    # Platform curricula accessible via org's user group
+    org = await _org_svc.get_organization(db, org_id)
+    platform_curricula = []
+    if org.user_group_id:
+        access_result = await db.execute(
+            select(Curriculum)
+            .join(CurriculumAccess, CurriculumAccess.curriculum_id == Curriculum.id)
+            .where(
+                CurriculumAccess.group_id == org.user_group_id,
+                Curriculum.organization_id.is_(None),
+            )
+        )
+        platform_curricula = access_result.scalars().all()
+
+    all_curricula = list(org_curricula) + list(platform_curricula)
+    responses = []
+    for c in all_curricula:
+        count = await db.scalar(
+            select(func.count(CurriculumCourse.course_id)).where(
+                CurriculumCourse.curriculum_id == c.id
+            )
+        )
+        responses.append(_curriculum_response(c, count or 0))
+    return responses
+
+
+@router.post("", status_code=status.HTTP_201_CREATED, response_model=CurriculumResponse)
+async def create_org_curriculum(
+    org_id: uuid.UUID,
+    body: CreateCurriculumRequest,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> CurriculumResponse:
+    """Create an org-scoped curriculum."""
+    await _org_svc.require_org_role(
+        db,
+        org_id,
+        uuid.UUID(current_user.id),
+        OrgMemberRole.owner,
+        OrgMemberRole.admin,
+    )
+
+    curriculum = Curriculum(
+        slug=body.slug,
+        title_fr=body.title_fr,
+        title_en=body.title_en,
+        description_fr=body.description_fr,
+        description_en=body.description_en,
+        cover_image_url=body.cover_image_url,
+        organization_id=org_id,
+        created_by=uuid.UUID(current_user.id),
+        status="draft",
+    )
+    db.add(curriculum)
+    await db.commit()
+    await db.refresh(curriculum)
+    return _curriculum_response(curriculum)
+
+
+@router.get("/{curriculum_id}", response_model=CurriculumDetailResponse)
+async def get_org_curriculum(
+    org_id: uuid.UUID,
+    curriculum_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> CurriculumDetailResponse:
+    """Get curriculum detail with courses."""
+    await _org_svc.require_org_role(db, org_id, uuid.UUID(current_user.id))
+
+    curriculum = await db.get(Curriculum, curriculum_id)
+    if not curriculum:
+        raise HTTPException(status_code=404, detail="Curriculum not found.")
+
+    # Get courses
+    cc_result = await db.execute(
+        select(Course)
+        .join(CurriculumCourse, CurriculumCourse.course_id == Course.id)
+        .where(CurriculumCourse.curriculum_id == curriculum_id)
+    )
+    courses = cc_result.scalars().all()
+
+    return CurriculumDetailResponse(
+        id=str(curriculum.id),
+        slug=curriculum.slug,
+        title_fr=curriculum.title_fr,
+        title_en=curriculum.title_en,
+        description_fr=curriculum.description_fr,
+        description_en=curriculum.description_en,
+        cover_image_url=curriculum.cover_image_url,
+        status=curriculum.status,
+        organization_id=str(curriculum.organization_id) if curriculum.organization_id else None,
+        course_count=len(courses),
+        courses=[
+            {
+                "id": str(c.id),
+                "title_fr": c.title_fr,
+                "title_en": c.title_en,
+                "cover_image_url": c.cover_image_url,
+            }
+            for c in courses
+        ],
+    )
+
+
+@router.patch("/{curriculum_id}", response_model=CurriculumResponse)
+async def update_org_curriculum(
+    org_id: uuid.UUID,
+    curriculum_id: uuid.UUID,
+    body: UpdateCurriculumRequest,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> CurriculumResponse:
+    """Update an org-scoped curriculum."""
+    await _org_svc.require_org_role(
+        db,
+        org_id,
+        uuid.UUID(current_user.id),
+        OrgMemberRole.owner,
+        OrgMemberRole.admin,
+    )
+
+    curriculum = await db.get(Curriculum, curriculum_id)
+    if not curriculum or curriculum.organization_id != org_id:
+        raise HTTPException(status_code=404, detail="Curriculum not found.")
+
+    updates = body.model_dump(exclude_unset=True)
+    for key, value in updates.items():
+        setattr(curriculum, key, value)
+
+    await db.commit()
+    await db.refresh(curriculum)
+    return _curriculum_response(curriculum)
+
+
+@router.put("/{curriculum_id}/courses", response_model=CurriculumResponse)
+async def set_curriculum_courses(
+    org_id: uuid.UUID,
+    curriculum_id: uuid.UUID,
+    body: SetCoursesRequest,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> CurriculumResponse:
+    """Set courses for an org curriculum (bulk replace)."""
+    await _org_svc.require_org_role(
+        db,
+        org_id,
+        uuid.UUID(current_user.id),
+        OrgMemberRole.owner,
+        OrgMemberRole.admin,
+    )
+
+    curriculum = await db.get(Curriculum, curriculum_id)
+    if not curriculum or curriculum.organization_id != org_id:
+        raise HTTPException(status_code=404, detail="Curriculum not found.")
+
+    # Delete existing
+    existing = await db.execute(
+        select(CurriculumCourse).where(CurriculumCourse.curriculum_id == curriculum_id)
+    )
+    for cc in existing.scalars().all():
+        await db.delete(cc)
+
+    # Add new
+    for cid_str in body.course_ids:
+        db.add(
+            CurriculumCourse(
+                curriculum_id=curriculum_id,
+                course_id=uuid.UUID(cid_str),
+            )
+        )
+
+    await db.commit()
+    return _curriculum_response(curriculum, len(body.course_ids))
+
+
+@router.post("/{curriculum_id}/publish", response_model=CurriculumResponse)
+async def publish_org_curriculum(
+    org_id: uuid.UUID,
+    curriculum_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> CurriculumResponse:
+    """Publish an org curriculum. Requires at least 1 course."""
+    await _org_svc.require_org_role(
+        db,
+        org_id,
+        uuid.UUID(current_user.id),
+        OrgMemberRole.owner,
+        OrgMemberRole.admin,
+    )
+
+    curriculum = await db.get(Curriculum, curriculum_id)
+    if not curriculum or curriculum.organization_id != org_id:
+        raise HTTPException(status_code=404, detail="Curriculum not found.")
+
+    count = await db.scalar(
+        select(func.count(CurriculumCourse.course_id)).where(
+            CurriculumCourse.curriculum_id == curriculum_id
+        )
+    )
+    if not count:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot publish a curriculum with no courses.",
+        )
+
+    curriculum.status = "published"
+    curriculum.published_at = datetime.now(UTC)
+    await db.commit()
+    await db.refresh(curriculum)
+    return _curriculum_response(curriculum, count)
+
+
+@router.post(
+    "/platform/{curriculum_id}/select",
+    status_code=status.HTTP_201_CREATED,
+)
+async def select_platform_curriculum(
+    org_id: uuid.UUID,
+    curriculum_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> dict:
+    """Grant org access to an existing published platform curriculum."""
+    await _org_svc.require_org_role(
+        db,
+        org_id,
+        uuid.UUID(current_user.id),
+        OrgMemberRole.owner,
+        OrgMemberRole.admin,
+    )
+
+    org = await _org_svc.get_organization(db, org_id)
+    if not org.user_group_id:
+        raise HTTPException(status_code=400, detail="Organization has no user group.")
+
+    curriculum = await db.get(Curriculum, curriculum_id)
+    if not curriculum or curriculum.organization_id is not None:
+        raise HTTPException(
+            status_code=404,
+            detail="Platform curriculum not found.",
+        )
+
+    # Check if already selected
+    existing = await db.execute(
+        select(CurriculumAccess).where(
+            CurriculumAccess.curriculum_id == curriculum_id,
+            CurriculumAccess.group_id == org.user_group_id,
+        )
+    )
+    if existing.scalar_one_or_none():
+        return {"status": "already_selected"}
+
+    db.add(
+        CurriculumAccess(
+            curriculum_id=curriculum_id,
+            group_id=org.user_group_id,
+            granted_by=uuid.UUID(current_user.id),
+        )
+    )
+    await db.commit()
+    return {"status": "selected"}

--- a/backend/app/api/v1/org_reports.py
+++ b/backend/app/api/v1/org_reports.py
@@ -1,0 +1,144 @@
+"""Organization reporting endpoints."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_db_session
+from app.api.deps_local_auth import AuthenticatedUser, get_current_user
+from app.domain.services.org_reporting_service import OrgReportingService
+from app.domain.services.organization_service import OrganizationService
+
+router = APIRouter(
+    prefix="/organizations/{org_id}/reports",
+    tags=["Organization Reports"],
+)
+
+_report_svc = OrgReportingService()
+_org_svc = OrganizationService()
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class OrgSummaryResponse(BaseModel):
+    total_codes: int
+    active_codes: int
+    total_redemptions: int
+    unique_learners: int
+    avg_completion_pct: float
+
+
+class LearnerProgressItem(BaseModel):
+    user_id: str
+    name: str
+    email: str | None
+    activated_at: str | None
+    courses_enrolled: int
+    avg_completion_pct: float
+
+
+class CodeUsageItem(BaseModel):
+    code_id: str
+    code: str
+    course_name: str | None
+    curriculum_id: str | None
+    max_uses: int | None
+    times_used: int
+    is_active: bool
+    created_at: str
+
+
+class CourseStatsResponse(BaseModel):
+    course_id: str
+    enrolled: int
+    avg_completion_pct: float
+    completed: int
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/summary", response_model=OrgSummaryResponse)
+async def get_org_summary(
+    org_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> OrgSummaryResponse:
+    """Get aggregate dashboard stats for the organization."""
+    await _org_svc.require_org_role(db, org_id, uuid.UUID(current_user.id))
+    data = await _report_svc.get_org_summary(db, org_id)
+    return OrgSummaryResponse(**data)
+
+
+@router.get("/learners", response_model=list[LearnerProgressItem])
+async def get_learner_progress(
+    org_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+    curriculum_id: uuid.UUID | None = Query(None),
+    course_id: uuid.UUID | None = Query(None),
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+) -> list[LearnerProgressItem]:
+    """Get per-learner progress for the organization."""
+    await _org_svc.require_org_role(db, org_id, uuid.UUID(current_user.id))
+    data = await _report_svc.get_learner_progress(
+        db,
+        org_id,
+        curriculum_id=curriculum_id,
+        course_id=course_id,
+        limit=limit,
+        offset=offset,
+    )
+    return [LearnerProgressItem(**item) for item in data]
+
+
+@router.get("/codes", response_model=list[CodeUsageItem])
+async def get_code_usage(
+    org_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> list[CodeUsageItem]:
+    """Get per-code usage stats for the organization."""
+    await _org_svc.require_org_role(db, org_id, uuid.UUID(current_user.id))
+    data = await _report_svc.get_code_usage_report(db, org_id)
+    return [CodeUsageItem(**item) for item in data]
+
+
+@router.get("/courses/{course_id}", response_model=CourseStatsResponse)
+async def get_course_stats(
+    org_id: uuid.UUID,
+    course_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> CourseStatsResponse:
+    """Get course completion stats for org learners."""
+    await _org_svc.require_org_role(db, org_id, uuid.UUID(current_user.id))
+    data = await _report_svc.get_course_completion_stats(db, org_id, course_id)
+    return CourseStatsResponse(**data)
+
+
+@router.get("/export")
+async def export_csv(
+    org_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> StreamingResponse:
+    """Export learner progress as CSV."""
+    await _org_svc.require_org_role(db, org_id, uuid.UUID(current_user.id))
+    csv_content = await _report_svc.export_csv(db, org_id)
+    return StreamingResponse(
+        iter([csv_content]),
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=org_learners.csv"},
+    )

--- a/backend/app/api/v1/organizations.py
+++ b/backend/app/api/v1/organizations.py
@@ -1,0 +1,268 @@
+"""Organization CRUD + member management endpoints."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, status
+from pydantic import BaseModel, Field
+
+from app.api.deps import get_db_session
+from app.api.deps_local_auth import AuthenticatedUser, get_current_user
+from app.domain.models.organization import OrgMemberRole
+from app.domain.models.user import User
+from app.domain.services.organization_service import OrganizationService
+
+router = APIRouter(prefix="/organizations", tags=["Organizations"])
+
+_svc = OrganizationService()
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class CreateOrgRequest(BaseModel):
+    name: str = Field(..., min_length=2, max_length=255)
+    slug: str | None = None
+    description: str | None = None
+    contact_email: str | None = None
+    logo_url: str | None = None
+
+
+class UpdateOrgRequest(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    contact_email: str | None = None
+    logo_url: str | None = None
+
+
+class AddMemberRequest(BaseModel):
+    email: str
+    role: OrgMemberRole = OrgMemberRole.viewer
+
+
+class UpdateMemberRoleRequest(BaseModel):
+    role: OrgMemberRole
+
+
+class OrgResponse(BaseModel):
+    id: str
+    name: str
+    slug: str
+    description: str | None = None
+    logo_url: str | None = None
+    contact_email: str | None = None
+    is_active: bool
+    created_at: str
+
+
+class OrgWithRoleResponse(BaseModel):
+    organization: OrgResponse
+    role: str
+    joined_at: str
+
+
+class MemberResponse(BaseModel):
+    user_id: str
+    name: str
+    email: str | None
+    role: str
+    joined_at: str
+
+
+class OrgCreditSummary(BaseModel):
+    balance: int
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _org_to_response(org) -> OrgResponse:
+    return OrgResponse(
+        id=str(org.id),
+        name=org.name,
+        slug=org.slug,
+        description=org.description,
+        logo_url=org.logo_url,
+        contact_email=org.contact_email,
+        is_active=org.is_active,
+        created_at=org.created_at.isoformat(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Organization CRUD
+# ---------------------------------------------------------------------------
+
+
+@router.post("", status_code=status.HTTP_201_CREATED, response_model=OrgResponse)
+async def create_organization(
+    body: CreateOrgRequest,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+) -> OrgResponse:
+    """Create a new organization. Any authenticated user can create."""
+    org = await _svc.create_organization(
+        db,
+        name=body.name,
+        slug=body.slug,
+        description=body.description,
+        contact_email=body.contact_email,
+        logo_url=body.logo_url,
+        creator_id=uuid.UUID(current_user.id),
+    )
+    return _org_to_response(org)
+
+
+@router.get("/me", response_model=list[OrgWithRoleResponse])
+async def list_my_organizations(
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+) -> list[OrgWithRoleResponse]:
+    """List all organizations where the current user is a member."""
+    memberships = await _svc.list_user_organizations(db, uuid.UUID(current_user.id))
+    return [
+        OrgWithRoleResponse(
+            organization=_org_to_response(m["organization"]),
+            role=m["role"].value if hasattr(m["role"], "value") else m["role"],
+            joined_at=m["joined_at"].isoformat() if m["joined_at"] else "",
+        )
+        for m in memberships
+    ]
+
+
+@router.get("/{org_id}", response_model=OrgResponse)
+async def get_organization(
+    org_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+) -> OrgResponse:
+    """Get organization details. Requires membership."""
+    await _svc.require_org_role(db, org_id, uuid.UUID(current_user.id))
+    org = await _svc.get_organization(db, org_id)
+    return _org_to_response(org)
+
+
+@router.patch("/{org_id}", response_model=OrgResponse)
+async def update_organization(
+    org_id: uuid.UUID,
+    body: UpdateOrgRequest,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+) -> OrgResponse:
+    """Update organization. Requires owner/admin role."""
+    updates = body.model_dump(exclude_unset=True)
+    org = await _svc.update_organization(db, org_id, uuid.UUID(current_user.id), **updates)
+    return _org_to_response(org)
+
+
+# ---------------------------------------------------------------------------
+# Member management
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{org_id}/members", response_model=list[MemberResponse])
+async def list_members(
+    org_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+) -> list[MemberResponse]:
+    """List organization members. Requires membership."""
+    await _svc.require_org_role(db, org_id, uuid.UUID(current_user.id))
+    members = await _svc.list_members(db, org_id)
+    return [
+        MemberResponse(
+            user_id=str(m.user_id),
+            name=m.user.name if m.user else "",
+            email=m.user.email if m.user else None,
+            role=m.role.value,
+            joined_at=m.joined_at.isoformat(),
+        )
+        for m in members
+    ]
+
+
+@router.post(
+    "/{org_id}/members",
+    status_code=status.HTTP_201_CREATED,
+    response_model=MemberResponse,
+)
+async def add_member(
+    org_id: uuid.UUID,
+    body: AddMemberRequest,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+) -> MemberResponse:
+    """Add a member by email. Requires owner/admin role."""
+    member = await _svc.add_member(
+        db,
+        org_id=org_id,
+        user_email=body.email,
+        role=body.role,
+        invited_by=uuid.UUID(current_user.id),
+    )
+    user_result = await db.get(User, member.user_id)
+    return MemberResponse(
+        user_id=str(member.user_id),
+        name=user_result.name if user_result else "",
+        email=user_result.email if user_result else None,
+        role=member.role.value,
+        joined_at=member.joined_at.isoformat(),
+    )
+
+
+@router.patch("/{org_id}/members/{user_id}", response_model=MemberResponse)
+async def update_member_role(
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    body: UpdateMemberRoleRequest,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+) -> MemberResponse:
+    """Update a member's role. Requires owner role."""
+    member = await _svc.update_member_role(
+        db, org_id, user_id, body.role, uuid.UUID(current_user.id)
+    )
+    user_result = await db.get(User, member.user_id)
+    return MemberResponse(
+        user_id=str(member.user_id),
+        name=user_result.name if user_result else "",
+        email=user_result.email if user_result else None,
+        role=member.role.value,
+        joined_at=member.joined_at.isoformat(),
+    )
+
+
+@router.delete(
+    "/{org_id}/members/{user_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def remove_member(
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+) -> None:
+    """Remove a member. Requires owner/admin role."""
+    await _svc.remove_member(db, org_id, user_id, uuid.UUID(current_user.id))
+
+
+# ---------------------------------------------------------------------------
+# Credits
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{org_id}/credits", response_model=OrgCreditSummary)
+async def get_org_credits(
+    org_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+) -> OrgCreditSummary:
+    """Get organization credit balance. Requires membership."""
+    await _svc.require_org_role(db, org_id, uuid.UUID(current_user.id))
+    balance = await _svc.get_org_credit_balance(db, org_id)
+    return OrgCreditSummary(balance=balance)

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -21,6 +21,10 @@ from app.api.v1.lesson_audio import (
 )
 from app.api.v1.local_auth import router as local_auth_router
 from app.api.v1.module_media import router as module_media_router
+from app.api.v1.org_codes import router as org_codes_router
+from app.api.v1.org_curricula import router as org_curricula_router
+from app.api.v1.org_reports import router as org_reports_router
+from app.api.v1.organizations import router as organizations_router
 from app.api.v1.placement import router as placement_router
 from app.api.v1.progress import router as progress_router
 from app.api.v1.quiz import router as quiz_router
@@ -60,3 +64,7 @@ api_v1_router.include_router(sms_relay_router)
 api_v1_router.include_router(source_images_router)
 api_v1_router.include_router(subscriptions_router)
 api_v1_router.include_router(activation_codes_router)
+api_v1_router.include_router(organizations_router)
+api_v1_router.include_router(org_curricula_router)
+api_v1_router.include_router(org_codes_router)
+api_v1_router.include_router(org_reports_router)


### PR DESCRIPTION
## Summary
- **organizations.py**: POST/GET/PATCH org + GET/POST/PATCH/DELETE members + GET credits
- **org_curricula.py**: List org+platform curricula, create/update/publish org curricula, set courses, select platform curricula
- **org_codes.py**: Generate with escrow, list, get, revoke with refund, QR codes
- **org_reports.py**: Dashboard summary, learner progress (paginated), code usage, course stats, CSV export
- All endpoints use `require_org_role()` for authorization

## Files Changed
- `backend/app/api/v1/organizations.py` — NEW (260 lines)
- `backend/app/api/v1/org_curricula.py` — NEW (360 lines)
- `backend/app/api/v1/org_codes.py` — NEW (210 lines)
- `backend/app/api/v1/org_reports.py` — NEW (150 lines)
- `backend/app/api/v1/router.py` — Added 4 new routers

## Test plan
- [ ] Backend starts without import errors
- [ ] POST /organizations creates org with auto UserGroup + CreditAccount
- [ ] GET /organizations/me returns user's orgs
- [ ] POST /organizations/{id}/members adds member by email
- [ ] POST /organizations/{id}/curricula creates org-scoped curriculum
- [ ] POST /organizations/{id}/codes generates codes with escrow
- [ ] GET /organizations/{id}/reports/summary returns KPIs
- [ ] GET /organizations/{id}/reports/export returns CSV

Closes #982, closes #983, closes #984, closes #985

🤖 Generated with [Claude Code](https://claude.com/claude-code)