### PR TITLE
fix: render markdown in lesson key points

### DIFF
--- a/frontend/components/learning/lesson-viewer.tsx
+++ b/frontend/components/learning/lesson-viewer.tsx
@@ -483,6 +483,13 @@ export function LessonViewer({
           {/* Lesson Illustration */}
           <LessonImage lessonId={lessonData.id} language={lessonData.language} />
 
+          {/* Introduction */}
+          {content.introduction && (
+            <div className="mb-8">
+              {renderContentWithImages(content.introduction)}
+            </div>
+          )}
+
           {/* Key Concepts */}
           <div className="mb-8">
             <div className="space-y-6">
@@ -516,9 +523,11 @@ export function LessonViewer({
               {content.key_points.map((point, index) => (
                 <li key={index} className="flex items-start gap-3">
                   <div className="w-2 h-2 bg-teal-500 rounded-full mt-3 flex-shrink-0" />
-                  <span className="text-base leading-relaxed text-gray-700">
-                    {point}
-                  </span>
+                  <div className="text-base leading-relaxed text-gray-700 prose prose-gray max-w-none prose-p:text-gray-700 prose-strong:text-gray-900 prose-p:my-0">
+                    <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeKatex]} components={mdComponents}>
+                      {point}
+                    </ReactMarkdown>
+                  </div>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Summary
- **Key points markdown rendering**: Key points were rendered as plain text inside `<span>` elements, causing markdown formatting (`**bold**`, etc.) to show as raw text. Now rendered through `<ReactMarkdown>` with proper prose styling.
- **Missing introduction section**: The `introduction` field was defined in `LessonContent` but never rendered. Added it before the concepts section using the existing `renderContentWithImages()` helper.

## Test plan
- [ ] Navigate to a generated lesson
- [ ] Verify key points render **bold**, *italic*, and other markdown formatting correctly
- [ ] Verify the introduction text appears above the concepts section
- [ ] Verify no visual regressions in concepts, example, and synthesis sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)