### PR TITLE
feat: disable self-registration by default with admin toggle

### DIFF
--- a/backend/app/api/v1/local_auth.py
+++ b/backend/app/api/v1/local_auth.py
@@ -8,9 +8,21 @@ from structlog import get_logger
 
 from ...api.deps import get_db_session
 from ...domain.services.local_auth_service import AuthenticationError, LocalAuthService
+from ...domain.services.platform_settings_service import PlatformSettingsService
 
 logger = get_logger(__name__)
 router = APIRouter(prefix="/auth", tags=["Authentication"])
+
+_settings_svc = PlatformSettingsService()
+
+
+async def _require_registration_enabled() -> None:
+    enabled = await _settings_svc.get("auth-self-registration-enabled")
+    if not enabled:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Self-registration is disabled for this instance.",
+        )
 
 
 # =============================================================================
@@ -190,7 +202,9 @@ class VerifyLoginOTPRequest(BaseModel):
 
 
 @router.post("/register", response_model=RegisterResponse)
-async def register(request: RegisterRequest, db=Depends(get_db_session)) -> RegisterResponse:
+async def register(
+    request: RegisterRequest, db=Depends(get_db_session), _guard=Depends(_require_registration_enabled)
+) -> RegisterResponse:
     """Register a new user with TOTP MFA setup.
 
     Flow:
@@ -466,7 +480,10 @@ async def logout(
 
 @router.post("/register-password", response_model=TokenResponse)
 async def register_with_password(
-    request: RegisterPasswordRequest, request_obj: Request, db=Depends(get_db_session)
+    request: RegisterPasswordRequest,
+    request_obj: Request,
+    db=Depends(get_db_session),
+    _guard=Depends(_require_registration_enabled),
 ) -> TokenResponse:
     """Register a new user with email or phone + password.
 
