### PR TITLE
fix: strip NUL bytes from PDF text before PostgreSQL save

### DIFF
--- a/backend/app/domain/models/__init__.py
+++ b/backend/app/domain/models/__init__.py
@@ -19,6 +19,7 @@ from app.domain.models.module_media import MediaStatus, MediaType, ModuleMedia
 from app.domain.models.module_unit import ModuleUnit
 from app.domain.models.organization import Organization, OrganizationMember, OrgMemberRole
 from app.domain.models.preassessment import CoursePreAssessment
+from app.domain.models.progress import UserModuleProgress
 from app.domain.models.question_bank import (
     QBankAudioStatus,
     QBankQuestion,
@@ -31,7 +32,6 @@ from app.domain.models.question_bank import (
     QuestionDifficulty,
     TestMode,
 )
-from app.domain.models.progress import UserModuleProgress
 from app.domain.models.quiz import PlacementTestAttempt, QuizAttempt, SummativeAssessmentAttempt
 from app.domain.models.sms_relay import (
     InboundSms,

--- a/backend/app/domain/models/question_bank.py
+++ b/backend/app/domain/models/question_bank.py
@@ -197,7 +197,9 @@ class QBankTestAttempt(Base):
     time_taken_sec: Mapped[int] = mapped_column(Integer, nullable=False)
     passed: Mapped[bool] = mapped_column(Boolean, nullable=False)
     category_breakdown: Mapped[dict | None] = mapped_column(JSON, nullable=True)
-    attempted_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    attempted_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
     attempt_number: Mapped[int] = mapped_column(Integer, server_default="1", default=1)
 
     test: Mapped[QBankTest] = relationship(back_populates="attempts")

--- a/backend/app/tasks/syllabus_generation.py
+++ b/backend/app/tasks/syllabus_generation.py
@@ -418,6 +418,9 @@ def generate_course_syllabus(
                 ]
                 resource_text = "\n\n---\n\n".join(pdf_sections)
 
+            # PostgreSQL text columns reject NUL (0x00) bytes
+            resource_text = resource_text.replace("\x00", "")
+
             logger.info(
                 "Resource text prepared for syllabus context",
                 course_id=course_id,

--- a/backend/migrations/versions/067_add_question_bank_tables.py
+++ b/backend/migrations/versions/067_add_question_bank_tables.py
@@ -7,8 +7,8 @@ Create Date: 2026-04-16
 """
 
 import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import JSON
 from alembic import op
+from sqlalchemy.dialects.postgresql import JSON
 
 revision = "067"
 down_revision = "066"


### PR DESCRIPTION
## Summary
- PDF extraction can produce NUL (0x00) characters that PostgreSQL text columns reject
- Strips NUL bytes from `resource_text` before saving `syllabus_context` to the courses table
- Fixes `ValueError: A string literal cannot contain NUL (0x00) characters` during syllabus generation

## Test plan
- [ ] Generate syllabus for the Meta MMS course — should complete without NUL byte error

🤖 Generated with [Claude Code](https://claude.com/claude-code)