### PR TITLE
feat: add question bank schema and models (#1499)

### DIFF
--- a/backend/app/domain/models/__init__.py
+++ b/backend/app/domain/models/__init__.py
@@ -20,6 +20,18 @@ from app.domain.models.module_unit import ModuleUnit
 from app.domain.models.organization import Organization, OrganizationMember, OrgMemberRole
 from app.domain.models.preassessment import CoursePreAssessment
 from app.domain.models.progress import UserModuleProgress
+from app.domain.models.question_bank import (
+    QBankAudioStatus,
+    QBankQuestion,
+    QBankQuestionAudio,
+    QBankTest,
+    QBankTestAttempt,
+    QuestionBank,
+    QuestionBankStatus,
+    QuestionBankType,
+    QuestionDifficulty,
+    TestMode,
+)
 from app.domain.models.quiz import PlacementTestAttempt, QuizAttempt, SummativeAssessmentAttempt
 from app.domain.models.sms_relay import (
     InboundSms,
@@ -70,6 +82,16 @@ __all__ = [
     "Organization",
     "OrganizationMember",
     "PlacementTestAttempt",
+    "QBankAudioStatus",
+    "QBankQuestion",
+    "QBankQuestionAudio",
+    "QBankTest",
+    "QBankTestAttempt",
+    "QuestionBank",
+    "QuestionBankStatus",
+    "QuestionBankType",
+    "QuestionDifficulty",
+    "TestMode",
     "QuizAttempt",
     "RefreshToken",
     "RelayDevice",

--- a/backend/app/domain/models/question_bank.py
+++ b/backend/app/domain/models/question_bank.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Enum,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSON
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.domain.models.base import Base
+
+if TYPE_CHECKING:
+    from app.domain.models.organization import Organization
+    from app.domain.models.user import User
+
+
+class QuestionBankType(enum.StrEnum):
+    driving = "driving"
+    exam_prep = "exam_prep"
+    psychotechnic = "psychotechnic"
+    general_culture = "general_culture"
+
+
+class QuestionBankStatus(enum.StrEnum):
+    draft = "draft"
+    published = "published"
+    archived = "archived"
+
+
+class QuestionDifficulty(enum.StrEnum):
+    easy = "easy"
+    medium = "medium"
+    hard = "hard"
+
+
+class TestMode(enum.StrEnum):
+    exam = "exam"
+    training = "training"
+    review = "review"
+
+
+class QBankAudioStatus(enum.StrEnum):
+    pending = "pending"
+    generating = "generating"
+    ready = "ready"
+    failed = "failed"
+
+
+class QuestionBank(Base):
+    __tablename__ = "question_banks"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("organizations.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    title: Mapped[str] = mapped_column(String(500), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    bank_type: Mapped[QuestionBankType] = mapped_column(
+        Enum(QuestionBankType, name="questionbanktype"), nullable=False
+    )
+    language: Mapped[str] = mapped_column(String(5), server_default="fr", default="fr")
+    time_per_question_sec: Mapped[int] = mapped_column(Integer, server_default="25", default=25)
+    passing_score: Mapped[float] = mapped_column(Float, server_default="80.0", default=80.0)
+    status: Mapped[QuestionBankStatus] = mapped_column(
+        Enum(QuestionBankStatus, name="questionbankstatus"),
+        server_default="draft",
+        default=QuestionBankStatus.draft,
+    )
+    created_by: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    organization: Mapped[Organization] = relationship(foreign_keys=[organization_id])
+    creator: Mapped[User] = relationship(foreign_keys=[created_by])
+    questions: Mapped[list[QBankQuestion]] = relationship(
+        back_populates="question_bank", cascade="all, delete-orphan"
+    )
+    tests: Mapped[list[QBankTest]] = relationship(
+        back_populates="question_bank", cascade="all, delete-orphan"
+    )
+
+
+class QBankQuestion(Base):
+    __tablename__ = "qbank_questions"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    question_bank_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("question_banks.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    order_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    image_storage_key: Mapped[str | None] = mapped_column(String, nullable=True)
+    image_url: Mapped[str | None] = mapped_column(String, nullable=True)
+    question_text: Mapped[str] = mapped_column(Text, nullable=False)
+    options: Mapped[list] = mapped_column(JSON, nullable=False)
+    correct_answer_indices: Mapped[list] = mapped_column(JSON, nullable=False)
+    explanation: Mapped[str | None] = mapped_column(Text, nullable=True)
+    source_page: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    source_pdf_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    category: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    difficulty: Mapped[QuestionDifficulty] = mapped_column(
+        Enum(QuestionDifficulty, name="questiondifficulty"),
+        server_default="medium",
+        default=QuestionDifficulty.medium,
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    question_bank: Mapped[QuestionBank] = relationship(back_populates="questions")
+    audio_files: Mapped[list[QBankQuestionAudio]] = relationship(
+        back_populates="question", cascade="all, delete-orphan"
+    )
+
+
+class QBankQuestionAudio(Base):
+    __tablename__ = "qbank_question_audio"
+    __table_args__ = (
+        UniqueConstraint("question_id", "language", name="uq_qbank_question_audio_lang"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    question_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("qbank_questions.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    language: Mapped[str] = mapped_column(String(10), nullable=False)
+    storage_key: Mapped[str | None] = mapped_column(String, nullable=True)
+    storage_url: Mapped[str | None] = mapped_column(String, nullable=True)
+    duration_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    status: Mapped[QBankAudioStatus] = mapped_column(
+        Enum(QBankAudioStatus, name="qbankaudiostatus"),
+        server_default="pending",
+        default=QBankAudioStatus.pending,
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    question: Mapped[QBankQuestion] = relationship(back_populates="audio_files")
+
+
+class QBankTest(Base):
+    __tablename__ = "qbank_tests"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    question_bank_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("question_banks.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    title: Mapped[str] = mapped_column(String(500), nullable=False)
+    mode: Mapped[TestMode] = mapped_column(Enum(TestMode, name="testmode"), nullable=False)
+    question_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    shuffle_questions: Mapped[bool] = mapped_column(Boolean, server_default="true", default=True)
+    time_per_question_sec: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    show_feedback: Mapped[bool] = mapped_column(Boolean, server_default="false", default=False)
+    filter_categories: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    filter_failed_only: Mapped[bool] = mapped_column(Boolean, server_default="false", default=False)
+    created_by: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    question_bank: Mapped[QuestionBank] = relationship(back_populates="tests")
+    creator: Mapped[User] = relationship(foreign_keys=[created_by])
+    attempts: Mapped[list[QBankTestAttempt]] = relationship(
+        back_populates="test", cascade="all, delete-orphan"
+    )
+
+
+class QBankTestAttempt(Base):
+    __tablename__ = "qbank_test_attempts"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    test_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("qbank_tests.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), index=True, nullable=False)
+    answers: Mapped[dict] = mapped_column(JSON, nullable=False)
+    score: Mapped[float] = mapped_column(Float, nullable=False)
+    total_questions: Mapped[int] = mapped_column(Integer, nullable=False)
+    correct_answers: Mapped[int] = mapped_column(Integer, nullable=False)
+    time_taken_sec: Mapped[int] = mapped_column(Integer, nullable=False)
+    passed: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    category_breakdown: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    attempted_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    attempt_number: Mapped[int] = mapped_column(Integer, server_default="1", default=1)
+
+    test: Mapped[QBankTest] = relationship(back_populates="attempts")
+    user: Mapped[User] = relationship(foreign_keys=[user_id])

--- a/backend/migrations/versions/067_add_question_bank_tables.py
+++ b/backend/migrations/versions/067_add_question_bank_tables.py
@@ -1,0 +1,194 @@
+"""Add question bank tables for image-based MCQ system.
+
+Revision ID: 067
+Revises: 066
+Create Date: 2026-04-16
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSON
+
+revision = "067"
+down_revision = "066"
+branch_labels = None
+depends_on = None
+
+
+def _create_enum_if_not_exists(name: str, values: list[str]) -> None:
+    """Create a PostgreSQL enum type only if it doesn't already exist (asyncpg-safe)."""
+    conn = op.get_bind()
+    result = conn.execute(sa.text("SELECT 1 FROM pg_type WHERE typname = :name"), {"name": name})
+    if not result.scalar():
+        vals = ", ".join(f"'{v}'" for v in values)
+        conn.execute(sa.text(f"CREATE TYPE {name} AS ENUM ({vals})"))
+
+
+def upgrade() -> None:
+    _create_enum_if_not_exists(
+        "questionbanktype", ["driving", "exam_prep", "psychotechnic", "general_culture"]
+    )
+    _create_enum_if_not_exists("questionbankstatus", ["draft", "published", "archived"])
+    _create_enum_if_not_exists("questiondifficulty", ["easy", "medium", "hard"])
+    _create_enum_if_not_exists("testmode", ["exam", "training", "review"])
+    _create_enum_if_not_exists("qbankaudiostatus", ["pending", "generating", "ready", "failed"])
+
+    op.create_table(
+        "question_banks",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "organization_id",
+            sa.Uuid(),
+            sa.ForeignKey("organizations.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("title", sa.String(500), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column(
+            "bank_type",
+            sa.Enum(
+                "driving",
+                "exam_prep",
+                "psychotechnic",
+                "general_culture",
+                name="questionbanktype",
+                create_type=False,
+            ),
+            nullable=False,
+        ),
+        sa.Column("language", sa.String(5), server_default="fr", nullable=False),
+        sa.Column("time_per_question_sec", sa.Integer(), server_default="25", nullable=False),
+        sa.Column("passing_score", sa.Float(), server_default="80.0", nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum("draft", "published", "archived", name="questionbankstatus", create_type=False),
+            server_default="draft",
+            nullable=False,
+        ),
+        sa.Column("created_by", sa.Uuid(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+    op.create_table(
+        "qbank_questions",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "question_bank_id",
+            sa.Uuid(),
+            sa.ForeignKey("question_banks.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("order_index", sa.Integer(), nullable=False),
+        sa.Column("image_storage_key", sa.String(), nullable=True),
+        sa.Column("image_url", sa.String(), nullable=True),
+        sa.Column("question_text", sa.Text(), nullable=False),
+        sa.Column("options", JSON(), nullable=False),
+        sa.Column("correct_answer_indices", JSON(), nullable=False),
+        sa.Column("explanation", sa.Text(), nullable=True),
+        sa.Column("source_page", sa.Integer(), nullable=True),
+        sa.Column("source_pdf_name", sa.String(), nullable=True),
+        sa.Column("category", sa.String(100), nullable=True),
+        sa.Column(
+            "difficulty",
+            sa.Enum("easy", "medium", "hard", name="questiondifficulty", create_type=False),
+            server_default="medium",
+            nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+    op.create_table(
+        "qbank_question_audio",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "question_id",
+            sa.Uuid(),
+            sa.ForeignKey("qbank_questions.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("language", sa.String(10), nullable=False),
+        sa.Column("storage_key", sa.String(), nullable=True),
+        sa.Column("storage_url", sa.String(), nullable=True),
+        sa.Column("duration_seconds", sa.Integer(), nullable=True),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "pending",
+                "generating",
+                "ready",
+                "failed",
+                name="qbankaudiostatus",
+                create_type=False,
+            ),
+            server_default="pending",
+            nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.UniqueConstraint("question_id", "language", name="uq_qbank_question_audio_lang"),
+    )
+
+    op.create_table(
+        "qbank_tests",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "question_bank_id",
+            sa.Uuid(),
+            sa.ForeignKey("question_banks.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("title", sa.String(500), nullable=False),
+        sa.Column(
+            "mode",
+            sa.Enum("exam", "training", "review", name="testmode", create_type=False),
+            nullable=False,
+        ),
+        sa.Column("question_count", sa.Integer(), nullable=True),
+        sa.Column("shuffle_questions", sa.Boolean(), server_default="true", nullable=False),
+        sa.Column("time_per_question_sec", sa.Integer(), nullable=True),
+        sa.Column("show_feedback", sa.Boolean(), server_default="false", nullable=False),
+        sa.Column("filter_categories", JSON(), nullable=True),
+        sa.Column("filter_failed_only", sa.Boolean(), server_default="false", nullable=False),
+        sa.Column("created_by", sa.Uuid(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+    op.create_table(
+        "qbank_test_attempts",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "test_id",
+            sa.Uuid(),
+            sa.ForeignKey("qbank_tests.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("user_id", sa.Uuid(), sa.ForeignKey("users.id"), nullable=False, index=True),
+        sa.Column("answers", JSON(), nullable=False),
+        sa.Column("score", sa.Float(), nullable=False),
+        sa.Column("total_questions", sa.Integer(), nullable=False),
+        sa.Column("correct_answers", sa.Integer(), nullable=False),
+        sa.Column("time_taken_sec", sa.Integer(), nullable=False),
+        sa.Column("passed", sa.Boolean(), nullable=False),
+        sa.Column("category_breakdown", JSON(), nullable=True),
+        sa.Column("attempted_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("attempt_number", sa.Integer(), server_default="1", nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("qbank_test_attempts")
+    op.drop_table("qbank_tests")
+    op.drop_table("qbank_question_audio")
+    op.drop_table("qbank_questions")
+    op.drop_table("question_banks")
+    op.execute("DROP TYPE IF EXISTS qbankaudiostatus")
+    op.execute("DROP TYPE IF EXISTS testmode")
+    op.execute("DROP TYPE IF EXISTS questiondifficulty")
+    op.execute("DROP TYPE IF EXISTS questionbankstatus")
+    op.execute("DROP TYPE IF EXISTS questionbanktype")


### PR DESCRIPTION
## Summary
- Add 5 new SQLAlchemy models for the image-based MCQ question bank system (Epic #1498)
- `QuestionBank`, `QBankQuestion`, `QBankQuestionAudio`, `QBankTest`, `QBankTestAttempt`
- 5 new enums: `QuestionBankType`, `QuestionBankStatus`, `QuestionDifficulty`, `TestMode`, `QBankAudioStatus`
- Alembic migration 067 creates all tables with idempotent enum creation
- Models registered in `__init__.py`

## Test plan
- [ ] Migration runs on server: `alembic upgrade head`
- [ ] Migration rolls back cleanly: `alembic downgrade 066`
- [ ] All 5 tables created with correct columns and constraints
- [ ] App starts without import errors

Closes #1499

🤖 Generated with [Claude Code](https://claude.com/claude-code)