### PR TITLE
fix: use postgresql.ENUM to prevent auto-creation of certificatestatus

### DIFF
--- a/backend/app/domain/models/certificate.py
+++ b/backend/app/domain/models/certificate.py
@@ -4,7 +4,8 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, String, Text, UniqueConstraint, func
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text, UniqueConstraint, func
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -57,7 +58,7 @@ class Certificate(Base):
     completed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     pdf_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     status: Mapped[str] = mapped_column(
-        Enum("valid", "revoked", name="certificatestatus", create_type=False),
+        postgresql.ENUM("valid", "revoked", name="certificatestatus", create_type=False),
         server_default="valid",
     )
     metadata_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)

--- a/backend/migrations/versions/068_add_certificate_tables.py
+++ b/backend/migrations/versions/068_add_certificate_tables.py
@@ -8,6 +8,7 @@ Create Date: 2026-04-16
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import JSONB
 
 revision = "068"
@@ -84,7 +85,7 @@ def upgrade() -> None:
         sa.Column("pdf_url", sa.String(500), nullable=True),
         sa.Column(
             "status",
-            sa.Enum("valid", "revoked", name="certificatestatus", create_type=False),
+            postgresql.ENUM("valid", "revoked", name="certificatestatus", create_type=False),
             server_default="valid",
             nullable=False,
         ),


### PR DESCRIPTION
## Summary
- Switch from `sa.Enum` to `postgresql.ENUM` with `create_type=False` in both the migration and model
- This prevents SQLAlchemy metadata from auto-emitting `CREATE TYPE certificatestatus` during migration

## Test plan
- [ ] CI passes
- [ ] Deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)