### PR TITLE
feat: lesson preview & edit step in AI wizard (9a-11a)

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -602,6 +602,7 @@ async def get_course_syllabus(
 
         syllabus.append(
             {
+                "id": str(mod.id),
                 "module_number": mod.module_number,
                 "title_fr": mod.title_fr,
                 "title_en": mod.title_en,

--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -22,6 +22,7 @@ import {
   ChevronDown,
   StopCircle,
   RotateCcw,
+  BookOpen,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -59,6 +60,7 @@ import {
 } from "@/lib/api-course-admin";
 import { getCourseTaxonomy, type TaxonomyItem } from "@/lib/api";
 import { SyllabusVisualEditor } from "@/components/admin/syllabus-visual-editor";
+import { LessonPreviewStep } from "@/components/admin/lesson-preview-step";
 
 // ── Step types ────────────────────────────────────────────────────────
 
@@ -68,6 +70,7 @@ type AIWizardStep =
   | "ai_proposal"
   | "generate"
   | "syllabus_edit"
+  | "lesson_preview"
   | "publish";
 
 const AI_STEPS: AIWizardStep[] = [
@@ -76,6 +79,7 @@ const AI_STEPS: AIWizardStep[] = [
   "ai_proposal",
   "generate",
   "syllabus_edit",
+  "lesson_preview",
   "publish",
 ];
 
@@ -85,6 +89,7 @@ const STEP_ICONS: Record<AIWizardStep, React.ReactNode> = {
   ai_proposal: <Wand2 className="h-4 w-4" />,
   generate: <Sparkles className="h-4 w-4" />,
   syllabus_edit: <GripVertical className="h-4 w-4" />,
+  lesson_preview: <BookOpen className="h-4 w-4" />,
   publish: <Rocket className="h-4 w-4" />,
 };
 
@@ -744,6 +749,7 @@ export function AICourseWizard({
     if (step === "ai_proposal") return proposedTitle.fr.trim().length > 0 && proposedTitle.en.trim().length > 0;
     if (step === "generate") return generatedModules.length > 0;
     if (step === "syllabus_edit") return generatedModules.length > 0;
+    if (step === "lesson_preview") return true; // Optional step — always skippable
     return false;
   };
 
@@ -1287,6 +1293,22 @@ export function AICourseWizard({
                     fetchOnMount
                   />
                 )}
+              </div>
+            )}
+
+            {/* ── LESSON PREVIEW STEP ───────────────────────────────── */}
+            {step === "lesson_preview" && (
+              <div className="space-y-4">
+                <div>
+                  <h3 className="text-xl font-semibold">{tAi("lessonPreview.title")}</h3>
+                  <p className="mt-1 text-sm text-muted-foreground">{tAi("lessonPreview.description")}</p>
+                </div>
+
+                {courseId && <LessonPreviewStep courseId={courseId} />}
+
+                <p className="text-xs text-muted-foreground text-center">
+                  {tAi("lessonPreview.skipHint")}
+                </p>
               </div>
             )}
 

--- a/frontend/components/admin/lesson-preview-step.tsx
+++ b/frontend/components/admin/lesson-preview-step.tsx
@@ -1,0 +1,416 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import { useTranslations, useLocale } from "next-intl";
+import {
+  ChevronDown,
+  ChevronRight,
+  Eye,
+  Pencil,
+  Lock,
+  Loader2,
+  CheckCircle2,
+  AlertCircle,
+  BookOpen,
+  Save,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import {
+  type SyllabusModule,
+  type LessonPreviewResponse,
+  type LessonContent,
+  getCourseSyllabus,
+  previewLesson,
+  editContent,
+} from "@/lib/api-course-admin";
+
+interface LessonPreviewStepProps {
+  courseId: string;
+}
+
+interface PreviewState {
+  loading: boolean;
+  data: LessonPreviewResponse | null;
+  error: string | null;
+  editing: boolean;
+  editedContent: LessonContent | null;
+  saving: boolean;
+  locked: boolean;
+}
+
+export function LessonPreviewStep({ courseId }: LessonPreviewStepProps) {
+  const t = useTranslations("AdminCourses.lessonPreview");
+  const locale = useLocale();
+
+  const [modules, setModules] = useState<SyllabusModule[]>([]);
+  const [isLoadingModules, setIsLoadingModules] = useState(true);
+  const [expandedModule, setExpandedModule] = useState<number | null>(null);
+  // Preview controls
+  const [language, setLanguage] = useState("fr");
+  const [country, setCountry] = useState("SN");
+
+  // Preview state per unit key
+  const [previews, setPreviews] = useState<Record<string, PreviewState>>({});
+
+  // Fetch modules on mount
+  useEffect(() => {
+    setIsLoadingModules(true);
+    getCourseSyllabus(courseId)
+      .then((data) => setModules(data.modules))
+      .catch(() => {})
+      .finally(() => setIsLoadingModules(false));
+  }, [courseId]);
+
+  const getPreviewKey = (moduleNumber: number, unitIdx: number) =>
+    `${moduleNumber}-${unitIdx}-${language}-${country}`;
+
+  const generatePreview = useCallback(
+    async (moduleId: string, moduleNumber: number, unitIdx: number) => {
+      const unitId = `${moduleNumber}.${unitIdx + 1}`;
+      const key = getPreviewKey(moduleNumber, unitIdx);
+
+      setPreviews((prev) => ({
+        ...prev,
+        [key]: { loading: true, data: null, error: null, editing: false, editedContent: null, saving: false, locked: false },
+      }));
+
+      try {
+        const result = await previewLesson(courseId, moduleId, unitId, language, country);
+        setPreviews((prev) => ({
+          ...prev,
+          [key]: { ...prev[key], loading: false, data: result, locked: false },
+        }));
+      } catch {
+        setPreviews((prev) => ({
+          ...prev,
+          [key]: { ...prev[key], loading: false, error: t("generateError") },
+        }));
+      }
+    },
+    [courseId, language, country, t]
+  );
+
+  const toggleEdit = useCallback((key: string) => {
+    setPreviews((prev) => {
+      const p = prev[key];
+      if (!p?.data) return prev;
+      return {
+        ...prev,
+        [key]: {
+          ...p,
+          editing: !p.editing,
+          editedContent: p.editing ? null : { ...p.data.content },
+        },
+      };
+    });
+  }, []);
+
+  const updateEditField = useCallback(
+    (key: string, field: keyof LessonContent, value: string | string[]) => {
+      setPreviews((prev) => {
+        const p = prev[key];
+        if (!p?.editedContent) return prev;
+        return {
+          ...prev,
+          [key]: {
+            ...p,
+            editedContent: { ...p.editedContent, [field]: value },
+          },
+        };
+      });
+    },
+    []
+  );
+
+  const saveEdit = useCallback(
+    async (key: string) => {
+      const p = previews[key];
+      if (!p?.data || !p.editedContent) return;
+
+      setPreviews((prev) => ({
+        ...prev,
+        [key]: { ...prev[key], saving: true },
+      }));
+
+      try {
+        await editContent(courseId, p.data.id, p.editedContent);
+        setPreviews((prev) => ({
+          ...prev,
+          [key]: {
+            ...prev[key],
+            saving: false,
+            editing: false,
+            locked: true,
+            data: { ...prev[key].data!, content: prev[key].editedContent! },
+            editedContent: null,
+          },
+        }));
+      } catch {
+        setPreviews((prev) => ({
+          ...prev,
+          [key]: { ...prev[key], saving: false },
+        }));
+      }
+    },
+    [courseId, previews]
+  );
+
+  if (isLoadingModules) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Language / Country selectors */}
+      <div className="flex gap-3 flex-wrap">
+        <div className="space-y-1">
+          <Label className="text-xs">{t("language")}</Label>
+          <Select value={language} onValueChange={(v) => v && setLanguage(v)}>
+            <SelectTrigger className="w-[120px] h-9">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="fr">Fran\u00e7ais</SelectItem>
+              <SelectItem value="en">English</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-1">
+          <Label className="text-xs">{t("country")}</Label>
+          <Select value={country} onValueChange={(v) => v && setCountry(v)}>
+            <SelectTrigger className="w-[120px] h-9">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="SN">S\u00e9n\u00e9gal</SelectItem>
+              <SelectItem value="ML">Mali</SelectItem>
+              <SelectItem value="BF">Burkina Faso</SelectItem>
+              <SelectItem value="CI">C\u00f4te d&apos;Ivoire</SelectItem>
+              <SelectItem value="GH">Ghana</SelectItem>
+              <SelectItem value="NG">Nigeria</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Module / Unit tree */}
+      {modules.map((mod, mIdx) => (
+        <div key={mIdx} className="rounded-lg border bg-card overflow-hidden">
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 p-3 text-left min-h-[44px] hover:bg-muted/50"
+            onClick={() => setExpandedModule(expandedModule === mIdx ? null : mIdx)}
+          >
+            {expandedModule === mIdx ? (
+              <ChevronDown className="h-4 w-4 shrink-0" />
+            ) : (
+              <ChevronRight className="h-4 w-4 shrink-0" />
+            )}
+            <Badge variant="outline" className="shrink-0 text-xs">
+              M{mod.module_number}
+            </Badge>
+            <span className="text-sm font-medium truncate">
+              {locale === "fr" ? mod.title_fr : mod.title_en}
+            </span>
+            <span className="text-xs text-muted-foreground ml-auto shrink-0">
+              {mod.units.length} {t("units")}
+            </span>
+          </button>
+
+          {expandedModule === mIdx && (
+            <div className="border-t px-3 pb-3 pt-2 space-y-2">
+              {mod.units
+                .filter((u) => u.unit_type === "lesson")
+                .map((unit, uIdx) => {
+                  const key = getPreviewKey(mod.module_number, uIdx);
+                  const preview = previews[key];
+                  const unitTitle = locale === "fr" ? unit.title_fr : unit.title_en;
+
+                  return (
+                    <div key={uIdx} className="space-y-2">
+                      <div className="flex items-center gap-2 rounded border bg-background p-2">
+                        <BookOpen className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                        <span className="text-sm truncate flex-1">{unitTitle || `Unit ${mod.module_number}.${uIdx + 1}`}</span>
+
+                        {preview?.locked && (
+                          <Badge className="gap-1 bg-amber-100 text-amber-800 border-amber-300 text-[10px] shrink-0">
+                            <Lock className="h-2.5 w-2.5" />
+                            {t("locked")}
+                          </Badge>
+                        )}
+
+                        {preview?.data && !preview.loading && (
+                          <>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-7 gap-1 text-xs shrink-0"
+                              onClick={() => toggleEdit(key)}
+                            >
+                              {preview.editing ? <Eye className="h-3 w-3" /> : <Pencil className="h-3 w-3" />}
+                              {preview.editing ? t("view") : t("edit")}
+                            </Button>
+                          </>
+                        )}
+
+                        {!preview?.data && !preview?.loading && (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-7 gap-1 text-xs shrink-0"
+                            onClick={() => generatePreview(mod.id || "", mod.module_number, uIdx)}
+                            disabled={!mod.id}
+                          >
+                            <Eye className="h-3 w-3" />
+                            {t("generate")}
+                          </Button>
+                        )}
+
+                        {preview?.loading && (
+                          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground shrink-0" />
+                        )}
+                      </div>
+
+                      {preview?.error && (
+                        <div className="flex items-center gap-2 rounded border border-destructive/30 bg-destructive/5 p-2 text-xs text-destructive">
+                          <AlertCircle className="h-3 w-3 shrink-0" />
+                          {preview.error}
+                        </div>
+                      )}
+
+                      {/* Preview content */}
+                      {preview?.data && !preview.editing && (
+                        <div className="rounded border bg-muted/20 p-3 max-h-96 overflow-y-auto">
+                          <div className="prose prose-sm dark:prose-invert max-w-none">
+                            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                              {preview.data.content.introduction}
+                            </ReactMarkdown>
+                            {preview.data.content.concepts.map((c, i) => (
+                              <ReactMarkdown key={i} remarkPlugins={[remarkGfm]}>
+                                {c}
+                              </ReactMarkdown>
+                            ))}
+                            {preview.data.content.key_points.length > 0 && (
+                              <>
+                                <h4>{t("keyPoints")}</h4>
+                                <ul>
+                                  {preview.data.content.key_points.map((kp, i) => (
+                                    <li key={i}>
+                                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{kp}</ReactMarkdown>
+                                    </li>
+                                  ))}
+                                </ul>
+                              </>
+                            )}
+                          </div>
+                          <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+                            {preview.data.cached && (
+                              <Badge variant="secondary" className="text-[10px]">
+                                <CheckCircle2 className="h-2.5 w-2.5 mr-0.5" />
+                                {t("cached")}
+                              </Badge>
+                            )}
+                            <span>{preview.data.language.toUpperCase()}</span>
+                            <span>{preview.data.country_context}</span>
+                          </div>
+                        </div>
+                      )}
+
+                      {/* Edit mode */}
+                      {preview?.editing && preview.editedContent && (
+                        <div className="rounded border bg-muted/20 p-3 space-y-3">
+                          <div className="space-y-1.5">
+                            <Label className="text-xs font-medium">{t("editIntroduction")}</Label>
+                            <Textarea
+                              value={preview.editedContent.introduction}
+                              onChange={(e) => updateEditField(key, "introduction", e.target.value)}
+                              className="min-h-[100px] text-sm"
+                            />
+                          </div>
+
+                          {preview.editedContent.concepts.map((concept, i) => (
+                            <div key={i} className="space-y-1.5">
+                              <Label className="text-xs font-medium">{t("editConcept", { n: i + 1 })}</Label>
+                              <Textarea
+                                value={concept}
+                                onChange={(e) => {
+                                  const updated = [...preview.editedContent!.concepts];
+                                  updated[i] = e.target.value;
+                                  updateEditField(key, "concepts", updated);
+                                }}
+                                className="min-h-[80px] text-sm"
+                              />
+                            </div>
+                          ))}
+
+                          <div className="space-y-1.5">
+                            <Label className="text-xs font-medium">{t("editSynthesis")}</Label>
+                            <Textarea
+                              value={preview.editedContent.synthesis}
+                              onChange={(e) => updateEditField(key, "synthesis", e.target.value)}
+                              className="min-h-[80px] text-sm"
+                            />
+                          </div>
+
+                          <div className="flex gap-2">
+                            <Button
+                              size="sm"
+                              onClick={() => saveEdit(key)}
+                              disabled={preview.saving}
+                              className="gap-1 min-h-[36px]"
+                            >
+                              {preview.saving ? (
+                                <Loader2 className="h-3 w-3 animate-spin" />
+                              ) : (
+                                <Save className="h-3 w-3" />
+                              )}
+                              {t("saveAndLock")}
+                            </Button>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => toggleEdit(key)}
+                              className="min-h-[36px]"
+                            >
+                              {t("cancel")}
+                            </Button>
+                          </div>
+
+                          <p className="text-xs text-muted-foreground flex items-center gap-1">
+                            <Lock className="h-3 w-3" />
+                            {t("lockHint")}
+                          </p>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+            </div>
+          )}
+        </div>
+      ))}
+
+      {modules.length === 0 && (
+        <div className="text-center py-8 text-sm text-muted-foreground">
+          {t("noModules")}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/api-course-admin.ts
+++ b/frontend/lib/api-course-admin.ts
@@ -221,6 +221,7 @@ export interface SyllabusUnit {
 }
 
 export interface SyllabusModule {
+  id?: string;
   module_number: number;
   title_fr: string;
   title_en: string;
@@ -251,6 +252,57 @@ export async function suggestCourseMetadata(
 ): Promise<SuggestedMetadata> {
   return apiFetch(`/api/v1/admin/courses/${courseId}/suggest-metadata`, {
     method: "POST",
+  });
+}
+
+// ── Lesson preview & editing ──────────────────────────────────────────
+
+export interface LessonContent {
+  introduction: string;
+  concepts: string[];
+  aof_example: string;
+  synthesis: string;
+  key_points: string[];
+  sources_cited: string[];
+}
+
+export interface LessonPreviewResponse {
+  id: string;
+  module_id: string;
+  unit_id: string;
+  language: string;
+  level: number;
+  country_context: string;
+  content: LessonContent;
+  cached: boolean;
+  country_fallback?: boolean;
+}
+
+export async function previewLesson(
+  courseId: string,
+  moduleId: string,
+  unitId: string,
+  language: string = "fr",
+  country: string = "SN",
+  level: number = 1
+): Promise<LessonPreviewResponse> {
+  return apiFetch(
+    `/api/v1/admin/courses/${courseId}/modules/${moduleId}/units/${unitId}/preview-lesson`,
+    {
+      method: "POST",
+      body: JSON.stringify({ language, country, level }),
+    }
+  );
+}
+
+export async function editContent(
+  courseId: string,
+  contentId: string,
+  content: LessonContent
+): Promise<{ id: string; is_manually_edited: boolean; validated: boolean }> {
+  return apiFetch(`/api/v1/admin/courses/${courseId}/content/${contentId}`, {
+    method: "PUT",
+    body: JSON.stringify({ content }),
   });
 }
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1516,7 +1516,8 @@
         "ai_proposal": "AI Proposal",
         "generate": "Generate",
         "syllabus_edit": "Edit Syllabus",
-        "publish": "Publish"
+        "publish": "Publish",
+        "lesson_preview": "Lessons"
       },
       "objectives": {
         "title": "Course Objectives",
@@ -1549,7 +1550,12 @@
         "indexNeeded": "RAG indexation is required before publishing. Start it now while you edit the syllabus."
       },
       "indexingBadge": "Indexing...",
-      "indexedBadge": "Indexed"
+      "indexedBadge": "Indexed",
+      "lessonPreview": {
+        "title": "Preview & Edit Lessons",
+        "description": "Generate lesson previews, review content, and edit before publishing. Edited lessons will be locked and served from cache.",
+        "skipHint": "This step is optional. Click Next to skip to publishing."
+      }
     },
     "syllabusEditor": {
       "untitledModule": "Untitled Module",
@@ -1563,6 +1569,25 @@
       "save": "Save Syllabus",
       "saveError": "Failed to save syllabus",
       "saveSuccess": "Syllabus saved successfully"
+    },
+    "lessonPreview": {
+      "language": "Language",
+      "country": "Country",
+      "units": "units",
+      "generate": "Preview",
+      "edit": "Edit",
+      "view": "View",
+      "locked": "Locked",
+      "cached": "Cached",
+      "keyPoints": "Key Points",
+      "editIntroduction": "Introduction",
+      "editConcept": "Concept {n}",
+      "editSynthesis": "Synthesis",
+      "saveAndLock": "Save & Lock",
+      "cancel": "Cancel",
+      "lockHint": "Saved lessons are locked and will never be regenerated.",
+      "generateError": "Failed to generate lesson preview.",
+      "noModules": "No modules found. Generate a syllabus first."
     }
   },
   "AdminSyllabus": {

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1516,7 +1516,8 @@
         "ai_proposal": "Proposition IA",
         "generate": "Générer",
         "syllabus_edit": "Modifier le programme",
-        "publish": "Publier"
+        "publish": "Publier",
+        "lesson_preview": "Leçons"
       },
       "objectives": {
         "title": "Objectifs du cours",
@@ -1549,7 +1550,12 @@
         "indexNeeded": "L'indexation RAG est nécessaire avant la publication. Lancez-la maintenant pendant que vous modifiez le programme."
       },
       "indexingBadge": "Indexation...",
-      "indexedBadge": "Indexé"
+      "indexedBadge": "Indexé",
+      "lessonPreview": {
+        "title": "Aperçu et modification des leçons",
+        "description": "Générez des aperçus de leçons, vérifiez le contenu et modifiez avant la publication. Les leçons modifiées seront verrouillées et servies depuis le cache.",
+        "skipHint": "Cette étape est optionnelle. Cliquez sur Suivant pour passer à la publication."
+      }
     },
     "syllabusEditor": {
       "untitledModule": "Module sans titre",
@@ -1563,6 +1569,25 @@
       "save": "Enregistrer le programme",
       "saveError": "Échec de l'enregistrement du programme",
       "saveSuccess": "Programme enregistré avec succès"
+    },
+    "lessonPreview": {
+      "language": "Langue",
+      "country": "Pays",
+      "units": "unités",
+      "generate": "Aperçu",
+      "edit": "Modifier",
+      "view": "Voir",
+      "locked": "Verrouillé",
+      "cached": "En cache",
+      "keyPoints": "Points clés",
+      "editIntroduction": "Introduction",
+      "editConcept": "Concept {n}",
+      "editSynthesis": "Synthèse",
+      "saveAndLock": "Enregistrer et verrouiller",
+      "cancel": "Annuler",
+      "lockHint": "Les leçons enregistrées sont verrouillées et ne seront jamais régénérées.",
+      "generateError": "Échec de la génération de l'aperçu de la leçon.",
+      "noModules": "Aucun module trouvé. Générez d'abord un programme."
     }
   },
   "AdminSyllabus": {


### PR DESCRIPTION
## Summary
Implements the alternative flow (9a-11a) in the AI-Assisted course creation wizard:

- **9a**: Generate and edit 1+ lessons in 1+ languages for a country
- **10a**: Publish
- **11a**: Edited lessons served from cache (locked), never regenerated

### Changes
- Add `lesson_preview` step between `syllabus_edit` and `publish` in AI wizard (7-step flow)
- New `LessonPreviewStep` component:
  - Module/unit tree view (fetches from `GET /syllabus` endpoint)
  - Language selector (FR/EN) and country selector (SN, ML, BF, CI, GH, NG)
  - "Preview" button per unit — calls `POST /preview-lesson` endpoint
  - Inline markdown rendering of generated lesson content
  - Edit mode with textarea editors for introduction, concepts, synthesis
  - "Save & Lock" saves edits via `PUT /content/{id}` and sets `is_manually_edited=True`
  - Locked lessons show padlock badge
- Add `previewLesson()` and `editContent()` to shared API module
- Add module `id` to `GET /syllabus` response
- Step is optional — "Skip to Publish" always available via Next button
- Add FR/EN i18n keys

**Backend was already implemented** (#1462): `is_manually_edited` field, preview endpoint, edit endpoint, lock logic in `get_or_generate_lesson()`.

Legacy wizard completely untouched.

## Test plan
- [ ] AI wizard now shows 7 steps (Upload → Objectives → AI Proposal → Generate → Edit Syllabus → Lessons → Publish)
- [ ] Lesson preview step shows module/unit tree from syllabus
- [ ] Select language/country → click Preview → lesson generates and renders
- [ ] Click Edit → edit content → Save & Lock → lesson shows "Locked" badge
- [ ] Locked lessons are served from cache when learners access them
- [ ] Step is skippable — Next button always enabled
- [ ] Legacy wizard unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)