### PR TITLE
feat: PDF certificate generation with ReportLab (#763)

### DIFF
--- a/backend/app/domain/services/certificate_pdf_service.py
+++ b/backend/app/domain/services/certificate_pdf_service.py
@@ -1,0 +1,270 @@
+"""Certificate PDF generation service — ReportLab-based A4 landscape certificates."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+from pathlib import Path
+from uuid import UUID
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.models.certificate import Certificate, CertificateTemplate
+from app.domain.models.course import Course
+from app.domain.models.user import User
+from app.infrastructure.config.settings import settings
+from app.infrastructure.storage.s3 import S3StorageService
+
+logger = structlog.get_logger()
+
+# A4 landscape dimensions in points (1 point = 1/72 inch)
+PAGE_W, PAGE_H = 842, 595
+
+# Platform brand colors
+COLOR_TEAL = (0.176, 0.416, 0.310)  # #2D6A4F
+COLOR_GOLD = (0.855, 0.647, 0.125)  # #DAA520
+COLOR_DARK = (0.133, 0.133, 0.133)  # #222222
+COLOR_GRAY = (0.400, 0.400, 0.400)  # #666666
+
+# Font paths — DejaVu for full French accent support
+_FONT_DIR = Path("/usr/share/fonts/truetype/dejavu")
+_FONT_REGULAR = _FONT_DIR / "DejaVuSans.ttf"
+_FONT_BOLD = _FONT_DIR / "DejaVuSans-Bold.ttf"
+
+
+def _register_fonts() -> str:
+    """Register DejaVu fonts with ReportLab. Returns the font family name."""
+    from reportlab.pdfbase import pdfmetrics
+    from reportlab.pdfbase.ttfonts import TTFont
+
+    family = "DejaVu"
+    if family not in pdfmetrics.getRegisteredFontNames():
+        pdfmetrics.registerFont(TTFont("DejaVu", str(_FONT_REGULAR)))
+        pdfmetrics.registerFont(TTFont("DejaVu-Bold", str(_FONT_BOLD)))
+    return family
+
+
+def _render_pdf(
+    certificate: Certificate,
+    template: CertificateTemplate,
+    course: Course,
+    user: User,
+    language: str,
+) -> bytes:
+    """Synchronous PDF rendering using ReportLab canvas. Returns PDF bytes."""
+    from reportlab.lib.units import mm
+    from reportlab.pdfgen.canvas import Canvas
+
+    _register_fonts()
+
+    buf = io.BytesIO()
+    c = Canvas(buf, pagesize=(PAGE_W, PAGE_H))
+    c.setTitle("Certificate" if language == "en" else "Certificat")
+
+    # ── Decorative border ──────────────────────────────────────
+    margin = 20
+    c.setStrokeColorRGB(*COLOR_TEAL)
+    c.setLineWidth(3)
+    c.roundRect(margin, margin, PAGE_W - 2 * margin, PAGE_H - 2 * margin, 10)
+
+    # Inner border (gold)
+    c.setStrokeColorRGB(*COLOR_GOLD)
+    c.setLineWidth(1.5)
+    c.roundRect(margin + 8, margin + 8, PAGE_W - 2 * (margin + 8), PAGE_H - 2 * (margin + 8), 8)
+
+    # ── Corner decorations ─────────────────────────────────────
+    corner_size = 30
+    c.setStrokeColorRGB(*COLOR_GOLD)
+    c.setLineWidth(2)
+    corners = [
+        (margin + 15, PAGE_H - margin - 15),  # top-left
+        (PAGE_W - margin - 15, PAGE_H - margin - 15),  # top-right
+        (margin + 15, margin + 15),  # bottom-left
+        (PAGE_W - margin - 15, margin + 15),  # bottom-right
+    ]
+    for cx, cy in corners:
+        c.circle(cx, cy, 4, stroke=1, fill=0)
+
+    # ── Platform name ──────────────────────────────────────────
+    y = PAGE_H - 70
+    c.setFont("DejaVu-Bold", 14)
+    c.setFillColorRGB(*COLOR_TEAL)
+    c.drawCentredString(PAGE_W / 2, y, "SIRA")
+
+    # ── Title ──────────────────────────────────────────────────
+    y -= 35
+    c.setFont("DejaVu-Bold", 26)
+    c.setFillColorRGB(*COLOR_TEAL)
+    if language == "fr":
+        c.drawCentredString(PAGE_W / 2, y, "CERTIFICAT DE REUSSITE")
+    else:
+        c.drawCentredString(PAGE_W / 2, y, "CERTIFICATE OF COMPLETION")
+
+    # ── Subtitle ───────────────────────────────────────────────
+    y -= 22
+    c.setFont("DejaVu", 10)
+    c.setFillColorRGB(*COLOR_GRAY)
+    if language == "fr":
+        c.drawCentredString(PAGE_W / 2, y, "Ce certificat est decerne a")
+    else:
+        c.drawCentredString(PAGE_W / 2, y, "This certificate is awarded to")
+
+    # ── Learner name ───────────────────────────────────────────
+    y -= 38
+    c.setFont("DejaVu-Bold", 24)
+    c.setFillColorRGB(*COLOR_DARK)
+    learner_name = user.name or user.email or "Learner"
+    c.drawCentredString(PAGE_W / 2, y, learner_name)
+
+    # ── Decorative line under name ─────────────────────────────
+    y -= 10
+    c.setStrokeColorRGB(*COLOR_GOLD)
+    c.setLineWidth(1)
+    c.line(PAGE_W / 2 - 120, y, PAGE_W / 2 + 120, y)
+
+    # ── Course completion text ─────────────────────────────────
+    y -= 25
+    c.setFont("DejaVu", 11)
+    c.setFillColorRGB(*COLOR_GRAY)
+    if language == "fr":
+        c.drawCentredString(PAGE_W / 2, y, "Pour avoir complete avec succes le cours")
+    else:
+        c.drawCentredString(PAGE_W / 2, y, "For successfully completing the course")
+
+    # ── Course title ───────────────────────────────────────────
+    y -= 30
+    c.setFont("DejaVu-Bold", 16)
+    c.setFillColorRGB(*COLOR_TEAL)
+    course_title = course.title_fr if language == "fr" else course.title_en
+    # Truncate very long titles
+    if len(course_title) > 60:
+        course_title = course_title[:57] + "..."
+    c.drawCentredString(PAGE_W / 2, y, course_title)
+
+    # ── Score & date ───────────────────────────────────────────
+    y -= 30
+    c.setFont("DejaVu", 10)
+    c.setFillColorRGB(*COLOR_DARK)
+    score_text = f"Score: {certificate.average_score:.0f}%"
+    date_str = certificate.completed_at.strftime("%d/%m/%Y") if certificate.completed_at else ""
+    date_label = "Date" if language == "en" else "Date"
+    info_text = f"{score_text}    |    {date_label}: {date_str}"
+    c.drawCentredString(PAGE_W / 2, y, info_text)
+
+    # ── Additional text from template ──────────────────────────
+    additional = template.additional_text_fr if language == "fr" else template.additional_text_en
+    if additional:
+        y -= 22
+        c.setFont("DejaVu", 9)
+        c.setFillColorRGB(*COLOR_GRAY)
+        if len(additional) > 100:
+            additional = additional[:97] + "..."
+        c.drawCentredString(PAGE_W / 2, y, additional)
+
+    # ── Organization & Signatory (left side) ───────────────────
+    y_bottom = 85
+    if template.organization_name:
+        c.setFont("DejaVu", 9)
+        c.setFillColorRGB(*COLOR_GRAY)
+        c.drawString(60, y_bottom + 40, template.organization_name)
+
+    if template.signatory_name:
+        c.setFont("DejaVu-Bold", 10)
+        c.setFillColorRGB(*COLOR_DARK)
+        c.drawString(60, y_bottom + 20, template.signatory_name)
+
+    if template.signatory_title:
+        c.setFont("DejaVu", 9)
+        c.setFillColorRGB(*COLOR_GRAY)
+        c.drawString(60, y_bottom + 5, template.signatory_title)
+
+    # Signature line
+    c.setStrokeColorRGB(*COLOR_GRAY)
+    c.setLineWidth(0.5)
+    c.line(60, y_bottom + 15, 250, y_bottom + 15)
+
+    # ── QR code (right side) ───────────────────────────────────
+    verification_url = f"{settings.frontend_url}/verify/{certificate.verification_code}"
+    try:
+        import qrcode
+
+        qr = qrcode.QRCode(version=1, box_size=3, border=1)
+        qr.add_data(verification_url)
+        qr.make(fit=True)
+        qr_img = qr.make_image(fill_color="black", back_color="white")
+
+        qr_buf = io.BytesIO()
+        qr_img.save(qr_buf, format="PNG")
+        qr_buf.seek(0)
+
+        from reportlab.lib.utils import ImageReader
+
+        qr_size = 70
+        c.drawImage(
+            ImageReader(qr_buf),
+            PAGE_W - 60 - qr_size,
+            y_bottom - 5,
+            width=qr_size,
+            height=qr_size,
+        )
+    except Exception:
+        logger.warning("QR code generation failed, skipping")
+
+    # ── Verification code footer ───────────────────────────────
+    c.setFont("DejaVu", 8)
+    c.setFillColorRGB(*COLOR_GRAY)
+    c.drawCentredString(PAGE_W / 2, margin + 12, f"Verification: {certificate.verification_code}")
+    c.drawCentredString(PAGE_W / 2, margin + 2, verification_url)
+
+    c.save()
+    return buf.getvalue()
+
+
+class CertificatePDFService:
+    """Generates certificate PDFs and stores them in MinIO."""
+
+    async def generate_pdf(
+        self,
+        certificate: Certificate,
+        template: CertificateTemplate,
+        course: Course,
+        user: User,
+        language: str = "fr",
+    ) -> bytes:
+        """Generate certificate PDF bytes. Runs ReportLab in a thread pool."""
+        return await asyncio.to_thread(
+            _render_pdf, certificate, template, course, user, language
+        )
+
+    async def generate_and_store(
+        self,
+        certificate: Certificate,
+        template: CertificateTemplate,
+        course: Course,
+        user: User,
+        db: AsyncSession,
+        language: str = "fr",
+    ) -> str:
+        """Generate PDF, upload to MinIO, update certificate record.
+
+        Returns the public URL of the stored PDF.
+        """
+        pdf_bytes = await self.generate_pdf(certificate, template, course, user, language)
+
+        # Upload to MinIO
+        storage = S3StorageService()
+        key = f"certificates/{certificate.id}.pdf"
+        url = await storage.upload_bytes(key, pdf_bytes, content_type="application/pdf")
+
+        # Update certificate record
+        certificate.pdf_url = url
+        await db.commit()
+
+        logger.info(
+            "certificate_pdf_generated",
+            certificate_id=str(certificate.id),
+            size_bytes=len(pdf_bytes),
+            url=url,
+        )
+        return url

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "resend>=2.26.0",
     "sentry-sdk[fastapi]>=2.19.0",
     "google-cloud-texttospeech>=2.29.0",
+    "reportlab>=4.0",
 ]
 
 [dependency-groups]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -281,7 +281,7 @@ dependencies = [
     { name = "click" },
     { name = "fastapi" },
     { name = "flower" },
-    { name = "google-generativeai" },
+    { name = "google-cloud-texttospeech" },
     { name = "httpx" },
     { name = "numpy" },
     { name = "openai" },
@@ -296,6 +296,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "qrcode", extra = ["pil"] },
     { name = "redis" },
+    { name = "reportlab" },
     { name = "resend" },
     { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "sqlalchemy", extra = ["asyncio"] },
@@ -326,7 +327,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.7" },
     { name = "fastapi", specifier = ">=0.135.2" },
     { name = "flower", specifier = ">=2.0.1" },
-    { name = "google-generativeai", specifier = ">=0.8.0" },
+    { name = "google-cloud-texttospeech", specifier = ">=2.29.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "openai", specifier = ">=2.30.0" },
@@ -341,6 +342,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "qrcode", extras = ["pil"], specifier = ">=8.2" },
     { name = "redis", specifier = ">=6.4.0" },
+    { name = "reportlab", specifier = ">=4.0" },
     { name = "resend", specifier = ">=2.26.0" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.19.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.48" },
@@ -981,22 +983,6 @@ wheels = [
 ]
 
 [[package]]
-name = "google-ai-generativelanguage"
-version = "0.6.15"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version >= '3.14'" },
-    { name = "google-api-core", version = "2.30.2", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version < '3.14'" },
-    { name = "google-auth" },
-    { name = "proto-plus" },
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/11/d1/48fe5d7a43d278e9f6b5ada810b0a3530bbeac7ed7fcbcd366f932f05316/google_ai_generativelanguage-0.6.15.tar.gz", hash = "sha256:8f6d9dc4c12b065fe2d0289026171acea5183ebf2d0b11cefe12f3821e159ec3", size = 1375443, upload-time = "2025-01-13T21:50:47.459Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/a3/67b8a6ff5001a1d8864922f2d6488dc2a14367ceb651bc3f09a947f2f306/google_ai_generativelanguage-0.6.15-py3-none-any.whl", hash = "sha256:5a03ef86377aa184ffef3662ca28f19eeee158733e45d7947982eb953c6ebb6c", size = 1327356, upload-time = "2025-01-13T21:50:44.174Z" },
-]
-
-[[package]]
 name = "google-api-core"
 version = "2.25.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1048,23 +1034,6 @@ grpc = [
 ]
 
 [[package]]
-name = "google-api-python-client"
-version = "2.193.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "google-api-core", version = "2.30.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "google-auth" },
-    { name = "google-auth-httplib2" },
-    { name = "httplib2" },
-    { name = "uritemplate" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/90/f4/e14b6815d3b1885328dd209676a3a4c704882743ac94e18ef0093894f5c8/google_api_python_client-2.193.0.tar.gz", hash = "sha256:8f88d16e89d11341e0a8b199cafde0fb7e6b44260dffb88d451577cbd1bb5d33", size = 14281006, upload-time = "2026-03-17T18:25:29.415Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/6d/fe75167797790a56d17799b75e1129bb93f7ff061efc7b36e9731bd4be2b/google_api_python_client-2.193.0-py3-none-any.whl", hash = "sha256:c42aa324b822109901cfecab5dc4fc3915d35a7b376835233c916c70610322db", size = 14856490, upload-time = "2026-03-17T18:25:26.608Z" },
-]
-
-[[package]]
 name = "google-auth"
 version = "2.49.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1078,35 +1047,20 @@ wheels = [
 ]
 
 [[package]]
-name = "google-auth-httplib2"
-version = "0.3.1"
+name = "google-cloud-texttospeech"
+version = "2.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version >= '3.14'" },
+    { name = "google-api-core", version = "2.30.2", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version < '3.14'" },
     { name = "google-auth" },
-    { name = "httplib2" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/99/107612bef8d24b298bb5a7c8466f908ecda791d43f9466f5c3978f5b24c1/google_auth_httplib2-0.3.1.tar.gz", hash = "sha256:0af542e815784cb64159b4469aa5d71dd41069ba93effa006e1916b1dcd88e55", size = 11152, upload-time = "2026-03-30T22:50:26.766Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/e9/93afb14d23a949acaa3f4e7cc51a0024671174e116e35f42850764b99634/google_auth_httplib2-0.3.1-py3-none-any.whl", hash = "sha256:682356a90ef4ba3d06548c37e9112eea6fc00395a11b0303a644c1a86abc275c", size = 9534, upload-time = "2026-03-30T22:49:03.384Z" },
-]
-
-[[package]]
-name = "google-generativeai"
-version = "0.8.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-ai-generativelanguage" },
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "google-api-core", version = "2.30.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "google-api-python-client" },
-    { name = "google-auth" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
     { name = "protobuf" },
-    { name = "pydantic" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/fe/670610dce6852c8fbdd723101a2ffb497d196bc242cb04a1312339f49d67/google_cloud_texttospeech-2.36.0.tar.gz", hash = "sha256:6c605af7e4774c1bac99fcaaf4538f152b10bba7738a23f42184557f444dc6b7", size = 196558, upload-time = "2026-04-02T21:23:42.236Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/0f/ef33b5bb71437966590c6297104c81051feae95d54b11ece08533ef937d3/google_generativeai-0.8.6-py3-none-any.whl", hash = "sha256:37a0eaaa95e5bbf888828e20a4a1b2c196cc9527d194706e58a68ff388aeb0fa", size = 155098, upload-time = "2025-12-16T17:53:58.61Z" },
+    { url = "https://files.pythonhosted.org/packages/76/1a/0317eaa1ccd6e3645d570851574bb7c1a1cfa3504bb114b7211db59b154d/google_cloud_texttospeech-2.36.0-py3-none-any.whl", hash = "sha256:03f76162543e9d77ecbab823c1cc3728c42ef40547353bcfdbd9ac0e71cb8121", size = 200086, upload-time = "2026-04-02T21:23:13.444Z" },
 ]
 
 [[package]]
@@ -1239,18 +1193,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
-]
-
-[[package]]
-name = "httplib2"
-version = "0.31.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyparsing" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
 ]
 
 [[package]]
@@ -2236,15 +2178,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyparsing"
-version = "3.3.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
-]
-
-[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2503,6 +2436,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/db/1a23f767fa250844772a9464306d34e0fafe2c317303b88a1415096b6324/regex-2026.3.32-cp314-cp314t-win32.whl", hash = "sha256:e480d3dac06c89bc2e0fd87524cc38c546ac8b4a38177650745e64acbbcfdeba", size = 275714, upload-time = "2026-03-28T21:49:14.528Z" },
     { url = "https://files.pythonhosted.org/packages/c2/2b/616d31b125ca76079d74d6b1d84ec0860ffdb41c379151135d06e35a8633/regex-2026.3.32-cp314-cp314t-win_amd64.whl", hash = "sha256:67015a8162d413af9e3309d9a24e385816666fbf09e48e3ec43342c8536f7df6", size = 285722, upload-time = "2026-03-28T21:49:16.642Z" },
     { url = "https://files.pythonhosted.org/packages/7e/91/043d9a00d6123c5fa22a3dc96b10445ce434a8110e1d5e53efb01f243c8b/regex-2026.3.32-cp314-cp314t-win_arm64.whl", hash = "sha256:1a6ac1ed758902e664e0d95c1ee5991aa6fb355423f378ed184c6ec47a1ec0e9", size = 275700, upload-time = "2026-03-28T21:49:19.348Z" },
+]
+
+[[package]]
+name = "reportlab"
+version = "4.4.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/57/28bfbf0a775b618b6e4d854ef8dd3f5c8988e5d614d8898703502a35f61c/reportlab-4.4.10.tar.gz", hash = "sha256:5cbbb34ac3546039d0086deb2938cdec06b12da3cdb836e813258eb33cd28487", size = 3714962, upload-time = "2026-02-12T10:45:21.325Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/2e/e1798b8b248e1517e74c6cdf10dd6edd485044e7edf46b5f11ffcc5a0add/reportlab-4.4.10-py3-none-any.whl", hash = "sha256:5abc815746ae2bc44e7ff25db96814f921349ca814c992c7eac3c26029bf7c24", size = 1955400, upload-time = "2026-02-12T10:45:18.828Z" },
 ]
 
 [[package]]
@@ -2795,15 +2741,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
-]
-
-[[package]]
-name = "uritemplate"
-version = "4.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- New `CertificatePDFService` in `backend/app/domain/services/certificate_pdf_service.py`
- A4 landscape layout with teal+gold decorative borders, QR code, bilingual text
- Uses ReportLab (new dependency) + DejaVu Sans for French accent support
- `generate_pdf()` runs in thread pool via `asyncio.to_thread()`
- `generate_and_store()` uploads to MinIO and updates certificate record
- QR code links to `{FRONTEND_URL}/verify/{code}`

Closes #763

## Test plan
- [ ] `from app.domain.services.certificate_pdf_service import CertificatePDFService` imports cleanly
- [ ] Generated PDF opens correctly and is < 500KB
- [ ] Both FR and EN versions render properly with accented characters
- [ ] QR code is scannable and links to correct verification URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)