### PR TITLE
feat: visual syllabus editor with reorder + inline edit

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -461,6 +461,109 @@ Respond with EXACTLY this JSON format and nothing else:
     )
 
 
+class SyllabusModuleUnit(BaseModel):
+    title_fr: str
+    title_en: str
+    unit_type: str = "lesson"
+    description_fr: str = ""
+    description_en: str = ""
+
+
+class SyllabusModule(BaseModel):
+    module_number: int
+    title_fr: str
+    title_en: str
+    description_fr: str = ""
+    description_en: str = ""
+    estimated_hours: int = 20
+    bloom_level: str = "understand"
+    units: list[SyllabusModuleUnit] = []
+
+
+class SaveSyllabusRequest(BaseModel):
+    modules: list[SyllabusModule]
+
+
+@router.patch("/{course_id}/syllabus")
+async def save_syllabus(
+    course_id: uuid.UUID,
+    request: SaveSyllabusRequest,
+    current_user: AuthenticatedUser = Depends(
+        require_role(UserRole.admin, UserRole.sub_admin)
+    ),
+    db=Depends(get_db_session),
+) -> dict:
+    """Save edited syllabus structure (modules + units). Replaces existing."""
+    result = await db.execute(select(Course).where(Course.id == course_id))
+    course = result.scalar_one_or_none()
+    if not course:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Course not found"
+        )
+
+    if not request.modules:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="At least one module is required",
+        )
+
+    # Delete existing modules and units (cascade)
+    await db.execute(
+        sa_delete(Module).where(Module.course_id == course_id)
+    )
+
+    # Create new modules and units
+    for m in request.modules:
+        if not m.units:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Module {m.module_number} must have at least one unit",
+            )
+        module = Module(
+            id=uuid.uuid4(),
+            course_id=course_id,
+            module_number=m.module_number,
+            title_fr=m.title_fr,
+            title_en=m.title_en,
+            description_fr=m.description_fr,
+            description_en=m.description_en,
+            estimated_hours=m.estimated_hours,
+            bloom_level=m.bloom_level,
+        )
+        db.add(module)
+
+        for idx, u in enumerate(m.units):
+            unit = ModuleUnit(
+                id=uuid.uuid4(),
+                module_id=module.id,
+                unit_number=f"{m.module_number}.{idx + 1}",
+                unit_type=u.unit_type,
+                title_fr=u.title_fr,
+                title_en=u.title_en,
+                description_fr=u.description_fr,
+                description_en=u.description_en,
+                order_index=idx,
+            )
+            db.add(unit)
+
+    # Update syllabus_json
+    course.syllabus_json = [m.model_dump() for m in request.modules]
+    course.creation_step = "generated"
+
+    await db.commit()
+
+    logger.info(
+        "Syllabus saved",
+        course_id=str(course_id),
+        modules=len(request.modules),
+        admin_id=current_user.id,
+    )
+    return {
+        "status": "saved",
+        "modules_count": len(request.modules),
+    }
+
+
 class GenerateStructureRequest(BaseModel):
     estimated_hours: int = 20
 

--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -58,6 +58,7 @@ import {
   formatBytes,
 } from "@/lib/api-course-admin";
 import { getCourseTaxonomy, type TaxonomyItem } from "@/lib/api";
+import { SyllabusVisualEditor } from "@/components/admin/syllabus-visual-editor";
 
 // ── Step types ────────────────────────────────────────────────────────
 
@@ -1279,12 +1280,28 @@ export function AICourseWizard({
                   </div>
                 )}
 
-                <Card>
-                  <CardContent className="flex flex-col items-center justify-center py-12 text-center">
-                    <GripVertical className="h-12 w-12 text-muted-foreground mb-3" />
-                    <p className="text-sm text-muted-foreground">{tAi("comingSoon")}</p>
-                  </CardContent>
-                </Card>
+                {/* Visual syllabus editor */}
+                {courseId && (
+                  <SyllabusVisualEditor
+                    courseId={courseId}
+                    initialModules={generatedModules.map((m, i) => ({
+                      module_number: m.module_number || i + 1,
+                      title_fr: m.title_fr,
+                      title_en: m.title_en,
+                      description_fr: "",
+                      description_en: "",
+                      estimated_hours: 20,
+                      bloom_level: "understand",
+                      units: [{
+                        title_fr: "",
+                        title_en: "",
+                        unit_type: "lesson",
+                        description_fr: "",
+                        description_en: "",
+                      }],
+                    }))}
+                  />
+                )}
               </div>
             )}
 