@@ -617,7 +634,10 @@ async def reset_password(
 
 @router.post("/register-email-otp", response_model=RegisterEmailOTPResponse)
 async def register_email_otp(
-    request: RegisterEmailOTPRequest, request_obj: Request, db=Depends(get_db_session)
+    request: RegisterEmailOTPRequest,
+    request_obj: Request,
+    db=Depends(get_db_session),
+    _guard=Depends(_require_registration_enabled),
 ) -> RegisterEmailOTPResponse:
     """Register a new user with email OTP verification.
 

--- a/backend/app/infrastructure/config/platform_defaults.py
+++ b/backend/app/infrastructure/config/platform_defaults.py
@@ -317,6 +317,14 @@ SETTING_DEFINITIONS: list[SettingDef] = [
         {"min": 4, "max": 20},
         True,
     ),
+    SettingDef(
+        "auth-self-registration-enabled",
+        "auth",
+        False,
+        "boolean",
+        "Allow self-registration",
+        "When disabled, only admins can create user accounts. Sign-up pages and registration endpoints are blocked.",
+    ),
     # ── Rate Limiting ──────────────────────────────────────
     SettingDef(
         "rate-limiting-global-requests-per-minute",

--- a/frontend/app/[locale]/(auth)/register-email-otp/page.tsx
+++ b/frontend/app/[locale]/(auth)/register-email-otp/page.tsx
@@ -1,6 +1,13 @@
+'use client';
+
 import { EmailOTPRegisterForm } from '@/components/auth/email-otp-register-form';
+import { useRegistrationGuard } from '@/hooks/use-registration-guard';
 
 export default function RegisterEmailOTPPage() {
+  const blocked = useRegistrationGuard();
+
+  if (blocked) return null;
+
   return (
     <div className="flex min-h-screen items-center justify-center p-4">
       <EmailOTPRegisterForm />

--- a/frontend/app/[locale]/(auth)/register-options/page.tsx
+++ b/frontend/app/[locale]/(auth)/register-options/page.tsx
@@ -11,10 +11,14 @@ import {
 } from '@/components/ui/card';
 import { Link } from '@/i18n/routing';
 import { cn } from '@/lib/utils';
+import { useRegistrationGuard } from '@/hooks/use-registration-guard';
 
 export default function RegisterOptionsPage() {
   const t = useTranslations('Auth');
   const tCommon = useTranslations('Common');
+  const blocked = useRegistrationGuard();
+
+  if (blocked) return null;
 
   return (
     <div className="flex min-h-screen items-center justify-center p-4">

--- a/frontend/app/[locale]/(auth)/register-password/page.tsx
+++ b/frontend/app/[locale]/(auth)/register-password/page.tsx
@@ -1,6 +1,13 @@
+'use client';
+
 import { PasswordRegisterForm } from '@/components/auth/password-register-form';
+import { useRegistrationGuard } from '@/hooks/use-registration-guard';
 
 export default function RegisterPasswordPage() {
+  const blocked = useRegistrationGuard();
+
+  if (blocked) return null;
+
   return (
     <div className="flex min-h-screen items-center justify-center p-4">
       <PasswordRegisterForm />

--- a/frontend/app/[locale]/(auth)/register-totp/page.tsx
+++ b/frontend/app/[locale]/(auth)/register-totp/page.tsx
@@ -1,6 +1,13 @@
+'use client';
+
 import { TOTPRegisterForm } from '@/components/auth/totp-register-form';
+import { useRegistrationGuard } from '@/hooks/use-registration-guard';
 
 export default function RegisterTOTPPage() {
+  const blocked = useRegistrationGuard();
+
+  if (blocked) return null;
+
   return (
     <div className="flex min-h-screen items-center justify-center p-4">
       <TOTPRegisterForm />

--- a/frontend/components/auth/password-login-form.tsx
+++ b/frontend/components/auth/password-login-form.tsx
@@ -16,6 +16,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { authClient, AuthError } from '@/lib/auth';
+import { useSettings } from '@/lib/settings-context';
 
 const createSchema = (t: (key: string) => string) =>
   z.object({
@@ -32,6 +33,8 @@ export function PasswordLoginForm({ redirectTo }: { redirectTo?: string }) {
 
   const [isLoading, setIsLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
+  const { getSetting } = useSettings();
+  const registrationEnabled = getSetting<boolean>('auth-self-registration-enabled', false);
 
   const schema = createSchema(t);
   const {
@@ -155,12 +158,14 @@ export function PasswordLoginForm({ redirectTo }: { redirectTo?: string }) {
             {isLoading ? tCommon('loading') : t('signIn')}
           </Button>
 
-          <div className="text-center text-sm">
-            <span className="text-muted-foreground">{t('noAccount')} </span>
-            <Link href="/register-options" className="font-medium text-primary hover:underline">
-              {t('signUp')}
-            </Link>
-          </div>
+          {registrationEnabled && (
+            <div className="text-center text-sm">
+              <span className="text-muted-foreground">{t('noAccount')} </span>
+              <Link href="/register-options" className="font-medium text-primary hover:underline">
+                {t('signUp')}
+              </Link>
+            </div>
+          )}
         </form>
       </CardContent>
     </Card>

--- a/frontend/components/auth/totp-login-form.tsx
+++ b/frontend/components/auth/totp-login-form.tsx
@@ -16,6 +16,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { authClient, AuthError } from '@/lib/auth';
+import { useSettings } from '@/lib/settings-context';
 
 const createLoginSchema = (t: (key: string) => string) => z.object({
   email: z.string().min(1, t('emailRequired')).email(t('emailInvalid')),
@@ -41,6 +42,8 @@ export function TOTPLoginForm({ redirectTo }: { redirectTo?: string }) {
   const [isLoading, setIsLoading] = useState(false);
   const [showMagicLink, setShowMagicLink] = useState(false);
   const [magicLinkSent, setMagicLinkSent] = useState(false);
+  const { getSetting } = useSettings();
+  const registrationEnabled = getSetting<boolean>('auth-self-registration-enabled', false);
 
   // Login form
   const loginSchema = createLoginSchema(t);
@@ -273,15 +276,17 @@ export function TOTPLoginForm({ redirectTo }: { redirectTo?: string }) {
           </div>
 
           {/* Registration Link */}
-          <div className="text-center text-sm">
-            <span className="text-muted-foreground">{t('noAccount')} </span>
-            <Link 
-              href="/register"
-              className="font-medium text-primary hover:underline"
-            >
-              {t('signUp')}
-            </Link>
-          </div>
+          {registrationEnabled && (
+            <div className="text-center text-sm">
+              <span className="text-muted-foreground">{t('noAccount')} </span>
+              <Link
+                href="/register"
+                className="font-medium text-primary hover:underline"
+              >
+                {t('signUp')}
+              </Link>
+            </div>
+          )}
         </form>
       </CardContent>
     </Card>

--- a/frontend/hooks/use-registration-guard.ts
+++ b/frontend/hooks/use-registration-guard.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from '@/i18n/routing';
+import { useSettings } from '@/lib/settings-context';
+
+/**
+ * Redirects to /login if self-registration is disabled.
+ * Returns true when still loading or redirecting (caller should render nothing).
+ */
+export function useRegistrationGuard(): boolean {
+  const { getSetting, loading } = useSettings();
+  const registrationEnabled = getSetting<boolean>('auth-self-registration-enabled', false);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && !registrationEnabled) {
+      router.replace('/login');
+    }
+  }, [loading, registrationEnabled, router]);
+
+  return loading || !registrationEnabled;
+}


### PR DESCRIPTION
## Summary
- Add `auth-self-registration-enabled` platform setting (default: `false`)
- Guard all registration endpoints with 403 when disabled
- Hide sign-up links on login page and redirect registration pages

## Test plan
- [ ] Login page shows no sign-up link by default
- [ ] Direct navigation to /register-options redirects to /login
- [ ] POST /auth/register-password returns 403
- [ ] Enabling setting via admin panel shows sign-up link and allows registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)