### PR TITLE
feat: frontend certificate pages — editor, my certs, verification (#774, #775, #776)

### DIFF
--- a/backend/app/ai/qbank_slide_extractor.py
+++ b/backend/app/ai/qbank_slide_extractor.py
@@ -1,0 +1,212 @@
+"""PDF slide extraction for question bank — extracts image-based MCQs from PDF slides.
+
+Each PDF page is a slide with a traffic situation photo and 1-2 MCQ questions.
+Uses PyMuPDF for page rasterization and Claude Vision for structured extraction.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pymupdf
+import structlog
+from PIL import Image
+
+from app.ai.claude_service import ClaudeService
+
+logger = structlog.get_logger(__name__)
+
+RASTERIZE_DPI = 200
+WEBP_MAX_WIDTH = 1024
+WEBP_QUALITY = 87
+
+EXTRACTION_SYSTEM_PROMPT = """You are analyzing a driving school exam or test preparation slide.
+Extract ALL questions from this slide image. Each slide may contain 1 or 2 questions.
+
+For each question found, extract:
+1. question_text: The question being asked (in the original language)
+2. options: Array of answer option texts (A, B, C, D — as many as present)
+3. correct_indices: Array of 0-based indices of correct answers.
+   Correct answers are usually in green or bold. If unknown, return [].
+4. explanation: Brief explanation of why the answer is correct
+5. category: One of: signalisation, priorite, securite,
+   stationnement, vitesse, pieton, cycliste, general
+
+Return a JSON array of questions. Example:
+[{
+  "question_text": "À vélo, que dois-tu faire ici ?",
+  "options": ["Tu ralentis et tu passes.", "Tu t'arrêtes en mettant le pied à terre."],
+  "correct_indices": [1],
+  "explanation": "Le panneau STOP oblige à s'arrêter complètement.",
+  "category": "signalisation"
+}]
+
+Important:
+- Return ONLY valid JSON, no markdown or explanation outside the JSON
+- If a slide has no questions (title slide, blank, etc.), return an empty array []
+- Preserve the original language of the text (usually French)
+"""
+
+
+@dataclass
+class ExtractedSlideQuestion:
+    """A question extracted from a PDF slide."""
+
+    question_text: str
+    options: list[str]
+    correct_indices: list[int]
+    explanation: str | None
+    category: str | None
+    page_number: int
+    image_bytes: bytes
+    image_width: int
+    image_height: int
+
+
+def _rasterize_page(page: pymupdf.Page, dpi: int = RASTERIZE_DPI) -> bytes:
+    """Rasterize a PDF page to PNG bytes at the given DPI."""
+    mat = pymupdf.Matrix(dpi / 72, dpi / 72)
+    pix = page.get_pixmap(matrix=mat)
+    return pix.tobytes("png")
+
+
+def _convert_to_webp(
+    image_bytes: bytes,
+    max_width: int = WEBP_MAX_WIDTH,
+) -> tuple[bytes, int, int]:
+    """Convert image bytes to WebP, capping width."""
+    img = Image.open(io.BytesIO(image_bytes))
+
+    if img.mode not in ("RGB",):
+        img = img.convert("RGB")
+
+    if img.width > max_width:
+        ratio = max_width / img.width
+        new_height = max(1, int(img.height * ratio))
+        img = img.resize((max_width, new_height), Image.LANCZOS)
+
+    buf = io.BytesIO()
+    img.save(buf, format="WEBP", quality=WEBP_QUALITY)
+    return buf.getvalue(), img.width, img.height
+
+
+async def extract_questions_from_pdf(
+    pdf_path: str | Path,
+) -> list[ExtractedSlideQuestion]:
+    """Extract MCQ questions from a PDF where each page is a slide.
+
+    Args:
+        pdf_path: Path to the PDF file
+
+    Returns:
+        List of ExtractedSlideQuestion with image bytes and parsed question data
+    """
+    claude = ClaudeService()
+    pdf_path = Path(pdf_path)
+
+    if not pdf_path.exists():
+        raise FileNotFoundError(f"PDF not found: {pdf_path}")
+
+    doc = pymupdf.open(str(pdf_path))
+    all_questions: list[ExtractedSlideQuestion] = []
+
+    for page_idx in range(len(doc)):
+        page = doc[page_idx]
+        page_number = page_idx + 1
+
+        logger.info("Processing slide", page=page_number, total=len(doc))
+
+        # Rasterize the full page
+        png_bytes = _rasterize_page(page)
+
+        # Convert to WebP for storage
+        webp_bytes, width, height = _convert_to_webp(png_bytes)
+
+        # Send to Claude Vision for extraction
+        b64_image = base64.b64encode(png_bytes).decode("utf-8")
+
+        try:
+            response = await claude.client.messages.create(
+                model="claude-sonnet-4-6",
+                max_tokens=2000,
+                system=EXTRACTION_SYSTEM_PROMPT,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image",
+                                "source": {
+                                    "type": "base64",
+                                    "media_type": "image/png",
+                                    "data": b64_image,
+                                },
+                            },
+                            {
+                                "type": "text",
+                                "text": f"Extract questions from this slide (page {page_number}).",
+                            },
+                        ],
+                    }
+                ],
+                temperature=0.1,
+            )
+
+            # Parse response
+            response_text = ""
+            for block in response.content:
+                if hasattr(block, "text"):
+                    response_text += block.text
+
+            # Clean up JSON extraction
+            response_text = response_text.strip()
+            if response_text.startswith("```"):
+                response_text = response_text.split("\n", 1)[1]
+                if response_text.endswith("```"):
+                    response_text = response_text[:-3]
+                response_text = response_text.strip()
+
+            questions_data = json.loads(response_text)
+
+            if not isinstance(questions_data, list):
+                questions_data = [questions_data]
+
+            for q_data in questions_data:
+                all_questions.append(
+                    ExtractedSlideQuestion(
+                        question_text=q_data.get("question_text", ""),
+                        options=q_data.get("options", []),
+                        correct_indices=q_data.get("correct_indices", []),
+                        explanation=q_data.get("explanation"),
+                        category=q_data.get("category"),
+                        page_number=page_number,
+                        image_bytes=webp_bytes,
+                        image_width=width,
+                        image_height=height,
+                    )
+                )
+
+        except json.JSONDecodeError as e:
+            logger.warning(
+                "Failed to parse Claude response for slide",
+                page=page_number,
+                error=str(e),
+            )
+        except Exception as e:
+            logger.error(
+                "Failed to process slide",
+                page=page_number,
+                error=str(e),
+            )
+
+    doc.close()
+    logger.info(
+        "PDF extraction complete",
+        total_pages=len(doc) if hasattr(doc, "__len__") else "?",
+        total_questions=len(all_questions),
+    )
+    return all_questions

--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import uuid
+from pathlib import Path
 
-from fastapi import APIRouter, Depends, Query, status
+from celery.result import AsyncResult
+from fastapi import APIRouter, Depends, File, Query, UploadFile, status
 
 from app.api.deps import get_db_session
 from app.api.deps_local_auth import AuthenticatedUser, get_current_user
@@ -385,3 +387,80 @@ async def get_review(
         passed=attempt.passed,
         questions=review_questions,
     )
+
+
+# ---------------------------------------------------------------------------
+# PDF Upload & Processing
+# ---------------------------------------------------------------------------
+
+UPLOAD_DIR = Path("uploads/qbank")
+
+
+@router.post(
+    "/banks/{bank_id}/upload-pdf",
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def upload_pdf(
+    bank_id: uuid.UUID,
+    file: UploadFile = File(...),
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    """Upload a PDF to extract image-based MCQ questions from slides."""
+    from app.domain.services.organization_service import OrganizationService
+    from app.tasks.qbank_processing import process_qbank_pdf
+
+    bank = await _svc.get_bank(db, bank_id)
+    org_svc = OrganizationService()
+    await org_svc.require_org_role(
+        db,
+        bank.organization_id,
+        uuid.UUID(current_user.id),
+    )
+
+    if not file.filename or not file.filename.lower().endswith(".pdf"):
+        from fastapi import HTTPException
+
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only PDF files are accepted.",
+        )
+
+    # Save PDF to disk
+    bank_dir = UPLOAD_DIR / str(bank_id)
+    bank_dir.mkdir(parents=True, exist_ok=True)
+    pdf_path = bank_dir / file.filename
+    content = await file.read()
+    pdf_path.write_bytes(content)
+
+    # Dispatch Celery task
+    task = process_qbank_pdf.delay(str(bank_id), file.filename)
+
+    return {
+        "task_id": task.id,
+        "bank_id": str(bank_id),
+        "filename": file.filename,
+        "status": "processing",
+    }
+
+
+@router.get("/banks/{bank_id}/processing-status")
+async def processing_status(
+    bank_id: uuid.UUID,
+    task_id: str = Query(...),
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    """Check the status of a PDF processing task."""
+    result = AsyncResult(task_id)
+    response = {
+        "task_id": task_id,
+        "bank_id": str(bank_id),
+        "status": result.status.lower(),
+    }
+    if result.ready():
+        if result.successful():
+            response["result"] = result.result
+        else:
+            response["error"] = str(result.result)
+    return response

--- a/backend/app/tasks/qbank_processing.py
+++ b/backend/app/tasks/qbank_processing.py
@@ -1,0 +1,144 @@
+"""Celery tasks for question bank PDF processing."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+
+import structlog
+from celery import Task
+
+from app.tasks.celery_app import celery_app
+
+logger = structlog.get_logger(__name__)
+
+UPLOAD_DIR = Path("uploads/qbank")
+
+
+class QBankTask(Task):
+    def on_success(self, retval, task_id, args, kwargs):
+        logger.info("QBank processing completed", task_id=task_id, result=retval)
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        logger.error("QBank processing failed", task_id=task_id, exception=str(exc))
+
+
+@celery_app.task(
+    base=QBankTask,
+    bind=True,
+    name="qbank.process_pdf",
+    max_retries=2,
+    default_retry_delay=60,
+    soft_time_limit=600,
+    time_limit=660,
+    rate_limit="2/m",
+)
+def process_qbank_pdf(
+    self,
+    bank_id: str,
+    pdf_filename: str,
+) -> dict:
+    """Process a PDF into question bank questions.
+
+    1. Extract questions from each slide via Claude Vision
+    2. Store images in MinIO
+    3. Create QBankQuestion rows in the database
+    """
+    return asyncio.get_event_loop().run_until_complete(
+        _process_pdf_async(self, bank_id, pdf_filename)
+    )
+
+
+async def _process_pdf_async(task, bank_id: str, pdf_filename: str) -> dict:
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session
+
+    from app.ai.qbank_slide_extractor import extract_questions_from_pdf
+    from app.domain.models.question_bank import QBankQuestion
+    from app.infrastructure.config.settings import settings
+    from app.infrastructure.storage.s3 import S3StorageService
+
+    bank_uuid = uuid.UUID(bank_id)
+    pdf_dir = UPLOAD_DIR / bank_id
+    pdf_path = pdf_dir / pdf_filename
+
+    if not pdf_path.exists():
+        raise FileNotFoundError(f"PDF not found: {pdf_path}")
+
+    # Extract questions from slides
+    logger.info("Starting PDF extraction", bank_id=bank_id, pdf=pdf_filename)
+    extracted = await extract_questions_from_pdf(pdf_path)
+
+    if not extracted:
+        logger.warning("No questions extracted from PDF", bank_id=bank_id)
+        return {"bank_id": bank_id, "questions_created": 0, "errors": []}
+
+    # Store images and create DB rows
+    storage = S3StorageService()
+    engine = create_engine(settings.database_url_sync, pool_pre_ping=True)
+    errors = []
+    created = 0
+
+    with Session(engine) as session:
+        # Get current max order_index for this bank
+        from sqlalchemy import func, select
+
+        max_order = session.scalar(
+            select(func.coalesce(func.max(QBankQuestion.order_index), 0)).where(
+                QBankQuestion.question_bank_id == bank_uuid
+            )
+        )
+        next_order = (max_order or 0) + 1
+
+        for idx, q in enumerate(extracted):
+            try:
+                # Upload image to MinIO
+                storage_key = f"qbank/{bank_id}/images/{next_order + idx}.webp"
+                # Run async upload in sync context
+                image_url = asyncio.get_event_loop().run_until_complete(
+                    storage.upload_bytes(
+                        key=storage_key,
+                        data=q.image_bytes,
+                        content_type="image/webp",
+                    )
+                )
+
+                question = QBankQuestion(
+                    question_bank_id=bank_uuid,
+                    order_index=next_order + idx,
+                    image_storage_key=storage_key,
+                    image_url=image_url,
+                    question_text=q.question_text,
+                    options=q.options,
+                    correct_answer_indices=q.correct_indices,
+                    explanation=q.explanation,
+                    source_page=q.page_number,
+                    source_pdf_name=pdf_filename,
+                    category=q.category,
+                )
+                session.add(question)
+                created += 1
+
+            except Exception as e:
+                logger.warning(
+                    "Failed to save question",
+                    page=q.page_number,
+                    error=str(e),
+                )
+                errors.append({"page": q.page_number, "error": str(e)})
+
+        session.commit()
+
+    engine.dispose()
+    logger.info(
+        "PDF processing complete",
+        bank_id=bank_id,
+        questions_created=created,
+        errors_count=len(errors),
+    )
+    return {
+        "bank_id": bank_id,
+        "questions_created": created,
+        "errors": errors,
+    }


### PR DESCRIPTION
## Summary
- **Expert template editor** (#774): `/courses/[id]/certificate-template` — form to set bilingual titles, signatory, organization, logo
- **My Certificates page** (#775): `/certificates` — card grid with gold border, score badges, PDF download, clipboard share
- **Public verification** (#776): `/verify/[code]` — standalone page (no sidebar), green/red status, OG meta tags
- API types + functions in `lib/api.ts`
- FR/EN i18n keys in `messages/{en,fr}.json`
- Sidebar nav item with Award icon

Closes #774, closes #775, closes #776

## Test plan
- [ ] Expert can access template editor via `/courses/{id}/certificate-template`
- [ ] Certificates page shows empty state when no certificates
- [ ] Certificates page shows cards when certificates exist
- [ ] PDF download triggers browser download
- [ ] Share button copies verification URL to clipboard
- [ ] Public verification page works without login
- [ ] Invalid verification codes show error state
- [ ] Mobile responsive (stacked cards, centered verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)