### PR TITLE
style: format question_bank files for ruff

### DIFF
--- a/backend/app/domain/models/question_bank.py
+++ b/backend/app/domain/models/question_bank.py
@@ -79,9 +79,7 @@ class QuestionBank(Base):
         server_default="draft",
         default=QuestionBankStatus.draft,
     )
-    created_by: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("users.id"), nullable=False
-    )
+    created_by: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
@@ -159,18 +157,14 @@ class QBankTest(Base):
         ForeignKey("question_banks.id", ondelete="CASCADE"), index=True, nullable=False
     )
     title: Mapped[str] = mapped_column(String(500), nullable=False)
-    mode: Mapped[TestMode] = mapped_column(
-        Enum(TestMode, name="testmode"), nullable=False
-    )
+    mode: Mapped[TestMode] = mapped_column(Enum(TestMode, name="testmode"), nullable=False)
     question_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
     shuffle_questions: Mapped[bool] = mapped_column(Boolean, server_default="true", default=True)
     time_per_question_sec: Mapped[int | None] = mapped_column(Integer, nullable=True)
     show_feedback: Mapped[bool] = mapped_column(Boolean, server_default="false", default=False)
     filter_categories: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     filter_failed_only: Mapped[bool] = mapped_column(Boolean, server_default="false", default=False)
-    created_by: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("users.id"), nullable=False
-    )
+    created_by: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     question_bank: Mapped[QuestionBank] = relationship(back_populates="tests")
@@ -187,9 +181,7 @@ class QBankTestAttempt(Base):
     test_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("qbank_tests.id", ondelete="CASCADE"), index=True, nullable=False
     )
-    user_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("users.id"), index=True, nullable=False
-    )
+    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), index=True, nullable=False)
     answers: Mapped[dict] = mapped_column(JSON, nullable=False)
     score: Mapped[float] = mapped_column(Float, nullable=False)
     total_questions: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/backend/migrations/versions/067_add_question_bank_tables.py
+++ b/backend/migrations/versions/067_add_question_bank_tables.py
@@ -17,7 +17,9 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute("CREATE TYPE questionbanktype AS ENUM ('driving', 'exam_prep', 'psychotechnic', 'general_culture')")
+    op.execute(
+        "CREATE TYPE questionbanktype AS ENUM ('driving', 'exam_prep', 'psychotechnic', 'general_culture')"
+    )
     op.execute("CREATE TYPE questionbankstatus AS ENUM ('draft', 'published', 'archived')")
     op.execute("CREATE TYPE questiondifficulty AS ENUM ('easy', 'medium', 'hard')")
     op.execute("CREATE TYPE testmode AS ENUM ('exam', 'training', 'review')")
