### PR TITLE
fix: enable force-retry for stuck syllabus generation in AI wizard

### DIFF
--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -276,6 +276,9 @@ export function AICourseWizard({
             setIsGenerating(true);
             setGenerateTaskId(genStatus.task.id ?? null);
             setGenerationStartTime(Date.now());
+          } else if (genStatus.creation_step === "generating") {
+            // Task is dead but creation_step never reset — enable force on next generate
+            setShouldForceGenerate(true);
           }
         } else if (resumeCreationStep === "generated") {
           // Generation done — fetch modules and go to syllabus_edit


### PR DESCRIPTION
## Summary
- When a previous generation attempt leaves `creation_step` stuck at `"generating"` (e.g. worker crash), the AI wizard now sets `shouldForceGenerate=true` so the retry passes `force=true` to the backend, avoiding the 409 Conflict
- Mirrors the existing logic already present in the legacy wizard (`course-wizard-client.tsx:375-376`)

## Test plan
- [ ] Find/create a course stuck in `creation_step = "generating"` 
- [ ] Open the AI course creation wizard for that course
- [ ] Click "Generate syllabus" — should succeed (no 409)
- [ ] Verify normal first-time generation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)