### PR TITLE
feat: org-scoped AI course creation (no duplication)

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -53,6 +53,7 @@ class CreateCourseRequest(BaseModel):
     price_credits: int = 0
     creation_mode: str = "legacy"
     objectives_json: dict | None = None
+    organization_id: str | None = None
 
 
 class UpdateCourseRequest(BaseModel):
@@ -227,6 +228,7 @@ async def create_course(
         preassessment_enabled=request.preassessment_enabled,
         visibility=request.visibility,
         price_credits=request.price_credits,
+        organization_id=uuid.UUID(request.organization_id) if request.organization_id else None,
     )
     db.add(course)
     await db.commit()

--- a/backend/app/api/v1/organizations.py
+++ b/backend/app/api/v1/organizations.py
@@ -266,3 +266,40 @@ async def get_org_credits(
     await _svc.require_org_role(db, org_id, uuid.UUID(current_user.id))
     balance = await _svc.get_org_credit_balance(db, org_id)
     return OrgCreditSummary(balance=balance)
+
+
+# ---------------------------------------------------------------------------
+# Org Courses (thin wrapper — reuses admin course endpoints)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{org_id}/courses")
+async def list_org_courses(
+    org_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+) -> list[dict]:
+    """List courses belonging to this organization."""
+    from sqlalchemy import select
+
+    from app.domain.models.course import Course
+
+    await _svc.require_org_role(db, org_id, uuid.UUID(current_user.id))
+    result = await db.execute(
+        select(Course).where(Course.organization_id == org_id).order_by(Course.created_at.desc())
+    )
+    courses = result.scalars().all()
+    return [
+        {
+            "id": str(c.id),
+            "slug": c.slug,
+            "title_fr": c.title_fr,
+            "title_en": c.title_en,
+            "status": c.status,
+            "creation_mode": c.creation_mode,
+            "creation_step": c.creation_step,
+            "created_at": c.created_at.isoformat(),
+            "cover_image_url": c.cover_image_url,
+        }
+        for c in courses
+    ]

--- a/backend/app/domain/models/course.py
+++ b/backend/app/domain/models/course.py
@@ -47,6 +47,9 @@ class Course(Base):
     visibility: Mapped[str] = mapped_column(String(10), server_default="public")
     price_credits: Mapped[int] = mapped_column(BIGINT, server_default="0")
     objectives_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    organization_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("organizations.id", ondelete="SET NULL"), nullable=True, index=True
+    )
     syllabus_context: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     published_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/backend/migrations/versions/066_add_organization_id_to_courses.py
