### PR TITLE
fix: Next button disabled after AI course generation reaches 100%

### DIFF
--- a/backend/app/tasks/syllabus_generation.py
+++ b/backend/app/tasks/syllabus_generation.py
@@ -52,7 +52,7 @@ class SyllabusTask(Task):
     retry_kwargs={"max_retries": 1, "countdown": 30},
     time_limit=3600,  # 60 min hard limit
     soft_time_limit=2700,  # 45 min soft limit
-    ignore_result=True,
+    ignore_result=False,
     acks_late=False,  # Acknowledge immediately to prevent duplicate dispatch
 )
 def generate_course_syllabus(

--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -600,7 +600,7 @@ export function AICourseWizard({
           return;
         }
 
-        if (status.task?.state === "SUCCESS") {
+        if (status.task?.state === "SUCCESS" || status.task?.state === "COMPLETE") {
           // Modules may be in meta.modules (during task) or status.modules (from DB)
           const modules = Array.isArray(meta.modules)
             ? meta.modules
@@ -677,7 +677,7 @@ export function AICourseWizard({
           if (staleSince > 60 * 1000) setIndexStaleWarning(true);
         }
 
-        if (status.task?.state === "SUCCESS") {
+        if (status.task?.state === "SUCCESS" || status.task?.state === "COMPLETE") {
           setIndexStatus({ indexed: true, chunks_indexed: status.chunks_indexed, images_indexed: status.images_indexed, task: status.task });
           setIsIndexing(false);
           setIndexStaleWarning(false);

--- a/frontend/components/admin/course-wizard-client.tsx
+++ b/frontend/components/admin/course-wizard-client.tsx
@@ -732,7 +732,7 @@ export function CourseWizardClient({
           return;
         }
 
-        if (status.task?.state === "SUCCESS") {
+        if (status.task?.state === "SUCCESS" || status.task?.state === "COMPLETE") {
           const modules = meta.modules;
           if (Array.isArray(modules)) {
             setGeneratedModules(modules as GeneratedModule[]);
@@ -864,7 +864,7 @@ export function CourseWizardClient({
           }
         }
 
-        if (status.task?.state === "SUCCESS") {
+        if (status.task?.state === "SUCCESS" || status.task?.state === "COMPLETE") {
           setIndexStatus({
             indexed: true,
             chunks_indexed: status.chunks_indexed,


### PR DESCRIPTION
## Summary
- Celery task `generate_course_syllabus` had `ignore_result=True`, preventing the `SUCCESS` state from being stored in Redis after task completion
- Frontend polling only checked for `SUCCESS` state — which never arrived — so `generatedModules` was never populated and the Next button stayed disabled
- Changed `ignore_result` to `False` and added `"COMPLETE"` as a fallback terminal state in both wizard components

Closes #1484

## Test plan
- [ ] Create an AI course, upload a PDF, go through to Generate step
- [ ] Wait for generation to reach 100%
- [ ] Verify the Next button becomes enabled
- [ ] Click Next and confirm modules load in the Edit Syllabus step
- [ ] Repeat with the legacy course wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)