### PR TITLE
fix: enable force-retry for stuck syllabus generation

### DIFF
--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -276,6 +276,9 @@ export function AICourseWizard({
             setIsGenerating(true);
             setGenerateTaskId(genStatus.task.id ?? null);
             setGenerationStartTime(Date.now());
+          } else if (genStatus.creation_step === "generating") {
+            // Task is dead but creation_step never reset — enable force on next generate
+            setShouldForceGenerate(true);
           }
         } else if (resumeCreationStep === "generated") {
           // Generation done — fetch modules and go to syllabus_edit


### PR DESCRIPTION
## Summary
- Merges dev → main to deploy the syllabus generation fix
- When a previous generation leaves `creation_step` stuck at `"generating"`, the AI wizard now sets `force=true` on retry to bypass the 409 Conflict

## Test plan
- [ ] Open the Meta MMS draft course in AI wizard
- [ ] Click "Generate syllabus" — should succeed (no 409)