### PR TITLE
feat: add question bank test-taking interface with per-question timer (#1505)

### DIFF
--- a/frontend/app/[locale]/(app)/qbank/tests/[testId]/client.tsx
+++ b/frontend/app/[locale]/(app)/qbank/tests/[testId]/client.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { QBankTestPlayer } from '@/components/qbank/qbank-test-player';
+
+export function QBankTestPlayerPage({ testId }: { testId: string }) {
+  return <QBankTestPlayer testId={testId} />;
+}

--- a/frontend/app/[locale]/(app)/qbank/tests/[testId]/page.tsx
+++ b/frontend/app/[locale]/(app)/qbank/tests/[testId]/page.tsx
@@ -1,0 +1,6 @@
+import { QBankTestPlayerPage } from './client';
+
+export default async function QBankTestPage({ params }: { params: Promise<{ testId: string }> }) {
+  const { testId } = await params;
+  return <QBankTestPlayerPage testId={testId} />;
+}

--- a/frontend/app/[locale]/(app)/qbank/tests/[testId]/results/client.tsx
+++ b/frontend/app/[locale]/(app)/qbank/tests/[testId]/results/client.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { QBankImageQuestion } from '@/components/qbank/qbank-image-question';
+import { getQBankTestReview, type QBankReviewResponse } from '@/lib/api';
+import { useRouter } from 'next/navigation';
+
+interface QBankTestResultsPageProps {
+  testId: string;
+  attemptId?: string;
+}
+
+export function QBankTestResultsPage({ testId, attemptId }: QBankTestResultsPageProps) {
+  const t = useTranslations('qbank');
+  const router = useRouter();
+  const [review, setReview] = useState<QBankReviewResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  useEffect(() => {
+    if (!attemptId) return;
+    getQBankTestReview(testId, attemptId)
+      .then(setReview)
+      .catch((err) => setError(err.message || 'Failed to load review'));
+  }, [testId, attemptId]);
+
+  if (!attemptId) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center px-4">
+        <p className="text-muted-foreground">Missing attempt ID</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center px-4">
+        <p className="text-destructive">{error}</p>
+      </div>
+    );
+  }
+
+  if (!review) {
+    return (
+      <div className="flex min-h-[50vh] flex-col items-center justify-center gap-3 px-4">
+        <LoadingSpinner className="h-8 w-8" />
+        <p className="text-muted-foreground">{t('loading')}</p>
+      </div>
+    );
+  }
+
+  const currentQuestion = review.questions[currentIndex];
+  const totalQuestions = review.questions.length;
+
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 px-4 py-4">
+      <div className="flex items-center justify-between">
+        <Badge variant={review.passed ? 'default' : 'destructive'}>
+          {review.passed ? t('passed') : t('failed')} — {Math.round(review.score)}%
+        </Badge>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between text-sm text-muted-foreground">
+          <span>{t('question', { current: currentIndex + 1, total: totalQuestions })}</span>
+        </div>
+        <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full rounded-full bg-primary transition-all duration-300"
+            style={{ width: `${((currentIndex + 1) / totalQuestions) * 100}%` }}
+          />
+        </div>
+      </div>
+
+      {currentQuestion && (
+        <>
+          <Card className={cn(
+            'border-2',
+            currentQuestion.is_correct === true && 'border-green-500/50',
+            currentQuestion.is_correct === false && 'border-red-500/50'
+          )}>
+            <CardContent className="pt-4">
+              <QBankImageQuestion
+                question={{
+                  id: currentQuestion.id,
+                  image_url: currentQuestion.image_url,
+                  question_text: currentQuestion.question_text,
+                  options: currentQuestion.options,
+                  category: currentQuestion.category,
+                  difficulty: '',
+                }}
+                selectedOption={currentQuestion.user_selected?.[0] ?? null}
+                onSelect={() => {}}
+                showFeedback={true}
+                correctIndices={currentQuestion.correct_answer_indices}
+              />
+              {currentQuestion.explanation && (
+                <div className="mt-4 rounded-lg bg-muted/50 p-3 text-sm text-muted-foreground">
+                  {currentQuestion.explanation}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <div className="flex items-center gap-3 pt-2">
+            <Button
+              variant="outline"
+              className="min-h-[44px] flex-1"
+              onClick={() => setCurrentIndex((prev) => Math.max(0, prev - 1))}
+              disabled={currentIndex === 0}
+            >
+              {t('previousQuestion')}
+            </Button>
+            {currentIndex < totalQuestions - 1 ? (
+              <Button
+                className="min-h-[44px] flex-1"
+                onClick={() => setCurrentIndex((prev) => prev + 1)}
+              >
+                {t('nextQuestion')}
+              </Button>
+            ) : (
+              <Button
+                className="min-h-[44px] flex-1"
+                onClick={() => router.push(`/qbank/tests/${testId}`)}
+              >
+                {t('retake')}
+              </Button>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/[locale]/(app)/qbank/tests/[testId]/results/page.tsx
+++ b/frontend/app/[locale]/(app)/qbank/tests/[testId]/results/page.tsx
@@ -1,0 +1,13 @@
+import { QBankTestResultsPage } from './client';
+
+export default async function QBankResultsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ testId: string }>;
+  searchParams: Promise<{ attempt_id?: string }>;
+}) {
+  const { testId } = await params;
+  const { attempt_id } = await searchParams;
+  return <QBankTestResultsPage testId={testId} attemptId={attempt_id} />;
+}

--- a/frontend/components/qbank/qbank-image-question.tsx
+++ b/frontend/components/qbank/qbank-image-question.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+import type { QBankQuestion } from '@/lib/api';
+
+const OPTION_LABELS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
+
+interface QBankImageQuestionProps {
+  question: QBankQuestion;
+  selectedOption: number | null;
+  onSelect: (index: number) => void;
+  showFeedback: boolean;
+  correctIndices?: number[];
+  onImageLoad?: () => void;
+}
+
+export function QBankImageQuestion({
+  question,
+  selectedOption,
+  onSelect,
+  showFeedback,
+  correctIndices,
+  onImageLoad,
+}: QBankImageQuestionProps) {
+  const t = useTranslations('qbank');
+
+  const getOptionStyle = (index: number) => {
+    if (!showFeedback || selectedOption === null) {
+      return selectedOption === index
+        ? 'border-primary bg-primary/10 ring-2 ring-primary'
+        : 'border-border hover:border-primary/50 hover:bg-muted/50';
+    }
+
+    const isCorrect = correctIndices?.includes(index);
+    const isSelected = selectedOption === index;
+
+    if (isCorrect) return 'border-green-500 bg-green-50 dark:bg-green-950/30';
+    if (isSelected && !isCorrect) return 'border-red-500 bg-red-50 dark:bg-red-950/30';
+    return 'border-border opacity-60';
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      {question.image_url && (
+        <div className="relative w-full overflow-hidden rounded-lg bg-muted">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={question.image_url}
+            alt={question.question_text}
+            className="w-full h-auto max-h-[300px] object-contain"
+            onLoad={onImageLoad}
+          />
+        </div>
+      )}
+
+      <p className="text-base font-medium leading-relaxed">{question.question_text}</p>
+
+      {showFeedback && selectedOption !== null && (
+        <div className={cn(
+          'rounded-lg px-3 py-2 text-sm font-medium',
+          correctIndices?.includes(selectedOption)
+            ? 'bg-green-100 text-green-800 dark:bg-green-950/50 dark:text-green-300'
+            : 'bg-red-100 text-red-800 dark:bg-red-950/50 dark:text-red-300'
+        )}>
+          {correctIndices?.includes(selectedOption) ? t('correct') : t('incorrect')}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2">
+        {question.options.map((option, index) => (
+          <button
+            key={index}
+            onClick={() => onSelect(index)}
+            disabled={showFeedback && selectedOption !== null}
+            className={cn(
+              'flex min-h-[44px] items-center gap-3 rounded-lg border-2 px-4 py-3 text-left transition-colors',
+              getOptionStyle(index),
+              'disabled:cursor-default'
+            )}
+          >
+            <span className={cn(
+              'flex h-8 w-8 shrink-0 items-center justify-center rounded-full border text-sm font-semibold',
+              selectedOption === index
+                ? 'border-primary bg-primary text-primary-foreground'
+                : 'border-muted-foreground/30'
+            )}>
+              {OPTION_LABELS[index]}
+            </span>
+            <span className="text-sm">{option}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/qbank/qbank-question-timer.tsx
+++ b/frontend/components/qbank/qbank-question-timer.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { cn } from '@/lib/utils';
+import { useTranslations } from 'next-intl';
+
+interface QBankQuestionTimerProps {
+  totalSeconds: number;
+  onExpire: () => void;
+  isRunning: boolean;
+  resetKey: number;
+}
+
+export function QBankQuestionTimer({ totalSeconds, onExpire, isRunning, resetKey }: QBankQuestionTimerProps) {
+  const t = useTranslations('qbank');
+  const [remaining, setRemaining] = useState(totalSeconds);
+  const onExpireRef = useRef(onExpire);
+  onExpireRef.current = onExpire;
+
+  useEffect(() => {
+    setRemaining(totalSeconds);
+  }, [resetKey, totalSeconds]);
+
+  useEffect(() => {
+    if (!isRunning || remaining <= 0) return;
+
+    const interval = setInterval(() => {
+      setRemaining((prev) => {
+        if (prev <= 1) {
+          clearInterval(interval);
+          onExpireRef.current();
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [isRunning, remaining <= 0, resetKey]);
+
+  const percentage = totalSeconds > 0 ? (remaining / totalSeconds) * 100 : 0;
+
+  const getColor = useCallback(() => {
+    if (remaining > 10) return 'bg-green-500';
+    if (remaining > 5) return 'bg-yellow-500';
+    return 'bg-red-500';
+  }, [remaining]);
+
+  return (
+    <div className="w-full space-y-1">
+      <div className="flex items-center justify-between text-sm">
+        <span className={cn(
+          'font-mono font-medium tabular-nums',
+          remaining <= 5 && 'text-red-600 animate-pulse'
+        )}>
+          {t('timeRemaining', { seconds: remaining })}
+        </span>
+      </div>
+      <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
+        <div
+          className={cn('h-full rounded-full transition-all duration-1000 ease-linear', getColor())}
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/qbank/qbank-test-player.tsx
+++ b/frontend/components/qbank/qbank-test-player.tsx
@@ -1,0 +1,258 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
+import { QBankQuestionTimer } from './qbank-question-timer';
+import { QBankImageQuestion } from './qbank-image-question';
+import { QBankTestResults } from './qbank-test-results';
+import {
+  startQBankTest,
+  submitQBankTest,
+  type QBankTestStartResponse,
+  type QBankTestAttemptResponse,
+} from '@/lib/api';
+
+type Phase = 'loading' | 'playing' | 'submitting' | 'done';
+
+interface QBankTestPlayerProps {
+  testId: string;
+}
+
+export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
+  const t = useTranslations('qbank');
+  const [phase, setPhase] = useState<Phase>('loading');
+  const [testData, setTestData] = useState<QBankTestStartResponse | null>(null);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [answers, setAnswers] = useState<Record<string, { selected: number[]; time_sec: number }>>({});
+  const [result, setResult] = useState<QBankTestAttemptResponse | null>(null);
+  const [timerResetKey, setTimerResetKey] = useState(0);
+  const [timerRunning, setTimerRunning] = useState(false);
+  const [showingFeedback, setShowingFeedback] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const questionStartTime = useRef<number>(Date.now());
+
+  useEffect(() => {
+    startQBankTest(testId)
+      .then((data) => {
+        setTestData(data);
+        setPhase('playing');
+        questionStartTime.current = Date.now();
+        if (data.mode === 'exam') {
+          setTimerRunning(true);
+        }
+      })
+      .catch((err) => {
+        setError(err.message || 'Failed to load test');
+      });
+  }, [testId]);
+
+  const currentQuestion = testData?.questions[currentIndex] ?? null;
+
+  const recordTime = useCallback(() => {
+    return Math.round((Date.now() - questionStartTime.current) / 1000);
+  }, []);
+
+  const goToNext = useCallback(() => {
+    if (!testData) return;
+    setShowingFeedback(false);
+    if (currentIndex < testData.questions.length - 1) {
+      setCurrentIndex((prev) => prev + 1);
+      setTimerResetKey((prev) => prev + 1);
+      questionStartTime.current = Date.now();
+      if (testData.mode === 'exam') {
+        setTimerRunning(true);
+      }
+    }
+  }, [testData, currentIndex]);
+
+  const handleSelect = useCallback((optionIndex: number) => {
+    if (!currentQuestion || showingFeedback) return;
+
+    const timeSec = recordTime();
+    setAnswers((prev) => ({
+      ...prev,
+      [currentQuestion.id]: { selected: [optionIndex], time_sec: timeSec },
+    }));
+
+    if (testData?.mode === 'training' && testData.show_feedback) {
+      setTimerRunning(false);
+      setShowingFeedback(true);
+    }
+  }, [currentQuestion, showingFeedback, recordTime, testData]);
+
+  const handleTimerExpire = useCallback(() => {
+    if (!currentQuestion) return;
+    const timeSec = recordTime();
+    setAnswers((prev) => {
+      if (prev[currentQuestion.id]) return prev;
+      return { ...prev, [currentQuestion.id]: { selected: [], time_sec: timeSec } };
+    });
+    setTimerRunning(false);
+
+    if (testData && currentIndex < testData.questions.length - 1) {
+      setTimeout(() => goToNext(), 500);
+    }
+  }, [currentQuestion, recordTime, testData, currentIndex, goToNext]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!testData) return;
+    setPhase('submitting');
+    try {
+      const res = await submitQBankTest(testId, answers);
+      setResult(res);
+      setPhase('done');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Submit failed');
+      setPhase('playing');
+    }
+  }, [testId, testData, answers]);
+
+  const handlePrevious = useCallback(() => {
+    if (currentIndex > 0) {
+      setShowingFeedback(false);
+      setCurrentIndex((prev) => prev - 1);
+      setTimerResetKey((prev) => prev + 1);
+      questionStartTime.current = Date.now();
+      if (testData?.mode === 'exam') {
+        setTimerRunning(true);
+      }
+    }
+  }, [currentIndex, testData]);
+
+  if (error) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center px-4">
+        <p className="text-destructive">{error}</p>
+      </div>
+    );
+  }
+
+  if (phase === 'loading') {
+    return (
+      <div className="flex min-h-[50vh] flex-col items-center justify-center gap-3 px-4">
+        <LoadingSpinner className="h-8 w-8" />
+        <p className="text-muted-foreground">{t('loading')}</p>
+      </div>
+    );
+  }
+
+  if (phase === 'done' && result) {
+    return <QBankTestResults attempt={result} testId={testId} />;
+  }
+
+  if (phase === 'submitting') {
+    return (
+      <div className="flex min-h-[50vh] flex-col items-center justify-center gap-3 px-4">
+        <LoadingSpinner className="h-8 w-8" />
+        <p className="text-muted-foreground">{t('submitTest')}...</p>
+      </div>
+    );
+  }
+
+  if (!testData || !currentQuestion) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center px-4">
+        <p className="text-muted-foreground">{t('noQuestions')}</p>
+      </div>
+    );
+  }
+
+  const totalQuestions = testData.questions.length;
+  const progressPercent = ((currentIndex + 1) / totalQuestions) * 100;
+  const selectedOption = answers[currentQuestion.id]?.selected[0] ?? null;
+  const isLastQuestion = currentIndex === totalQuestions - 1;
+  const isExamMode = testData.mode === 'exam';
+  const hasTimer = testData.time_per_question_sec > 0 && testData.mode !== 'review';
+
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 px-4 py-4">
+      <div className="space-y-2">
+        <div className="flex items-center justify-between text-sm text-muted-foreground">
+          <span>{t('question', { current: currentIndex + 1, total: totalQuestions })}</span>
+          {testData.title && <span className="truncate ml-2 font-medium text-foreground">{testData.title}</span>}
+        </div>
+        <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full rounded-full bg-primary transition-all duration-300"
+            style={{ width: `${progressPercent}%` }}
+          />
+        </div>
+      </div>
+
+      {hasTimer && (
+        <QBankQuestionTimer
+          totalSeconds={testData.time_per_question_sec}
+          onExpire={handleTimerExpire}
+          isRunning={timerRunning && !showingFeedback}
+          resetKey={timerResetKey}
+        />
+      )}
+
+      <QBankImageQuestion
+        question={currentQuestion}
+        selectedOption={selectedOption}
+        onSelect={handleSelect}
+        showFeedback={showingFeedback || testData.mode === 'review'}
+        correctIndices={testData.mode === 'review' ? [] : undefined}
+        onImageLoad={() => {
+          if (hasTimer && !showingFeedback) {
+            setTimerRunning(true);
+          }
+        }}
+      />
+
+      <div className="flex items-center gap-3 pt-2">
+        {!isExamMode && (
+          <Button
+            variant="outline"
+            className="min-h-[44px] flex-1"
+            onClick={handlePrevious}
+            disabled={currentIndex === 0}
+          >
+            {t('previousQuestion')}
+          </Button>
+        )}
+
+        {showingFeedback && !isLastQuestion && (
+          <Button
+            className="min-h-[44px] flex-1"
+            onClick={goToNext}
+          >
+            {t('nextQuestion')}
+          </Button>
+        )}
+
+        {!showingFeedback && !isExamMode && selectedOption !== null && !isLastQuestion && (
+          <Button
+            className="min-h-[44px] flex-1"
+            onClick={goToNext}
+          >
+            {t('nextQuestion')}
+          </Button>
+        )}
+
+        {isExamMode && !isLastQuestion && selectedOption !== null && (
+          <Button
+            className="min-h-[44px] flex-1"
+            onClick={goToNext}
+          >
+            {t('nextQuestion')}
+          </Button>
+        )}
+
+        {((isLastQuestion && selectedOption !== null && !showingFeedback) ||
+          (isLastQuestion && showingFeedback)) && (
+          <Button
+            className={cn('min-h-[44px]', isExamMode ? 'w-full' : 'flex-1')}
+            onClick={handleSubmit}
+          >
+            {t('submitTest')}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/qbank/qbank-test-results.tsx
+++ b/frontend/components/qbank/qbank-test-results.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import type { QBankTestAttemptResponse } from '@/lib/api';
+
+interface QBankTestResultsProps {
+  attempt: QBankTestAttemptResponse;
+  testId: string;
+}
+
+export function QBankTestResults({ attempt, testId }: QBankTestResultsProps) {
+  const t = useTranslations('qbank');
+  const router = useRouter();
+
+  const scorePercent = Math.round(attempt.score);
+
+  return (
+    <div className="mx-auto flex w-full max-w-lg flex-col items-center gap-6 px-4 py-6">
+      <div className="flex flex-col items-center gap-3">
+        <div className={cn(
+          'flex h-28 w-28 items-center justify-center rounded-full text-3xl font-bold',
+          attempt.passed
+            ? 'bg-green-100 text-green-700 dark:bg-green-950/50 dark:text-green-400'
+            : 'bg-red-100 text-red-700 dark:bg-red-950/50 dark:text-red-400'
+        )}>
+          {scorePercent}%
+        </div>
+        <Badge variant={attempt.passed ? 'default' : 'destructive'}>
+          {attempt.passed ? t('passed') : t('failed')}
+        </Badge>
+      </div>
+
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle>{t('score')}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">{t('score')}</span>
+            <span className="font-medium">{attempt.correct_answers} / {attempt.total_questions}</span>
+          </div>
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">{t('timeTaken', { seconds: attempt.time_taken_sec })}</span>
+          </div>
+        </CardContent>
+      </Card>
+
+      {attempt.category_breakdown && Object.keys(attempt.category_breakdown).length > 0 && (
+        <Card className="w-full">
+          <CardHeader>
+            <CardTitle>{t('categoryBreakdown')}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {Object.entries(attempt.category_breakdown).map(([category, { correct, total }]) => {
+              const pct = total > 0 ? Math.round((correct / total) * 100) : 0;
+              return (
+                <div key={category} className="space-y-1">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="truncate">{category}</span>
+                    <span className="shrink-0 font-medium">{correct}/{total}</span>
+                  </div>
+                  <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                    <div
+                      className={cn(
+                        'h-full rounded-full transition-all',
+                        pct >= 70 ? 'bg-green-500' : pct >= 50 ? 'bg-yellow-500' : 'bg-red-500'
+                      )}
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="flex w-full gap-3">
+        <Button
+          variant="outline"
+          className="flex-1 min-h-[44px]"
+          onClick={() => router.push(`/qbank/tests/${testId}`)}
+        >
+          {t('retake')}
+        </Button>
+        <Button
+          className="flex-1 min-h-[44px]"
+          onClick={() => router.push(`/qbank/tests/${testId}/results?attempt_id=${attempt.id}`)}
+        >
+          {t('reviewAnswers')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1470,3 +1470,80 @@ export async function downloadCertificatePdf(certificateId: string): Promise<Blo
 export async function verifyCertificate(code: string): Promise<CertificateVerifyResponse> {
   return apiFetch<CertificateVerifyResponse>(`/api/v1/verify/${code}`);
 }
+
+// Question Bank API
+export interface QBankQuestion {
+  id: string;
+  image_url: string | null;
+  question_text: string;
+  options: string[];
+  category: string | null;
+  difficulty: string;
+}
+
+export interface QBankTestStartResponse {
+  test_id: string;
+  title: string;
+  mode: string;
+  time_per_question_sec: number;
+  show_feedback: boolean;
+  questions: QBankQuestion[];
+  total_questions: number;
+}
+
+export interface QBankTestAttemptResponse {
+  id: string;
+  test_id: string;
+  score: number;
+  total_questions: number;
+  correct_answers: number;
+  time_taken_sec: number;
+  passed: boolean;
+  category_breakdown: Record<string, { correct: number; total: number }> | null;
+  attempted_at: string;
+  attempt_number: number;
+}
+
+export interface QBankReviewQuestion {
+  id: string;
+  image_url: string | null;
+  question_text: string;
+  options: string[];
+  correct_answer_indices: number[];
+  explanation: string | null;
+  category: string | null;
+  user_selected: number[] | null;
+  is_correct: boolean | null;
+}
+
+export interface QBankReviewResponse {
+  test_id: string;
+  attempt_id: string;
+  score: number;
+  passed: boolean;
+  questions: QBankReviewQuestion[];
+}
+
+export async function startQBankTest(testId: string): Promise<QBankTestStartResponse> {
+  return apiFetch<QBankTestStartResponse>(`/api/v1/qbank/tests/${testId}/start`);
+}
+
+export async function submitQBankTest(
+  testId: string,
+  answers: Record<string, { selected: number[]; time_sec: number }>
+): Promise<QBankTestAttemptResponse> {
+  return apiFetch<QBankTestAttemptResponse>(`/api/v1/qbank/tests/${testId}/submit`, {
+    method: "POST",
+    body: JSON.stringify({ answers }),
+  });
+}
+
+export async function getQBankTestHistory(testId: string): Promise<QBankTestAttemptResponse[]> {
+  return apiFetch<QBankTestAttemptResponse[]>(`/api/v1/qbank/tests/${testId}/history`);
+}
+
+export async function getQBankTestReview(
+  testId: string, attemptId: string
+): Promise<QBankReviewResponse> {
+  return apiFetch<QBankReviewResponse>(`/api/v1/qbank/tests/${testId}/review/${attemptId}`);
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1979,5 +1979,23 @@
     "signedBy": "Signed by",
     "copyLink": "Copy verification link",
     "linkCopied": "Link copied!"
+  },
+  "qbank": {
+    "loading": "Loading test...",
+    "question": "Question {current} of {total}",
+    "timeRemaining": "{seconds}s",
+    "submitTest": "Finish Test",
+    "nextQuestion": "Next Question",
+    "previousQuestion": "Previous Question",
+    "score": "Score",
+    "passed": "Passed",
+    "failed": "Failed",
+    "correct": "Correct!",
+    "incorrect": "Incorrect",
+    "retake": "Retake",
+    "reviewAnswers": "Review Answers",
+    "categoryBreakdown": "Results by Category",
+    "timeTaken": "Total time: {seconds}s",
+    "noQuestions": "No questions available"
   }
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1979,5 +1979,23 @@
     "signedBy": "Signé par",
     "copyLink": "Copier le lien de vérification",
     "linkCopied": "Lien copié !"
+  },
+  "qbank": {
+    "loading": "Chargement du test...",
+    "question": "Question {current} sur {total}",
+    "timeRemaining": "{seconds}s",
+    "submitTest": "Terminer le test",
+    "nextQuestion": "Question suivante",
+    "previousQuestion": "Question précédente",
+    "score": "Score",
+    "passed": "Réussi",
+    "failed": "Échoué",
+    "correct": "Correct !",
+    "incorrect": "Incorrect",
+    "retake": "Recommencer",
+    "reviewAnswers": "Revoir les réponses",
+    "categoryBreakdown": "Résultats par catégorie",
+    "timeTaken": "Temps total : {seconds}s",
+    "noQuestions": "Aucune question disponible"
   }
 }


### PR DESCRIPTION
## Summary
- **qbank-test-player.tsx**: Core test orchestration — loads questions, manages exam/training/review modes, handles submit
- **qbank-question-timer.tsx**: Per-question countdown with green→yellow→red progress bar, auto-advance on expire
- **qbank-image-question.tsx**: Image + question text + A/B/C/D option buttons with 44px touch targets, feedback coloring
- **qbank-test-results.tsx**: Score display, pass/fail badge, category breakdown bars, retake/review buttons
- **Results page**: Per-question review with correct/incorrect answers and explanations
- **API layer**: 5 TypeScript interfaces + 4 API functions in lib/api.ts
- **i18n**: 17 keys in FR/EN for test-taking UI

## Test plan
- [ ] Navigate to `/fr/qbank/tests/{testId}` — test loads
- [ ] Exam mode: timer counts down per question, auto-advances, no feedback
- [ ] Training mode: immediate feedback after answer selection
- [ ] Submit shows results with score + pass/fail
- [ ] Results page shows per-question review
- [ ] Mobile responsive at 320px

Closes #1505

🤖 Generated with [Claude Code](https://claude.com/claude-code)