### PR TITLE
fix: audio generation receives actual lesson text

### DIFF
--- a/backend/app/domain/services/lesson_service.py
+++ b/backend/app/domain/services/lesson_service.py
@@ -40,6 +40,35 @@ from app.domain.services.platform_settings_service import SettingsCache
 logger = structlog.get_logger()
 
 
+def extract_lesson_text(content) -> str:
+    """Extract readable text from lesson content (dict or LessonContent model).
+
+    Works with both raw dicts (from GeneratedContent.content JSON column)
+    and Pydantic LessonContent objects.
+    """
+    if isinstance(content, dict):
+        d = content
+    elif hasattr(content, "model_dump"):
+        d = content.model_dump()
+    else:
+        return str(content)[:2000]
+
+    parts: list[str] = []
+    if d.get("introduction"):
+        parts.append(str(d["introduction"]))
+    if d.get("concepts"):
+        concepts = d["concepts"]
+        if isinstance(concepts, list):
+            parts.extend(str(c) for c in concepts if c)
+        else:
+            parts.append(str(concepts))
+    if d.get("aof_example"):
+        parts.append(str(d["aof_example"]))
+    if d.get("synthesis"):
+        parts.append(str(d["synthesis"]))
+    return "\n\n".join(parts) if parts else str(d)[:2000]
+
+
 class LessonGenerationService:
     """Service for orchestrating lesson content generation."""
 
@@ -812,22 +841,8 @@ class LessonGenerationService:
             unit_id=lesson_response.unit_id,
         )
 
-        # Extract text from all lesson sections for audio generation
-        content_dict = lesson_response.content.model_dump()
-        parts = []
-        if content_dict.get("introduction"):
-            parts.append(str(content_dict["introduction"]))
-        if content_dict.get("concepts"):
-            concepts = content_dict["concepts"]
-            if isinstance(concepts, list):
-                parts.extend(str(c) for c in concepts if c)
-            else:
-                parts.append(str(concepts))
-        if content_dict.get("aof_example"):
-            parts.append(str(content_dict["aof_example"]))
-        if content_dict.get("synthesis"):
-            parts.append(str(content_dict["synthesis"]))
-        lesson_text = "\n\n".join(parts) if parts else str(content_dict)[:2000]
+        # Extract text from all lesson sections for audio/image generation
+        lesson_text = extract_lesson_text(lesson_response.content)
 
         try:
             from sqlalchemy import select as sa_select

--- a/backend/app/tasks/content_generation.py
+++ b/backend/app/tasks/content_generation.py
@@ -570,15 +570,15 @@ def generate_country_content_task(
                         level=level,
                         session=session,
                     )
-                    lesson_text = ""
-                    if hasattr(result_obj, "content") and result_obj.content is not None:
-                        lesson_text = getattr(result_obj.content, "content", "") or ""
+                    from app.domain.services.lesson_service import extract_lesson_text
+
+                    lesson_text = extract_lesson_text(result_obj.content) if hasattr(result_obj, "content") and result_obj.content is not None else ""
                     generate_lesson_audio.delay(
                         str(result_obj.id),
                         module_id,
                         unit_id,
                         language,
-                        lesson_text,
+                        lesson_text[:4000],
                     )
                     logger.info(
                         "Country-targeted lesson ready",
@@ -1147,12 +1147,9 @@ def prefetch_next_lessons_task(
                                 user_id=user_id,
                             )
                             try:
-                                lesson_text = ""
-                                if hasattr(content, "content") and content.content is not None:
-                                    if isinstance(content.content, dict):
-                                        lesson_text = content.content.get("content", "") or ""
-                                    else:
-                                        lesson_text = getattr(content.content, "content", "") or ""
+                                from app.domain.services.lesson_service import extract_lesson_text
+
+                                lesson_text = extract_lesson_text(content.content) if hasattr(content, "content") and content.content is not None else ""
                                 generate_lesson_audio.apply_async(
                                     kwargs={
                                         "lesson_id": str(content.id),
@@ -1536,18 +1533,16 @@ def pregenerate_on_publish_task(self, course_id: str) -> dict:
                                     label=label,
                                     content_id=str(content.id),
                                 )
-                                lesson_text = ""
-                                if hasattr(content, "content") and isinstance(
-                                    content.content, dict
-                                ):
-                                    lesson_text = content.content.get("content", "")
+                                from app.domain.services.lesson_service import extract_lesson_text
+
+                                lesson_text = extract_lesson_text(content.content) if hasattr(content, "content") and content.content is not None else ""
                                 generate_lesson_audio.apply_async(
                                     kwargs={
                                         "lesson_id": str(content.id),
                                         "module_id": str(module.id),
                                         "unit_id": unit_id,
                                         "language": language,
-                                        "lesson_content": lesson_text,
+                                        "lesson_content": lesson_text[:4000],
                                     },
                                     priority=5,
                                 )


### PR DESCRIPTION
## Summary
- 3 of 4 code paths dispatching `generate_lesson_audio` were passing **empty string** as `lesson_content` because they accessed a non-existent `"content"` key on `LessonContent` (which has `introduction`, `concepts`, `aof_example`, `synthesis`)
- Extracted a shared `extract_lesson_text()` helper in `lesson_service.py` that correctly assembles lesson prose from all sections
- Fixed all 3 broken call sites in `content_generation.py`: `pregenerate_on_publish_task`, `prefetch_next_lessons_task`, `generate_country_targeted_content`
- Refactored `_cache_lesson_content` to reuse the same helper

## Test plan
- [x] All 22 existing `test_pregenerate_on_publish.py` tests pass
- [x] `extract_lesson_text()` verified manually with dict input
- [ ] After deploy: regenerate audio for existing lessons to get correct content

🤖 Generated with [Claude Code](https://claude.com/claude-code)