### PR TITLE
fix: prevent duplicate enum creation in certificate model

### DIFF
--- a/backend/app/domain/models/certificate.py
+++ b/backend/app/domain/models/certificate.py
@@ -57,7 +57,8 @@ class Certificate(Base):
     completed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     pdf_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     status: Mapped[str] = mapped_column(
-        Enum("valid", "revoked", name="certificatestatus"), server_default="valid"
+        Enum("valid", "revoked", name="certificatestatus", create_type=False),
+        server_default="valid",
     )
     metadata_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     issued_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())


### PR DESCRIPTION
## Summary
- Add `create_type=False` to the `Enum` in the Certificate model to prevent SQLAlchemy from auto-creating the `certificatestatus` type during migration
- The enum is already created explicitly in migration 068

## Test plan
- [ ] CI passes
- [ ] Deploy succeeds — migration runs without duplicate type error

🤖 Generated with [Claude Code](https://claude.com/claude-code)