### PR TITLE
feat(qbank): test results and review pages (#1506)

### DIFF
--- a/frontend/app/[locale]/(app)/qbank/tests/[testId]/results/page.tsx
+++ b/frontend/app/[locale]/(app)/qbank/tests/[testId]/results/page.tsx
@@ -1,0 +1,54 @@
+import { notFound } from 'next/navigation';
+import { getTranslations } from 'next-intl/server';
+import { QBankTestResults } from '@/components/qbank/qbank-test-results';
+import { getQBankTest, getQBankAttempt, getQBankAttemptHistory } from '@/lib/api';
+import type { QBankAttemptSummary } from '@/lib/api';
+
+interface ResultsPageProps {
+  params: Promise<{ locale: string; testId: string }>;
+  searchParams: Promise<{ attempt?: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string; testId: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'QBank' });
+  return { title: t('results.pageTitle') };
+}
+
+export default async function QBankTestResultsPage({
+  params,
+  searchParams,
+}: ResultsPageProps) {
+  const { testId } = await params;
+  const { attempt: attemptId } = await searchParams;
+
+  if (!attemptId) {
+    notFound();
+  }
+
+  const id = attemptId as string;
+
+  const [test, attempt, history] = await Promise.all([
+    getQBankTest(testId).catch(() => null),
+    getQBankAttempt(testId, id).catch(() => null),
+    getQBankAttemptHistory(testId).catch((): QBankAttemptSummary[] => []),
+  ]);
+
+  if (!test || !attempt) {
+    notFound();
+  }
+
+  return (
+    <QBankTestResults
+      testId={testId}
+      testTitle={test.title}
+      attempt={attempt}
+      passingScore={test.passing_score}
+      history={history}
+    />
+  );
+}

--- a/frontend/app/[locale]/(app)/qbank/tests/[testId]/review/page.tsx
+++ b/frontend/app/[locale]/(app)/qbank/tests/[testId]/review/page.tsx
@@ -1,0 +1,50 @@
+import { notFound } from 'next/navigation';
+import { getTranslations } from 'next-intl/server';
+import { QBankReviewMode } from '@/components/qbank/qbank-review-mode';
+import { getQBankTest, getQBankAttempt } from '@/lib/api';
+
+interface ReviewPageProps {
+  params: Promise<{ locale: string; testId: string }>;
+  searchParams: Promise<{ attempt?: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string; testId: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'QBank' });
+  return { title: t('review.pageTitle') };
+}
+
+export default async function QBankReviewPage({
+  params,
+  searchParams,
+}: ReviewPageProps) {
+  const { testId } = await params;
+  const { attempt: attemptId } = await searchParams;
+
+  if (!attemptId) {
+    notFound();
+  }
+
+  const id = attemptId as string;
+
+  const [test, attempt] = await Promise.all([
+    getQBankTest(testId).catch(() => null),
+    getQBankAttempt(testId, id).catch(() => null),
+  ]);
+
+  if (!test || !attempt) {
+    notFound();
+  }
+
+  return (
+    <QBankReviewMode
+      testId={testId}
+      testTitle={test.title}
+      questions={attempt.question_results}
+    />
+  );
+}

