### PR TITLE
fix: make /verify/[code] publicly accessible

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -10,6 +10,7 @@ const PUBLIC_PATTERNS = [
   /^\/(fr|en)\/(login|register|register-options|register-totp|register-email-otp|register-password|magic-link|forgot-password)(\/.*)*/,
   /^\/(fr|en)\/courses(\/[^/]+)?$/,
   /^\/(fr|en)\/about$/,
+  /^\/(fr|en)\/verify\/[^/]+$/,
   /^\/api\//,
   /^\/_next\//,
   /^\/favicon\.ico$/,


### PR DESCRIPTION
The certificate verification page needs to bypass auth middleware so verification links can be shared publicly.