@@ -26,14 +28,36 @@ def upgrade() -> None:
     op.create_table(
         "question_banks",
         sa.Column("id", sa.Uuid(), primary_key=True),
-        sa.Column("organization_id", sa.Uuid(), sa.ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True),
+        sa.Column(
+            "organization_id",
+            sa.Uuid(),
+            sa.ForeignKey("organizations.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
         sa.Column("title", sa.String(500), nullable=False),
         sa.Column("description", sa.Text(), nullable=True),
-        sa.Column("bank_type", sa.Enum("driving", "exam_prep", "psychotechnic", "general_culture", name="questionbanktype", create_type=False), nullable=False),
+        sa.Column(
+            "bank_type",
+            sa.Enum(
+                "driving",
+                "exam_prep",
+                "psychotechnic",
+                "general_culture",
+                name="questionbanktype",
+                create_type=False,
+            ),
+            nullable=False,
+        ),
         sa.Column("language", sa.String(5), server_default="fr", nullable=False),
         sa.Column("time_per_question_sec", sa.Integer(), server_default="25", nullable=False),
         sa.Column("passing_score", sa.Float(), server_default="80.0", nullable=False),
-        sa.Column("status", sa.Enum("draft", "published", "archived", name="questionbankstatus", create_type=False), server_default="draft", nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum("draft", "published", "archived", name="questionbankstatus", create_type=False),
+            server_default="draft",
+            nullable=False,
+        ),
         sa.Column("created_by", sa.Uuid(), sa.ForeignKey("users.id"), nullable=False),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
         sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
@@ -42,7 +66,13 @@ def upgrade() -> None:
     op.create_table(
         "qbank_questions",
         sa.Column("id", sa.Uuid(), primary_key=True),
-        sa.Column("question_bank_id", sa.Uuid(), sa.ForeignKey("question_banks.id", ondelete="CASCADE"), nullable=False, index=True),
+        sa.Column(
+            "question_bank_id",
+            sa.Uuid(),
+            sa.ForeignKey("question_banks.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
         sa.Column("order_index", sa.Integer(), nullable=False),
         sa.Column("image_storage_key", sa.String(), nullable=True),
         sa.Column("image_url", sa.String(), nullable=True),
@@ -53,19 +83,42 @@ def upgrade() -> None:
         sa.Column("source_page", sa.Integer(), nullable=True),
         sa.Column("source_pdf_name", sa.String(), nullable=True),
         sa.Column("category", sa.String(100), nullable=True),
-        sa.Column("difficulty", sa.Enum("easy", "medium", "hard", name="questiondifficulty", create_type=False), server_default="medium", nullable=False),
+        sa.Column(
+            "difficulty",
+            sa.Enum("easy", "medium", "hard", name="questiondifficulty", create_type=False),
+            server_default="medium",
+            nullable=False,
+        ),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
     )
 
     op.create_table(
         "qbank_question_audio",
         sa.Column("id", sa.Uuid(), primary_key=True),
-        sa.Column("question_id", sa.Uuid(), sa.ForeignKey("qbank_questions.id", ondelete="CASCADE"), nullable=False, index=True),
+        sa.Column(
+            "question_id",
+            sa.Uuid(),
+            sa.ForeignKey("qbank_questions.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
         sa.Column("language", sa.String(10), nullable=False),
         sa.Column("storage_key", sa.String(), nullable=True),
         sa.Column("storage_url", sa.String(), nullable=True),
         sa.Column("duration_seconds", sa.Integer(), nullable=True),
-        sa.Column("status", sa.Enum("pending", "generating", "ready", "failed", name="qbankaudiostatus", create_type=False), server_default="pending", nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "pending",
+                "generating",
+                "ready",
+                "failed",
+                name="qbankaudiostatus",
+                create_type=False,
+            ),
+            server_default="pending",
+            nullable=False,
+        ),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
         sa.UniqueConstraint("question_id", "language", name="uq_qbank_question_audio_lang"),
     )
@@ -73,9 +126,19 @@ def upgrade() -> None:
     op.create_table(
         "qbank_tests",
         sa.Column("id", sa.Uuid(), primary_key=True),
-        sa.Column("question_bank_id", sa.Uuid(), sa.ForeignKey("question_banks.id", ondelete="CASCADE"), nullable=False, index=True),
+        sa.Column(
+            "question_bank_id",
+            sa.Uuid(),
+            sa.ForeignKey("question_banks.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
         sa.Column("title", sa.String(500), nullable=False),
-        sa.Column("mode", sa.Enum("exam", "training", "review", name="testmode", create_type=False), nullable=False),
+        sa.Column(
+            "mode",
+            sa.Enum("exam", "training", "review", name="testmode", create_type=False),
+            nullable=False,
+        ),
         sa.Column("question_count", sa.Integer(), nullable=True),
         sa.Column("shuffle_questions", sa.Boolean(), server_default="true", nullable=False),
         sa.Column("time_per_question_sec", sa.Integer(), nullable=True),
@@ -89,7 +152,13 @@ def upgrade() -> None:
     op.create_table(
         "qbank_test_attempts",
         sa.Column("id", sa.Uuid(), primary_key=True),
-        sa.Column("test_id", sa.Uuid(), sa.ForeignKey("qbank_tests.id", ondelete="CASCADE"), nullable=False, index=True),
+        sa.Column(
+            "test_id",
+            sa.Uuid(),
+            sa.ForeignKey("qbank_tests.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
         sa.Column("user_id", sa.Uuid(), sa.ForeignKey("users.id"), nullable=False, index=True),
         sa.Column("answers", JSON(), nullable=False),
         sa.Column("score", sa.Float(), nullable=False),


### PR DESCRIPTION
## Summary
- Format `question_bank.py` and migration `067` to pass ruff format check
- Includes NUL byte fix from previous PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)