### PR TITLE
fix: format migration 068 for ruff

### DIFF
--- a/backend/migrations/versions/068_add_certificate_tables.py
+++ b/backend/migrations/versions/068_add_certificate_tables.py
@@ -20,10 +20,12 @@ def _create_enum_if_not_exists(name: str, values: list[str]) -> None:
     """Create a PostgreSQL enum type only if it doesn't already exist."""
     conn = op.get_bind()
     vals = ", ".join(f"'{v}'" for v in values)
-    conn.execute(sa.text(
-        f"DO $$ BEGIN CREATE TYPE {name} AS ENUM ({vals}); "
-        f"EXCEPTION WHEN duplicate_object THEN NULL; END $$"
-    ))
+    conn.execute(
+        sa.text(
+            f"DO $$ BEGIN CREATE TYPE {name} AS ENUM ({vals}); "
+            f"EXCEPTION WHEN duplicate_object THEN NULL; END $$"
+        )
+    )
 
 
 def upgrade() -> None:


### PR DESCRIPTION
## Summary
- Apply ruff format to migration 068 to fix CI format check

🤖 Generated with [Claude Code](https://claude.com/claude-code)