### PR TITLE
feat: question bank CRUD service and API (#1500)

### DIFF
--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -1,0 +1,428 @@
+"""Question Bank API — CRUD for banks, questions, tests, attempts."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, Query, status
+
+from app.api.deps import get_db_session
+from app.api.deps_local_auth import AuthenticatedUser, get_current_user
+from app.api.v1.schemas.qbank import (
+    QuestionBankCreate,
+    QuestionBankResponse,
+    QuestionBankUpdate,
+    QuestionListResponse,
+    QuestionResponse,
+    QuestionUpdate,
+    TestAttemptResponse,
+    TestCreate,
+    TestResponse,
+    TestReviewQuestion,
+    TestReviewResponse,
+    TestStartQuestion,
+    TestStartResponse,
+    TestSubmitRequest,
+    TestUpdate,
+)
+from app.domain.services.qbank_service import QBankService
+
+router = APIRouter(prefix="/qbank", tags=["Question Bank"])
+
+_svc = QBankService()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _bank_response(bank, question_count: int = 0, test_count: int = 0):
+    return QuestionBankResponse(
+        id=str(bank.id),
+        organization_id=str(bank.organization_id),
+        title=bank.title,
+        description=bank.description,
+        bank_type=bank.bank_type.value
+        if hasattr(bank.bank_type, "value")
+        else bank.bank_type,
+        language=bank.language,
+        time_per_question_sec=bank.time_per_question_sec,
+        passing_score=bank.passing_score,
+        status=bank.status.value
+        if hasattr(bank.status, "value")
+        else bank.status,
+        question_count=question_count,
+        test_count=test_count,
+        created_by=str(bank.created_by),
+        created_at=bank.created_at.isoformat(),
+        updated_at=bank.updated_at.isoformat(),
+    )
+
+
+def _question_response(q):
+    return QuestionResponse(
+        id=str(q.id),
+        question_bank_id=str(q.question_bank_id),
+        order_index=q.order_index,
+        image_url=q.image_url,
+        question_text=q.question_text,
+        options=q.options,
+        correct_answer_indices=q.correct_answer_indices,
+        explanation=q.explanation,
+        source_page=q.source_page,
+        source_pdf_name=q.source_pdf_name,
+        category=q.category,
+        difficulty=q.difficulty.value
+        if hasattr(q.difficulty, "value")
+        else q.difficulty,
+        created_at=q.created_at.isoformat(),
+    )
+
+
+def _test_response(t):
+    return TestResponse(
+        id=str(t.id),
+        question_bank_id=str(t.question_bank_id),
+        title=t.title,
+        mode=t.mode.value if hasattr(t.mode, "value") else t.mode,
+        question_count=t.question_count,
+        shuffle_questions=t.shuffle_questions,
+        time_per_question_sec=t.time_per_question_sec,
+        show_feedback=t.show_feedback,
+        filter_categories=t.filter_categories,
+        filter_failed_only=t.filter_failed_only,
+        created_by=str(t.created_by),
+        created_at=t.created_at.isoformat(),
+    )
+
+
+def _attempt_response(a):
+    return TestAttemptResponse(
+        id=str(a.id),
+        test_id=str(a.test_id),
+        score=a.score,
+        total_questions=a.total_questions,
+        correct_answers=a.correct_answers,
+        time_taken_sec=a.time_taken_sec,
+        passed=a.passed,
+        category_breakdown=a.category_breakdown,
+        attempted_at=a.attempted_at.isoformat(),
+        attempt_number=a.attempt_number,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Question Bank CRUD
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/banks",
+    status_code=status.HTTP_201_CREATED,
+    response_model=QuestionBankResponse,
+)
+async def create_bank(
+    body: QuestionBankCreate,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    bank = await _svc.create_bank(
+        db,
+        organization_id=body.organization_id,
+        title=body.title,
+        description=body.description,
+        bank_type=body.bank_type,
+        language=body.language,
+        time_per_question_sec=body.time_per_question_sec,
+        passing_score=body.passing_score,
+        created_by=uuid.UUID(current_user.id),
+    )
+    return _bank_response(bank)
+
+
+@router.get("/banks", response_model=list[QuestionBankResponse])
+async def list_banks(
+    org_id: uuid.UUID = Query(...),
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    items = await _svc.list_org_banks(db, org_id)
+    return [
+        _bank_response(
+            item["bank"], item["question_count"], item["test_count"]
+        )
+        for item in items
+    ]
+
+
+@router.get("/banks/{bank_id}", response_model=QuestionBankResponse)
+async def get_bank(
+    bank_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    bank = await _svc.get_bank(db, bank_id)
+    return _bank_response(bank)
+
+
+@router.patch("/banks/{bank_id}", response_model=QuestionBankResponse)
+async def update_bank(
+    bank_id: uuid.UUID,
+    body: QuestionBankUpdate,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    updates = body.model_dump(exclude_unset=True)
+    bank = await _svc.update_bank(
+        db, bank_id, uuid.UUID(current_user.id), **updates
+    )
+    return _bank_response(bank)
+
+
+@router.delete(
+    "/banks/{bank_id}", status_code=status.HTTP_204_NO_CONTENT
+)
+async def delete_bank(
+    bank_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    await _svc.delete_bank(db, bank_id, uuid.UUID(current_user.id))
+
+
+# ---------------------------------------------------------------------------
+# Questions
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/banks/{bank_id}/questions",
+    response_model=QuestionListResponse,
+)
+async def list_questions(
+    bank_id: uuid.UUID,
+    page: int = Query(1, ge=1),
+    per_page: int = Query(50, ge=1, le=200),
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    data = await _svc.list_questions(db, bank_id, page, per_page)
+    return QuestionListResponse(
+        questions=[_question_response(q) for q in data["questions"]],
+        total=data["total"],
+        page=data["page"],
+        per_page=data["per_page"],
+    )
+
+
+@router.patch(
+    "/questions/{question_id}", response_model=QuestionResponse
+)
+async def update_question(
+    question_id: uuid.UUID,
+    body: QuestionUpdate,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    updates = body.model_dump(exclude_unset=True)
+    q = await _svc.update_question(
+        db, question_id, uuid.UUID(current_user.id), **updates
+    )
+    return _question_response(q)
+
+
+@router.delete(
+    "/questions/{question_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_question(
+    question_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    await _svc.delete_question(
+        db, question_id, uuid.UUID(current_user.id)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test CRUD
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/tests",
+    status_code=status.HTTP_201_CREATED,
+    response_model=TestResponse,
+)
+async def create_test(
+    body: TestCreate,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    test = await _svc.create_test(
+        db,
+        question_bank_id=body.question_bank_id,
+        title=body.title,
+        mode=body.mode,
+        created_by=uuid.UUID(current_user.id),
+        question_count=body.question_count,
+        shuffle_questions=body.shuffle_questions,
+        time_per_question_sec=body.time_per_question_sec,
+        show_feedback=body.show_feedback,
+        filter_categories=body.filter_categories,
+        filter_failed_only=body.filter_failed_only,
+    )
+    return _test_response(test)
+
+
+@router.get("/tests", response_model=list[TestResponse])
+async def list_tests(
+    bank_id: uuid.UUID = Query(...),
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    tests = await _svc.list_tests(db, bank_id)
+    return [_test_response(t) for t in tests]
+
+
+@router.patch("/tests/{test_id}", response_model=TestResponse)
+async def update_test(
+    test_id: uuid.UUID,
+    body: TestUpdate,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    updates = body.model_dump(exclude_unset=True)
+    test = await _svc.update_test(
+        db, test_id, uuid.UUID(current_user.id), **updates
+    )
+    return _test_response(test)
+
+
+@router.delete(
+    "/tests/{test_id}", status_code=status.HTTP_204_NO_CONTENT
+)
+async def delete_test(
+    test_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    await _svc.delete_test(
+        db, test_id, uuid.UUID(current_user.id)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test Session — start / submit / history / review
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/tests/{test_id}/start", response_model=TestStartResponse
+)
+async def start_test(
+    test_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    data = await _svc.start_test(
+        db, test_id, uuid.UUID(current_user.id)
+    )
+    test = data["test"]
+    questions = [
+        TestStartQuestion(
+            id=str(q.id),
+            image_url=q.image_url,
+            question_text=q.question_text,
+            options=q.options,
+            category=q.category,
+            difficulty=q.difficulty.value
+            if hasattr(q.difficulty, "value")
+            else q.difficulty,
+        )
+        for q in data["questions"]
+    ]
+
+    return TestStartResponse(
+        test_id=str(test.id),
+        title=test.title,
+        mode=test.mode.value
+        if hasattr(test.mode, "value")
+        else test.mode,
+        time_per_question_sec=data["time_per_question_sec"],
+        show_feedback=test.show_feedback,
+        questions=questions,
+        total_questions=len(questions),
+    )
+
+
+@router.post(
+    "/tests/{test_id}/submit",
+    response_model=TestAttemptResponse,
+)
+async def submit_test(
+    test_id: uuid.UUID,
+    body: TestSubmitRequest,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    attempt = await _svc.submit_test(
+        db, test_id, uuid.UUID(current_user.id), body.answers
+    )
+    return _attempt_response(attempt)
+
+
+@router.get(
+    "/tests/{test_id}/history",
+    response_model=list[TestAttemptResponse],
+)
+async def get_history(
+    test_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    attempts = await _svc.get_attempt_history(
+        db, test_id, uuid.UUID(current_user.id)
+    )
+    return [_attempt_response(a) for a in attempts]
+
+
+@router.get(
+    "/tests/{test_id}/review/{attempt_id}",
+    response_model=TestReviewResponse,
+)
+async def get_review(
+    test_id: uuid.UUID,
+    attempt_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    data = await _svc.get_review(
+        db, test_id, attempt_id, uuid.UUID(current_user.id)
+    )
+    attempt = data["attempt"]
+    review_questions = [
+        TestReviewQuestion(
+            id=str(item["question"].id),
+            image_url=item["question"].image_url,
+            question_text=item["question"].question_text,
+            options=item["question"].options,
+            correct_answer_indices=item[
+                "question"
+            ].correct_answer_indices,
+            explanation=item["question"].explanation,
+            category=item["question"].category,
+            user_selected=item["user_selected"],
+            is_correct=item["is_correct"],
+        )
+        for item in data["questions"]
+    ]
+    return TestReviewResponse(
+        test_id=str(test_id),
+        attempt_id=str(attempt.id),
+        score=attempt.score,
+        passed=attempt.passed,
+        questions=review_questions,
+    )

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -27,6 +27,7 @@ from app.api.v1.org_reports import router as org_reports_router
 from app.api.v1.organizations import router as organizations_router
 from app.api.v1.placement import router as placement_router
 from app.api.v1.progress import router as progress_router
+from app.api.v1.qbank import router as qbank_router
 from app.api.v1.quiz import router as quiz_router
 from app.api.v1.sms_relay import (
     router as sms_relay_router,
@@ -68,3 +69,4 @@ api_v1_router.include_router(organizations_router)
 api_v1_router.include_router(org_curricula_router)
 api_v1_router.include_router(org_codes_router)
 api_v1_router.include_router(org_reports_router)
+api_v1_router.include_router(qbank_router)

--- a/backend/app/api/v1/schemas/qbank.py
+++ b/backend/app/api/v1/schemas/qbank.py
@@ -1,0 +1,201 @@
+"""Question Bank API schemas."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Question Bank
+# ---------------------------------------------------------------------------
+
+
+class QuestionBankCreate(BaseModel):
+    organization_id: UUID
+    title: str = Field(..., min_length=2, max_length=500)
+    description: str | None = None
+    bank_type: str = Field(..., pattern=r"^(driving|exam_prep|psychotechnic|general_culture)$")
+    language: str = Field(default="fr", max_length=5)
+    time_per_question_sec: int = Field(default=25, ge=5, le=120)
+    passing_score: float = Field(default=80.0, ge=0, le=100)
+
+
+class QuestionBankUpdate(BaseModel):
+    title: str | None = Field(default=None, min_length=2, max_length=500)
+    description: str | None = None
+    language: str | None = Field(default=None, max_length=5)
+    time_per_question_sec: int | None = Field(default=None, ge=5, le=120)
+    passing_score: float | None = Field(default=None, ge=0, le=100)
+    status: str | None = Field(
+        default=None, pattern=r"^(draft|published|archived)$"
+    )
+
+
+class QuestionBankResponse(BaseModel):
+    id: str
+    organization_id: str
+    title: str
+    description: str | None = None
+    bank_type: str
+    language: str
+    time_per_question_sec: int
+    passing_score: float
+    status: str
+    question_count: int = 0
+    test_count: int = 0
+    created_by: str
+    created_at: str
+    updated_at: str
+
+
+# ---------------------------------------------------------------------------
+# Question
+# ---------------------------------------------------------------------------
+
+
+class QuestionUpdate(BaseModel):
+    question_text: str | None = None
+    options: list[str] | None = None
+    correct_answer_indices: list[int] | None = None
+    explanation: str | None = None
+    category: str | None = Field(default=None, max_length=100)
+    difficulty: str | None = Field(
+        default=None, pattern=r"^(easy|medium|hard)$"
+    )
+
+
+class QuestionResponse(BaseModel):
+    id: str
+    question_bank_id: str
+    order_index: int
+    image_url: str | None = None
+    question_text: str
+    options: list[str]
+    correct_answer_indices: list[int]
+    explanation: str | None = None
+    source_page: int | None = None
+    source_pdf_name: str | None = None
+    category: str | None = None
+    difficulty: str
+    created_at: str
+
+
+class QuestionListResponse(BaseModel):
+    questions: list[QuestionResponse]
+    total: int
+    page: int
+    per_page: int
+
+
+# ---------------------------------------------------------------------------
+# Test Configuration
+# ---------------------------------------------------------------------------
+
+
+class TestCreate(BaseModel):
+    question_bank_id: UUID
+    title: str = Field(..., min_length=2, max_length=500)
+    mode: str = Field(..., pattern=r"^(exam|training|review)$")
+    question_count: int | None = Field(default=None, ge=1, le=500)
+    shuffle_questions: bool = True
+    time_per_question_sec: int | None = Field(default=None, ge=5, le=120)
+    show_feedback: bool = False
+    filter_categories: list[str] | None = None
+    filter_failed_only: bool = False
+
+
+class TestUpdate(BaseModel):
+    title: str | None = Field(default=None, min_length=2, max_length=500)
+    mode: str | None = Field(
+        default=None, pattern=r"^(exam|training|review)$"
+    )
+    question_count: int | None = Field(default=None, ge=1, le=500)
+    shuffle_questions: bool | None = None
+    time_per_question_sec: int | None = Field(default=None, ge=5, le=120)
+    show_feedback: bool | None = None
+    filter_categories: list[str] | None = None
+    filter_failed_only: bool | None = None
+
+
+class TestResponse(BaseModel):
+    id: str
+    question_bank_id: str
+    title: str
+    mode: str
+    question_count: int | None = None
+    shuffle_questions: bool
+    time_per_question_sec: int | None = None
+    show_feedback: bool
+    filter_categories: list[str] | None = None
+    filter_failed_only: bool
+    created_by: str
+    created_at: str
+
+
+# ---------------------------------------------------------------------------
+# Test Session (taking a test)
+# ---------------------------------------------------------------------------
+
+
+class TestStartQuestion(BaseModel):
+    id: str
+    image_url: str | None = None
+    question_text: str
+    options: list[str]
+    category: str | None = None
+    difficulty: str
+
+
+class TestStartResponse(BaseModel):
+    test_id: str
+    title: str
+    mode: str
+    time_per_question_sec: int
+    show_feedback: bool
+    questions: list[TestStartQuestion]
+    total_questions: int
+
+
+class TestSubmitRequest(BaseModel):
+    answers: dict[str, dict] = Field(
+        ...,
+        description='Map of question_id to {"selected": [int], "time_sec": int}',
+    )
+
+
+class TestAttemptResponse(BaseModel):
+    id: str
+    test_id: str
+    score: float
+    total_questions: int
+    correct_answers: int
+    time_taken_sec: int
+    passed: bool
+    category_breakdown: dict | None = None
+    attempted_at: str
+    attempt_number: int
+
+
+class TestAttemptDetail(TestAttemptResponse):
+    answers: dict
+
+
+class TestReviewQuestion(BaseModel):
+    id: str
+    image_url: str | None = None
+    question_text: str
+    options: list[str]
+    correct_answer_indices: list[int]
+    explanation: str | None = None
+    category: str | None = None
+    user_selected: list[int] | None = None
+    is_correct: bool | None = None
+
+
+class TestReviewResponse(BaseModel):
+    test_id: str
+    attempt_id: str
+    score: float
+    passed: bool
+    questions: list[TestReviewQuestion]

--- a/backend/app/domain/services/qbank_service.py
+++ b/backend/app/domain/services/qbank_service.py
@@ -1,0 +1,550 @@
+"""Question Bank service — CRUD for banks, questions, tests, attempts."""
+
+from __future__ import annotations
+
+import random
+import uuid
+from collections import defaultdict
+
+import structlog
+from fastapi import HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.models.organization import OrgMemberRole
+from app.domain.models.question_bank import (
+    QBankQuestion,
+    QBankTest,
+    QBankTestAttempt,
+    QuestionBank,
+)
+from app.domain.services.organization_service import OrganizationService
+
+logger = structlog.get_logger(__name__)
+
+_org_svc = OrganizationService()
+
+
+class QBankService:
+    # ------------------------------------------------------------------
+    # Question Bank CRUD
+    # ------------------------------------------------------------------
+
+    async def create_bank(
+        self,
+        db: AsyncSession,
+        *,
+        organization_id: uuid.UUID,
+        title: str,
+        bank_type: str,
+        created_by: uuid.UUID,
+        description: str | None = None,
+        language: str = "fr",
+        time_per_question_sec: int = 25,
+        passing_score: float = 80.0,
+    ) -> QuestionBank:
+        await _org_svc.require_org_role(
+            db, organization_id, created_by,
+            OrgMemberRole.owner, OrgMemberRole.admin,
+        )
+        bank = QuestionBank(
+            organization_id=organization_id,
+            title=title,
+            description=description,
+            bank_type=bank_type,
+            language=language,
+            time_per_question_sec=time_per_question_sec,
+            passing_score=passing_score,
+            created_by=created_by,
+        )
+        db.add(bank)
+        await db.commit()
+        await db.refresh(bank)
+        return bank
+
+    async def get_bank(
+        self, db: AsyncSession, bank_id: uuid.UUID
+    ) -> QuestionBank:
+        bank = await db.get(QuestionBank, bank_id)
+        if bank is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Question bank not found.",
+            )
+        return bank
+
+    async def list_org_banks(
+        self, db: AsyncSession, organization_id: uuid.UUID
+    ) -> list[dict]:
+        result = await db.execute(
+            select(QuestionBank)
+            .where(QuestionBank.organization_id == organization_id)
+            .order_by(QuestionBank.created_at.desc())
+        )
+        banks = result.scalars().all()
+        out = []
+        for bank in banks:
+            q_count = await db.scalar(
+                select(func.count())
+                .select_from(QBankQuestion)
+                .where(QBankQuestion.question_bank_id == bank.id)
+            )
+            t_count = await db.scalar(
+                select(func.count())
+                .select_from(QBankTest)
+                .where(QBankTest.question_bank_id == bank.id)
+            )
+            out.append({
+                "bank": bank,
+                "question_count": q_count or 0,
+                "test_count": t_count or 0,
+            })
+        return out
+
+    async def update_bank(
+        self,
+        db: AsyncSession,
+        bank_id: uuid.UUID,
+        actor_id: uuid.UUID,
+        **fields,
+    ) -> QuestionBank:
+        bank = await self.get_bank(db, bank_id)
+        await _org_svc.require_org_role(
+            db, bank.organization_id, actor_id,
+            OrgMemberRole.owner, OrgMemberRole.admin,
+        )
+        allowed = {
+            "title", "description", "language",
+            "time_per_question_sec", "passing_score", "status",
+        }
+        for key, value in fields.items():
+            if key in allowed and value is not None:
+                setattr(bank, key, value)
+        await db.commit()
+        await db.refresh(bank)
+        return bank
+
+    async def delete_bank(
+        self,
+        db: AsyncSession,
+        bank_id: uuid.UUID,
+        actor_id: uuid.UUID,
+    ) -> None:
+        bank = await self.get_bank(db, bank_id)
+        await _org_svc.require_org_role(
+            db, bank.organization_id, actor_id,
+            OrgMemberRole.owner, OrgMemberRole.admin,
+        )
+        await db.delete(bank)
+        await db.commit()
+
+    # ------------------------------------------------------------------
+    # Questions
+    # ------------------------------------------------------------------
+
+    async def list_questions(
+        self,
+        db: AsyncSession,
+        bank_id: uuid.UUID,
+        page: int = 1,
+        per_page: int = 50,
+    ) -> dict:
+        total = await db.scalar(
+            select(func.count())
+            .select_from(QBankQuestion)
+            .where(QBankQuestion.question_bank_id == bank_id)
+        )
+        result = await db.execute(
+            select(QBankQuestion)
+            .where(QBankQuestion.question_bank_id == bank_id)
+            .order_by(QBankQuestion.order_index)
+            .offset((page - 1) * per_page)
+            .limit(per_page)
+        )
+        return {
+            "questions": result.scalars().all(),
+            "total": total or 0,
+            "page": page,
+            "per_page": per_page,
+        }
+
+    async def update_question(
+        self,
+        db: AsyncSession,
+        question_id: uuid.UUID,
+        actor_id: uuid.UUID,
+        **fields,
+    ) -> QBankQuestion:
+        question = await db.get(QBankQuestion, question_id)
+        if question is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Question not found.",
+            )
+        bank = await self.get_bank(db, question.question_bank_id)
+        await _org_svc.require_org_role(
+            db, bank.organization_id, actor_id,
+            OrgMemberRole.owner, OrgMemberRole.admin,
+        )
+        allowed = {
+            "question_text", "options", "correct_answer_indices",
+            "explanation", "category", "difficulty",
+        }
+        for key, value in fields.items():
+            if key in allowed and value is not None:
+                setattr(question, key, value)
+        await db.commit()
+        await db.refresh(question)
+        return question
+
+    async def delete_question(
+        self,
+        db: AsyncSession,
+        question_id: uuid.UUID,
+        actor_id: uuid.UUID,
+    ) -> None:
+        question = await db.get(QBankQuestion, question_id)
+        if question is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Question not found.",
+            )
+        bank = await self.get_bank(db, question.question_bank_id)
+        await _org_svc.require_org_role(
+            db, bank.organization_id, actor_id,
+            OrgMemberRole.owner, OrgMemberRole.admin,
+        )
+        await db.delete(question)
+        await db.commit()
+
+    # ------------------------------------------------------------------
+    # Test CRUD
+    # ------------------------------------------------------------------
+
+    async def create_test(
+        self,
+        db: AsyncSession,
+        *,
+        question_bank_id: uuid.UUID,
+        title: str,
+        mode: str,
+        created_by: uuid.UUID,
+        question_count: int | None = None,
+        shuffle_questions: bool = True,
+        time_per_question_sec: int | None = None,
+        show_feedback: bool = False,
+        filter_categories: list[str] | None = None,
+        filter_failed_only: bool = False,
+    ) -> QBankTest:
+        bank = await self.get_bank(db, question_bank_id)
+        await _org_svc.require_org_role(
+            db, bank.organization_id, created_by,
+            OrgMemberRole.owner, OrgMemberRole.admin,
+        )
+        test = QBankTest(
+            question_bank_id=question_bank_id,
+            title=title,
+            mode=mode,
+            question_count=question_count,
+            shuffle_questions=shuffle_questions,
+            time_per_question_sec=time_per_question_sec,
+            show_feedback=show_feedback,
+            filter_categories=filter_categories,
+            filter_failed_only=filter_failed_only,
+            created_by=created_by,
+        )
+        db.add(test)
+        await db.commit()
+        await db.refresh(test)
+        return test
+
+    async def get_test(
+        self, db: AsyncSession, test_id: uuid.UUID
+    ) -> QBankTest:
+        test = await db.get(QBankTest, test_id)
+        if test is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Test not found.",
+            )
+        return test
+
+    async def list_tests(
+        self, db: AsyncSession, bank_id: uuid.UUID
+    ) -> list[QBankTest]:
+        result = await db.execute(
+            select(QBankTest)
+            .where(QBankTest.question_bank_id == bank_id)
+            .order_by(QBankTest.created_at.desc())
+        )
+        return list(result.scalars().all())
+
+    async def update_test(
+        self,
+        db: AsyncSession,
+        test_id: uuid.UUID,
+        actor_id: uuid.UUID,
+        **fields,
+    ) -> QBankTest:
+        test = await self.get_test(db, test_id)
+        bank = await self.get_bank(db, test.question_bank_id)
+        await _org_svc.require_org_role(
+            db, bank.organization_id, actor_id,
+            OrgMemberRole.owner, OrgMemberRole.admin,
+        )
+        allowed = {
+            "title", "mode", "question_count", "shuffle_questions",
+            "time_per_question_sec", "show_feedback",
+            "filter_categories", "filter_failed_only",
+        }
+        for key, value in fields.items():
+            if key in allowed and value is not None:
+                setattr(test, key, value)
+        await db.commit()
+        await db.refresh(test)
+        return test
+
+    async def delete_test(
+        self,
+        db: AsyncSession,
+        test_id: uuid.UUID,
+        actor_id: uuid.UUID,
+    ) -> None:
+        test = await self.get_test(db, test_id)
+        bank = await self.get_bank(db, test.question_bank_id)
+        await _org_svc.require_org_role(
+            db, bank.organization_id, actor_id,
+            OrgMemberRole.owner, OrgMemberRole.admin,
+        )
+        await db.delete(test)
+        await db.commit()
+
+    # ------------------------------------------------------------------
+    # Test Session — start / submit / history / review
+    # ------------------------------------------------------------------
+
+    async def start_test(
+        self,
+        db: AsyncSession,
+        test_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> dict:
+        test = await self.get_test(db, test_id)
+        bank = await self.get_bank(db, test.question_bank_id)
+
+        # Build question query
+        stmt = (
+            select(QBankQuestion)
+            .where(QBankQuestion.question_bank_id == bank.id)
+        )
+
+        # Filter by categories if configured
+        if test.filter_categories:
+            stmt = stmt.where(
+                QBankQuestion.category.in_(test.filter_categories)
+            )
+
+        # Filter to previously failed questions only
+        if test.filter_failed_only:
+            failed_ids = await self._get_failed_question_ids(
+                db, test_id, user_id
+            )
+            if failed_ids:
+                stmt = stmt.where(QBankQuestion.id.in_(failed_ids))
+
+        stmt = stmt.order_by(QBankQuestion.order_index)
+        result = await db.execute(stmt)
+        questions = list(result.scalars().all())
+
+        # Shuffle if configured
+        if test.shuffle_questions:
+            random.shuffle(questions)
+
+        # Limit question count
+        if test.question_count and len(questions) > test.question_count:
+            questions = questions[: test.question_count]
+
+        time_per_q = test.time_per_question_sec or bank.time_per_question_sec
+
+        return {
+            "test": test,
+            "bank": bank,
+            "questions": questions,
+            "time_per_question_sec": time_per_q,
+        }
+
+    async def submit_test(
+        self,
+        db: AsyncSession,
+        test_id: uuid.UUID,
+        user_id: uuid.UUID,
+        answers: dict,
+    ) -> QBankTestAttempt:
+        test = await self.get_test(db, test_id)
+        bank = await self.get_bank(db, test.question_bank_id)
+
+        # Load all questions for scoring
+        question_ids = list(answers.keys())
+        result = await db.execute(
+            select(QBankQuestion).where(
+                QBankQuestion.id.in_(
+                    [uuid.UUID(qid) for qid in question_ids]
+                )
+            )
+        )
+        questions_map = {
+            str(q.id): q for q in result.scalars().all()
+        }
+
+        correct = 0
+        total = len(question_ids)
+        total_time = 0
+        category_counts: dict[str, dict] = defaultdict(
+            lambda: {"correct": 0, "total": 0}
+        )
+
+        for qid, answer_data in answers.items():
+            question = questions_map.get(qid)
+            if not question:
+                continue
+            selected = answer_data.get("selected", [])
+            time_sec = answer_data.get("time_sec", 0)
+            total_time += time_sec
+
+            is_correct = sorted(selected) == sorted(
+                question.correct_answer_indices
+            )
+            if is_correct:
+                correct += 1
+
+            cat = question.category or "uncategorized"
+            category_counts[cat]["total"] += 1
+            if is_correct:
+                category_counts[cat]["correct"] += 1
+
+        score = (correct / total * 100) if total > 0 else 0
+        passed = score >= bank.passing_score
+
+        # Count previous attempts
+        prev_count = await db.scalar(
+            select(func.count())
+            .select_from(QBankTestAttempt)
+            .where(
+                QBankTestAttempt.test_id == test_id,
+                QBankTestAttempt.user_id == user_id,
+            )
+        )
+
+        attempt = QBankTestAttempt(
+            test_id=test_id,
+            user_id=user_id,
+            answers=answers,
+            score=score,
+            total_questions=total,
+            correct_answers=correct,
+            time_taken_sec=total_time,
+            passed=passed,
+            category_breakdown=dict(category_counts),
+            attempt_number=(prev_count or 0) + 1,
+        )
+        db.add(attempt)
+        await db.commit()
+        await db.refresh(attempt)
+        return attempt
+
+    async def get_attempt_history(
+        self,
+        db: AsyncSession,
+        test_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> list[QBankTestAttempt]:
+        result = await db.execute(
+            select(QBankTestAttempt)
+            .where(
+                QBankTestAttempt.test_id == test_id,
+                QBankTestAttempt.user_id == user_id,
+            )
+            .order_by(QBankTestAttempt.attempted_at.desc())
+        )
+        return list(result.scalars().all())
+
+    async def get_review(
+        self,
+        db: AsyncSession,
+        test_id: uuid.UUID,
+        attempt_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> dict:
+        attempt = await db.get(QBankTestAttempt, attempt_id)
+        if attempt is None or attempt.user_id != user_id:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Attempt not found.",
+            )
+        await self.get_test(db, test_id)
+
+        question_ids = [
+            uuid.UUID(qid) for qid in attempt.answers
+        ]
+        result = await db.execute(
+            select(QBankQuestion).where(
+                QBankQuestion.id.in_(question_ids)
+            )
+        )
+        questions = {str(q.id): q for q in result.scalars().all()}
+
+        review_questions = []
+        for qid, answer_data in attempt.answers.items():
+            q = questions.get(qid)
+            if not q:
+                continue
+            selected = answer_data.get("selected", [])
+            is_correct = sorted(selected) == sorted(
+                q.correct_answer_indices
+            )
+            review_questions.append({
+                "question": q,
+                "user_selected": selected,
+                "is_correct": is_correct,
+            })
+
+        return {
+            "attempt": attempt,
+            "questions": review_questions,
+        }
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def _get_failed_question_ids(
+        self,
+        db: AsyncSession,
+        test_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> list[uuid.UUID]:
+        """Get question IDs the user answered incorrectly in their last attempt."""
+        result = await db.execute(
+            select(QBankTestAttempt)
+            .where(
+                QBankTestAttempt.test_id == test_id,
+                QBankTestAttempt.user_id == user_id,
+            )
+            .order_by(QBankTestAttempt.attempted_at.desc())
+            .limit(1)
+        )
+        last_attempt = result.scalar_one_or_none()
+        if not last_attempt:
+            return []
+
+        failed_ids = []
+        for qid, answer_data in last_attempt.answers.items():
+            # We need to check against the actual question
+            question = await db.get(QBankQuestion, uuid.UUID(qid))
+            if question:
+                selected = answer_data.get("selected", [])
+                if sorted(selected) != sorted(
+                    question.correct_answer_indices
+                ):
+                    failed_ids.append(question.id)
+        return failed_ids


### PR DESCRIPTION
## Summary
- Add QBankService with full CRUD for banks, questions, tests, and attempts
- Scoring engine with category breakdown and pass/fail logic
- Training mode filter (retry failed questions only)
- REST API at `/api/v1/qbank/` with org-admin authorization
- Pydantic V2 schemas for all endpoints

## Test plan
- [ ] App starts without import errors
- [ ] POST /qbank/banks creates a bank
- [ ] GET /qbank/banks?org_id= lists banks
- [ ] POST /qbank/tests creates a test config
- [ ] GET /qbank/tests/{id}/start returns questions
- [ ] POST /qbank/tests/{id}/submit scores correctly

Closes #1500

🤖 Generated with [Claude Code](https://claude.com/claude-code)