### PR TITLE
fix: auto-trigger RAG indexation after syllabus generation

### DIFF
--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -614,6 +614,23 @@ export function AICourseWizard({
             setGeneratedModules(modules as GeneratedModule[]);
           }
           setIsGenerating(false);
+
+          // Auto-trigger RAG indexation after successful generation
+          if (!isIndexing && courseId) {
+            try {
+              const idxStatus = await getIndexStatusApi(courseId);
+              if (!idxStatus.indexed) {
+                const idxResult = await triggerIndexation(courseId);
+                setTaskId(idxResult.task_id);
+                setIsIndexing(true);
+                lastIndexProgressTimeRef.current = Date.now();
+              } else {
+                setIndexStatus({ indexed: true, chunks_indexed: idxStatus.chunks_indexed, images_indexed: idxStatus.images_indexed, task: idxStatus.task });
+              }
+            } catch {
+              // indexation auto-trigger is best-effort
+            }
+          }
           return;
         }
 


### PR DESCRIPTION
## Summary
- Auto-trigger RAG indexation when syllabus generation completes successfully
- Previously indexation only triggered on PDF upload — if Edit Syllabus step was skipped, courses remained unindexed (RAG chunks = 0)
- Also includes NUL byte stripping fix for PDF text

## Test plan
- [ ] Generate syllabus for a course → indexation should auto-start after generation completes
- [ ] Verify RAG chunks > 0 at Publish step

🤖 Generated with [Claude Code](https://claude.com/claude-code)