### PR TITLE
feat(onboarding): replace ECOWAS with West Africa, add Other options

### DIFF
--- a/backend/app/api/v1/schemas/users.py
+++ b/backend/app/api/v1/schemas/users.py
@@ -11,7 +11,7 @@ class OnboardingRequest(BaseModel):
     preferred_language: str = Field(
         ..., pattern="^(fr|en)$", description="User's preferred language"
     )
-    country: str = Field(..., description="ECOWAS country code")
+    country: str = Field(..., description="Country code")
     professional_role: str = Field(..., description="Professional role")
     current_level: int = Field(..., ge=1, le=4, description="Self-assessed skill level (1-4)")
 

--- a/frontend/app/[locale]/(app)/profile/profile-client.tsx
+++ b/frontend/app/[locale]/(app)/profile/profile-client.tsx
@@ -73,7 +73,7 @@ const profileSchema = z.object({
 
 type ProfileFormData = z.infer<typeof profileSchema>;
 
-const ECOWAS_COUNTRIES = [
+const WEST_AFRICAN_COUNTRIES = [
   { code: "BJ", name: "Benin" },
   { code: "BF", name: "Burkina Faso" },
   { code: "CV", name: "Cape Verde" },
@@ -89,6 +89,8 @@ const ECOWAS_COUNTRIES = [
   { code: "SN", name: "Senegal" },
   { code: "SL", name: "Sierra Leone" },
   { code: "TG", name: "Togo" },
+  { code: "OWA", name: "Other West African" },
+  { code: "OTH", name: "Other" },
 ];
 
 const PROFESSIONAL_ROLES = [
@@ -255,7 +257,7 @@ export function ProfileClient() {
                 <Badge variant="outline">{profile.preferred_language.toUpperCase()}</Badge>
                 {profile.country && (
                   <Badge variant="outline">
-                    {ECOWAS_COUNTRIES.find(c => c.code === profile.country)?.name || profile.country}
+                    {WEST_AFRICAN_COUNTRIES.find(c => c.code === profile.country)?.name || profile.country}
                   </Badge>
                 )}
               </div>
@@ -376,7 +378,7 @@ export function ProfileClient() {
                         </SelectTrigger>
                       </FormControl>
                       <SelectContent>
-                        {ECOWAS_COUNTRIES.map((country) => (
+                        {WEST_AFRICAN_COUNTRIES.map((country) => (
                           <SelectItem key={country.code} value={country.code}>
                             {country.name}
                           </SelectItem>

--- a/frontend/components/onboarding/steps/country-step.tsx
+++ b/frontend/components/onboarding/steps/country-step.tsx
@@ -29,7 +29,9 @@ const countries = [
   'nigeria',
   'senegal',
   'sierra-leone',
-  'togo'
+  'togo',
+  'other-west-african',
+  'other'
 ];
 
 const countryFlags: { [key: string]: string } = {
@@ -47,7 +49,9 @@ const countryFlags: { [key: string]: string } = {
   'nigeria': '🇳🇬',
   'senegal': '🇸🇳',
   'sierra-leone': '🇸🇱',
-  'togo': '🇹🇬'
+  'togo': '🇹🇬',
+  'other-west-african': '🌍',
+  'other': '🌐'
 };
 
 export function CountryStep({ value, onChange }: CountryStepProps) {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -482,7 +482,7 @@
     },
     "step2": {
       "title": "Select Your Country",
-      "description": "Choose your ECOWAS country for localized content",
+      "description": "Choose your West African country for localized content",
       "selectCountry": "Select your country",
       "countries": {
         "benin": "Benin",
@@ -499,7 +499,9 @@
         "nigeria": "Nigeria",
         "senegal": "Senegal",
         "sierra-leone": "Sierra Leone",
-        "togo": "Togo"
+        "togo": "Togo",
+        "other-west-african": "Other West African",
+        "other": "Other"
       }
     },
     "step3": {

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -482,7 +482,7 @@
     },
     "step2": {
       "title": "Sélectionnez Votre Pays",
-      "description": "Choisissez votre pays CEDEAO pour un contenu localisé",
+      "description": "Choisissez votre pays d'Afrique de l'Ouest pour un contenu localisé",
       "selectCountry": "Sélectionnez votre pays",
       "countries": {
         "benin": "Bénin",
@@ -499,7 +499,9 @@
         "nigeria": "Nigeria",
         "senegal": "Sénégal",
         "sierra-leone": "Sierra Leone",
-        "togo": "Togo"
+        "togo": "Togo",
+        "other-west-african": "Autre pays ouest-africain",
+        "other": "Autre"
       }
     },
     "step3": {


### PR DESCRIPTION
## Summary

Replace references to \"ECOWAS\" with \"West Africa\" in country selection UI, and add two new country options: \"Other West African\" and \"Other\".

## Changes

- **`frontend/components/onboarding/steps/country-step.tsx`** — Added `'other-west-african'` and `'other'` to the countries array, with flag entries `🌍` and `🌐`
- **`frontend/app/[locale]/(app)/profile/profile-client.tsx`** — Renamed `ECOWAS_COUNTRIES` → `WEST_AFRICAN_COUNTRIES`, added `OWA` (Other West African) and `OTH` (Other) entries, updated all references
- **`frontend/messages/en.json`** — Updated step2 description; added `other-west-african` and `other` country keys
- **`frontend/messages/fr.json`** — Updated step2 description; added `other-west-african` and `other` country keys
- **`backend/app/api/v1/schemas/users.py`** — Updated field description from `"ECOWAS country code"` to `"Country code"`

## Test plan
- [ ] Backend tests pass
- [ ] Frontend lint/tests pass
- [ ] Onboarding country step shows "Other West African" and "Other" options
- [ ] Profile page country dropdown shows new options
- [ ] FR/EN language switching works correctly for new entries
- [ ] Manually verified on mobile viewport

Closes #1481

Generated with [Claude Code](https://claude.ai/code)