### PR TITLE
fix: refactor qbank timer to pass React 19 lint rules

### DIFF
--- a/frontend/components/qbank/qbank-question-timer.tsx
+++ b/frontend/components/qbank/qbank-question-timer.tsx
@@ -12,16 +12,27 @@ interface QBankQuestionTimerProps {
 }
 
 export function QBankQuestionTimer({ totalSeconds, onExpire, isRunning, resetKey }: QBankQuestionTimerProps) {
+  return (
+    <QBankQuestionTimerInner
+      key={resetKey}
+      totalSeconds={totalSeconds}
+      onExpire={onExpire}
+      isRunning={isRunning}
+    />
+  );
+}
+
+function QBankQuestionTimerInner({
+  totalSeconds,
+  onExpire,
+  isRunning,
+}: Omit<QBankQuestionTimerProps, 'resetKey'>) {
   const t = useTranslations('qbank');
   const [remaining, setRemaining] = useState(totalSeconds);
   const onExpireRef = useRef(onExpire);
   useEffect(() => {
     onExpireRef.current = onExpire;
   }, [onExpire]);
-
-  useEffect(() => {
-    setRemaining(totalSeconds);
-  }, [resetKey, totalSeconds]);
 
   useEffect(() => {
     if (!isRunning || remaining <= 0) return;
@@ -38,7 +49,7 @@ export function QBankQuestionTimer({ totalSeconds, onExpire, isRunning, resetKey
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [isRunning, remaining, resetKey]);
+  }, [isRunning, remaining]);
 
   const percentage = totalSeconds > 0 ? (remaining / totalSeconds) * 100 : 0;
 


### PR DESCRIPTION
## Summary
- Refactor QBankQuestionTimer to use key-based reset pattern instead of setState in useEffect
- Fixes react-hooks/set-state-in-effect lint error blocking CI

## Test plan
- [ ] CI passes
- [ ] Deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)