### PR TITLE
feat(qbank): question audio generation FR + Moore + Dioula (#1502)

### DIFF
--- a/backend/app/api/v1/qbank_audio.py
+++ b/backend/app/api/v1/qbank_audio.py
@@ -1,0 +1,372 @@
+"""QBank question audio endpoints: TTS generation trigger, manual upload, and retrieval."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Annotated, Literal
+
+import structlog
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_db_session
+from app.domain.models.qbank_question_audio import QBankQuestionAudio
+from app.infrastructure.storage.s3 import S3StorageService
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/qbank/questions", tags=["qbank-audio"])
+
+AudioLanguage = Literal["fr", "mos", "dyu"]
+
+_ALLOWED_AUDIO_TYPES = frozenset(
+    {"audio/wav", "audio/x-wav", "audio/mpeg", "audio/ogg", "audio/webm"}
+)
+_MAX_AUDIO_SIZE = 10 * 1024 * 1024
+
+
+class QBankAudioResponse(BaseModel):
+    audio_id: uuid.UUID = Field(..., description="Audio record ID")
+    question_id: uuid.UUID = Field(..., description="Question ID")
+    language: str = Field(..., description="Language code (fr / mos / dyu)")
+    status: str = Field(..., description="pending | generating | ready | failed")
+    audio_url: str | None = Field(None, description="Proxied audio URL when ready")
+    duration_seconds: int | None = Field(None)
+    file_size_bytes: int | None = Field(None)
+    is_manual_upload: bool = Field(False)
+
+
+class TriggerAudioRequest(BaseModel):
+    question_text: str = Field(..., min_length=1, description="Question stem text")
+    choices: list[dict] | None = Field(None, description='List of {"text": "..."} option dicts')
+    language: AudioLanguage = Field("fr", description="Target language")
+
+
+class BatchTriggerRequest(BaseModel):
+    bank_id: uuid.UUID = Field(..., description="Question bank UUID")
+    language: AudioLanguage = Field("fr")
+    questions: list[dict] = Field(
+        ...,
+        description='List of {"id": "uuid", "text": "...", "choices": [...]} dicts',
+    )
+
+
+def _audio_url(audio: QBankQuestionAudio) -> str | None:
+    if audio.status != "ready":
+        return None
+    return f"/api/v1/qbank/questions/{audio.question_id}/audio/{audio.id}/data"
+
+
+def _to_response(audio: QBankQuestionAudio) -> QBankAudioResponse:
+    return QBankAudioResponse(
+        audio_id=audio.id,
+        question_id=audio.question_id,
+        language=audio.language,
+        status=audio.status,
+        audio_url=_audio_url(audio),
+        duration_seconds=audio.duration_seconds if audio.status == "ready" else None,
+        file_size_bytes=audio.file_size_bytes if audio.status == "ready" else None,
+        is_manual_upload=audio.is_manual_upload,
+    )
+
+
+@router.get(
+    "/{question_id}/audio",
+    response_model=QBankAudioResponse,
+    status_code=status.HTTP_200_OK,
+    responses={404: {"description": "No audio found for this question + language"}},
+)
+async def get_question_audio(
+    question_id: uuid.UUID,
+    lang: Annotated[AudioLanguage, Query(description="Language: fr | mos | dyu")] = "fr",
+    db: AsyncSession = Depends(get_db_session),
+) -> QBankAudioResponse:
+    """Return audio record (URL + status) for a question in the requested language."""
+    result = await db.execute(
+        select(QBankQuestionAudio)
+        .where(
+            QBankQuestionAudio.question_id == question_id,
+            QBankQuestionAudio.language == lang,
+        )
+        .order_by(QBankQuestionAudio.created_at.desc())
+        .limit(1)
+    )
+    audio = result.scalars().first()
+
+    if audio is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "error": "qbank_audio_not_found",
+                "message": f"No audio for question {question_id} in language '{lang}'",
+            },
+        )
+
+    logger.info(
+        "QBank audio retrieved",
+        question_id=str(question_id),
+        language=lang,
+        audio_status=audio.status,
+    )
+    return _to_response(audio)
+
+
+@router.post(
+    "/{question_id}/audio/trigger",
+    response_model=QBankAudioResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def trigger_question_audio(
+    question_id: uuid.UUID,
+    body: TriggerAudioRequest,
+    db: AsyncSession = Depends(get_db_session),
+) -> QBankAudioResponse:
+    """Trigger async TTS generation for a question.
+
+    Dispatches a Celery task. Returns a pending audio record immediately.
+    """
+    from app.tasks.qbank_processing import generate_question_audio_task
+
+    existing = await db.execute(
+        select(QBankQuestionAudio)
+        .where(
+            QBankQuestionAudio.question_id == question_id,
+            QBankQuestionAudio.language == body.language,
+            QBankQuestionAudio.status.in_(["ready", "generating", "pending"]),
+        )
+        .limit(1)
+    )
+    audio = existing.scalars().first()
+    if audio is not None:
+        return _to_response(audio)
+
+    record = QBankQuestionAudio(
+        id=uuid.uuid4(),
+        question_id=question_id,
+        language=body.language,
+        status="pending",
+        is_manual_upload=False,
+    )
+    db.add(record)
+    await db.commit()
+    await db.refresh(record)
+
+    generate_question_audio_task.apply_async(
+        kwargs={
+            "question_id": str(question_id),
+            "language": body.language,
+            "question_text": body.question_text,
+            "choices": body.choices,
+        },
+        priority=5,
+    )
+
+    logger.info(
+        "QBank audio generation triggered",
+        question_id=str(question_id),
+        language=body.language,
+        audio_id=str(record.id),
+    )
+    return _to_response(record)
+
+
+@router.post(
+    "/{question_id}/audio",
+    response_model=QBankAudioResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Upload manual audio recording for a question",
+)
+async def upload_question_audio(
+    question_id: uuid.UUID,
+    lang: Annotated[AudioLanguage, Query(description="Language: fr | mos | dyu")] = "fr",
+    file: UploadFile = File(..., description="Audio file (WAV, MP3, OGG, WebM)"),
+    db: AsyncSession = Depends(get_db_session),
+) -> QBankAudioResponse:
+    """Upload a manual audio recording as a fallback for TTS generation.
+
+    Stores in MinIO, creates/updates the qbank_question_audio row.
+    Content-Type must be a supported audio format.
+    Max size: 10MB.
+    """
+    content_type = file.content_type or ""
+    if content_type not in _ALLOWED_AUDIO_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail={
+                "error": "unsupported_audio_type",
+                "message": f"Content-Type '{content_type}' not supported. "
+                f"Use one of: {sorted(_ALLOWED_AUDIO_TYPES)}",
+            },
+        )
+
+    audio_bytes = await file.read()
+    if len(audio_bytes) > _MAX_AUDIO_SIZE:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail={
+                "error": "audio_too_large",
+                "message": f"Audio file exceeds 10MB limit ({len(audio_bytes)} bytes)",
+            },
+        )
+    if not audio_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": "empty_file", "message": "Uploaded file is empty"},
+        )
+
+    ext_map = {
+        "audio/wav": "wav",
+        "audio/x-wav": "wav",
+        "audio/mpeg": "mp3",
+        "audio/ogg": "ogg",
+        "audio/webm": "webm",
+    }
+    ext = ext_map.get(content_type, "bin")
+    storage_key = f"qbank-audio/{question_id}/{lang}/manual.{ext}"
+
+    storage = S3StorageService()
+    storage_url = await storage.upload_bytes(
+        key=storage_key,
+        data=audio_bytes,
+        content_type=content_type,
+    )
+
+    existing = await db.execute(
+        select(QBankQuestionAudio)
+        .where(
+            QBankQuestionAudio.question_id == question_id,
+            QBankQuestionAudio.language == lang,
+        )
+        .limit(1)
+    )
+    record = existing.scalars().first()
+
+    if record is None:
+        record = QBankQuestionAudio(
+            id=uuid.uuid4(),
+            question_id=question_id,
+            language=lang,
+            is_manual_upload=True,
+        )
+        db.add(record)
+
+    record.status = "ready"
+    record.storage_key = storage_key
+    record.storage_url = storage_url
+    record.file_size_bytes = len(audio_bytes)
+    record.is_manual_upload = True
+    from datetime import datetime
+
+    record.generated_at = datetime.utcnow()
+
+    await db.commit()
+    await db.refresh(record)
+
+    logger.info(
+        "Manual audio uploaded for question",
+        question_id=str(question_id),
+        language=lang,
+        audio_id=str(record.id),
+        size_bytes=len(audio_bytes),
+    )
+    return _to_response(record)
+
+
+@router.get(
+    "/{question_id}/audio/{audio_id}/data",
+    status_code=status.HTTP_200_OK,
+    responses={
+        200: {"content": {"audio/wav": {}, "audio/mpeg": {}}, "description": "Audio bytes"},
+        404: {"description": "Audio not found or not ready"},
+    },
+)
+async def get_audio_data(
+    question_id: uuid.UUID,
+    audio_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db_session),
+):
+    """Proxy audio bytes from MinIO for a question audio record."""
+    from fastapi import Response
+
+    result = await db.execute(select(QBankQuestionAudio).where(QBankQuestionAudio.id == audio_id))
+    audio = result.scalar_one_or_none()
+
+    if audio is None or audio.question_id != question_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "audio_not_found", "message": f"Audio {audio_id} not found"},
+        )
+
+    if audio.status != "ready":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "error": "audio_not_ready",
+                "message": f"Audio {audio_id} is not ready (status: {audio.status})",
+            },
+        )
+
+    if not audio.storage_key:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "audio_data_unavailable", "message": "No stored audio data"},
+        )
+
+    try:
+        storage = S3StorageService()
+        audio_bytes = await storage.download_bytes(audio.storage_key)
+    except Exception as exc:
+        logger.warning("S3 download failed", key=audio.storage_key, error=str(exc))
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "audio_data_unavailable", "message": "Could not retrieve audio"},
+        ) from exc
+
+    media_type = "audio/wav"
+    if audio.storage_key.endswith(".mp3"):
+        media_type = "audio/mpeg"
+    elif audio.storage_key.endswith(".ogg"):
+        media_type = "audio/ogg"
+
+    return Response(
+        content=audio_bytes,
+        media_type=media_type,
+        headers={"Cache-Control": "public, max-age=31536000, immutable"},
+    )
+
+
+@router.post(
+    "/audio/batch",
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Trigger batch TTS audio generation for a question bank",
+)
+async def trigger_batch_audio(body: BatchTriggerRequest) -> dict:
+    """Dispatch a Celery task to generate TTS audio for all questions in a bank."""
+    from app.tasks.qbank_processing import generate_qbank_audio_task
+
+    task = generate_qbank_audio_task.apply_async(
+        kwargs={
+            "bank_id": str(body.bank_id),
+            "language": body.language,
+            "questions": body.questions,
+        },
+        priority=3,
+    )
+
+    logger.info(
+        "Batch qbank audio task dispatched",
+        bank_id=str(body.bank_id),
+        language=body.language,
+        question_count=len(body.questions),
+        task_id=task.id,
+    )
+
+    return {
+        "task_id": task.id,
+        "bank_id": str(body.bank_id),
+        "language": body.language,
+        "question_count": len(body.questions),
+        "status": "queued",
+    }

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -27,6 +27,7 @@ from app.api.v1.org_reports import router as org_reports_router
 from app.api.v1.organizations import router as organizations_router
 from app.api.v1.placement import router as placement_router
 from app.api.v1.progress import router as progress_router
+from app.api.v1.qbank_audio import router as qbank_audio_router
 from app.api.v1.quiz import router as quiz_router
 from app.api.v1.sms_relay import (
     router as sms_relay_router,
@@ -42,6 +43,7 @@ api_v1_router.include_router(analytics_router)
 api_v1_router.include_router(local_auth_router)
 api_v1_router.include_router(users_router)
 api_v1_router.include_router(placement_router)
+api_v1_router.include_router(qbank_audio_router)
 api_v1_router.include_router(dashboard_router)
 api_v1_router.include_router(progress_router)
 api_v1_router.include_router(content_router)

--- a/backend/app/domain/models/__init__.py
+++ b/backend/app/domain/models/__init__.py
@@ -20,6 +20,7 @@ from app.domain.models.module_unit import ModuleUnit
 from app.domain.models.organization import Organization, OrganizationMember, OrgMemberRole
 from app.domain.models.preassessment import CoursePreAssessment
 from app.domain.models.progress import UserModuleProgress
+from app.domain.models.qbank_question_audio import QBankQuestionAudio
 from app.domain.models.quiz import PlacementTestAttempt, QuizAttempt, SummativeAssessmentAttempt
 from app.domain.models.sms_relay import (
     InboundSms,
@@ -70,6 +71,7 @@ __all__ = [
     "Organization",
     "OrganizationMember",
     "PlacementTestAttempt",
+    "QBankQuestionAudio",
     "QuizAttempt",
     "RefreshToken",
     "RelayDevice",

--- a/backend/app/domain/models/qbank_question_audio.py
+++ b/backend/app/domain/models/qbank_question_audio.py
@@ -1,0 +1,55 @@
+"""QBank question audio model for TTS audio per question per language."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from sqlalchemy import Index, Integer, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.domain.models.base import Base
+
+if TYPE_CHECKING:
+    pass
+
+
+class QBankQuestionAudio(Base):
+    __tablename__ = "qbank_question_audio"
+    __table_args__ = (
+        Index("ix_qbank_question_audio_question_id", "question_id"),
+        Index("ix_qbank_question_audio_status", "status"),
+        sa.UniqueConstraint(
+            "question_id",
+            "language",
+            name="uq_qbank_question_audio_question_lang",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    question_id: Mapped[uuid.UUID] = mapped_column(
+        sa.Uuid(),
+        nullable=False,
+    )
+    language: Mapped[str] = mapped_column(String(10), server_default="fr")
+    storage_key: Mapped[str | None] = mapped_column(Text, nullable=True)
+    storage_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    duration_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    file_size_bytes: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    is_manual_upload: Mapped[bool] = mapped_column(sa.Boolean, server_default="false")
+    status: Mapped[str] = mapped_column(
+        sa.Enum(
+            "pending",
+            "generating",
+            "ready",
+            "failed",
+            name="qbank_audio_status_enum",
+            create_type=True,
+        ),
+        server_default="pending",
+    )
+    generated_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    created_at: Mapped[datetime] = mapped_column(server_default=func.now())

--- a/backend/app/domain/services/qbank_audio_service.py
+++ b/backend/app/domain/services/qbank_audio_service.py
@@ -1,0 +1,296 @@
+"""QBank question audio generation: Gemini TTS (FR) + Meta MMS (Moore/Dioula) + MinIO upload."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.models.qbank_question_audio import QBankQuestionAudio
+from app.infrastructure.config.settings import settings
+from app.infrastructure.storage.s3 import S3StorageService
+
+logger = structlog.get_logger(__name__)
+
+SUPPORTED_LANGUAGES = frozenset({"fr", "mos", "dyu"})
+_GEMINI_LANGUAGES = frozenset({"fr"})
+_MMS_LANGUAGES = frozenset({"mos", "dyu"})
+
+
+def _build_question_audio_script(
+    question_text: str,
+    choices: list[dict[str, str]] | None = None,
+) -> str:
+    """Concatenate question text + options into a spoken audio script."""
+    parts = [question_text.strip()]
+    if choices:
+        option_labels = ["A", "B", "C", "D", "E"]
+        for i, choice in enumerate(choices[:5]):
+            label = option_labels[i]
+            text = choice.get("text", "").strip()
+            if text:
+                parts.append(f"Option {label}: {text}")
+    return "  ".join(parts)
+
+
+class QBankAudioService:
+    """Pipeline: DB cache check → TTS (Gemini or MMS) → MinIO upload."""
+
+    def __init__(self, storage: S3StorageService | None = None) -> None:
+        self._storage = storage or S3StorageService()
+
+    async def generate_question_audio(
+        self,
+        question_id: uuid.UUID,
+        language: str,
+        question_text: str,
+        choices: list[dict[str, str]] | None = None,
+        session: AsyncSession | None = None,
+        *,
+        _session: AsyncSession | None = None,
+    ) -> QBankQuestionAudio:
+        """Generate or return cached TTS audio for a single question.
+
+        Args:
+            question_id: UUID of the qbank question.
+            language: "fr" (Gemini TTS), "mos" or "dyu" (Meta MMS).
+            question_text: The question stem text.
+            choices: Optional list of {"text": "..."} option dicts.
+            session: Async SQLAlchemy session.
+
+        Returns:
+            QBankQuestionAudio record (status="ready" on success).
+        """
+        db = session or _session
+        if db is None:
+            raise ValueError("session is required")
+
+        if language not in SUPPORTED_LANGUAGES:
+            raise ValueError(
+                f"Unsupported language '{language}'. Supported: {sorted(SUPPORTED_LANGUAGES)}"
+            )
+
+        cached = await self._find_cached(question_id, language, db)
+        if cached is not None:
+            logger.info(
+                "Returning cached question audio",
+                question_id=str(question_id),
+                language=language,
+            )
+            return cached
+
+        record = QBankQuestionAudio(
+            id=uuid.uuid4(),
+            question_id=question_id,
+            language=language,
+            status="pending",
+            is_manual_upload=False,
+        )
+        db.add(record)
+        try:
+            await db.flush()
+        except Exception:
+            await db.rollback()
+            cached = await self._find_cached(question_id, language, db)
+            if cached is not None:
+                return cached
+            raise
+
+        try:
+            record.status = "generating"
+            await db.flush()
+
+            script = _build_question_audio_script(question_text, choices)
+
+            if language in _GEMINI_LANGUAGES:
+                audio_bytes, content_type = await self._call_gemini_tts(script, language)
+                ext = "wav"
+            else:
+                audio_bytes, content_type = await self._call_mms_tts(script, language)
+                ext = "wav"
+
+            storage_key = f"qbank-audio/{question_id}/{language}/question.{ext}"
+            storage_url = await self._storage.upload_bytes(
+                key=storage_key,
+                data=audio_bytes,
+                content_type=content_type,
+            )
+
+            record.status = "ready"
+            record.storage_key = storage_key
+            record.storage_url = storage_url
+            record.duration_seconds = _estimate_duration_wav(len(audio_bytes))
+            record.file_size_bytes = len(audio_bytes)
+            record.generated_at = datetime.utcnow()
+            await db.commit()
+
+            logger.info(
+                "Question audio generated",
+                question_id=str(question_id),
+                language=language,
+                audio_id=str(record.id),
+                size_bytes=len(audio_bytes),
+            )
+
+        except Exception as exc:
+            record.status = "failed"
+            record.error_message = str(exc)
+            await db.commit()
+            logger.error(
+                "Question audio generation failed",
+                question_id=str(question_id),
+                language=language,
+                error=str(exc),
+            )
+            raise
+
+        return record
+
+    async def batch_generate_audio(
+        self,
+        bank_id: uuid.UUID,
+        language: str,
+        questions: list[dict],
+        session: AsyncSession,
+    ) -> dict:
+        """Generate TTS audio for all questions in a bank.
+
+        Args:
+            bank_id: UUID of the question bank (for logging).
+            language: Target language ("fr", "mos", "dyu").
+            questions: List of {"id": uuid, "text": str, "choices": [...]} dicts.
+            session: Async SQLAlchemy session.
+
+        Returns:
+            {"generated": [...], "skipped": [...], "failed": [...]}
+        """
+        generated: list[str] = []
+        skipped: list[str] = []
+        failed: list[str] = []
+
+        for q in questions:
+            qid_raw = q.get("id")
+            question_text = q.get("text", "")
+            choices = q.get("choices")
+            if not qid_raw or not question_text:
+                continue
+
+            qid = uuid.UUID(str(qid_raw))
+            label = str(qid)
+
+            existing = await self._find_cached(qid, language, session)
+            if existing is not None:
+                skipped.append(label)
+                continue
+
+            try:
+                await self.generate_question_audio(
+                    question_id=qid,
+                    language=language,
+                    question_text=question_text,
+                    choices=choices,
+                    session=session,
+                )
+                generated.append(label)
+            except Exception as exc:
+                failed.append(label)
+                logger.error(
+                    "Batch audio: question failed",
+                    bank_id=str(bank_id),
+                    question_id=label,
+                    language=language,
+                    error=str(exc),
+                )
+
+        logger.info(
+            "Batch audio generation complete",
+            bank_id=str(bank_id),
+            language=language,
+            generated=len(generated),
+            skipped=len(skipped),
+            failed=len(failed),
+        )
+
+        return {"generated": generated, "skipped": skipped, "failed": failed}
+
+    async def _find_cached(
+        self,
+        question_id: uuid.UUID,
+        language: str,
+        session: AsyncSession,
+    ) -> QBankQuestionAudio | None:
+        result = await session.execute(
+            select(QBankQuestionAudio)
+            .where(
+                QBankQuestionAudio.question_id == question_id,
+                QBankQuestionAudio.language == language,
+                QBankQuestionAudio.status == "ready",
+            )
+            .limit(1)
+        )
+        return result.scalars().first()
+
+    async def _call_gemini_tts(self, script: str, language: str) -> tuple[bytes, str]:
+        """Call Google Gemini TTS API for French synthesis.
+
+        Returns:
+            (audio_bytes, content_type)
+        """
+        import google.generativeai as genai
+
+        genai.configure(api_key=settings.google_api_key)
+
+        voice_name = "fr-FR-Standard-A"
+        tts_config = {
+            "voice_config": {
+                "prebuilt_voice_config": {"voice_name": voice_name},
+            }
+        }
+
+        model = genai.GenerativeModel("gemini-2.5-flash-preview-tts")
+        response = model.generate_content(
+            contents=script,
+            generation_config=genai.types.GenerationConfig(
+                response_modalities=["AUDIO"],
+                speech_config=tts_config,
+            ),
+        )
+
+        audio_bytes: bytes = b""
+        for part in response.candidates[0].content.parts:
+            if hasattr(part, "inline_data") and part.inline_data:
+                audio_bytes += part.inline_data.data
+
+        if not audio_bytes:
+            raise ValueError("Gemini TTS returned empty audio for question")
+
+        logger.info(
+            "Gemini TTS: question audio generated",
+            language=language,
+            size_bytes=len(audio_bytes),
+        )
+        return audio_bytes, "audio/wav"
+
+    async def _call_mms_tts(self, script: str, language: str) -> tuple[bytes, str]:
+        """Call Meta MMS sidecar for Moore/Dioula synthesis.
+
+        Returns:
+            (audio_bytes, content_type)
+        """
+        from app.integrations.mms_tts import MMSTTSClient
+
+        client = MMSTTSClient()
+        audio_bytes = await client.synthesize(text=script, language=language)
+        return audio_bytes, "audio/wav"
+
+
+def _estimate_duration_wav(file_size_bytes: int) -> int:
+    """Estimate WAV audio duration from file size.
+
+    WAV PCM 16kHz mono 16-bit = 32000 bytes/sec.
+    """
+    bytes_per_second = 32000
+    return max(1, file_size_bytes // bytes_per_second)

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -77,6 +77,9 @@ class Settings(BaseSettings):
     upload_max_pdf_tokens: int = 5000
     upload_max_csv_rows: int = 20
 
+    # Meta MMS TTS sidecar (for Moore/Dioula synthesis)
+    mms_sidecar_url: str = "http://localhost:5050"
+
     # MinIO / S3-compatible object storage
     minio_endpoint: str = "http://localhost:9000"
     minio_access_key: str = ""

--- a/backend/app/integrations/mms_tts.py
+++ b/backend/app/integrations/mms_tts.py
@@ -1,0 +1,87 @@
+"""Meta MMS TTS HTTP client for Moore (mos) and Dioula (dyu) synthesis."""
+
+from __future__ import annotations
+
+import structlog
+
+from app.infrastructure.config.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+MMS_LANGUAGE_CODES: dict[str, str] = {
+    "mos": "mos",
+    "dyu": "dyu",
+}
+
+_SUPPORTED_LANGUAGES = frozenset(MMS_LANGUAGE_CODES)
+
+
+class MMSTTSClient:
+    """Async HTTP client for the Meta MMS TTS Docker sidecar.
+
+    The sidecar exposes a single POST endpoint:
+        POST /synthesize
+        Body: {"text": "<text>", "language": "<mos|dyu>"}
+        Response: WAV audio bytes (Content-Type: audio/wav)
+
+    Configured via MMS_SIDECAR_URL env variable.
+    """
+
+    def __init__(self, base_url: str | None = None) -> None:
+        self._base_url = (base_url or settings.mms_sidecar_url).rstrip("/")
+
+    async def synthesize(self, text: str, language: str) -> bytes:
+        """Synthesize speech for the given text using Meta MMS.
+
+        Args:
+            text: Plain text to synthesize (no markdown).
+            language: Language code — "mos" (Moore) or "dyu" (Dioula).
+
+        Returns:
+            WAV audio bytes.
+
+        Raises:
+            ValueError: If language is not supported.
+            RuntimeError: If the MMS sidecar returns a non-2xx response.
+        """
+        if language not in _SUPPORTED_LANGUAGES:
+            raise ValueError(
+                f"MMS TTS: unsupported language '{language}'. "
+                f"Supported: {sorted(_SUPPORTED_LANGUAGES)}"
+            )
+
+        import httpx
+
+        url = f"{self._base_url}/synthesize"
+        payload = {"text": text, "language": language}
+
+        logger.info(
+            "MMS TTS: synthesizing",
+            language=language,
+            text_length=len(text),
+            url=url,
+        )
+
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.post(url, json=payload)
+
+        if response.status_code != 200:
+            error_body = response.text[:500]
+            logger.error(
+                "MMS TTS: sidecar error",
+                status_code=response.status_code,
+                body=error_body,
+                language=language,
+            )
+            raise RuntimeError(f"MMS TTS sidecar returned {response.status_code}: {error_body}")
+
+        audio_bytes = response.content
+        if not audio_bytes:
+            raise RuntimeError("MMS TTS sidecar returned empty audio bytes")
+
+        logger.info(
+            "MMS TTS: synthesis complete",
+            language=language,
+            audio_size_bytes=len(audio_bytes),
+        )
+        return audio_bytes

--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -22,6 +22,7 @@ celery_app = Celery(
         "app.tasks.file_cleanup",
         "app.tasks.image_indexation",
         "app.tasks.preassessment_generation",
+        "app.tasks.qbank_processing",
         "app.tasks.rag_indexation",
         "app.tasks.syllabus_generation",
         "app.tasks.subscription",

--- a/backend/app/tasks/qbank_processing.py
+++ b/backend/app/tasks/qbank_processing.py
@@ -1,0 +1,180 @@
+"""Celery tasks for QBank audio generation (FR/Moore/Dioula)."""
+
+from __future__ import annotations
+
+import uuid
+
+import structlog
+from celery import Task
+
+from app.tasks.celery_app import celery_app
+
+logger = structlog.get_logger(__name__)
+
+SOFT_LIMIT = 300
+HARD_LIMIT = 360
+
+
+class QBankCallbackTask(Task):
+    def on_success(self, retval, task_id, args, kwargs):
+        logger.info("QBank task completed", task_id=task_id, result=retval)
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        logger.error(
+            "QBank task failed",
+            task_id=task_id,
+            exception=str(exc),
+            traceback=einfo.traceback,
+        )
+
+
+@celery_app.task(
+    bind=True,
+    base=QBankCallbackTask,
+    soft_time_limit=120,
+    time_limit=150,
+    rate_limit="10/m",
+    autoretry_for=(Exception,),
+    retry_kwargs={"max_retries": 3, "countdown": 30},
+)
+def generate_question_audio_task(
+    self,
+    question_id: str,
+    language: str,
+    question_text: str,
+    choices: list[dict] | None = None,
+) -> dict:
+    """Generate TTS audio for a single qbank question.
+
+    Args:
+        question_id: UUID string of the question.
+        language: "fr" (Gemini TTS), "mos" or "dyu" (Meta MMS).
+        question_text: The question stem text.
+        choices: Optional list of {"text": "..."} option dicts.
+
+    Returns:
+        dict with audio_id and status.
+    """
+    import asyncio
+
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+    from app.domain.services.qbank_audio_service import QBankAudioService
+    from app.infrastructure.config.settings import settings
+
+    logger.info(
+        "Starting question audio generation",
+        question_id=question_id,
+        language=language,
+        task_id=self.request.id,
+    )
+
+    async def _run() -> dict:
+        engine = create_async_engine(settings.database_url, echo=False, pool_size=5, max_overflow=2)
+        session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        try:
+            async with session_factory() as session:
+                service = QBankAudioService()
+                audio = await service.generate_question_audio(
+                    question_id=uuid.UUID(question_id),
+                    language=language,
+                    question_text=question_text,
+                    choices=choices,
+                    session=session,
+                )
+                return {"audio_id": str(audio.id), "status": audio.status}
+        finally:
+            await engine.dispose()
+
+    try:
+        result = asyncio.run(_run())
+        logger.info(
+            "Question audio generation completed",
+            question_id=question_id,
+            result=result,
+            task_id=self.request.id,
+        )
+        return result
+    except Exception as exc:
+        logger.error(
+            "Question audio generation failed",
+            question_id=question_id,
+            language=language,
+            exception=str(exc),
+            task_id=self.request.id,
+        )
+        return {"audio_id": None, "status": "failed", "error": str(exc)}
+
+
+@celery_app.task(
+    bind=True,
+    base=QBankCallbackTask,
+    soft_time_limit=SOFT_LIMIT,
+    time_limit=HARD_LIMIT,
+    rate_limit="2/m",
+)
+def generate_qbank_audio_task(
+    self,
+    bank_id: str,
+    language: str,
+    questions: list[dict],
+) -> dict:
+    """Batch TTS generation for all questions in a question bank.
+
+    Args:
+        bank_id: UUID string of the question bank.
+        language: Target language ("fr", "mos", "dyu").
+        questions: List of {"id": str, "text": str, "choices": [...]} dicts.
+
+    Returns:
+        dict with generated/skipped/failed lists.
+    """
+    import asyncio
+
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+    from app.domain.services.qbank_audio_service import QBankAudioService
+    from app.infrastructure.config.settings import settings
+
+    logger.info(
+        "Starting batch qbank audio generation",
+        bank_id=bank_id,
+        language=language,
+        question_count=len(questions),
+        task_id=self.request.id,
+    )
+
+    async def _run() -> dict:
+        engine = create_async_engine(settings.database_url, echo=False, pool_size=5, max_overflow=2)
+        session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        try:
+            async with session_factory() as session:
+                service = QBankAudioService()
+                return await service.batch_generate_audio(
+                    bank_id=uuid.UUID(bank_id),
+                    language=language,
+                    questions=questions,
+                    session=session,
+                )
+        finally:
+            await engine.dispose()
+
+    try:
+        result = asyncio.run(_run())
+        logger.info(
+            "Batch qbank audio generation completed",
+            bank_id=bank_id,
+            language=language,
+            result=result,
+            task_id=self.request.id,
+        )
+        return result
+    except Exception as exc:
+        logger.error(
+            "Batch qbank audio generation failed",
+            bank_id=bank_id,
+            language=language,
+            exception=str(exc),
+            task_id=self.request.id,
+        )
+        return {"generated": [], "skipped": [], "failed": [], "error": str(exc)}

--- a/backend/migrations/versions/067_add_qbank_question_audio_table.py
+++ b/backend/migrations/versions/067_add_qbank_question_audio_table.py
@@ -1,0 +1,59 @@
+"""Add qbank_question_audio table for per-question TTS audio (FR + Moore + Dioula).
+
+Revision ID: 067
+Revises: 066
+Create Date: 2026-04-16
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "067"
+down_revision = "066"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE TYPE qbank_audio_status_enum AS ENUM ('pending', 'generating', 'ready', 'failed')")
+
+    op.create_table(
+        "qbank_question_audio",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("question_id", sa.Uuid(), nullable=False),
+        sa.Column("language", sa.String(10), nullable=False, server_default="fr"),
+        sa.Column("storage_key", sa.Text(), nullable=True),
+        sa.Column("storage_url", sa.Text(), nullable=True),
+        sa.Column("duration_seconds", sa.Integer(), nullable=True),
+        sa.Column("file_size_bytes", sa.Integer(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("is_manual_upload", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "pending",
+                "generating",
+                "ready",
+                "failed",
+                name="qbank_audio_status_enum",
+                create_type=False,
+            ),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column("generated_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("question_id", "language", name="uq_qbank_question_audio_question_lang"),
+    )
+
+    op.create_index("ix_qbank_question_audio_question_id", "qbank_question_audio", ["question_id"])
+    op.create_index("ix_qbank_question_audio_status", "qbank_question_audio", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_qbank_question_audio_status", table_name="qbank_question_audio")
+    op.drop_index("ix_qbank_question_audio_question_id", table_name="qbank_question_audio")
+    op.drop_table("qbank_question_audio")
+    op.execute("DROP TYPE IF EXISTS qbank_audio_status_enum")


### PR DESCRIPTION
## Summary

Implements TTS audio generation for qbank questions in 3 languages: French (via Gemini TTS), Moore (`mos`) and Dioula (`dyu`) via the Meta MMS HTTP sidecar.

## Changes

- **`backend/migrations/versions/067_add_qbank_question_audio_table.py`** — Alembic migration: creates `qbank_question_audio` table with `qbank_audio_status_enum` (pending/generating/ready/failed), unique constraint on `(question_id, language)`
- **`backend/app/domain/models/qbank_question_audio.py`** — `QBankQuestionAudio` SQLAlchemy model
- **`backend/app/integrations/mms_tts.py`** — `MMSTTSClient`: async HTTP client for Meta MMS Docker sidecar (`POST /synthesize`, returns WAV bytes)
- **`backend/app/domain/services/qbank_audio_service.py`** — `QBankAudioService`: Gemini TTS (fr) + MMS (mos/dyu) + MinIO upload; `generate_question_audio()` and `batch_generate_audio()` with cache deduplication and race-condition protection
- **`backend/app/tasks/qbank_processing.py`** — Celery tasks: `generate_question_audio_task` (single, rate 10/m) and `generate_qbank_audio_task` (batch, rate 2/m)
- **`backend/app/api/v1/qbank_audio.py`** — API endpoints:
  - `GET /api/v1/qbank/questions/{id}/audio?lang=fr` — retrieve audio URL + status
  - `POST /api/v1/qbank/questions/{id}/audio/trigger` — trigger async TTS generation
  - `POST /api/v1/qbank/questions/{id}/audio` — manual recording upload (WAV/MP3/OGG/WebM, ≤10MB)
  - `GET /api/v1/qbank/questions/{id}/audio/{audio_id}/data` — proxy audio bytes from MinIO
  - `POST /api/v1/qbank/questions/audio/batch` — batch generation for entire bank
- **`backend/app/infrastructure/config/settings.py`** — adds `mms_sidecar_url` setting (default `http://localhost:5050`)
- **`backend/app/domain/models/__init__.py`** — exports `QBankQuestionAudio`
- **`backend/app/tasks/celery_app.py`** — registers `app.tasks.qbank_processing`
- **`backend/app/api/v1/router.py`** — mounts `qbank_audio_router`

## Dependencies

- Depends on #1500 (QBank CRUD API — `qbank_questions` table must exist before FK can be added)
- Depends on MMS Docker sidecar (TBD) for Moore/Dioula synthesis

## Test plan

- [ ] Backend lint passes (`ruff check` — verified locally)
- [ ] Migration 067 applies cleanly on top of 066
- [ ] French audio generated via Gemini TTS
- [ ] Moore/Dioula audio generated via MMS sidecar
- [ ] Manual upload endpoint stores file in MinIO and marks status=ready
- [ ] Batch generation processes entire bank, skipping already-cached questions
- [ ] Audio URL is proxy-served from MinIO, not exposed directly

Closes #1502

Generated with [Claude Code](https://claude.ai/code)