### PR TITLE
feat: add certificate_templates + certificates tables + migration (#760)

### DIFF
--- a/backend/app/domain/models/__init__.py
+++ b/backend/app/domain/models/__init__.py
@@ -2,6 +2,7 @@ from app.domain.models.activation_code import ActivationCode, ActivationCodeRede
 from app.domain.models.audit_log import AuditLog
 from app.domain.models.auth import MagicLink, RefreshToken, TOTPSecret
 from app.domain.models.base import Base
+from app.domain.models.certificate import Certificate, CertificateTemplate
 from app.domain.models.content import GeneratedContent
 from app.domain.models.conversation import TutorConversation
 from app.domain.models.course import Course, UserCourseEnrollment
@@ -56,6 +57,8 @@ __all__ = [
     "ActivationCodeRedemption",
     "AuditLog",
     "Base",
+    "Certificate",
+    "CertificateTemplate",
     "Course",
     "CoursePreAssessment",
     "CourseResource",

--- a/backend/app/domain/models/certificate.py
+++ b/backend/app/domain/models/certificate.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, String, Text, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.domain.models.base import Base
+
+if TYPE_CHECKING:
+    from app.domain.models.course import Course
+    from app.domain.models.user import User
+
+
+class CertificateTemplate(Base):
+    __tablename__ = "certificate_templates"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    course_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("courses.id", ondelete="CASCADE"), unique=True, index=True
+    )
+    title_fr: Mapped[str] = mapped_column(Text)
+    title_en: Mapped[str] = mapped_column(Text)
+    organization_name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    signatory_name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    signatory_title: Mapped[str | None] = mapped_column(Text, nullable=True)
+    logo_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    additional_text_fr: Mapped[str | None] = mapped_column(Text, nullable=True)
+    additional_text_en: Mapped[str | None] = mapped_column(Text, nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, server_default="true")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    course: Mapped[Course] = relationship(back_populates="certificate_template")
+    certificates: Mapped[list[Certificate]] = relationship(back_populates="template")
+
+
+class Certificate(Base):
+    __tablename__ = "certificates"
+    __table_args__ = (
+        UniqueConstraint("user_id", "course_id", name="uq_certificate_user_course"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    template_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("certificate_templates.id", ondelete="SET NULL"), nullable=True
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), index=True)
+    course_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("courses.id", ondelete="CASCADE"), index=True
+    )
+    verification_code: Mapped[str] = mapped_column(String(20), unique=True, index=True)
+    average_score: Mapped[float]
+    completed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    pdf_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    status: Mapped[str] = mapped_column(
+        Enum("valid", "revoked", name="certificatestatus"), server_default="valid"
+    )
+    metadata_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    issued_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    template: Mapped[CertificateTemplate | None] = relationship(back_populates="certificates")
+    user: Mapped[User] = relationship(back_populates="certificates")
+    course: Mapped[Course] = relationship(back_populates="certificates")

--- a/backend/app/domain/models/course.py
+++ b/backend/app/domain/models/course.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.domain.models.base import Base
 
 if TYPE_CHECKING:
+    from app.domain.models.certificate import Certificate, CertificateTemplate
     from app.domain.models.course_resource import CourseResource
     from app.domain.models.module import Module
     from app.domain.models.preassessment import CoursePreAssessment
@@ -65,6 +66,12 @@ class Course(Base):
         secondary="course_taxonomy", lazy="selectin"
     )
     preassessments: Mapped[list[CoursePreAssessment]] = relationship(
+        back_populates="course", passive_deletes=True
+    )
+    certificate_template: Mapped[CertificateTemplate | None] = relationship(
+        back_populates="course", uselist=False, passive_deletes=True
+    )
+    certificates: Mapped[list[Certificate]] = relationship(
         back_populates="course", passive_deletes=True
     )
 

--- a/backend/app/domain/models/user.py
+++ b/backend/app/domain/models/user.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
         RefreshToken,
         TOTPSecret,
     )