--- a/frontend/components/qbank/qbank-review-mode.tsx
+++ b/frontend/components/qbank/qbank-review-mode.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { useRouter } from '@/i18n/routing';
+import { CheckCircle, XCircle, Clock, ArrowLeft, Filter } from 'lucide-react';
+import Image from 'next/image';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Toggle } from '@/components/ui/toggle';
+import type { QBankQuestionResult } from '@/lib/api';
+
+interface QBankReviewModeProps {
+  testId: string;
+  testTitle: string;
+  questions: QBankQuestionResult[];
+}
+
+function formatTime(seconds: number): string {
+  const minutes = Math.floor(seconds / 60);
+  const remaining = seconds % 60;
+  if (minutes > 0) return `${minutes}m ${remaining}s`;
+  return `${seconds}s`;
+}
+
+export function QBankReviewMode({ testId, testTitle, questions }: QBankReviewModeProps) {
+  const t = useTranslations('QBank');
+  const router = useRouter();
+  const [showIncorrectOnly, setShowIncorrectOnly] = useState(false);
+
+  const displayed = showIncorrectOnly
+    ? questions.filter((q) => !q.is_correct)
+    : questions;
+
+  const incorrectCount = questions.filter((q) => !q.is_correct).length;
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-4">
+      <div className="flex items-center justify-between gap-4">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => router.push(`/qbank/tests/${testId}/results`)}
+          className="min-h-10 -ml-2"
+        >
+          <ArrowLeft className="w-4 h-4 mr-1" />
+          {t('review.back')}
+        </Button>
+
+        <Toggle
+          pressed={showIncorrectOnly}
+          onPressedChange={setShowIncorrectOnly}
+          aria-label={t('review.filterIncorrect')}
+          className="min-h-10 gap-2 text-sm"
+        >
+          <Filter className="w-4 h-4" />
+          {t('review.incorrect')}
+          {incorrectCount > 0 && (
+            <Badge variant="destructive" className="ml-1 text-xs px-1.5 py-0">
+              {incorrectCount}
+            </Badge>
+          )}
+        </Toggle>
+      </div>
+
+      <div className="space-y-1">
+        <h1 className="text-lg font-bold text-stone-900">{testTitle}</h1>
+        <p className="text-sm text-stone-500">
+          {showIncorrectOnly
+            ? t('review.showingIncorrect', { count: incorrectCount })
+            : t('review.showingAll', { count: questions.length })}
+        </p>
+      </div>
+
+      {displayed.length === 0 && (
+        <Card>
+          <CardContent className="p-8 text-center text-stone-500">
+            {t('review.noIncorrect')}
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="space-y-4">
+        {displayed.map((q) => {
+          const globalIdx = questions.indexOf(q);
+          return (
+            <Card
+              key={q.question_id}
+              className={`border-l-4 ${
+                q.is_correct ? 'border-l-green-500' : 'border-l-red-500'
+              }`}
+            >
+              <CardContent className="p-4 space-y-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex items-center gap-2 shrink-0">
+                    <Badge variant="outline" className="text-xs">
+                      {t('review.questionNumber', { n: globalIdx + 1 })}
+                    </Badge>
+                    {q.category && (
+                      <Badge variant="secondary" className="text-xs">
+                        {q.category}
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-1 text-xs text-stone-500 shrink-0">
+                    <Clock className="w-3 h-3" />
+                    {formatTime(q.time_taken_seconds)}
+                  </div>
+                </div>
+
+                {q.image_url && (
+                  <div className="relative w-full aspect-video rounded-md overflow-hidden bg-stone-100">
+                    <Image
+                      src={q.image_url}
+                      alt={t('review.questionImage')}
+                      fill
+                      className="object-contain"
+                    />
+                  </div>
+                )}
+
+                <p className="text-stone-900 text-sm leading-relaxed">{q.question_text}</p>
+
+                <div className="space-y-2">
+                  {q.options.map((option, optIdx) => {
+                    const isCorrect = optIdx === q.correct_option_index;
+                    const isUserAnswer = optIdx === q.user_answer_index;
+                    const isWrongUserAnswer = isUserAnswer && !q.is_correct;
+
+                    let optionClass =
+                      'p-3 rounded-lg border text-sm leading-snug';
+
+                    if (isCorrect) {
+                      optionClass +=
+                        ' bg-green-50 border-green-300 text-green-900 font-medium';
+                    } else if (isWrongUserAnswer) {
+                      optionClass += ' bg-red-50 border-red-300 text-red-900';
+                    } else {
+                      optionClass += ' bg-stone-50 border-stone-200 text-stone-600';
+                    }
+
+                    return (
+                      <div key={optIdx} className={optionClass}>
+                        <div className="flex items-start gap-2">
+                          <div className="shrink-0 mt-0.5">
+                            {isCorrect ? (
+                              <CheckCircle className="w-4 h-4 text-green-600" />
+                            ) : isWrongUserAnswer ? (
+                              <XCircle className="w-4 h-4 text-red-600" />
+                            ) : (
+                              <span className="w-4 h-4 inline-block" />
+                            )}
+                          </div>
+                          <span>{option}</span>
+                          {isUserAnswer && !isCorrect && (
+                            <Badge
+                              variant="destructive"
+                              className="ml-auto text-xs shrink-0"
+                            >
+                              {t('review.yourAnswer')}
+                            </Badge>
+                          )}
+                          {isCorrect && (
+                            <Badge className="ml-auto text-xs shrink-0 bg-green-600">
+                              {t('review.correctAnswer')}
+                            </Badge>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+
+                {q.user_answer_index === null && (
+                  <div className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
+                    {t('review.notAnswered')}
+                  </div>
+                )}
+
+                {q.explanation && (
+                  <div className="pt-2 border-t border-stone-100">
+                    <p className="text-xs font-semibold text-stone-600 mb-1">
+                      {t('review.explanation')}
+                    </p>
+                    <p className="text-sm text-stone-700 leading-relaxed">{q.explanation}</p>
+                  </div>
+                )}
+
+                {q.sources_cited.length > 0 && (
+                  <div className="text-xs text-stone-400 space-y-0.5">
+                    {q.sources_cited.map((src, sIdx) => (
+                      <div key={sIdx}>{t('review.source', { source: src })}</div>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+
+      {displayed.length > 0 && (
+        <div className="pb-4">
+          <Button
+            variant="outline"
+            className="w-full min-h-11"
+            onClick={() => router.push(`/qbank/tests/${testId}/results`)}
+          >
+            <ArrowLeft className="w-4 h-4 mr-2" />
+            {t('review.backToResults')}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/qbank/qbank-test-results.tsx
+++ b/frontend/components/qbank/qbank-test-results.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { useRouter } from '@/i18n/routing';
+import {
+  Trophy,
+  Target,
+  Clock,
+  CheckCircle,
+  XCircle,
+  RotateCcw,
+  Eye,
+  ArrowLeft,
+  TrendingUp,
+  History,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Progress } from '@/components/ui/progress';
+import type { QBankAttempt, QBankAttemptSummary } from '@/lib/api';
+
+interface QBankTestResultsProps {
+  testId: string;
+  testTitle: string;
+  attempt: QBankAttempt;
+  passingScore: number;
+  history: QBankAttemptSummary[];
+}
+
+function formatTime(seconds: number): string {
+  const minutes = Math.floor(seconds / 60);
+  const remaining = seconds % 60;
+  if (minutes > 0) return `${minutes}m ${remaining}s`;
+  return `${seconds}s`;
+}
+
+function formatDate(iso: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  }).format(new Date(iso));
+}
+
+export function QBankTestResults({
+  testId,
+  testTitle,
+  attempt,
+  passingScore,
+  history,
+}: QBankTestResultsProps) {
+  const t = useTranslations('QBank');
+  const router = useRouter();
+
+  const isPassed = attempt.passed;
+  const scoreColor = isPassed ? 'text-green-700' : 'text-red-700';
+  const scoreBg = isPassed ? 'bg-green-50 border-green-200' : 'bg-red-50 border-red-200';
+
+  const handleRetake = () => {
+    router.push(`/qbank/tests/${testId}`);
+  };
+
+  const handleReview = () => {
+    router.push(`/qbank/tests/${testId}/review?attempt=${attempt.id}`);
+  };
+
+  const handleBack = () => {
+    router.push('/qbank');
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-6">
+      <div className="text-center space-y-3">
+        <div
+          className={`mx-auto w-20 h-20 rounded-full flex items-center justify-center ${
+            isPassed ? 'bg-green-100' : 'bg-red-100'
+          }`}
+        >
+          {isPassed ? (
+            <Trophy className="w-10 h-10 text-green-600" />
+          ) : (
+            <Target className="w-10 h-10 text-red-600" />
+          )}
+        </div>
+        <h1 className="text-2xl font-bold text-stone-900">{testTitle}</h1>
+        <Badge
+          variant={isPassed ? 'default' : 'destructive'}
+          className="text-sm px-4 py-1"
+        >
+          {isPassed ? t('results.passed') : t('results.failed')}
+        </Badge>
+      </div>
+
+      <Card className={scoreBg}>
+        <CardContent className="p-6 space-y-4">
+          <div className="text-center">
+            <div className={`text-5xl font-bold ${scoreColor}`}>
+              {attempt.score_percent}%
+            </div>
+            <p className="text-sm text-stone-600 mt-1">
+              {t('results.passingScore', { score: passingScore })}
+            </p>
+          </div>
+
+          <Progress
+            value={attempt.score_percent}
+            className={`h-3 ${isPassed ? '[&>div]:bg-green-500' : '[&>div]:bg-red-500'}`}
+          />
+
+          <div className="grid grid-cols-3 gap-4 pt-2 text-center">
+            <div>
+              <div className="flex items-center justify-center gap-1 text-green-600 mb-1">
+                <CheckCircle className="w-4 h-4" />
+                <span className="text-xl font-bold text-stone-900">
+                  {attempt.correct_answers}
+                </span>
+              </div>
+              <p className="text-xs text-stone-500">{t('results.correct')}</p>
+            </div>
+            <div>
+              <div className="flex items-center justify-center gap-1 text-red-600 mb-1">
+                <XCircle className="w-4 h-4" />
+                <span className="text-xl font-bold text-stone-900">
+                  {attempt.total_questions - attempt.correct_answers}
+                </span>
+              </div>
+              <p className="text-xs text-stone-500">{t('results.incorrect')}</p>
+            </div>
+            <div>
+              <div className="flex items-center justify-center gap-1 mb-1">
+                <Clock className="w-4 h-4 text-stone-500" />
+                <span className="text-xl font-bold text-stone-900">
+                  {formatTime(attempt.total_time_seconds)}
+                </span>
+              </div>
+              <p className="text-xs text-stone-500">{t('results.timeTaken')}</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {attempt.category_breakdown.length > 0 && (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <TrendingUp className="w-4 h-4" />
+              {t('results.categoryBreakdown')}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {attempt.category_breakdown.map((cat) => (
+              <div key={cat.category} className="space-y-1">
+                <div className="flex justify-between text-sm">
+                  <span className="font-medium text-stone-700 truncate flex-1 mr-2">
+                    {cat.category}
+                  </span>
+                  <span className="text-stone-500 shrink-0">
+                    {cat.correct}/{cat.total} ({cat.score_percent}%)
+                  </span>
+                </div>
+                <Progress
+                  value={cat.score_percent}
+                  className={`h-2 ${
+                    cat.score_percent >= passingScore
+                      ? '[&>div]:bg-green-500'
+                      : '[&>div]:bg-amber-500'
+                  }`}
+                />
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
+      {history.length > 1 && (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <History className="w-4 h-4" />
+              {t('results.attemptHistory')}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {history.slice(0, 5).map((h, idx) => (
+                <div
+                  key={h.id}
+                  className="flex items-center justify-between py-2 border-b border-stone-100 last:border-0"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-stone-500">#{history.length - idx}</span>
+                    <span className="text-sm text-stone-600">{formatDate(h.completed_at)}</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`text-sm font-semibold ${
+                        h.passed ? 'text-green-600' : 'text-red-600'
+                      }`}
+                    >
+                      {h.score_percent}%
+                    </span>
+                    <Badge variant={h.passed ? 'default' : 'secondary'} className="text-xs">
+                      {h.passed ? t('results.pass') : t('results.fail')}
+                    </Badge>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="flex flex-col sm:flex-row gap-3">
+        <Button variant="outline" onClick={handleBack} className="min-h-11 sm:flex-1">
+          <ArrowLeft className="w-4 h-4 mr-2" />
+          {t('results.backToBank')}
+        </Button>
+        <Button variant="outline" onClick={handleReview} className="min-h-11 sm:flex-1">
+          <Eye className="w-4 h-4 mr-2" />
+          {t('results.reviewAnswers')}
+        </Button>
+        <Button onClick={handleRetake} className="min-h-11 sm:flex-1">
+          <RotateCcw className="w-4 h-4 mr-2" />
+          {t('results.retakeTest')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1388,3 +1388,88 @@ export async function exportOrgCsv(orgId: string): Promise<string> {
   });
   return res.text();
 }
+
+// QBank Types
+export interface QBankQuestion {
+  id: string;
+  question_text: string;
+  image_url?: string;
+  options: string[];
+  correct_option_index: number;
+  explanation?: string;
+  category?: string;
+  sources_cited: string[];
+}
+
+export interface QBankTest {
+  id: string;
+  title: string;
+  description?: string;
+  questions: QBankQuestion[];
+  passing_score: number;
+  time_limit_minutes?: number;
+  created_at: string;
+}
+
+export interface QBankQuestionResult {
+  question_id: string;
+  user_answer_index: number | null;
+  correct_option_index: number;
+  is_correct: boolean;
+  time_taken_seconds: number;
+  question_text: string;
+  image_url?: string;
+  options: string[];
+  explanation?: string;
+  category?: string;
+  sources_cited: string[];
+}
+
+export interface QBankCategoryBreakdown {
+  category: string;
+  correct: number;
+  total: number;
+  score_percent: number;
+}
+
+export interface QBankAttempt {
+  id: string;
+  test_id: string;
+  score_percent: number;
+  passed: boolean;
+  correct_answers: number;
+  total_questions: number;
+  total_time_seconds: number;
+  completed_at: string;
+  question_results: QBankQuestionResult[];
+  category_breakdown: QBankCategoryBreakdown[];
+}
+
+export interface QBankAttemptSummary {
+  id: string;
+  score_percent: number;
+  passed: boolean;
+  correct_answers: number;
+  total_questions: number;
+  total_time_seconds: number;
+  completed_at: string;
+}
+
+export async function getQBankTest(testId: string): Promise<QBankTest> {
+  const { authClient } = await import("./auth");
+  return authClient.authenticatedFetch<QBankTest>(`/api/v1/qbank/tests/${testId}`);
+}
+
+export async function getQBankAttempt(testId: string, attemptId: string): Promise<QBankAttempt> {
+  const { authClient } = await import("./auth");
+  return authClient.authenticatedFetch<QBankAttempt>(
+    `/api/v1/qbank/tests/${testId}/attempts/${attemptId}`
+  );
+}
+
+export async function getQBankAttemptHistory(testId: string): Promise<QBankAttemptSummary[]> {
+  const { authClient } = await import("./auth");
+  return authClient.authenticatedFetch<QBankAttemptSummary[]>(
+    `/api/v1/qbank/tests/${testId}/attempts`
+  );
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1937,5 +1937,40 @@
     "contactCta": "Questions, partnerships, or feedback — we'd love to hear from you.",
     "ctaBrowse": "Browse Courses",
     "ctaExpert": "Become an Expert"
+  },
+  "QBank": {
+    "results": {
+      "pageTitle": "Test Results",
+      "passed": "Passed",
+      "failed": "Failed",
+      "pass": "Pass",
+      "fail": "Fail",
+      "passingScore": "Passing score: {score}%",
+      "correct": "Correct",
+      "incorrect": "Incorrect",
+      "timeTaken": "Time taken",
+      "categoryBreakdown": "Category breakdown",
+      "attemptHistory": "Previous attempts",
+      "backToBank": "Back to bank",
+      "reviewAnswers": "Review answers",
+      "retakeTest": "Retake test"
+    },
+    "review": {
+      "pageTitle": "Review Answers",
+      "back": "Back",
+      "backToResults": "Back to results",
+      "filterIncorrect": "Show incorrect only",
+      "incorrect": "Incorrect only",
+      "showingAll": "Showing all {count} questions",
+      "showingIncorrect": "Showing {count} incorrect answer(s)",
+      "noIncorrect": "Great job — no incorrect answers!",
+      "questionNumber": "Q{n}",
+      "questionImage": "Question image",
+      "yourAnswer": "Your answer",
+      "correctAnswer": "Correct",
+      "notAnswered": "Not answered",
+      "explanation": "Explanation",
+      "source": "Source: {source}"
+    }
   }
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1937,5 +1937,40 @@
     "contactCta": "Questions, partenariats ou retours — nous serions ravis de vous entendre.",
     "ctaBrowse": "Parcourir les cours",
     "ctaExpert": "Devenir expert"
+  },
+  "QBank": {
+    "results": {
+      "pageTitle": "Résultats du test",
+      "passed": "Réussi",
+      "failed": "Échoué",
+      "pass": "Réussi",
+      "fail": "Échoué",
+      "passingScore": "Score de passage : {score}%",
+      "correct": "Correct",
+      "incorrect": "Incorrect",
+      "timeTaken": "Temps pris",
+      "categoryBreakdown": "Répartition par catégorie",
+      "attemptHistory": "Tentatives précédentes",
+      "backToBank": "Retour à la banque",
+      "reviewAnswers": "Revoir les réponses",
+      "retakeTest": "Reprendre le test"
+    },
+    "review": {
+      "pageTitle": "Révision des réponses",
+      "back": "Retour",
+      "backToResults": "Retour aux résultats",
+      "filterIncorrect": "Afficher uniquement les incorrectes",
+      "incorrect": "Incorrectes seulement",
+      "showingAll": "Affichage de {count} questions",
+      "showingIncorrect": "Affichage de {count} réponse(s) incorrecte(s)",
+      "noIncorrect": "Bravo — aucune réponse incorrecte !",
+      "questionNumber": "Q{n}",
+      "questionImage": "Image de la question",
+      "yourAnswer": "Votre réponse",
+      "correctAnswer": "Correct",
+      "notAnswered": "Sans réponse",
+      "explanation": "Explication",
+      "source": "Source : {source}"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Implements the QBank test results and review pages as specified in #1506.

## Changes

- `frontend/lib/api.ts` — Added QBank API types (`QBankQuestion`, `QBankTest`, `QBankAttempt`, `QBankQuestionResult`, `QBankCategoryBreakdown`, `QBankAttemptSummary`) and fetch functions (`getQBankTest`, `getQBankAttempt`, `getQBankAttemptHistory`)
- `frontend/components/qbank/qbank-test-results.tsx` — Score display with large percentage, color-coded pass/fail badge, time taken, category breakdown bars, attempt history list, and action buttons (Retake, Review, Back)
- `frontend/components/qbank/qbank-review-mode.tsx` — Scrollable question cards with image support, color-coded correct/incorrect options, filter toggle (all / incorrect only), explanation and source citations
- `frontend/app/[locale]/(app)/qbank/tests/[testId]/results/page.tsx` — Server component results page (requires `?attempt=<id>` query param)
- `frontend/app/[locale]/(app)/qbank/tests/[testId]/review/page.tsx` — Server component review page (requires `?attempt=<id>` query param)
- `frontend/messages/en.json` — English translations for QBank namespace
- `frontend/messages/fr.json` — French translations for QBank namespace

## Test plan

- [ ] Backend tests pass (depends on #1500 CRUD API)
- [ ] Frontend lint passes (`eslint` — verified clean)
- [ ] Frontend vitest passes (no unit tests yet for new components)
- [ ] Results page shows score prominently with pass/fail color coding
- [ ] Category breakdown renders when categories exist
- [ ] Review page shows all questions with correct answers highlighted
- [ ] Filter toggle shows incorrect-only questions
- [ ] Attempt history section visible when multiple attempts exist
- [ ] Mobile-responsive at 320px viewport

Closes #1506

Generated with [Claude Code](https://claude.ai/code)