### PR TITLE
feat: auto-trigger RAG indexation on PDF upload for AI-assisted courses

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -999,6 +999,25 @@ async def upload_course_resource(
         resources_created=len(resources_created),
     )
 
+    # Auto-trigger RAG indexation for AI-assisted courses
+    if course.creation_mode == "ai_assisted" and course.rag_collection_id:
+        # Only dispatch if no indexation is already running
+        if not course.indexation_task_id or (
+            course.indexation_task_id
+            and AsyncResult(course.indexation_task_id).state
+            in ("SUCCESS", "FAILURE", "REVOKED")
+        ):
+            task = index_course_resources.delay(
+                str(course_id), course.rag_collection_id
+            )
+            course.indexation_task_id = task.id
+            await db.commit()
+            logger.info(
+                "Auto-triggered RAG indexation for AI-assisted course",
+                course_id=str(course_id),
+                task_id=task.id,
+            )
+
     return {
         "course_id": str(course_id),
         "name": safe_name,

--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -266,8 +266,22 @@ export function AICourseWizard({
       setFiles((prev) =>
         prev.map((f) => (f.name === file.name ? { ...f, status: "uploaded" as const } : f))
       );
+
+      // Check if backend auto-triggered indexation (AI-assisted mode)
+      if (!isIndexing) {
+        try {
+          const status = await getIndexStatusApi(courseId);
+          if (status.task && ["PENDING", "STARTED", "RETRY"].includes(status.task.state)) {
+            setTaskId(status.task.id ?? null);
+            setIsIndexing(true);
+            lastIndexProgressTimeRef.current = Date.now();
+          }
+        } catch {
+          // ignore — indexation check is best-effort
+        }
+      }
     },
-    [courseId]
+    [courseId, isIndexing]
   );
 
   const handleFiles = useCallback(
@@ -688,6 +702,19 @@ export function AICourseWizard({
           <div className="flex items-center gap-2">
             <Sparkles className="h-5 w-5 text-primary" />
             <h2 className="text-lg font-semibold">{tAi("title")}</h2>
+            {/* Persistent indexation badge */}
+            {isIndexing && step !== "syllabus_edit" && (
+              <Badge className="gap-1 bg-amber-100 text-amber-800 border-amber-300 hover:bg-amber-100 dark:bg-amber-900 dark:text-amber-200 text-xs">
+                <Database className="h-3 w-3 animate-pulse" />
+                {tAi("indexingBadge")}
+              </Badge>
+            )}
+            {indexStatus?.indexed && !isIndexing && (
+              <Badge className="gap-1 bg-green-100 text-green-800 border-green-300 hover:bg-green-100 dark:bg-green-900 dark:text-green-200 text-xs">
+                <CheckCircle2 className="h-3 w-3" />
+                {tAi("indexedBadge")}
+              </Badge>
+            )}
           </div>
           <Button variant="ghost" size="icon" onClick={handleClose} aria-label={t("close")}>
             <X className="h-5 w-5" />

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1530,7 +1530,9 @@
         "title": "Edit Syllabus",
         "description": "Reorganize modules, edit titles, and adjust the course structure.",
         "indexNeeded": "RAG indexation is required before publishing. Start it now while you edit the syllabus."
-      }
+      },
+      "indexingBadge": "Indexing...",
+      "indexedBadge": "Indexed"
     }
   },
   "AdminSyllabus": {

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1530,7 +1530,9 @@
         "title": "Modifier le programme",
         "description": "Réorganisez les modules, modifiez les titres et ajustez la structure du cours.",
         "indexNeeded": "L'indexation RAG est nécessaire avant la publication. Lancez-la maintenant pendant que vous modifiez le programme."
-      }
+      },
+      "indexingBadge": "Indexation...",
+      "indexedBadge": "Indexé"
     }
   },
   "AdminSyllabus": {


### PR DESCRIPTION
## Summary
- Backend: auto-dispatch `index_course_resources` Celery task after PDF upload when `creation_mode == "ai_assisted"` (idempotent — skips if already running)
- Frontend: AI wizard checks indexation status after each file upload and starts polling if auto-triggered
- Frontend: persistent indexation badge in wizard header shows "Indexing..." or "Indexed" across all steps
- Legacy wizard completely untouched

Closes #1458

## Test plan
- [ ] Upload PDF in AI-Assisted wizard → indexation auto-starts
- [ ] Indexation badge appears in wizard header
- [ ] Badge persists across wizard steps
- [ ] Publish still gates on indexation completion
- [ ] Legacy wizard: indexation NOT auto-triggered (manual trigger only)
- [ ] Re-uploading a PDF while indexation runs doesn't dispatch duplicate task

🤖 Generated with [Claude Code](https://claude.com/claude-code)