### PR TITLE
feat(infra): Meta MMS TTS Docker sidecar for Moore/Dioula/Bambara

### DIFF
--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -77,6 +77,9 @@ class Settings(BaseSettings):
     upload_max_pdf_tokens: int = 5000
     upload_max_csv_rows: int = 20
 
+    # MMS TTS sidecar (Meta Massively Multilingual Speech)
+    mms_tts_url: str = "http://mms-tts:5050"
+
     # MinIO / S3-compatible object storage
     minio_endpoint: str = "http://localhost:9000"
     minio_access_key: str = ""

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -156,6 +156,23 @@ services:
       - etutor-data
     restart: unless-stopped
 
+  mms-tts:
+    build: ./infrastructure/mms-tts
+    container_name: etutor-mms-tts
+    networks:
+      - etutor-data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5050/health"]
+      interval: 30s
+      timeout: 10s
+      start_period: 90s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+    restart: unless-stopped
+
 volumes:
   pgdata:
   redisdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,22 @@ services:
       start_period: 10s
       retries: 3
 
+  mms-tts:
+    build: ./infrastructure/mms-tts
+    container_name: santepublique-mms-tts
+    ports:
+      - "5050:5050"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5050/health"]
+      interval: 30s
+      timeout: 10s
+      start_period: 60s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+
 volumes:
   pgdata:
   redisdata:

--- a/infrastructure/mms-tts/Dockerfile
+++ b/infrastructure/mms-tts/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir transformers torch scipy fastapi uvicorn[standard] huggingface_hub
+
+COPY server.py /app/server.py
+
+EXPOSE 5050
+
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "5050"]

--- a/infrastructure/mms-tts/server.py
+++ b/infrastructure/mms-tts/server.py
@@ -1,0 +1,87 @@
+import io
+import logging
+import os
+from contextlib import asynccontextmanager
+
+import scipy.io.wavfile
+import torch
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import Response
+from pydantic import BaseModel
+from transformers import VitsModel, AutoTokenizer
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+SUPPORTED_LANGUAGES = {
+    "mos": "facebook/mms-tts-mos",
+    "dyu": "facebook/mms-tts-dyu",
+    "bam": "facebook/mms-tts-bam",
+}
+
+models: dict = {}
+tokenizers: dict = {}
+
+
+def load_models() -> None:
+    for lang, model_id in SUPPORTED_LANGUAGES.items():
+        logger.info(f"Loading model for {lang}: {model_id}")
+        try:
+            tokenizers[lang] = AutoTokenizer.from_pretrained(model_id)
+            models[lang] = VitsModel.from_pretrained(model_id)
+            models[lang].eval()
+            logger.info(f"Model loaded for {lang}")
+        except Exception as e:
+            logger.error(f"Failed to load model for {lang}: {e}")
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    load_models()
+    yield
+
+
+app = FastAPI(title="MMS TTS Server", lifespan=lifespan)
+
+
+class SynthesizeRequest(BaseModel):
+    text: str
+    language: str
+
+
+@app.get("/health")
+async def health() -> dict:
+    loaded = [lang for lang in SUPPORTED_LANGUAGES if lang in models]
+    return {"status": "ok", "loaded_languages": loaded}
+
+
+@app.post("/synthesize")
+async def synthesize(request: SynthesizeRequest) -> Response:
+    lang = request.language.lower()
+    if lang not in SUPPORTED_LANGUAGES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported language '{lang}'. Supported: {list(SUPPORTED_LANGUAGES.keys())}",
+        )
+    if lang not in models:
+        raise HTTPException(
+            status_code=503,
+            detail=f"Model for language '{lang}' is not loaded.",
+        )
+    if not request.text.strip():
+        raise HTTPException(status_code=400, detail="Text must not be empty.")
+
+    try:
+        inputs = tokenizers[lang](request.text, return_tensors="pt")
+        with torch.no_grad():
+            output = models[lang](**inputs)
+        waveform = output.waveform.squeeze().numpy()
+        sample_rate = models[lang].config.sampling_rate
+
+        buf = io.BytesIO()
+        scipy.io.wavfile.write(buf, sample_rate, waveform)
+        buf.seek(0)
+        return Response(content=buf.read(), media_type="audio/wav")
+    except Exception as e:
+        logger.error(f"Synthesis failed for language '{lang}': {e}")
+        raise HTTPException(status_code=500, detail="Synthesis failed.")


### PR DESCRIPTION
## Summary
- Deploy Meta MMS (Massively Multilingual Speech) as a Docker sidecar for TTS in West African languages not supported by standard cloud TTS providers
- Supports Moore (`mos`), Dioula/Jula (`dyu`), and Bambara (`bam`)

## Changes
- `infrastructure/mms-tts/Dockerfile` — minimal python:3.11-slim image with transformers, torch, scipy, fastapi
- `infrastructure/mms-tts/server.py` — FastAPI server with `POST /synthesize` (text + language → WAV) and `GET /health`; preloads all 3 language models on startup
- `docker-compose.yml` — adds `mms-tts` service (dev, port 5050, 4G memory limit, healthcheck)
- `docker-compose.prod.yml` — adds `mms-tts` service (prod, `etutor-data` network, 4G limit, restart policy)
- `backend/app/infrastructure/config/settings.py` — adds `mms_tts_url` setting (default: `http://mms-tts:5050`)

## Test plan
- [ ] `docker compose up mms-tts` builds and starts without errors
- [ ] `GET http://localhost:5050/health` returns `{"status": "ok", "loaded_languages": ["mos", "dyu", "bam"]}`
- [ ] `POST /synthesize` with `{"text": "Bonjour", "language": "mos"}` returns a valid WAV audio response
- [ ] Backend can read `settings.mms_tts_url`
- [ ] Backend tests pass (`uv run pytest`)
- [ ] Frontend lint/tests pass

Closes #1503

Generated with [Claude Code](https://claude.ai/code)