### PR TITLE
feat: course objectives + AI title/description proposal

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -52,6 +52,7 @@ class CreateCourseRequest(BaseModel):
     visibility: str = "public"
     price_credits: int = 0
     creation_mode: str = "legacy"
+    objectives_json: dict | None = None
 
 
 class CourseResponse(BaseModel):
@@ -343,6 +344,121 @@ async def archive_course(
     img_count = await _fetch_image_count(db, course.rag_collection_id)
     logger.info("Course archived", course_id=str(course_id), admin_id=current_user.id)
     return _course_to_response(course, image_count=img_count)
+
+
+class SuggestMetadataResponse(BaseModel):
+    title_fr: str
+    title_en: str
+    description_fr: str
+    description_en: str
+
+
+@router.post("/{course_id}/suggest-metadata", response_model=SuggestMetadataResponse)
+async def suggest_course_metadata(
+    course_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
+    db=Depends(get_db_session),
+) -> SuggestMetadataResponse:
+    """Use Claude to propose a title and description based on uploaded PDFs + objectives.
+
+    Synchronous single-turn call — returns within ~10s. Not a Celery task.
+    """
+    from app.domain.models.course_resource import CourseResource
+
+    result = await db.execute(select(Course).where(Course.id == course_id))
+    course = result.scalar_one_or_none()
+    if not course:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
+
+    # Gather context from uploaded resources
+    res_result = await db.execute(
+        select(CourseResource.raw_text)
+        .where(CourseResource.course_id == course_id)
+        .limit(5)
+    )
+    resource_texts = [r for (r,) in res_result if r]
+    context_text = "\n\n---\n\n".join(resource_texts)[:80_000]  # Cap at 80K chars
+
+    # Build objectives context
+    objectives_text = ""
+    if course.objectives_json:
+        obj = course.objectives_json
+        if obj.get("fr"):
+            objectives_text += "Objectives (FR): " + "; ".join(obj["fr"]) + "\n"
+        if obj.get("en"):
+            objectives_text += "Objectives (EN): " + "; ".join(obj["en"]) + "\n"
+
+    # Get taxonomy info
+    cats = course.taxonomy_categories or []
+    domains = [tc.slug for tc in cats if tc.type == "domain"]
+    levels = [tc.slug for tc in cats if tc.type == "level"]
+    audiences = [tc.slug for tc in cats if tc.type == "audience"]
+
+    taxonomy_text = ""
+    if domains:
+        taxonomy_text += f"Domain: {', '.join(domains)}\n"
+    if levels:
+        taxonomy_text += f"Level: {', '.join(levels)}\n"
+    if audiences:
+        taxonomy_text += f"Audience: {', '.join(audiences)}\n"
+
+    prompt = f"""Based on the following course materials and context, propose a title and description for this course.
+The title and description must be provided in both French (FR) and English (EN).
+
+{taxonomy_text}
+{objectives_text}
+Estimated hours: {course.estimated_hours}
+
+COURSE MATERIALS (excerpt):
+{context_text[:40_000] if context_text else "(No materials uploaded yet)"}
+
+Respond with EXACTLY this JSON format and nothing else:
+{{
+  "title_fr": "...",
+  "title_en": "...",
+  "description_fr": "A 2-3 sentence description in French",
+  "description_en": "A 2-3 sentence description in English"
+}}"""
+
+    import json as json_module
+    import os
+
+    from anthropic import Anthropic
+
+    api_key = os.getenv("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="AI service not configured",
+        )
+    client = Anthropic(api_key=api_key)
+    response = client.messages.create(
+        model="claude-sonnet-4-20250514",
+        max_tokens=1024,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    response_text = response.content[0].text.strip()
+
+    # Parse JSON from response
+    try:
+        # Try to extract JSON from possible markdown code block
+        if "```" in response_text:
+            json_start = response_text.find("{")
+            json_end = response_text.rfind("}") + 1
+            response_text = response_text[json_start:json_end]
+        parsed = json_module.loads(response_text)
+    except (json_module.JSONDecodeError, ValueError):
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Failed to parse AI response",
+        )
+
+    return SuggestMetadataResponse(
+        title_fr=parsed.get("title_fr", ""),
+        title_en=parsed.get("title_en", ""),
+        description_fr=parsed.get("description_fr", ""),
+        description_en=parsed.get("description_en", ""),
+    )
 
 
 class GenerateStructureRequest(BaseModel):

--- a/backend/app/domain/models/course.py
+++ b/backend/app/domain/models/course.py
@@ -46,6 +46,7 @@ class Course(Base):
     preassessment_mandatory: Mapped[bool] = mapped_column(server_default="false")
     visibility: Mapped[str] = mapped_column(String(10), server_default="public")
     price_credits: Mapped[int] = mapped_column(BIGINT, server_default="0")
+    objectives_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     syllabus_context: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     published_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/backend/app/domain/services/course_agent_service.py
+++ b/backend/app/domain/services/course_agent_service.py
@@ -205,6 +205,7 @@ class CourseAgentService:
         description_fr: str | None = None,
         description_en: str | None = None,
         audience_type: list[str] | None = None,
+        objectives_json: dict | None = None,
     ) -> str:
         """Build the syllabus generation prompt, using admin override if available."""
         from app.ai.prompts.audience import (
@@ -240,6 +241,18 @@ class CourseAgentService:
             if description_en:
                 description_block += f"- Description (EN): {description_en}\n"
 
+        objectives_block = ""
+        if objectives_json:
+            objectives_block = "\n## Course Objectives\n"
+            if objectives_json.get("fr"):
+                objectives_block += "Objectives (FR):\n"
+                for obj in objectives_json["fr"]:
+                    objectives_block += f"  - {obj}\n"
+            if objectives_json.get("en"):
+                objectives_block += "Objectives (EN):\n"
+                for obj in objectives_json["en"]:
+                    objectives_block += f"  - {obj}\n"
+
         if audience_ctx.is_kids:
             return self._build_kids_prompt(
                 title_fr=title_fr,
@@ -267,6 +280,7 @@ class CourseAgentService:
             f"- Level(s): {levels_str}\n"
             f"- Target audience: {audience_str}\n"
             f"- Estimated total hours: {estimated_hours}\n\n"
+            f"{objectives_block}\n"
             f"{resource_block}\n\n"
             "## Design principles (mandatory)\n"
             "- Progressive complexity: start with foundational concepts "
@@ -417,6 +431,7 @@ class CourseAgentService:
         audience_type: list[str] | None = None,
         estimated_hours: int = 20,
         resource_text: str | None = None,
+        objectives_json: dict | None = None,
     ) -> list[dict[str, Any]]:
         """
         Generate a course module outline using Claude API.
@@ -467,6 +482,7 @@ class CourseAgentService:
                 description_fr=course_description_fr,
                 description_en=course_description_en,
                 audience_type=audience_type,
+                objectives_json=objectives_json,
             )
 
             _model = "claude-sonnet-4-6"

--- a/backend/app/tasks/syllabus_generation.py
+++ b/backend/app/tasks/syllabus_generation.py
@@ -114,6 +114,7 @@ def generate_course_syllabus(
                     "domain_slugs": [tc.slug for tc in cats if tc.type == "domain"],
                     "level_slugs": [tc.slug for tc in cats if tc.type == "level"],
                     "audience_slugs": [tc.slug for tc in cats if tc.type == "audience"],
+                    "objectives_json": course.objectives_json,
                 }
         finally:
             await engine.dispose()
@@ -136,6 +137,7 @@ def generate_course_syllabus(
     domain_slugs = course_data["domain_slugs"]
     level_slugs = course_data["level_slugs"]
     audience_slugs = course_data["audience_slugs"]
+    objectives_json = course_data.get("objectives_json")
 
     # ── Phase 1.5: Load resources from DB (pre-extracted at upload time) ──────
     from pathlib import Path
@@ -456,6 +458,7 @@ def generate_course_syllabus(
             audience_type=audience_slugs,
             estimated_hours=estimated_hours or course_hours,
             resource_text=resource_text,
+            objectives_json=objectives_json,
         )
 
     module_dicts = asyncio.run(_call_claude())

--- a/backend/migrations/versions/063_add_objectives_json_to_courses.py
+++ b/backend/migrations/versions/063_add_objectives_json_to_courses.py
@@ -1,0 +1,24 @@
+"""Add objectives_json to courses.
+
+Revision ID: 063
+Revises: 062
+Create Date: 2026-04-14
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "063"
+down_revision = "062"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("courses", sa.Column("objectives_json", JSONB, nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("courses", "objectives_json")

--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -24,6 +24,9 @@ import {
   RotateCcw,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -49,9 +52,12 @@ import {
   getIndexStatusApi,
   cancelIndexationApi,
   reindexImagesApi,
+  updateAdminCourse,
   publishAdminCourse,
+  suggestCourseMetadata,
   formatBytes,
 } from "@/lib/api-course-admin";
+import { getCourseTaxonomy, type TaxonomyItem } from "@/lib/api";
 
 // ── Step types ────────────────────────────────────────────────────────
 
@@ -152,6 +158,7 @@ export function AICourseWizard({
 }: AICourseWizardProps) {
   const t = useTranslations("AdminCourses.wizard");
   const tAi = useTranslations("AdminCourses.aiWizard");
+  const locale = useLocale();
   const queryClient = useQueryClient();
 
   // ── State ─────────────────────────────────────────────────────────
@@ -162,6 +169,25 @@ export function AICourseWizard({
   const [pendingFiles, setPendingFiles] = useState<File[]>([]);
   const [isFetchingExistingFiles, setIsFetchingExistingFiles] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Objectives state
+  const [objectivesFr, setObjectivesFr] = useState("");
+  const [objectivesEn, setObjectivesEn] = useState("");
+  const [estimatedHours, setEstimatedHours] = useState(20);
+  const [domainOptions, setDomainOptions] = useState<TaxonomyItem[]>([]);
+  const [levelOptions, setLevelOptions] = useState<TaxonomyItem[]>([]);
+  const [audienceOptions, setAudienceOptions] = useState<TaxonomyItem[]>([]);
+  const [selectedDomains, setSelectedDomains] = useState<string[]>([]);
+  const [selectedLevels, setSelectedLevels] = useState<string[]>([]);
+  const [selectedAudience, setSelectedAudience] = useState<string[]>([]);
+  const [isSavingObjectives, setIsSavingObjectives] = useState(false);
+
+  // AI proposal state
+  const [proposedTitle, setProposedTitle] = useState({ fr: "", en: "" });
+  const [proposedDescription, setProposedDescription] = useState({ fr: "", en: "" });
+  const [isLoadingProposal, setIsLoadingProposal] = useState(false);
+  const [proposalError, setProposalError] = useState<string | null>(null);
+  const [isSavingProposal, setIsSavingProposal] = useState(false);
 
   // Generation state
   const [generatedModules, setGeneratedModules] = useState<GeneratedModule[]>([]);
@@ -204,6 +230,16 @@ export function AICourseWizard({
   const [showCloseConfirm, setShowCloseConfirm] = useState(false);
 
   const stepIndex = AI_STEPS.indexOf(step);
+
+  // ── Load taxonomy ──────────────────────────────────────────────────
+
+  useEffect(() => {
+    getCourseTaxonomy().then((tax) => {
+      setDomainOptions(tax.domains);
+      setLevelOptions(tax.levels);
+      setAudienceOptions(tax.audience_types);
+    }).catch(() => {});
+  }, []);
 
   // ── Hydrate on resume ─────────────────────────────────────────────
 
@@ -371,6 +407,73 @@ export function AICourseWizard({
       // Stay on upload step
     }
   }, [courseId, pendingFiles]);
+
+  // ── Objectives save ────────────────────────────────────────────────
+
+  const saveObjectives = useCallback(async () => {
+    if (!courseId) return;
+    setIsSavingObjectives(true);
+    try {
+      const objFr = objectivesFr.split("\n").map(s => s.trim()).filter(Boolean);
+      const objEn = objectivesEn.split("\n").map(s => s.trim()).filter(Boolean);
+      await updateAdminCourse(courseId, {
+        objectives_json: { fr: objFr, en: objEn },
+        course_domain: selectedDomains,
+        course_level: selectedLevels,
+        audience_type: selectedAudience,
+        estimated_hours: estimatedHours,
+      });
+      setStep("ai_proposal");
+    } catch {
+      // stay on step
+    } finally {
+      setIsSavingObjectives(false);
+    }
+  }, [courseId, objectivesFr, objectivesEn, selectedDomains, selectedLevels, selectedAudience, estimatedHours]);
+
+  // ── AI Proposal ───────────────────────────────────────────────────
+
+  const fetchProposal = useCallback(async () => {
+    if (!courseId) return;
+    setIsLoadingProposal(true);
+    setProposalError(null);
+    try {
+      const result = await suggestCourseMetadata(courseId);
+      setProposedTitle({ fr: result.title_fr, en: result.title_en });
+      setProposedDescription({ fr: result.description_fr, en: result.description_en });
+    } catch {
+      setProposalError(tAi("aiProposal.error"));
+    } finally {
+      setIsLoadingProposal(false);
+    }
+  }, [courseId, tAi]);
+
+  // Fetch proposal when entering the AI proposal step
+  useEffect(() => {
+    if (step !== "ai_proposal" || !courseId) return;
+    // Only fetch if no proposal yet
+    if (!proposedTitle.fr && !proposedTitle.en) {
+      fetchProposal();
+    }
+  }, [step, courseId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const validateProposal = useCallback(async () => {
+    if (!courseId) return;
+    setIsSavingProposal(true);
+    try {
+      await updateAdminCourse(courseId, {
+        title_fr: proposedTitle.fr,
+        title_en: proposedTitle.en,
+        description_fr: proposedDescription.fr || null,
+        description_en: proposedDescription.en || null,
+      });
+      setStep("generate");
+    } catch {
+      // stay on step
+    } finally {
+      setIsSavingProposal(false);
+    }
+  }, [courseId, proposedTitle, proposedDescription]);
 
   // ── Generation polling (reuses shared API) ────────────────────────
 
@@ -636,8 +739,8 @@ export function AICourseWizard({
 
   const canGoNext = (): boolean => {
     if (step === "upload") return files.filter((f) => f.status === "uploaded").length > 0;
-    if (step === "objectives") return true; // Will be gated when objectives step is implemented
-    if (step === "ai_proposal") return true; // Will be gated when AI proposal step is implemented
+    if (step === "objectives") return objectivesFr.trim().length > 0 || objectivesEn.trim().length > 0;
+    if (step === "ai_proposal") return proposedTitle.fr.trim().length > 0 && proposedTitle.en.trim().length > 0;
     if (step === "generate") return generatedModules.length > 0;
     if (step === "syllabus_edit") return generatedModules.length > 0;
     return false;
@@ -646,6 +749,14 @@ export function AICourseWizard({
   const handleNext = () => {
     if (step === "upload") {
       createCourse();
+      return;
+    }
+    if (step === "objectives") {
+      saveObjectives();
+      return;
+    }
+    if (step === "ai_proposal") {
+      validateProposal();
       return;
     }
     const idx = AI_STEPS.indexOf(step);
@@ -831,35 +942,162 @@ export function AICourseWizard({
               </div>
             )}
 
-            {/* ── OBJECTIVES STEP (placeholder) ───────────────────── */}
+            {/* ── OBJECTIVES STEP ────────────────────────────────── */}
             {step === "objectives" && (
               <div className="space-y-4">
                 <div>
                   <h3 className="text-xl font-semibold">{tAi("objectives.title")}</h3>
                   <p className="mt-1 text-sm text-muted-foreground">{tAi("objectives.description")}</p>
                 </div>
-                <Card>
-                  <CardContent className="flex flex-col items-center justify-center py-12 text-center">
-                    <Target className="h-12 w-12 text-muted-foreground mb-3" />
-                    <p className="text-sm text-muted-foreground">{tAi("comingSoon")}</p>
-                  </CardContent>
-                </Card>
+
+                <div className="space-y-4">
+                  <div className="space-y-1.5">
+                    <Label htmlFor="objectives_fr">{tAi("objectives.objectivesFr")}</Label>
+                    <Textarea
+                      id="objectives_fr"
+                      value={objectivesFr}
+                      onChange={(e) => setObjectivesFr(e.target.value)}
+                      placeholder={tAi("objectives.objectivesFrPlaceholder")}
+                      className="min-h-[100px] resize-none text-base"
+                      rows={4}
+                    />
+                    <p className="text-xs text-muted-foreground">{tAi("objectives.objectivesHint")}</p>
+                  </div>
+
+                  <div className="space-y-1.5">
+                    <Label htmlFor="objectives_en">{tAi("objectives.objectivesEn")}</Label>
+                    <Textarea
+                      id="objectives_en"
+                      value={objectivesEn}
+                      onChange={(e) => setObjectivesEn(e.target.value)}
+                      placeholder={tAi("objectives.objectivesEnPlaceholder")}
+                      className="min-h-[100px] resize-none text-base"
+                      rows={4}
+                    />
+                  </div>
+
+                  {[
+                    { label: tAi("objectives.domain"), options: domainOptions, selected: selectedDomains, setSelected: setSelectedDomains },
+                    { label: tAi("objectives.level"), options: levelOptions, selected: selectedLevels, setSelected: setSelectedLevels },
+                    { label: tAi("objectives.audience"), options: audienceOptions, selected: selectedAudience, setSelected: setSelectedAudience },
+                  ].map(({ label, options, selected, setSelected }) => (
+                    <div key={label} className="space-y-1.5">
+                      <Label>{label}</Label>
+                      <div className="flex flex-wrap gap-1.5">
+                        {options.map((opt) => {
+                          const sel = selected.includes(opt.value);
+                          return (
+                            <button
+                              key={opt.value}
+                              type="button"
+                              onClick={() =>
+                                setSelected(sel ? selected.filter((v) => v !== opt.value) : [...selected, opt.value])
+                              }
+                              className={`rounded-full px-2.5 py-1 text-xs font-medium transition-colors min-h-[32px] ${
+                                sel
+                                  ? "bg-teal-600 text-white hover:bg-teal-700"
+                                  : "bg-stone-100 text-stone-600 hover:bg-stone-200 border border-stone-200"
+                              }`}
+                            >
+                              {locale === "fr" ? opt.label_fr : opt.label_en}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ))}
+
+                  <div className="space-y-1.5">
+                    <Label htmlFor="estimated_hours">{tAi("objectives.estimatedHours")}</Label>
+                    <Input
+                      id="estimated_hours"
+                      type="number"
+                      min={1}
+                      max={500}
+                      value={estimatedHours}
+                      onChange={(e) => setEstimatedHours(parseInt(e.target.value) || 20)}
+                    />
+                  </div>
+                </div>
               </div>
             )}
 
-            {/* ── AI PROPOSAL STEP (placeholder) ──────────────────── */}
+            {/* ── AI PROPOSAL STEP ───────────────────────────────── */}
             {step === "ai_proposal" && (
               <div className="space-y-4">
                 <div>
                   <h3 className="text-xl font-semibold">{tAi("aiProposal.title")}</h3>
                   <p className="mt-1 text-sm text-muted-foreground">{tAi("aiProposal.description")}</p>
                 </div>
-                <Card>
-                  <CardContent className="flex flex-col items-center justify-center py-12 text-center">
-                    <Wand2 className="h-12 w-12 text-muted-foreground mb-3" />
-                    <p className="text-sm text-muted-foreground">{tAi("comingSoon")}</p>
-                  </CardContent>
-                </Card>
+
+                {isLoadingProposal && (
+                  <div className="flex flex-col items-center justify-center py-12 gap-3">
+                    <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                    <p className="text-sm text-muted-foreground">{tAi("aiProposal.loading")}</p>
+                  </div>
+                )}
+
+                {proposalError && (
+                  <div className="flex flex-col gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-3">
+                    <div className="flex items-center gap-2 text-sm text-destructive">
+                      <AlertCircle className="h-4 w-4 shrink-0" />
+                      {proposalError}
+                    </div>
+                    <Button variant="outline" size="sm" onClick={fetchProposal} className="self-start min-h-[44px]">
+                      <Wand2 className="mr-2 h-4 w-4" />
+                      {tAi("aiProposal.retry")}
+                    </Button>
+                  </div>
+                )}
+
+                {!isLoadingProposal && !proposalError && (
+                  <div className="space-y-4">
+                    <div className="space-y-1.5">
+                      <Label htmlFor="proposed_title_fr">{tAi("aiProposal.titleFr")}</Label>
+                      <Input
+                        id="proposed_title_fr"
+                        value={proposedTitle.fr}
+                        onChange={(e) => setProposedTitle((p) => ({ ...p, fr: e.target.value }))}
+                      />
+                    </div>
+
+                    <div className="space-y-1.5">
+                      <Label htmlFor="proposed_title_en">{tAi("aiProposal.titleEn")}</Label>
+                      <Input
+                        id="proposed_title_en"
+                        value={proposedTitle.en}
+                        onChange={(e) => setProposedTitle((p) => ({ ...p, en: e.target.value }))}
+                      />
+                    </div>
+
+                    <div className="space-y-1.5">
+                      <Label htmlFor="proposed_desc_fr">{tAi("aiProposal.descriptionFr")}</Label>
+                      <Textarea
+                        id="proposed_desc_fr"
+                        value={proposedDescription.fr}
+                        onChange={(e) => setProposedDescription((p) => ({ ...p, fr: e.target.value }))}
+                        className="min-h-[80px] resize-none text-base"
+                        rows={3}
+                      />
+                    </div>
+
+                    <div className="space-y-1.5">
+                      <Label htmlFor="proposed_desc_en">{tAi("aiProposal.descriptionEn")}</Label>
+                      <Textarea
+                        id="proposed_desc_en"
+                        value={proposedDescription.en}
+                        onChange={(e) => setProposedDescription((p) => ({ ...p, en: e.target.value }))}
+                        className="min-h-[80px] resize-none text-base"
+                        rows={3}
+                      />
+                    </div>
+
+                    <Button variant="outline" onClick={fetchProposal} disabled={isLoadingProposal} className="w-full min-h-[44px]">
+                      <Wand2 className="mr-2 h-4 w-4" />
+                      {tAi("aiProposal.regenerate")}
+                    </Button>
+                  </div>
+                )}
               </div>
             )}
 

--- a/frontend/lib/api-course-admin.ts
+++ b/frontend/lib/api-course-admin.ts
@@ -210,6 +210,23 @@ export async function reindexImagesApi(
   });
 }
 
+// ── AI metadata suggestion ────────────────────────────────────────────
+
+export interface SuggestedMetadata {
+  title_fr: string;
+  title_en: string;
+  description_fr: string;
+  description_en: string;
+}
+
+export async function suggestCourseMetadata(
+  courseId: string
+): Promise<SuggestedMetadata> {
+  return apiFetch(`/api/v1/admin/courses/${courseId}/suggest-metadata`, {
+    method: "POST",
+  });
+}
+
 // ── Publishing ────────────────────────────────────────────────────────
 
 export async function publishAdminCourse(courseId: string): Promise<void> {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1520,11 +1520,28 @@
       },
       "objectives": {
         "title": "Course Objectives",
-        "description": "Define the learning objectives, target audience, level, and expected duration."
+        "description": "Define the learning objectives, target audience, level, and expected duration.",
+        "objectivesFr": "Learning Objectives (French)",
+        "objectivesEn": "Learning Objectives (English)",
+        "objectivesFrPlaceholder": "Enter one objective per line...\nExample: Understand the principles of disease prevention",
+        "objectivesEnPlaceholder": "Enter one objective per line...\nExample: Understand the principles of disease prevention",
+        "objectivesHint": "One objective per line. These will guide the AI in generating the course structure.",
+        "domain": "Domain",
+        "level": "Level",
+        "audience": "Audience",
+        "estimatedHours": "Estimated Hours"
       },
       "aiProposal": {
         "title": "AI-Proposed Title & Description",
-        "description": "Review and edit the AI-generated title and description for your course."
+        "description": "Review and edit the AI-generated title and description for your course.",
+        "loading": "AI is analyzing your materials and objectives...",
+        "error": "Failed to generate proposal. Please try again.",
+        "retry": "Retry",
+        "titleFr": "Title (French) *",
+        "titleEn": "Title (English) *",
+        "descriptionFr": "Description (French)",
+        "descriptionEn": "Description (English)",
+        "regenerate": "Regenerate Proposal"
       },
       "syllabusEdit": {
         "title": "Edit Syllabus",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1520,11 +1520,28 @@
       },
       "objectives": {
         "title": "Objectifs du cours",
-        "description": "Définissez les objectifs d'apprentissage, le public cible, le niveau et la durée prévue."
+        "description": "Définissez les objectifs d'apprentissage, le public cible, le niveau et la durée prévue.",
+        "objectivesFr": "Objectifs d'apprentissage (Français)",
+        "objectivesEn": "Objectifs d'apprentissage (Anglais)",
+        "objectivesFrPlaceholder": "Un objectif par ligne...\nExemple : Comprendre les principes de prévention des maladies",
+        "objectivesEnPlaceholder": "Un objectif par ligne...\nExemple : Understand the principles of disease prevention",
+        "objectivesHint": "Un objectif par ligne. Ceux-ci guideront l'IA dans la génération de la structure du cours.",
+        "domain": "Domaine",
+        "level": "Niveau",
+        "audience": "Public cible",
+        "estimatedHours": "Heures estimées"
       },
       "aiProposal": {
         "title": "Titre et description proposés par l'IA",
-        "description": "Vérifiez et modifiez le titre et la description générés par l'IA pour votre cours."
+        "description": "Vérifiez et modifiez le titre et la description générés par l'IA pour votre cours.",
+        "loading": "L'IA analyse vos documents et objectifs...",
+        "error": "Échec de la génération de la proposition. Veuillez réessayer.",
+        "retry": "Réessayer",
+        "titleFr": "Titre (Français) *",
+        "titleEn": "Titre (Anglais) *",
+        "descriptionFr": "Description (Français)",
+        "descriptionEn": "Description (Anglais)",
+        "regenerate": "Régénérer la proposition"
       },
       "syllabusEdit": {
         "title": "Modifier le programme",


### PR DESCRIPTION
## Summary
- Add `objectives_json` (JSONB) to Course model + Alembic migration 063
- Add `POST /admin/courses/{id}/suggest-metadata` endpoint — Claude proposes title/description from PDFs + objectives (synchronous, ~10s)
- Implement objectives step in AI wizard: FR/EN objectives, taxonomy selectors, estimated hours
- Implement AI proposal step: editable AI-generated title/description with regenerate button
- Feed objectives into syllabus generation prompt
- Legacy wizard completely untouched

Closes #1459, closes #1460

## Test plan
- [ ] Objectives step: enter objectives, select taxonomy, set hours → saves to course
- [ ] AI proposal step: loads proposal from Claude based on PDFs + objectives
- [ ] Edit proposed title/description → validate saves to course
- [ ] "Regenerate" button fetches new proposal
- [ ] Objectives appear in syllabus generation prompt
- [ ] Backend: `POST /suggest-metadata` returns valid JSON with title/description

🤖 Generated with [Claude Code](https://claude.com/claude-code)