### PR TITLE
fix: deploy pipeline must fail on migration errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -207,9 +207,11 @@ jobs:
             # Restart services
             docker compose up -d
 
-            # Run database migrations then restart backend to pick up schema changes
+            # Run database migrations — fail deploy if migrations fail
             sleep 10
-            docker compose exec -T -e PYTHONPATH=/app backend uv run alembic upgrade head || echo "Migration warning (may already be applied)"
+            echo "Running database migrations..."
+            docker compose exec -T -e PYTHONPATH=/app backend uv run alembic upgrade head
+            echo "Migrations completed successfully."
             docker compose up -d --force-recreate backend
             sleep 15
 

--- a/backend/migrations/versions/058_add_lesson_id_index_to_generated_images.py
+++ b/backend/migrations/versions/058_add_lesson_id_index_to_generated_images.py
@@ -15,10 +15,8 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.create_index(
-        "ix_generated_images_lesson_id",
-        "generated_images",
-        ["lesson_id"],
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_generated_images_lesson_id ON generated_images (lesson_id)"
     )
 
 

--- a/backend/migrations/versions/060_create_organizations_tables.py
+++ b/backend/migrations/versions/060_create_organizations_tables.py
@@ -93,8 +93,13 @@ def upgrade() -> None:
     op.create_index("ix_org_members_user_id", "organization_members", ["user_id"])
 
     # --- Extend credit_accounts: add organization_id, make user_id nullable ---
-    # Drop the existing unique constraint on user_id
-    op.drop_constraint("credit_accounts_user_id_key", "credit_accounts", type_="unique")
+    # Drop the existing unique constraint on user_id (name may vary)
+    op.execute(
+        "DO $$ BEGIN "
+        "ALTER TABLE credit_accounts DROP CONSTRAINT IF EXISTS credit_accounts_user_id_key; "
+        "ALTER TABLE credit_accounts DROP CONSTRAINT IF EXISTS uq_credit_accounts_user_id; "
+        "EXCEPTION WHEN undefined_object THEN NULL; END $$"
+    )
 
     # Make user_id nullable
     op.alter_column("credit_accounts", "user_id", existing_type=sa.Uuid(), nullable=True)


### PR DESCRIPTION
## Summary
Root cause fix for curricula appearing empty after Epic 17 deploy.

**Problem**: `deploy.yml` line 212 ran migrations with `|| echo "Migration warning"`, silently swallowing failures. When migration 058 failed (duplicate index), the DB stayed at version 057 while new code (expecting 060/061 schema) ran. SQLAlchemy queries for `organization_id` column on `curricula` caused 500 errors.

**Fixes**:
1. **Remove `|| echo`** from migration step — deploy now fails hard if migrations fail
2. **Migration 058**: `CREATE INDEX IF NOT EXISTS` (idempotent)
3. **Migration 060**: `DROP CONSTRAINT IF EXISTS` with both possible constraint names (idempotent)

## Files Changed
- `.github/workflows/deploy.yml` — Remove error swallowing from migration step
- `backend/migrations/versions/058_*` — Make idempotent
- `backend/migrations/versions/060_*` — Make idempotent

## Test plan
- [ ] Deploy to server — migrations should run and succeed (already at 061)
- [ ] Curricula page shows all 4 existing curricula
- [ ] If a migration fails, deploy should FAIL (not silently continue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)