### PR TITLE
fix: idempotent CREATE TYPE in role migration

### DIFF
--- a/backend/migrations/versions/018_add_role_to_users.py
+++ b/backend/migrations/versions/018_add_role_to_users.py
@@ -22,7 +22,10 @@ def upgrade() -> None:
     if "role" in columns:
         return
 
-    op.execute("CREATE TYPE IF NOT EXISTS userrole AS ENUM ('user', 'expert', 'admin')")
+    op.execute(
+        "DO $$ BEGIN CREATE TYPE userrole AS ENUM ('user', 'expert', 'admin'); "
+        "EXCEPTION WHEN duplicate_object THEN NULL; END $$;"
+    )
     op.add_column(
         "users",
         sa.Column(


### PR DESCRIPTION
PostgreSQL doesn't support CREATE TYPE IF NOT EXISTS. Use DO/EXCEPTION pattern.