### PR TITLE
fix: handle pre-existing enum types in migration 067

### DIFF
--- a/backend/migrations/versions/067_add_question_bank_tables.py
+++ b/backend/migrations/versions/067_add_question_bank_tables.py
@@ -18,12 +18,30 @@ depends_on = None
 
 def upgrade() -> None:
     op.execute(
-        "CREATE TYPE questionbanktype AS ENUM ('driving', 'exam_prep', 'psychotechnic', 'general_culture')"
+        "DO $$ BEGIN CREATE TYPE questionbanktype AS ENUM"
+        " ('driving', 'exam_prep', 'psychotechnic', 'general_culture');"
+        " EXCEPTION WHEN duplicate_object THEN NULL; END $$"
     )
-    op.execute("CREATE TYPE questionbankstatus AS ENUM ('draft', 'published', 'archived')")
-    op.execute("CREATE TYPE questiondifficulty AS ENUM ('easy', 'medium', 'hard')")
-    op.execute("CREATE TYPE testmode AS ENUM ('exam', 'training', 'review')")
-    op.execute("CREATE TYPE qbankaudiostatus AS ENUM ('pending', 'generating', 'ready', 'failed')")
+    op.execute(
+        "DO $$ BEGIN CREATE TYPE questionbankstatus AS ENUM"
+        " ('draft', 'published', 'archived');"
+        " EXCEPTION WHEN duplicate_object THEN NULL; END $$"
+    )
+    op.execute(
+        "DO $$ BEGIN CREATE TYPE questiondifficulty AS ENUM"
+        " ('easy', 'medium', 'hard');"
+        " EXCEPTION WHEN duplicate_object THEN NULL; END $$"
+    )
+    op.execute(
+        "DO $$ BEGIN CREATE TYPE testmode AS ENUM"
+        " ('exam', 'training', 'review');"
+        " EXCEPTION WHEN duplicate_object THEN NULL; END $$"
+    )
+    op.execute(
+        "DO $$ BEGIN CREATE TYPE qbankaudiostatus AS ENUM"
+        " ('pending', 'generating', 'ready', 'failed');"
+        " EXCEPTION WHEN duplicate_object THEN NULL; END $$"
+    )
 
     op.create_table(
         "question_banks",


### PR DESCRIPTION
## Summary
- Migration 067 fails on deploy because enum types were partially created from a previous failed run
- Use DO/EXCEPTION blocks to skip CREATE TYPE if enum already exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)