+++ b/backend/migrations/versions/066_add_organization_id_to_courses.py
@@ -1,0 +1,34 @@
+"""Add organization_id to courses for org-scoped course creation.
+
+Revision ID: 066
+Revises: 065
+Create Date: 2026-04-14
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "066"
+down_revision = "065"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("courses", sa.Column("organization_id", sa.Uuid(), nullable=True))
+    op.create_foreign_key(
+        "fk_courses_organization_id",
+        "courses",
+        "organizations",
+        ["organization_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index("ix_courses_organization_id", "courses", ["organization_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_courses_organization_id", "courses")
+    op.drop_constraint("fk_courses_organization_id", "courses", type_="foreignkey")
+    op.drop_column("courses", "organization_id")

--- a/frontend/app/[locale]/org/[orgSlug]/courses/page.tsx
+++ b/frontend/app/[locale]/org/[orgSlug]/courses/page.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import { useOrg } from "@/components/org/org-context";
+import { AICourseWizard } from "@/components/admin/ai-course-wizard";
+import { fetchOrgCourses } from "@/lib/api";
+import { Plus, GraduationCap, Loader2, Play } from "lucide-react";
+
+interface OrgCourse {
+  id: string;
+  slug: string;
+  title_fr: string;
+  title_en: string;
+  status: string;
+  creation_mode: string;
+  creation_step: string;
+  created_at: string;
+  cover_image_url?: string;
+}
+
+export default function OrgCoursesPage() {
+  const t = useTranslations("Organization");
+  const locale = useLocale();
+  const { orgId } = useOrg();
+  const [courses, setCourses] = useState<OrgCourse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [wizardOpen, setWizardOpen] = useState(false);
+  const [resumeCourse, setResumeCourse] = useState<OrgCourse | null>(null);
+
+  const loadCourses = () => {
+    if (!orgId) return;
+    fetchOrgCourses(orgId)
+      .then(setCourses)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    loadCourses();
+  }, [orgId]);
+
+  const handleCourseCreated = () => {
+    setWizardOpen(false);
+    setResumeCourse(null);
+    loadCourses();
+  };
+
+  const handleResume = (course: OrgCourse) => {
+    setResumeCourse(course);
+    setWizardOpen(true);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 className="h-8 w-8 animate-spin text-green-600" />
+      </div>
+    );
+  }
+
+  if (wizardOpen) {
+    return (
+      <AICourseWizard
+        onClose={() => {
+          setWizardOpen(false);
+          setResumeCourse(null);
+        }}
+        onCourseCreated={handleCourseCreated}
+        resumeCourseId={resumeCourse?.id}
+        resumeCreationStep={resumeCourse?.creation_step}
+        organizationId={orgId ?? undefined}
+      />
+    );
+  }
+
+  const statusColors: Record<string, string> = {
+    draft: "bg-gray-100 text-gray-600",
+    published: "bg-green-100 text-green-700",
+    archived: "bg-amber-100 text-amber-700",
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Courses</h1>
+        <button
+          onClick={() => setWizardOpen(true)}
+          className="flex items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
+        >
+          <Plus className="h-4 w-4" />
+          Create Course (AI)
+        </button>
+      </div>
+
+      {courses.length === 0 ? (
+        <div className="rounded-lg border bg-white p-12 text-center">
+          <GraduationCap className="h-12 w-12 text-gray-300 mx-auto mb-4" />
+          <p className="text-gray-600 font-medium">No courses yet</p>
+          <p className="text-sm text-gray-500 mt-1">
+            Create your first AI-assisted course for this organization.
+          </p>
+          <button
+            onClick={() => setWizardOpen(true)}
+            className="inline-flex items-center gap-2 mt-4 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
+          >
+            <Plus className="h-4 w-4" />
+            Create Course (AI)
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {courses.map((c) => {
+            const title = locale === "fr" ? c.title_fr : c.title_en;
+            const isInProgress =
+              c.status === "draft" && c.creation_step !== "published";
+            return (
+              <div
+                key={c.id}
+                className="flex items-center justify-between rounded-lg border bg-white p-4"
+              >
+                <div className="flex items-center gap-3">
+                  {c.cover_image_url ? (
+                    <img
+                      src={c.cover_image_url}
+                      alt={title}
+                      className="h-12 w-12 rounded-lg object-cover"
+                    />
+                  ) : (
+                    <div className="h-12 w-12 rounded-lg bg-green-100 flex items-center justify-center">
+                      <GraduationCap className="h-6 w-6 text-green-600" />
+                    </div>
+                  )}
+                  <div>
+                    <p className="font-medium">{title}</p>
+                    <p className="text-xs text-gray-500">
+                      {c.creation_mode === "ai_assisted"
+                        ? "AI Assisted"
+                        : "Legacy"}{" "}
+                      · {c.creation_step}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <span
+                    className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                      statusColors[c.status] || "bg-gray-100 text-gray-600"
+                    }`}
+                  >
+                    {c.status}
+                  </span>
+                  {isInProgress && (
+                    <button
+                      onClick={() => handleResume(c)}
+                      className="flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium hover:bg-gray-50"
+                    >
+                      <Play className="h-3.5 w-3.5" />
+                      Resume
+                    </button>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -154,6 +154,7 @@ interface AICourseWizardProps {
   onCourseCreated: () => void;
   resumeCourseId?: string;
   resumeCreationStep?: string;
+  organizationId?: string;
 }
 
 export function AICourseWizard({
@@ -161,6 +162,7 @@ export function AICourseWizard({
   onCourseCreated,
   resumeCourseId,
   resumeCreationStep,
+  organizationId,
 }: AICourseWizardProps) {
   const t = useTranslations("AdminCourses.wizard");
   const tAi = useTranslations("AdminCourses.aiWizard");
@@ -428,6 +430,7 @@ export function AICourseWizard({
         title_fr: "Nouveau cours (AI)",
         title_en: "New course (AI)",
         creation_mode: "ai_assisted",
+        organization_id: organizationId,
       });
       setCourseId(course.id);
 

--- a/frontend/components/org/org-nav.tsx
+++ b/frontend/components/org/org-nav.tsx
@@ -7,6 +7,7 @@ import { useOrg } from "./org-context";
 import {
   LayoutDashboard,
   BookOpen,
+  GraduationCap,
   QrCode,
   BarChart3,
   Users,
@@ -24,6 +25,7 @@ export function OrgNav() {
   const base = `/${locale}/org/${org.slug}`;
   const tabs = [
     { href: base, label: t("dashboard"), icon: LayoutDashboard },
+    { href: `${base}/courses`, label: "Courses", icon: GraduationCap },
     { href: `${base}/curricula`, label: t("curricula"), icon: Library },
     { href: `${base}/codes`, label: t("codes"), icon: QrCode },
     { href: `${base}/reports`, label: t("reports"), icon: BarChart3 },

--- a/frontend/lib/api-course-admin.ts
+++ b/frontend/lib/api-course-admin.ts
@@ -70,6 +70,7 @@ export async function createAdminCourse(data: {
   audience_type?: string[];
   estimated_hours?: number;
   creation_mode?: string;
+  organization_id?: string;
 }): Promise<{ id: string; creation_step: string }> {
   return apiFetch("/api/v1/admin/courses", {
     method: "POST",

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1310,6 +1310,20 @@ export async function createOrgCurriculum(orgId: string, data: {
   });
 }
 
+export async function fetchOrgCourses(orgId: string): Promise<{
+  id: string;
+  slug: string;
+  title_fr: string;
+  title_en: string;
+  status: string;
+  creation_mode: string;
+  creation_step: string;
+  created_at: string;
+  cover_image_url?: string;
+}[]> {
+  return apiFetch(`/api/v1/organizations/${orgId}/courses`);
+}
+
 export async function setOrgCurriculumCourses(
   orgId: string,
   curriculumId: string,


### PR DESCRIPTION
## Summary
Sub_admins can create AI-assisted courses from org pages, scoped to the organization.

**Zero code duplication:**
- Reuses `AICourseWizard` (1 new optional prop: `organizationId`)
- Reuses `api-course-admin.ts` (1 new optional field: `organization_id`)
- Reuses all admin course endpoints (same backend)
- Only new code: thin org courses list endpoint + org courses page

## Changes
- `Course` model: add `organization_id` FK + migration 066
- `POST /admin/courses`: accepts optional `organization_id`
- `GET /organizations/{id}/courses`: thin list endpoint
- `AICourseWizard`: passes `organization_id` on create
- New `/org/{slug}/courses` page with course list + AI wizard
- Courses tab added to org nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)