### PR TITLE
feat(frontend): add Organizations sidebar link + list/create pages

### DIFF
--- a/frontend/app/[locale]/(app)/organizations/create/page.tsx
+++ b/frontend/app/[locale]/(app)/organizations/create/page.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+import { createOrganization } from "@/lib/api";
+import { Building2, ArrowLeft } from "lucide-react";
+import Link from "next/link";
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/[\s_]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+export default function CreateOrganizationPage() {
+  const t = useTranslations("Organization");
+  const locale = useLocale();
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [slug, setSlug] = useState("");
+  const [slugManual, setSlugManual] = useState(false);
+  const [description, setDescription] = useState("");
+  const [contactEmail, setContactEmail] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleNameChange = (val: string) => {
+    setName(val);
+    if (!slugManual) {
+      setSlug(slugify(val));
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    setSubmitting(true);
+    setError("");
+    try {
+      const org = await createOrganization({
+        name: name.trim(),
+        slug: slug || undefined,
+        description: description || undefined,
+        contact_email: contactEmail || undefined,
+      });
+      router.push(`/${locale}/org/${org.slug}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create organization");
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="max-w-lg mx-auto space-y-6">
+      <div>
+        <Link
+          href={`/${locale}/organizations`}
+          className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 mb-4"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          {t("title")}
+        </Link>
+        <h1 className="text-2xl font-bold flex items-center gap-3">
+          <Building2 className="h-6 w-6 text-green-600" />
+          {t("createOrg")}
+        </h1>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border bg-white p-6">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            {t("orgName")} *
+          </label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => handleNameChange(e.target.value)}
+            required
+            className="w-full rounded-md border px-3 py-2 text-sm"
+            placeholder="My Organization"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            {t("orgSlug")}
+          </label>
+          <input
+            type="text"
+            value={slug}
+            onChange={(e) => {
+              setSlug(e.target.value);
+              setSlugManual(true);
+            }}
+            className="w-full rounded-md border px-3 py-2 text-sm font-mono"
+            placeholder="my-organization"
+          />
+          <p className="text-xs text-gray-400 mt-1">
+            URL: /org/{slug || "..."}
+          </p>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            {t("orgDescription")}
+          </label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+            className="w-full rounded-md border px-3 py-2 text-sm"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            {t("contactEmail")}
+          </label>
+          <input
+            type="email"
+            value={contactEmail}
+            onChange={(e) => setContactEmail(e.target.value)}
+            className="w-full rounded-md border px-3 py-2 text-sm"
+            placeholder="contact@organization.com"
+          />
+        </div>
+
+        {error && (
+          <div className="rounded-md bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={submitting || !name.trim()}
+          className="w-full rounded-lg bg-green-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50"
+        >
+          {submitting ? "..." : t("createOrg")}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/app/[locale]/(app)/organizations/page.tsx
+++ b/frontend/app/[locale]/(app)/organizations/page.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import Link from "next/link";
+import { fetchMyOrganizations } from "@/lib/api";
+import type { OrgWithRole } from "@/lib/api";
+import { Building2, Plus, Users, ChevronRight } from "lucide-react";
+
+export default function OrganizationsPage() {
+  const t = useTranslations("Organization");
+  const locale = useLocale();
+  const [orgs, setOrgs] = useState<OrgWithRole[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchMyOrganizations()
+      .then(setOrgs)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-green-600" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">{t("title")}</h1>
+        </div>
+        <Link
+          href={`/${locale}/organizations/create`}
+          className="flex items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
+        >
+          <Plus className="h-4 w-4" />
+          {t("createOrg")}
+        </Link>
+      </div>
+
+      {orgs.length === 0 ? (
+        <div className="rounded-lg border bg-white p-12 text-center">
+          <Building2 className="h-12 w-12 text-gray-300 mx-auto mb-4" />
+          <p className="text-gray-600 font-medium">{t("noOrgs")}</p>
+          <Link
+            href={`/${locale}/organizations/create`}
+            className="inline-flex items-center gap-2 mt-4 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
+          >
+            <Plus className="h-4 w-4" />
+            {t("createOrg")}
+          </Link>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {orgs.map((m) => (
+            <Link
+              key={m.organization.id}
+              href={`/${locale}/org/${m.organization.slug}`}
+              className="flex items-center justify-between rounded-lg border bg-white p-4 hover:bg-gray-50 transition-colors"
+            >
+              <div className="flex items-center gap-4">
+                {m.organization.logo_url ? (
+                  <img
+                    src={m.organization.logo_url}
+                    alt={m.organization.name}
+                    className="h-10 w-10 rounded-lg object-cover"
+                  />
+                ) : (
+                  <div className="h-10 w-10 rounded-lg bg-green-100 flex items-center justify-center">
+                    <Building2 className="h-5 w-5 text-green-600" />
+                  </div>
+                )}
+                <div>
+                  <p className="font-medium">{m.organization.name}</p>
+                  <div className="flex items-center gap-2 text-xs text-gray-500">
+                    <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 font-medium">
+                      <Users className="h-3 w-3" />
+                      {t(m.role as "owner" | "admin" | "viewer")}
+                    </span>
+                    {m.organization.contact_email && (
+                      <span>{m.organization.contact_email}</span>
+                    )}
+                  </div>
+                </div>
+              </div>
+              <ChevronRight className="h-5 w-5 text-gray-400" />
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -15,6 +15,7 @@ import {
   ChevronRight,
   Menu,
   LogOut,
+  Building2,
   ShieldCheck,
   Wallet,
 } from "lucide-react";
@@ -124,6 +125,12 @@ export function Sidebar() {
       label: t("subscribe"),
       icon: Wallet,
       description: t("subscribeDescription")
+    },
+    {
+      href: `/${locale}/organizations`,
+      label: t("organizations"),
+      icon: Building2,
+      description: t("organizationsDescription")
     },
     ...(userRole === "admin" || userRole === "expert"
       ? [

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -44,7 +44,9 @@
     "adminDescription": "Access the administration panel",
     "more": "More",
     "moreMenuLabel": "More navigation options",
-    "closeMoreMenu": "Close more menu"
+    "closeMoreMenu": "Close more menu",
+    "organizations": "Organizations",
+    "organizationsDescription": "Manage your organizations"
   },
   "Auth": {
     "login": "Sign in",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -44,7 +44,9 @@
     "adminDescription": "Accéder au panneau d'administration",
     "more": "Plus",
     "moreMenuLabel": "Plus d'options de navigation",
-    "closeMoreMenu": "Fermer le menu Plus"
+    "closeMoreMenu": "Fermer le menu Plus",
+    "organizations": "Organisations",
+    "organizationsDescription": "Gérer vos organisations"
   },
   "Auth": {
     "login": "Se connecter",


### PR DESCRIPTION
## Summary
Missing UI entry point for org management. Users had no way to reach the org pages.

- Add "Organizations" link in sidebar (Building2 icon, after Subscription)
- Add /organizations page: lists user's orgs with role badges, empty state with Create CTA
- Add /organizations/create page: form with name, auto-slug, description, contact email
- FR/EN i18n keys

## Test plan
- [ ] Login → sidebar shows "Organizations" link
- [ ] Click → My Organizations page (empty state with Create button)
- [ ] Click Create → fill form → submit → redirected to org dashboard
- [ ] Back to Organizations → org appears in list

🤖 Generated with [Claude Code](https://claude.com/claude-code)