### PR TITLE
feat: lesson preview, content editing, and locked content

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -564,6 +564,85 @@ async def save_syllabus(
     }
 
 
+class PreviewLessonRequest(BaseModel):
+    language: str = "fr"
+    country: str = "SN"
+    level: int = 1
+
+
+@router.post(
+    "/{course_id}/modules/{module_id}/units/{unit_id}/preview-lesson"
+)
+async def preview_lesson(
+    course_id: uuid.UUID,
+    module_id: uuid.UUID,
+    unit_id: str,
+    request: PreviewLessonRequest,
+    current_user: AuthenticatedUser = Depends(
+        require_role(UserRole.admin, UserRole.sub_admin)
+    ),
+    db=Depends(get_db_session),
+) -> dict:
+    """Generate a lesson preview for admin review before publishing."""
+    from app.domain.services.lesson_service import LessonGenerationService
+
+    service = LessonGenerationService()
+    lesson = await service.get_or_generate_lesson(
+        module_id=module_id,
+        unit_id=unit_id,
+        language=request.language,
+        country=request.country,
+        level=request.level,
+        session=db,
+        user_id=uuid.UUID(current_user.id),
+    )
+    return lesson.model_dump()
+
+
+class EditContentRequest(BaseModel):
+    content: dict
+
+
+@router.put("/{course_id}/content/{content_id}")
+async def edit_content(
+    course_id: uuid.UUID,
+    content_id: uuid.UUID,
+    request: EditContentRequest,
+    current_user: AuthenticatedUser = Depends(
+        require_role(UserRole.admin, UserRole.sub_admin)
+    ),
+    db=Depends(get_db_session),
+) -> dict:
+    """Edit generated content and mark as manually edited (locked)."""
+    from app.domain.models.content import GeneratedContent
+
+    result = await db.execute(
+        select(GeneratedContent).where(GeneratedContent.id == content_id)
+    )
+    content = result.scalar_one_or_none()
+    if not content:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Content not found",
+        )
+
+    content.content = request.content
+    content.is_manually_edited = True
+    content.validated = True
+    await db.commit()
+
+    logger.info(
+        "Content edited and locked",
+        content_id=str(content_id),
+        admin_id=current_user.id,
+    )
+    return {
+        "id": str(content.id),
+        "is_manually_edited": True,
+        "validated": True,
+    }
+
+
 class GenerateStructureRequest(BaseModel):
     estimated_hours: int = 20
 

--- a/backend/app/domain/models/content.py
+++ b/backend/app/domain/models/content.py
@@ -31,6 +31,7 @@ class GeneratedContent(Base):
     country_context: Mapped[str | None] = mapped_column(String)
     generated_at: Mapped[datetime] = mapped_column(server_default=func.now())
     validated: Mapped[bool] = mapped_column(Boolean, server_default="false")
+    is_manually_edited: Mapped[bool] = mapped_column(Boolean, server_default="false")
 
     module: Mapped[Module] = relationship(back_populates="generated_content")
     quiz_attempts: Mapped[list[QuizAttempt]] = relationship(

--- a/backend/app/domain/services/lesson_service.py
+++ b/backend/app/domain/services/lesson_service.py
@@ -78,6 +78,31 @@ class LessonGenerationService:
         Returns:
             LessonResponse with generated or cached content
         """
+        # Always return manually edited content, even with force_regenerate
+        if force_regenerate:
+            locked_query = (
+                select(GeneratedContent.id)
+                .where(GeneratedContent.module_id == module_id)
+                .where(GeneratedContent.content_type == "lesson")
+                .where(GeneratedContent.language == language)
+                .where(GeneratedContent.content["unit_id"].astext == unit_id)
+                .where(GeneratedContent.is_manually_edited.is_(True))
+                .limit(1)
+            )
+            locked_result = await session.execute(locked_query)
+            if locked_result.scalar_one_or_none():
+                logger.info(
+                    "Returning manually edited lesson (locked, ignoring force_regenerate)",
+                    module_id=str(module_id),
+                    unit_id=unit_id,
+                )
+                # Fetch via the normal cache path which handles image refs
+                cached, _ = await self._get_cached_lesson(
+                    module_id, unit_id, language, country, level, session
+                )
+                if cached:
+                    return cached
+
         # Check for existing cached content first
         if not force_regenerate:
             cached_lesson, is_fallback = await self._get_cached_lesson(

--- a/backend/migrations/versions/064_add_is_manually_edited_to_generated_content.py
+++ b/backend/migrations/versions/064_add_is_manually_edited_to_generated_content.py
@@ -1,0 +1,26 @@
+"""Add is_manually_edited to generated_content.
+
+Revision ID: 064
+Revises: 063
+Create Date: 2026-04-14
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "064"
+down_revision = "063"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "generated_content",
+        sa.Column("is_manually_edited", sa.Boolean, server_default="false", nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("generated_content", "is_manually_edited")


### PR DESCRIPTION
## Summary
- Add `is_manually_edited` boolean to `GeneratedContent` + Alembic migration 064
- Add `POST /admin/courses/{id}/modules/{mid}/units/{uid}/preview-lesson` — triggers lesson generation for admin preview
- Add `PUT /admin/courses/{id}/content/{cid}` — edit content JSON and lock it (`is_manually_edited=True`)
- Modify `get_or_generate_lesson()`: when `is_manually_edited=True`, always return cached content even with `force_regenerate=True`
- Legacy wizard completely untouched

Closes #1462

## Test plan
- [ ] `POST preview-lesson` generates and returns a lesson for a given unit/language/country
- [ ] `PUT content/{id}` updates content JSON and sets `is_manually_edited=True`
- [ ] Subsequent calls with `force_regenerate=True` return locked content
- [ ] Normal (non-locked) lessons still regenerate normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)