--- a/frontend/components/admin/syllabus-visual-editor.tsx
+++ b/frontend/components/admin/syllabus-visual-editor.tsx
@@ -1,0 +1,437 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useTranslations, useLocale } from "next-intl";
+import {
+  ChevronDown,
+  ChevronUp,
+  Plus,
+  Trash2,
+  GripVertical,
+  BookOpen,
+  HelpCircle,
+  FileText,
+  Save,
+  CheckCircle2,
+  AlertCircle,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { apiFetch } from "@/lib/api";
+
+interface SyllabusUnit {
+  title_fr: string;
+  title_en: string;
+  unit_type: string;
+  description_fr: string;
+  description_en: string;
+}
+
+interface SyllabusModule {
+  module_number: number;
+  title_fr: string;
+  title_en: string;
+  description_fr: string;
+  description_en: string;
+  estimated_hours: number;
+  bloom_level: string;
+  units: SyllabusUnit[];
+}
+
+interface SyllabusVisualEditorProps {
+  courseId: string;
+  initialModules?: SyllabusModule[];
+  onSaved?: () => void;
+}
+
+const UNIT_TYPE_ICONS: Record<string, React.ReactNode> = {
+  lesson: <BookOpen className="h-3.5 w-3.5" />,
+  quiz: <HelpCircle className="h-3.5 w-3.5" />,
+  "case-study": <FileText className="h-3.5 w-3.5" />,
+};
+
+export function SyllabusVisualEditor({
+  courseId,
+  initialModules = [],
+  onSaved,
+}: SyllabusVisualEditorProps) {
+  const t = useTranslations("AdminCourses.syllabusEditor");
+  const locale = useLocale();
+  const [modules, setModules] = useState<SyllabusModule[]>(initialModules);
+  const [expandedModule, setExpandedModule] = useState<number | null>(
+    initialModules.length > 0 ? 0 : null
+  );
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+
+  // ── Module operations ─────────────────────────────────────────────
+
+  const addModule = useCallback(() => {
+    const newNum = modules.length + 1;
+    setModules((prev) => [
+      ...prev,
+      {
+        module_number: newNum,
+        title_fr: "",
+        title_en: "",
+        description_fr: "",
+        description_en: "",
+        estimated_hours: 20,
+        bloom_level: "understand",
+        units: [
+          {
+            title_fr: "",
+            title_en: "",
+            unit_type: "lesson",
+            description_fr: "",
+            description_en: "",
+          },
+        ],
+      },
+    ]);
+    setExpandedModule(modules.length);
+  }, [modules.length]);
+
+  const removeModule = useCallback(
+    (idx: number) => {
+      setModules((prev) => {
+        const next = prev.filter((_, i) => i !== idx);
+        return next.map((m, i) => ({ ...m, module_number: i + 1 }));
+      });
+      if (expandedModule === idx) setExpandedModule(null);
+    },
+    [expandedModule]
+  );
+
+  const moveModule = useCallback((idx: number, direction: "up" | "down") => {
+    setModules((prev) => {
+      const next = [...prev];
+      const targetIdx = direction === "up" ? idx - 1 : idx + 1;
+      if (targetIdx < 0 || targetIdx >= next.length) return prev;
+      [next[idx], next[targetIdx]] = [next[targetIdx], next[idx]];
+      return next.map((m, i) => ({ ...m, module_number: i + 1 }));
+    });
+  }, []);
+
+  const updateModuleTitle = useCallback(
+    (idx: number, lang: "fr" | "en", value: string) => {
+      setModules((prev) =>
+        prev.map((m, i) =>
+          i === idx
+            ? { ...m, [lang === "fr" ? "title_fr" : "title_en"]: value }
+            : m
+        )
+      );
+    },
+    []
+  );
+
+  // ── Unit operations ───────────────────────────────────────────────
+
+  const addUnit = useCallback((moduleIdx: number) => {
+    setModules((prev) =>
+      prev.map((m, i) =>
+        i === moduleIdx
+          ? {
+              ...m,
+              units: [
+                ...m.units,
+                {
+                  title_fr: "",
+                  title_en: "",
+                  unit_type: "lesson",
+                  description_fr: "",
+                  description_en: "",
+                },
+              ],
+            }
+          : m
+      )
+    );
+  }, []);
+
+  const removeUnit = useCallback((moduleIdx: number, unitIdx: number) => {
+    setModules((prev) =>
+      prev.map((m, i) =>
+        i === moduleIdx
+          ? { ...m, units: m.units.filter((_, j) => j !== unitIdx) }
+          : m
+      )
+    );
+  }, []);
+
+  const moveUnit = useCallback(
+    (moduleIdx: number, unitIdx: number, direction: "up" | "down") => {
+      setModules((prev) =>
+        prev.map((m, i) => {
+          if (i !== moduleIdx) return m;
+          const units = [...m.units];
+          const targetIdx = direction === "up" ? unitIdx - 1 : unitIdx + 1;
+          if (targetIdx < 0 || targetIdx >= units.length) return m;
+          [units[unitIdx], units[targetIdx]] = [
+            units[targetIdx],
+            units[unitIdx],
+          ];
+          return { ...m, units };
+        })
+      );
+    },
+    []
+  );
+
+  const updateUnitTitle = useCallback(
+    (moduleIdx: number, unitIdx: number, lang: "fr" | "en", value: string) => {
+      setModules((prev) =>
+        prev.map((m, i) =>
+          i === moduleIdx
+            ? {
+                ...m,
+                units: m.units.map((u, j) =>
+                  j === unitIdx
+                    ? {
+                        ...u,
+                        [lang === "fr" ? "title_fr" : "title_en"]: value,
+                      }
+                    : u
+                ),
+              }
+            : m
+        )
+      );
+    },
+    []
+  );
+
+  // ── Save ──────────────────────────────────────────────────────────
+
+  const saveSyllabus = useCallback(async () => {
+    setIsSaving(true);
+    setSaveError(null);
+    setSaveSuccess(false);
+    try {
+      await apiFetch(`/api/v1/admin/courses/${courseId}/syllabus`, {
+        method: "PATCH",
+        body: JSON.stringify({ modules }),
+      });
+      setSaveSuccess(true);
+      onSaved?.();
+      setTimeout(() => setSaveSuccess(false), 3000);
+    } catch {
+      setSaveError(t("saveError"));
+    } finally {
+      setIsSaving(false);
+    }
+  }, [courseId, modules, onSaved, t]);
+
+  // ── Render ────────────────────────────────────────────────────────
+
+  return (
+    <div className="space-y-3">
+      {modules.map((mod, mIdx) => (
+        <div
+          key={mIdx}
+          className="rounded-lg border bg-card overflow-hidden"
+        >
+          {/* Module header */}
+          <div className="flex items-center gap-2 p-3 border-b bg-muted/30">
+            <div className="flex flex-col gap-0.5">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-5 w-5"
+                disabled={mIdx === 0}
+                onClick={() => moveModule(mIdx, "up")}
+              >
+                <ChevronUp className="h-3 w-3" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-5 w-5"
+                disabled={mIdx === modules.length - 1}
+                onClick={() => moveModule(mIdx, "down")}
+              >
+                <ChevronDown className="h-3 w-3" />
+              </Button>
+            </div>
+
+            <Badge variant="outline" className="shrink-0 text-xs">
+              M{mod.module_number}
+            </Badge>
+
+            <button
+              type="button"
+              className="flex-1 text-left min-w-0"
+              onClick={() =>
+                setExpandedModule(expandedModule === mIdx ? null : mIdx)
+              }
+            >
+              <p className="text-sm font-medium truncate">
+                {(locale === "fr" ? mod.title_fr : mod.title_en) ||
+                  t("untitledModule")}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {mod.units.length} {t("units")}
+              </p>
+            </button>
+
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0 text-destructive hover:text-destructive"
+              onClick={() => removeModule(mIdx)}
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+
+          {/* Module expanded content */}
+          {expandedModule === mIdx && (
+            <div className="p-3 space-y-3">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                <Input
+                  value={mod.title_fr}
+                  onChange={(e) =>
+                    updateModuleTitle(mIdx, "fr", e.target.value)
+                  }
+                  placeholder={t("titleFrPlaceholder")}
+                  className="text-sm"
+                />
+                <Input
+                  value={mod.title_en}
+                  onChange={(e) =>
+                    updateModuleTitle(mIdx, "en", e.target.value)
+                  }
+                  placeholder={t("titleEnPlaceholder")}
+                  className="text-sm"
+                />
+              </div>
+
+              {/* Units */}
+              <div className="space-y-2 pl-4 border-l-2 border-primary/20">
+                {mod.units.map((unit, uIdx) => (
+                  <div
+                    key={uIdx}
+                    className="flex items-center gap-2 rounded border bg-background p-2"
+                  >
+                    <div className="flex flex-col gap-0.5">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-4 w-4"
+                        disabled={uIdx === 0}
+                        onClick={() => moveUnit(mIdx, uIdx, "up")}
+                      >
+                        <ChevronUp className="h-2.5 w-2.5" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-4 w-4"
+                        disabled={uIdx === mod.units.length - 1}
+                        onClick={() => moveUnit(mIdx, uIdx, "down")}
+                      >
+                        <ChevronDown className="h-2.5 w-2.5" />
+                      </Button>
+                    </div>
+
+                    <div className="text-muted-foreground shrink-0">
+                      {UNIT_TYPE_ICONS[unit.unit_type] || (
+                        <GripVertical className="h-3.5 w-3.5" />
+                      )}
+                    </div>
+
+                    <div className="flex-1 grid grid-cols-1 sm:grid-cols-2 gap-1 min-w-0">
+                      <Input
+                        value={unit.title_fr}
+                        onChange={(e) =>
+                          updateUnitTitle(mIdx, uIdx, "fr", e.target.value)
+                        }
+                        placeholder={t("unitTitleFrPlaceholder")}
+                        className="text-xs h-8"
+                      />
+                      <Input
+                        value={unit.title_en}
+                        onChange={(e) =>
+                          updateUnitTitle(mIdx, uIdx, "en", e.target.value)
+                        }
+                        placeholder={t("unitTitleEnPlaceholder")}
+                        className="text-xs h-8"
+                      />
+                    </div>
+
+                    <Badge variant="secondary" className="text-[10px] shrink-0">
+                      {unit.unit_type}
+                    </Badge>
+
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6 shrink-0 text-destructive hover:text-destructive"
+                      onClick={() => removeUnit(mIdx, uIdx)}
+                      disabled={mod.units.length <= 1}
+                    >
+                      <Trash2 className="h-3 w-3" />
+                    </Button>
+                  </div>
+                ))}
+
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="w-full min-h-[36px] border border-dashed"
+                  onClick={() => addUnit(mIdx)}
+                >
+                  <Plus className="mr-1 h-3 w-3" />
+                  {t("addUnit")}
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      ))}
+
+      {/* Add module button */}
+      <Button
+        variant="outline"
+        className="w-full min-h-[44px] border-dashed"
+        onClick={addModule}
+      >
+        <Plus className="mr-2 h-4 w-4" />
+        {t("addModule")}
+      </Button>
+
+      {/* Save button */}
+      {modules.length > 0 && (
+        <div className="space-y-2 pt-2">
+          {saveError && (
+            <div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              {saveError}
+            </div>
+          )}
+          {saveSuccess && (
+            <div className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-3 text-sm text-green-700 dark:border-green-900 dark:bg-green-950 dark:text-green-400">
+              <CheckCircle2 className="h-4 w-4 shrink-0" />
+              {t("saveSuccess")}
+            </div>
+          )}
+          <Button
+            onClick={saveSyllabus}
+            disabled={isSaving}
+            className="w-full min-h-[44px]"
+          >
+            {isSaving ? (
+              <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent mr-2" />
+            ) : (
+              <Save className="mr-2 h-4 w-4" />
+            )}
+            {t("save")}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1550,6 +1550,19 @@
       },
       "indexingBadge": "Indexing...",
       "indexedBadge": "Indexed"
+    },
+    "syllabusEditor": {
+      "untitledModule": "Untitled Module",
+      "units": "units",
+      "titleFrPlaceholder": "Module title (French)",
+      "titleEnPlaceholder": "Module title (English)",
+      "unitTitleFrPlaceholder": "Unit title (FR)",
+      "unitTitleEnPlaceholder": "Unit title (EN)",
+      "addModule": "Add Module",
+      "addUnit": "Add Unit",
+      "save": "Save Syllabus",
+      "saveError": "Failed to save syllabus",
+      "saveSuccess": "Syllabus saved successfully"
     }
   },
   "AdminSyllabus": {

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1550,6 +1550,19 @@
       },
       "indexingBadge": "Indexation...",
       "indexedBadge": "Indexé"
+    },
+    "syllabusEditor": {
+      "untitledModule": "Module sans titre",
+      "units": "unités",
+      "titleFrPlaceholder": "Titre du module (Français)",
+      "titleEnPlaceholder": "Titre du module (Anglais)",
+      "unitTitleFrPlaceholder": "Titre de l'unité (FR)",
+      "unitTitleEnPlaceholder": "Titre de l'unité (EN)",
+      "addModule": "Ajouter un module",
+      "addUnit": "Ajouter une unité",
+      "save": "Enregistrer le programme",
+      "saveError": "Échec de l'enregistrement du programme",
+      "saveSuccess": "Programme enregistré avec succès"
     }
   },
   "AdminSyllabus": {


### PR DESCRIPTION
## Summary
- Backend: `PATCH /admin/courses/{id}/syllabus` — accepts full syllabus JSON, replays into Module + ModuleUnit rows
- Frontend: new `SyllabusVisualEditor` component with up/down reorder, inline title editing (FR/EN), add/delete modules and units
- Integrated as `syllabus_edit` step in AI wizard (alongside indexation progress)
- Legacy wizard completely untouched

Closes #1461

## Test plan
- [ ] Syllabus edit step shows modules from generation
- [ ] Reorder modules with up/down buttons
- [ ] Inline edit module titles (FR/EN)
- [ ] Expand module to see/edit units
- [ ] Add/delete modules and units
- [ ] Save button persists changes to backend
- [ ] Indexation progress shows inline on same step

🤖 Generated with [Claude Code](https://claude.com/claude-code)