### PR TITLE
fix: robust enum creation in certificate migration

### DIFF
--- a/backend/migrations/versions/068_add_certificate_tables.py
+++ b/backend/migrations/versions/068_add_certificate_tables.py
@@ -17,12 +17,13 @@ depends_on = None
 
 
 def _create_enum_if_not_exists(name: str, values: list[str]) -> None:
-    """Create a PostgreSQL enum type only if it doesn't already exist (asyncpg-safe)."""
+    """Create a PostgreSQL enum type only if it doesn't already exist."""
     conn = op.get_bind()
-    result = conn.execute(sa.text("SELECT 1 FROM pg_type WHERE typname = :name"), {"name": name})
-    if not result.scalar():
-        vals = ", ".join(f"'{v}'" for v in values)
-        conn.execute(sa.text(f"CREATE TYPE {name} AS ENUM ({vals})"))
+    vals = ", ".join(f"'{v}'" for v in values)
+    conn.execute(sa.text(
+        f"DO $$ BEGIN CREATE TYPE {name} AS ENUM ({vals}); "
+        f"EXCEPTION WHEN duplicate_object THEN NULL; END $$"
+    ))
 
 
 def upgrade() -> None:


### PR DESCRIPTION
## Summary
- Use DO/EXCEPTION block instead of pg_type check for creating the `certificatestatus` enum
- Fixes deploy failure where enum already existed from a prior partial migration run

## Test plan
- [ ] CI passes
- [ ] Deploy succeeds — migration runs without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)