### PR TITLE
fix: hydrate syllabus editor with full modules+units on resume

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -574,6 +574,57 @@ async def save_syllabus(
     }
 
 
+@router.get("/{course_id}/syllabus")
+async def get_course_syllabus(
+    course_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
+    db=Depends(get_db_session),
+) -> dict:
+    """Get full syllabus structure (modules + units) for a course."""
+    result = await db.execute(select(Course).where(Course.id == course_id))
+    course = result.scalar_one_or_none()
+    if not course:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
+
+    modules_result = await db.execute(
+        select(Module).where(Module.course_id == course_id).order_by(Module.module_number)
+    )
+    modules = modules_result.scalars().all()
+
+    syllabus = []
+    for mod in modules:
+        units_result = await db.execute(
+            select(ModuleUnit)
+            .where(ModuleUnit.module_id == mod.id)
+            .order_by(ModuleUnit.order_index)
+        )
+        units = units_result.scalars().all()
+
+        syllabus.append(
+            {
+                "module_number": mod.module_number,
+                "title_fr": mod.title_fr,
+                "title_en": mod.title_en,
+                "description_fr": mod.description_fr or "",
+                "description_en": mod.description_en or "",
+                "estimated_hours": mod.estimated_hours,
+                "bloom_level": mod.bloom_level or "understand",
+                "units": [
+                    {
+                        "title_fr": u.title_fr,
+                        "title_en": u.title_en,
+                        "unit_type": u.unit_type or "lesson",
+                        "description_fr": u.description_fr or "",
+                        "description_en": u.description_en or "",
+                    }
+                    for u in units
+                ],
+            }
+        )
+
+    return {"modules": syllabus}
+
+
 class PreviewLessonRequest(BaseModel):
     language: str = "fr"
     country: str = "SN"

--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -1284,22 +1284,7 @@ export function AICourseWizard({
                 {courseId && (
                   <SyllabusVisualEditor
                     courseId={courseId}
-                    initialModules={generatedModules.map((m, i) => ({
-                      module_number: m.module_number || i + 1,
-                      title_fr: m.title_fr,
-                      title_en: m.title_en,
-                      description_fr: "",
-                      description_en: "",
-                      estimated_hours: 20,
-                      bloom_level: "understand",
-                      units: [{
-                        title_fr: "",
-                        title_en: "",
-                        unit_type: "lesson",
-                        description_fr: "",
-                        description_en: "",
-                      }],
-                    }))}
+                    fetchOnMount
                   />
                 )}
               </div>

--- a/frontend/components/admin/syllabus-visual-editor.tsx
+++ b/frontend/components/admin/syllabus-visual-editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import {
   ChevronDown,
@@ -19,28 +19,14 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { apiFetch } from "@/lib/api";
-
-interface SyllabusUnit {
-  title_fr: string;
-  title_en: string;
-  unit_type: string;
-  description_fr: string;
-  description_en: string;
-}
-
-interface SyllabusModule {
-  module_number: number;
-  title_fr: string;
-  title_en: string;
-  description_fr: string;
-  description_en: string;
-  estimated_hours: number;
-  bloom_level: string;
-  units: SyllabusUnit[];
-}
+import {
+  type SyllabusModule,
+  getCourseSyllabus,
+} from "@/lib/api-course-admin";
 
 interface SyllabusVisualEditorProps {
   courseId: string;
+  fetchOnMount?: boolean;
   initialModules?: SyllabusModule[];
   onSaved?: () => void;
 }
@@ -54,6 +40,7 @@ const UNIT_TYPE_ICONS: Record<string, React.ReactNode> = {
 export function SyllabusVisualEditor({
   courseId,
   initialModules = [],
+  fetchOnMount = false,
   onSaved,
 }: SyllabusVisualEditorProps) {
   const t = useTranslations("AdminCourses.syllabusEditor");
@@ -65,6 +52,22 @@ export function SyllabusVisualEditor({
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Fetch full syllabus from backend when initialModules is empty
+  useEffect(() => {
+    if (!fetchOnMount || initialModules.length > 0) return;
+    setIsLoading(true);
+    getCourseSyllabus(courseId)
+      .then((data) => {
+        if (data.modules.length > 0) {
+          setModules(data.modules);
+          setExpandedModule(0);
+        }
+      })
+      .catch(() => {})
+      .finally(() => setIsLoading(false));
+  }, [courseId, fetchOnMount]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── Module operations ─────────────────────────────────────────────
 
@@ -226,6 +229,14 @@ export function SyllabusVisualEditor({
   }, [courseId, modules, onSaved, t]);
 
   // ── Render ────────────────────────────────────────────────────────
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-3">

--- a/frontend/lib/api-course-admin.ts
+++ b/frontend/lib/api-course-admin.ts
@@ -210,6 +210,33 @@ export async function reindexImagesApi(
   });
 }
 
+// ── Syllabus ──────────────────────────────────────────────────────────
+
+export interface SyllabusUnit {
+  title_fr: string;
+  title_en: string;
+  unit_type: string;
+  description_fr: string;
+  description_en: string;
+}
+
+export interface SyllabusModule {
+  module_number: number;
+  title_fr: string;
+  title_en: string;
+  description_fr: string;
+  description_en: string;
+  estimated_hours: number;
+  bloom_level: string;
+  units: SyllabusUnit[];
+}
+
+export async function getCourseSyllabus(
+  courseId: string
+): Promise<{ modules: SyllabusModule[] }> {
+  return apiFetch(`/api/v1/admin/courses/${courseId}/syllabus`);
+}
+
 // ── AI metadata suggestion ────────────────────────────────────────────
 
 export interface SuggestedMetadata {


### PR DESCRIPTION
## Summary
- Add `GET /admin/courses/{id}/syllabus` endpoint — returns full module structure with units
- Add `getCourseSyllabus()` to shared API module
- `SyllabusVisualEditor` fetches modules from backend on mount when `fetchOnMount` is true
- AI wizard passes `fetchOnMount` to the editor

Fixes the issue where resuming an AI-assisted course on the "Edit Syllabus" step showed an empty editor instead of the generated modules.

## Test plan
- [ ] Resume AI course with generated modules → Edit Syllabus step shows all modules with units
- [ ] Modules display correct titles, descriptions, bloom levels
- [ ] Units display correct titles and types (lesson/quiz/case-study)
- [ ] Editor still works for fresh generation flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)