+    from app.domain.models.certificate import Certificate
     from app.domain.models.conversation import TutorConversation
     from app.domain.models.credit import CreditAccount
     from app.domain.models.flashcard import FlashcardReview
@@ -95,3 +96,4 @@ class User(Base):
     )
     subscription: Mapped[Subscription | None] = relationship(back_populates="user", uselist=False)
     subscription_payments: Mapped[list[SubscriptionPayment]] = relationship(back_populates="user")
+    certificates: Mapped[list[Certificate]] = relationship(back_populates="user")

--- a/backend/migrations/versions/068_add_certificate_tables.py
+++ b/backend/migrations/versions/068_add_certificate_tables.py
@@ -1,0 +1,97 @@
+"""Add certificate_templates and certificates tables.
+
+Revision ID: 068
+Revises: 067
+Create Date: 2026-04-16
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "068"
+down_revision = "067"
+branch_labels = None
+depends_on = None
+
+
+def _create_enum_if_not_exists(name: str, values: list[str]) -> None:
+    """Create a PostgreSQL enum type only if it doesn't already exist (asyncpg-safe)."""
+    conn = op.get_bind()
+    result = conn.execute(sa.text("SELECT 1 FROM pg_type WHERE typname = :name"), {"name": name})
+    if not result.scalar():
+        vals = ", ".join(f"'{v}'" for v in values)
+        conn.execute(sa.text(f"CREATE TYPE {name} AS ENUM ({vals})"))
+
+
+def upgrade() -> None:
+    _create_enum_if_not_exists("certificatestatus", ["valid", "revoked"])
+
+    op.create_table(
+        "certificate_templates",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "course_id",
+            sa.Uuid(),
+            sa.ForeignKey("courses.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+            index=True,
+        ),
+        sa.Column("title_fr", sa.Text(), nullable=False),
+        sa.Column("title_en", sa.Text(), nullable=False),
+        sa.Column("organization_name", sa.Text(), nullable=True),
+        sa.Column("signatory_name", sa.Text(), nullable=True),
+        sa.Column("signatory_title", sa.Text(), nullable=True),
+        sa.Column("logo_url", sa.String(500), nullable=True),
+        sa.Column("additional_text_fr", sa.Text(), nullable=True),
+        sa.Column("additional_text_en", sa.Text(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), server_default="true", nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+    op.create_table(
+        "certificates",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "template_id",
+            sa.Uuid(),
+            sa.ForeignKey("certificate_templates.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "user_id",
+            sa.Uuid(),
+            sa.ForeignKey("users.id"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "course_id",
+            sa.Uuid(),
+            sa.ForeignKey("courses.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("verification_code", sa.String(20), nullable=False, unique=True, index=True),
+        sa.Column("average_score", sa.Float(), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("pdf_url", sa.String(500), nullable=True),
+        sa.Column(
+            "status",
+            sa.Enum("valid", "revoked", name="certificatestatus", create_type=False),
+            server_default="valid",
+            nullable=False,
+        ),
+        sa.Column("metadata_json", JSONB(), nullable=True),
+        sa.Column("issued_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.UniqueConstraint("user_id", "course_id", name="uq_certificate_user_course"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("certificates")
+    op.drop_table("certificate_templates")
+    op.execute("DROP TYPE IF EXISTS certificatestatus")


### PR DESCRIPTION
## Summary
- Add `CertificateTemplate` and `Certificate` SQLAlchemy models in `backend/app/domain/models/certificate.py`
- Add Alembic migration 068 creating both tables with indexes, unique constraints, and `certificatestatus` enum
- Wire relationships into `Course` and `User` models
- Register new models in `__init__.py`

Closes #760

## Test plan
- [ ] `uv run alembic upgrade head` runs cleanly
- [ ] `uv run alembic downgrade -1` reverses cleanly
- [ ] Models importable: `from app.domain.models.certificate import Certificate, CertificateTemplate`
- [ ] Unique constraint prevents duplicate certificates per user+course

🤖 Generated with [Claude Code](https://claude.com/claude-code)