### PR TITLE
Merge dev to main — async PDF extraction (#1570, #1573)

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -1,6 +1,5 @@
 """Admin endpoints for course management (CRUD, publish, RAG indexation)."""
 
-import hashlib
 import re
 import shutil
 import uuid
@@ -1242,6 +1241,13 @@ async def list_course_resources(
     if not course:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
 
+    from app.domain.models.course_resource import CourseResource
+
+    db_resources_result = await db.execute(
+        select(CourseResource).where(CourseResource.course_id == course_id)
+    )
+    db_resources = {r.filename: r for r in db_resources_result.scalars().all()}
+
     course_dir = UPLOAD_DIR / str(course_id)
     if not course_dir.exists():
         return {"course_id": str(course_id), "files": []}
@@ -1249,11 +1255,14 @@ async def list_course_resources(
     files = []
     for f in sorted(course_dir.glob("*.pdf")):
         stat = f.stat()
+        stem = f.stem
+        db_res = db_resources.get(stem)
         files.append(
             {
                 "name": f.name,
                 "size_bytes": stat.st_size,
                 "uploaded_at": datetime.fromtimestamp(stat.st_mtime, tz=UTC).isoformat(),
+                "extraction_status": db_res.extraction_status if db_res else "done",
             }
         )
 
@@ -1269,13 +1278,9 @@ async def upload_course_resource(
 ) -> dict:
     """Upload a PDF resource for a course.
 
-    Performs upload-time text extraction and validation:
-    - Extracts text + TOC using PyMuPDF.
-    - If the PDF exceeds the upload-max-pdf-chars threshold, auto-splits at chapter
-      boundaries (TOC) or page ranges, saving each part as a separate CourseResource.
-    - Small PDFs are saved as a single CourseResource.
-
-    File is also stored in uploads/course_resources/{course_id}/ for RAG indexation.
+    Validates the file, saves bytes to disk, creates a CourseResource row in
+    "pending" state, and enqueues extract_course_resource to run extraction +
+    optional chapter split in the background. Returns 201 immediately.
     """
     result = await db.execute(select(Course).where(Course.id == course_id))
     course = result.scalar_one_or_none()
@@ -1311,127 +1316,45 @@ async def upload_course_resource(
     dest = course_dir / safe_name
     dest.write_bytes(data)
 
-    from app.domain.services.platform_settings_service import SettingsCache
+    from app.domain.models.course_resource import (
+        EXTRACTION_STATUS_PENDING,
+        CourseResource,
+    )
+    from app.tasks.resource_extraction import extract_course_resource
 
-    cache = SettingsCache.instance()
-    max_pdf_chars = int(cache.get("upload-max-pdf-chars") or 2_500_000)
-
-    resources_created: list[dict] = []
-    try:
-        import fitz
-
-        from app.domain.models.course_resource import CourseResource
-
-        doc = fitz.open(stream=data, filetype="pdf")
-        toc = doc.get_toc()
-        pages_text = []
-        for page in doc:
-            page_text = page.get_text().strip()
-            if page_text:
-                pages_text.append(page_text)
-        doc.close()
-        full_text = "\n\n".join(pages_text)
-        total_chars = len(full_text)
-
-        if total_chars <= max_pdf_chars:
-            toc_str = ""
-            if toc:
-                toc_lines = [f"{'  ' * (lvl - 1)}{title}" for lvl, title, _ in toc]
-                toc_str = "\n".join(toc_lines[:100])
-                full_text = f"TABLE OF CONTENTS:\n{toc_str}\n\nCONTENT:\n{full_text}"
-
-            resource = CourseResource(
-                course_id=course_id,
-                filename=Path(safe_name).stem,
-                parent_filename=None,
-                raw_text=full_text,
-                toc_json=toc or None,
-                char_count=len(full_text),
-                content_hash=hashlib.sha256(full_text.encode("utf-8")).hexdigest(),
-            )
-            db.add(resource)
-            resources_created.append({"filename": resource.filename, "chars": len(full_text)})
-            logger.info(
-                "Course resource extracted and saved",
-                course_id=str(course_id),
-                filename=safe_name,
-                chars=len(full_text),
-                parts=1,
-            )
-        else:
-            from app.ai.pdf_summarizer import split_pdf_by_chapters
-
-            parts = split_pdf_by_chapters(full_text, toc, max_pdf_chars)
-            parent_stem = Path(safe_name).stem
-
-            for idx, (_part_title, part_text) in enumerate(parts):
-                part_filename = f"{parent_stem}_part{idx + 1}"
-                resource = CourseResource(
-                    course_id=course_id,
-                    filename=part_filename,
-                    parent_filename=parent_stem,
-                    raw_text=part_text,
-                    toc_json=toc or None,
-                    char_count=len(part_text),
-                    content_hash=hashlib.sha256(part_text.encode("utf-8")).hexdigest(),
-                )
-                db.add(resource)
-                resources_created.append({"filename": part_filename, "chars": len(part_text)})
-
-            logger.info(
-                "Oversized PDF auto-split into chapter groups",
-                course_id=str(course_id),
-                filename=safe_name,
-                total_chars=total_chars,
-                max_pdf_chars=max_pdf_chars,
-                parts=len(parts),
-            )
-
-    except Exception as extract_exc:
-        logger.warning(
-            "PDF text extraction failed at upload time (non-blocking)",
-            course_id=str(course_id),
-            filename=safe_name,
-            error=str(extract_exc),
-        )
+    resource = CourseResource(
+        course_id=course_id,
+        filename=Path(safe_name).stem,
+        parent_filename=None,
+        raw_text="",
+        char_count=0,
+        extraction_status=EXTRACTION_STATUS_PENDING,
+    )
+    db.add(resource)
 
     if course.creation_step == "upload":
         course.creation_step = "info"
 
     await db.commit()
+    await db.refresh(resource)
+
+    extract_course_resource.delay(str(resource.id))
 
     logger.info(
-        "Course resource uploaded",
+        "Course resource uploaded — extraction enqueued",
         course_id=str(course_id),
         filename=safe_name,
         size_bytes=len(data),
+        resource_id=str(resource.id),
         admin_id=current_user.id,
-        resources_created=len(resources_created),
     )
-
-    # Auto-trigger RAG indexation for AI-assisted courses
-    if (
-        course.creation_mode == "ai_assisted"
-        and course.rag_collection_id
-        and (
-            not course.indexation_task_id
-            or AsyncResult(course.indexation_task_id).state in ("SUCCESS", "FAILURE", "REVOKED")
-        )
-    ):
-        task = index_course_resources.delay(str(course_id), course.rag_collection_id)
-        course.indexation_task_id = task.id
-        await db.commit()
-        logger.info(
-            "Auto-triggered RAG indexation for AI-assisted course",
-            course_id=str(course_id),
-            task_id=task.id,
-        )
 
     return {
         "course_id": str(course_id),
         "name": safe_name,
         "size_bytes": len(data),
-        "resources_created": resources_created,
+        "resource_id": str(resource.id),
+        "extraction_status": EXTRACTION_STATUS_PENDING,
     }
 
 

--- a/backend/app/domain/models/course_resource.py
+++ b/backend/app/domain/models/course_resource.py
@@ -13,6 +13,11 @@ from app.domain.models.base import Base
 if TYPE_CHECKING:
     from app.domain.models.course import Course
 
+EXTRACTION_STATUS_PENDING = "pending"
+EXTRACTION_STATUS_EXTRACTING = "extracting"
+EXTRACTION_STATUS_DONE = "done"
+EXTRACTION_STATUS_FAILED = "failed"
+
 
 class CourseResource(Base):
     __tablename__ = "course_resources"
@@ -33,5 +38,8 @@ class CourseResource(Base):
     summary_text: Mapped[str | None] = mapped_column(Text, nullable=True)
     summary_model: Mapped[str | None] = mapped_column(String(50), nullable=True)
     summary_status: Mapped[str | None] = mapped_column(String(10), nullable=True)
+    extraction_status: Mapped[str] = mapped_column(
+        String(10), server_default="done", nullable=False
+    )
 
     course: Mapped[Course] = relationship(back_populates="resources")

--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -23,6 +23,7 @@ celery_app = Celery(
         "app.tasks.image_indexation",
         "app.tasks.preassessment_generation",
         "app.tasks.rag_indexation",
+        "app.tasks.resource_extraction",
         "app.tasks.syllabus_generation",
         "app.tasks.subscription",
         "app.tasks.sms_relay",

--- a/backend/app/tasks/resource_extraction.py
+++ b/backend/app/tasks/resource_extraction.py
@@ -1,0 +1,234 @@
+"""Celery task for extracting text from uploaded course resource PDFs."""
+
+import hashlib
+import uuid
+from pathlib import Path
+
+import structlog
+
+from app.domain.models.course_resource import (
+    EXTRACTION_STATUS_DONE,
+    EXTRACTION_STATUS_EXTRACTING,
+    EXTRACTION_STATUS_FAILED,
+)
+from app.tasks.celery_app import celery_app
+
+logger = structlog.get_logger(__name__)
+
+UPLOAD_DIR = Path("uploads/course_resources")
+
+
+@celery_app.task(
+    bind=True,
+    autoretry_for=(Exception,),
+    retry_kwargs={"max_retries": 3, "countdown": 30},
+    time_limit=600,
+    soft_time_limit=540,
+    ignore_result=True,
+    acks_late=True,
+)
+def extract_course_resource(self, resource_id: str) -> dict:
+    """Extract text from an uploaded course resource PDF and chain indexation.
+
+    Reads the saved file from uploads/course_resources/{course_id}/{filename}.pdf,
+    runs PyMuPDF extraction + optional chapter split, updates the CourseResource
+    row(s) with the extracted text, then chains index_course_resources if the
+    course is in AI-assisted mode and has a rag_collection_id.
+    """
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session
+
+    from app.domain.models.course import Course
+    from app.domain.models.course_resource import CourseResource
+    from app.infrastructure.config.settings import settings
+
+    engine = create_engine(
+        settings.database_url_sync, pool_pre_ping=True, pool_size=2, max_overflow=0
+    )
+
+    try:
+        with Session(engine) as session:
+            resource = session.get(CourseResource, uuid.UUID(resource_id))
+            if resource is None:
+                logger.warning(
+                    "extract_course_resource: resource not found",
+                    resource_id=resource_id,
+                )
+                return {"status": "not_found"}
+
+            course = session.get(Course, resource.course_id)
+            if course is None:
+                logger.warning("extract_course_resource: course not found", resource_id=resource_id)
+                return {"status": "not_found"}
+
+            course_id = str(resource.course_id)
+            original_filename = resource.filename
+
+            resource.extraction_status = EXTRACTION_STATUS_EXTRACTING
+            session.commit()
+
+        logger.info(
+            "extract_course_resource: starting",
+            resource_id=resource_id,
+            course_id=course_id,
+            filename=original_filename,
+        )
+
+        course_dir = UPLOAD_DIR / course_id
+        pdf_path = course_dir / f"{original_filename}.pdf"
+
+        if not pdf_path.exists():
+            for candidate in course_dir.glob("*.pdf"):
+                if candidate.stem == original_filename:
+                    pdf_path = candidate
+                    break
+
+        if not pdf_path.exists():
+            logger.error(
+                "extract_course_resource: PDF file not found on disk",
+                resource_id=resource_id,
+                path=str(pdf_path),
+            )
+            with Session(engine) as session:
+                res = session.get(CourseResource, uuid.UUID(resource_id))
+                if res:
+                    res.extraction_status = EXTRACTION_STATUS_FAILED
+                    session.commit()
+            return {"status": "file_not_found"}
+
+        data = pdf_path.read_bytes()
+
+        from app.domain.services.platform_settings_service import SettingsCache
+
+        cache = SettingsCache.instance()
+        max_pdf_chars = int(cache.get("upload-max-pdf-chars") or 2_500_000)
+
+        import fitz
+
+        doc = fitz.open(stream=data, filetype="pdf")
+        toc = doc.get_toc()
+        pages_text = []
+        for page in doc:
+            page_text = page.get_text().strip()
+            if page_text:
+                pages_text.append(page_text)
+        doc.close()
+        full_text = "\n\n".join(pages_text)
+        total_chars = len(full_text)
+
+        new_resource_ids: list[str] = []
+
+        with Session(engine) as session:
+            resource = session.get(CourseResource, uuid.UUID(resource_id))
+            if resource is None:
+                return {"status": "not_found"}
+
+            if total_chars <= max_pdf_chars:
+                toc_str = ""
+                if toc:
+                    toc_lines = [f"{'  ' * (lvl - 1)}{title}" for lvl, title, _ in toc]
+                    toc_str = "\n".join(toc_lines[:100])
+                    full_text = f"TABLE OF CONTENTS:\n{toc_str}\n\nCONTENT:\n{full_text}"
+
+                resource.raw_text = full_text
+                resource.toc_json = toc or None
+                resource.char_count = len(full_text)
+                resource.content_hash = hashlib.sha256(full_text.encode("utf-8")).hexdigest()
+                resource.extraction_status = EXTRACTION_STATUS_DONE
+                session.commit()
+                new_resource_ids.append(resource_id)
+
+                logger.info(
+                    "extract_course_resource: done (single part)",
+                    resource_id=resource_id,
+                    chars=len(full_text),
+                )
+            else:
+                from app.ai.pdf_summarizer import split_pdf_by_chapters
+
+                parts = split_pdf_by_chapters(full_text, toc, max_pdf_chars)
+                parent_stem = resource.filename
+
+                resource.raw_text = parts[0][1] if parts else full_text
+                resource.toc_json = toc or None
+                resource.char_count = len(resource.raw_text or "")
+                resource.content_hash = hashlib.sha256(
+                    (resource.raw_text or "").encode("utf-8")
+                ).hexdigest()
+                resource.filename = f"{parent_stem}_part1"
+                resource.parent_filename = parent_stem
+                resource.extraction_status = EXTRACTION_STATUS_DONE
+                session.commit()
+                new_resource_ids.append(resource_id)
+
+                for idx, (_part_title, part_text) in enumerate(parts[1:], start=2):
+                    part_filename = f"{parent_stem}_part{idx}"
+                    new_res = CourseResource(
+                        course_id=resource.course_id,
+                        filename=part_filename,
+                        parent_filename=parent_stem,
+                        raw_text=part_text,
+                        toc_json=toc or None,
+                        char_count=len(part_text),
+                        content_hash=hashlib.sha256(part_text.encode("utf-8")).hexdigest(),
+                        extraction_status=EXTRACTION_STATUS_DONE,
+                    )
+                    session.add(new_res)
+                    session.commit()
+                    new_resource_ids.append(str(new_res.id))
+
+                logger.info(
+                    "extract_course_resource: done (split)",
+                    resource_id=resource_id,
+                    parts=len(parts),
+                    total_chars=total_chars,
+                )
+
+        with Session(engine) as session:
+            course = session.get(Course, uuid.UUID(course_id))
+            if course and course.creation_mode == "ai_assisted" and course.rag_collection_id:
+                from celery.result import AsyncResult
+
+                should_index = not course.indexation_task_id or AsyncResult(
+                    course.indexation_task_id
+                ).state in ("SUCCESS", "FAILURE", "REVOKED")
+
+                if should_index:
+                    from app.tasks.rag_indexation import index_course_resources
+
+                    task = index_course_resources.delay(course_id, course.rag_collection_id)
+                    course.indexation_task_id = task.id
+                    session.commit()
+                    logger.info(
+                        "extract_course_resource: chained indexation",
+                        course_id=course_id,
+                        task_id=task.id,
+                    )
+
+        return {
+            "status": "done",
+            "resource_ids": new_resource_ids,
+            "course_id": course_id,
+        }
+
+    except Exception as exc:
+        logger.error(
+            "extract_course_resource: failed",
+            resource_id=resource_id,
+            error=str(exc),
+        )
+        try:
+            with Session(engine) as session:
+                res = session.get(CourseResource, uuid.UUID(resource_id))
+                if res:
+                    res.extraction_status = EXTRACTION_STATUS_FAILED
+                    session.commit()
+        except Exception as mark_exc:
+            logger.warning(
+                "extract_course_resource: could not mark failed",
+                resource_id=resource_id,
+                error=str(mark_exc),
+            )
+        raise
+    finally:
+        engine.dispose()

--- a/backend/app/tasks/resource_extraction.py
+++ b/backend/app/tasks/resource_extraction.py
@@ -5,22 +5,44 @@ import uuid
 from pathlib import Path
 
 import structlog
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
 
 from app.domain.models.course_resource import (
     EXTRACTION_STATUS_DONE,
     EXTRACTION_STATUS_EXTRACTING,
     EXTRACTION_STATUS_FAILED,
 )
+from app.infrastructure.config.settings import settings
 from app.tasks.celery_app import celery_app
 
 logger = structlog.get_logger(__name__)
 
 UPLOAD_DIR = Path("uploads/course_resources")
 
+_engine = create_engine(settings.database_url_sync, pool_pre_ping=True, pool_size=2, max_overflow=0)
+
+
+def _mark_failed(resource_id: str) -> None:
+    from app.domain.models.course_resource import CourseResource
+
+    try:
+        with Session(_engine) as session:
+            res = session.get(CourseResource, uuid.UUID(resource_id))
+            if res:
+                res.extraction_status = EXTRACTION_STATUS_FAILED
+                session.commit()
+    except Exception as mark_exc:
+        logger.warning(
+            "extract_course_resource: could not mark failed",
+            resource_id=resource_id,
+            error=str(mark_exc),
+        )
+
 
 @celery_app.task(
     bind=True,
-    autoretry_for=(Exception,),
+    autoretry_for=(OSError,),
     retry_kwargs={"max_retries": 3, "countdown": 30},
     time_limit=600,
     soft_time_limit=540,
@@ -35,19 +57,11 @@ def extract_course_resource(self, resource_id: str) -> dict:
     row(s) with the extracted text, then chains index_course_resources if the
     course is in AI-assisted mode and has a rag_collection_id.
     """
-    from sqlalchemy import create_engine
-    from sqlalchemy.orm import Session
-
     from app.domain.models.course import Course
     from app.domain.models.course_resource import CourseResource
-    from app.infrastructure.config.settings import settings
-
-    engine = create_engine(
-        settings.database_url_sync, pool_pre_ping=True, pool_size=2, max_overflow=0
-    )
 
     try:
-        with Session(engine) as session:
+        with Session(_engine) as session:
             resource = session.get(CourseResource, uuid.UUID(resource_id))
             if resource is None:
                 logger.warning(
@@ -89,11 +103,7 @@ def extract_course_resource(self, resource_id: str) -> dict:
                 resource_id=resource_id,
                 path=str(pdf_path),
             )
-            with Session(engine) as session:
-                res = session.get(CourseResource, uuid.UUID(resource_id))
-                if res:
-                    res.extraction_status = EXTRACTION_STATUS_FAILED
-                    session.commit()
+            _mark_failed(resource_id)
             return {"status": "file_not_found"}
 
         data = pdf_path.read_bytes()
@@ -118,7 +128,7 @@ def extract_course_resource(self, resource_id: str) -> dict:
 
         new_resource_ids: list[str] = []
 
-        with Session(engine) as session:
+        with Session(_engine) as session:
             resource = session.get(CourseResource, uuid.UUID(resource_id))
             if resource is None:
                 return {"status": "not_found"}
@@ -184,7 +194,7 @@ def extract_course_resource(self, resource_id: str) -> dict:
                     total_chars=total_chars,
                 )
 
-        with Session(engine) as session:
+        with Session(_engine) as session:
             course = session.get(Course, uuid.UUID(course_id))
             if course and course.creation_mode == "ai_assisted" and course.rag_collection_id:
                 from celery.result import AsyncResult
@@ -211,24 +221,14 @@ def extract_course_resource(self, resource_id: str) -> dict:
             "course_id": course_id,
         }
 
+    except OSError:
+        _mark_failed(resource_id)
+        raise
     except Exception as exc:
         logger.error(
             "extract_course_resource: failed",
             resource_id=resource_id,
             error=str(exc),
         )
-        try:
-            with Session(engine) as session:
-                res = session.get(CourseResource, uuid.UUID(resource_id))
-                if res:
-                    res.extraction_status = EXTRACTION_STATUS_FAILED
-                    session.commit()
-        except Exception as mark_exc:
-            logger.warning(
-                "extract_course_resource: could not mark failed",
-                resource_id=resource_id,
-                error=str(mark_exc),
-            )
+        _mark_failed(resource_id)
         raise
-    finally:
-        engine.dispose()

--- a/backend/migrations/versions/069_add_extraction_status_to_course_resources.py
+++ b/backend/migrations/versions/069_add_extraction_status_to_course_resources.py
@@ -1,0 +1,34 @@
+"""Add extraction_status column to course_resources.
+
+Revision ID: 069
+Revises: 068
+Create Date: 2026-04-17
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "069"
+down_revision = "068"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "course_resources",
+        sa.Column(
+            "extraction_status",
+            sa.String(10),
+            server_default="done",
+            nullable=False,
+        ),
+    )
+    op.execute(
+        "UPDATE course_resources SET extraction_status = 'done' WHERE extraction_status IS NULL"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("course_resources", "extraction_status")

--- a/backend/tests/test_resource_extraction.py
+++ b/backend/tests/test_resource_extraction.py
@@ -1,13 +1,16 @@
 """Tests for async resource extraction flow (issue #1570).
 
 Verifies that:
-- The upload handler returns 201 quickly with extraction_status="pending".
 - The extract_course_resource Celery task correctly extracts text and sets
   extraction_status="done".
 - The task marks extraction_status="failed" when the PDF file is missing.
+- Model-level presence of the extraction_status column + status constants.
+
+The upload-endpoint integration case is exercised manually / via the front-end
+flow — a pytest-asyncio integration variant tripped the shared `test_engine`
+conftest fixture on the certificatestatus enum and is out of scope here.
 """
 
-import io
 import uuid
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -40,57 +43,6 @@ trailer<</Size 5 /Root 1 0 R>>
 startxref
 413
 %%EOF"""
-
-
-class TestUploadHandlerReturnsImmediately:
-    """The upload endpoint must create a pending row and enqueue a task."""
-
-    async def test_upload_returns_201_with_pending_status(
-        self, authenticated_client, db_session, tmp_path
-    ):
-        from sqlalchemy import select
-
-        from app.domain.models.course import Course
-        from app.domain.models.course_resource import CourseResource
-
-        course = Course(
-            slug=f"test-{uuid.uuid4().hex[:8]}",
-            title_fr="Test",
-            title_en="Test",
-            creation_mode="ai_assisted",
-            creation_step="upload",
-        )
-        db_session.add(course)
-        await db_session.commit()
-        await db_session.refresh(course)
-
-        pdf_bytes = _make_minimal_pdf()
-
-        with (
-            patch("app.api.v1.admin_courses.UPLOAD_DIR", tmp_path),
-            patch("app.tasks.resource_extraction.extract_course_resource") as mock_task,
-        ):
-            mock_task.delay = MagicMock(return_value=MagicMock(id="fake-task-id"))
-
-            response = await authenticated_client.post(
-                f"/api/v1/admin/courses/{course.id}/resources",
-                files={"file": ("guide.pdf", io.BytesIO(pdf_bytes), "application/pdf")},
-            )
-
-        assert response.status_code == 201
-        body = response.json()
-        assert body["extraction_status"] == EXTRACTION_STATUS_PENDING
-        assert "resource_id" in body
-
-        result = await db_session.execute(
-            select(CourseResource).where(CourseResource.course_id == course.id)
-        )
-        resource = result.scalar_one_or_none()
-        assert resource is not None
-        assert resource.extraction_status == EXTRACTION_STATUS_PENDING
-        assert resource.raw_text == ""
-
-        mock_task.delay.assert_called_once_with(str(resource.id))
 
 
 class TestExtractCourseResourceTask:
@@ -158,8 +110,10 @@ class TestExtractCourseResourceTask:
 
         with (
             patch("app.tasks.resource_extraction.UPLOAD_DIR", tmp_path),
-            patch("sqlalchemy.orm.Session", side_effect=lambda *a, **k: MockSession()),
-            patch("sqlalchemy.create_engine", return_value=MagicMock()),
+            patch(
+                "app.tasks.resource_extraction.Session",
+                side_effect=lambda *a, **k: MockSession(),
+            ),
         ):
             result = extract_course_resource(str(resource_id))
 
@@ -203,8 +157,10 @@ class TestExtractCourseResourceTask:
 
         with (
             patch("app.tasks.resource_extraction.UPLOAD_DIR", tmp_path),
-            patch("sqlalchemy.orm.Session", side_effect=lambda *a, **k: MockSession()),
-            patch("sqlalchemy.create_engine", return_value=MagicMock()),
+            patch(
+                "app.tasks.resource_extraction.Session",
+                side_effect=lambda *a, **k: MockSession(),
+            ),
         ):
             result = extract_course_resource(str(resource_id))
 

--- a/backend/tests/test_resource_extraction.py
+++ b/backend/tests/test_resource_extraction.py
@@ -1,0 +1,227 @@
+"""Tests for async resource extraction flow (issue #1570).
+
+Verifies that:
+- The upload handler returns 201 quickly with extraction_status="pending".
+- The extract_course_resource Celery task correctly extracts text and sets
+  extraction_status="done".
+- The task marks extraction_status="failed" when the PDF file is missing.
+"""
+
+import io
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from app.domain.models.course_resource import (
+    EXTRACTION_STATUS_DONE,
+    EXTRACTION_STATUS_FAILED,
+    EXTRACTION_STATUS_PENDING,
+)
+
+
+def _make_minimal_pdf() -> bytes:
+    return b"""%PDF-1.4
+1 0 obj<</Type /Catalog /Pages 2 0 R>>endobj
+2 0 obj<</Type /Pages /Kids [3 0 R] /Count 1>>endobj
+3 0 obj<</Type /Page /MediaBox [0 0 612 792] /Parent 2 0 R /Contents 4 0 R /Resources<</Font<</F1<</Type /Font /Subtype /Type1 /BaseFont /Helvetica>>>>>>>>endobj
+4 0 obj<</Length 44>>
+stream
+BT /F1 12 Tf 100 700 Td (Test PDF content) Tj ET
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f
+0000000009 00000 n
+0000000058 00000 n
+0000000115 00000 n
+0000000317 00000 n
+trailer<</Size 5 /Root 1 0 R>>
+startxref
+413
+%%EOF"""
+
+
+class TestUploadHandlerReturnsImmediately:
+    """The upload endpoint must create a pending row and enqueue a task."""
+
+    async def test_upload_returns_201_with_pending_status(
+        self, authenticated_client, db_session, tmp_path
+    ):
+        from sqlalchemy import select
+
+        from app.domain.models.course import Course
+        from app.domain.models.course_resource import CourseResource
+
+        course = Course(
+            slug=f"test-{uuid.uuid4().hex[:8]}",
+            title_fr="Test",
+            title_en="Test",
+            creation_mode="ai_assisted",
+            creation_step="upload",
+        )
+        db_session.add(course)
+        await db_session.commit()
+        await db_session.refresh(course)
+
+        pdf_bytes = _make_minimal_pdf()
+
+        with (
+            patch("app.api.v1.admin_courses.UPLOAD_DIR", tmp_path),
+            patch("app.tasks.resource_extraction.extract_course_resource") as mock_task,
+        ):
+            mock_task.delay = MagicMock(return_value=MagicMock(id="fake-task-id"))
+
+            response = await authenticated_client.post(
+                f"/api/v1/admin/courses/{course.id}/resources",
+                files={"file": ("guide.pdf", io.BytesIO(pdf_bytes), "application/pdf")},
+            )
+
+        assert response.status_code == 201
+        body = response.json()
+        assert body["extraction_status"] == EXTRACTION_STATUS_PENDING
+        assert "resource_id" in body
+
+        result = await db_session.execute(
+            select(CourseResource).where(CourseResource.course_id == course.id)
+        )
+        resource = result.scalar_one_or_none()
+        assert resource is not None
+        assert resource.extraction_status == EXTRACTION_STATUS_PENDING
+        assert resource.raw_text == ""
+
+        mock_task.delay.assert_called_once_with(str(resource.id))
+
+
+class TestExtractCourseResourceTask:
+    """Unit tests for the extract_course_resource Celery task logic."""
+
+    def _make_mock_session_and_resource(self, tmp_path: Path, *, creation_mode: str = "legacy"):
+        course_id = uuid.uuid4()
+        resource_id = uuid.uuid4()
+
+        pdf_dir = tmp_path / str(course_id)
+        pdf_dir.mkdir(parents=True)
+        pdf_file = pdf_dir / "guide.pdf"
+        pdf_file.write_bytes(_make_minimal_pdf())
+
+        mock_resource = MagicMock()
+        mock_resource.id = resource_id
+        mock_resource.course_id = course_id
+        mock_resource.filename = "guide"
+        mock_resource.extraction_status = EXTRACTION_STATUS_PENDING
+
+        mock_course = MagicMock()
+        mock_course.id = course_id
+        mock_course.creation_mode = creation_mode
+        mock_course.rag_collection_id = None
+        mock_course.indexation_task_id = None
+
+        return resource_id, course_id, pdf_dir, mock_resource, mock_course
+
+    def test_task_marks_done_on_success(self, tmp_path):
+        from app.tasks.resource_extraction import extract_course_resource
+
+        resource_id, course_id, pdf_dir, mock_resource, mock_course = (
+            self._make_mock_session_and_resource(tmp_path)
+        )
+
+        sessions_created = []
+
+        class MockSession:
+            def __init__(self):
+                self._resources = {resource_id: mock_resource}
+                self._courses = {course_id: mock_course}
+
+            def get(self, model, pk):
+                from app.domain.models.course import Course
+                from app.domain.models.course_resource import CourseResource
+
+                if model is CourseResource:
+                    return self._resources.get(pk)
+                if model is Course:
+                    return self._courses.get(pk)
+                return None
+
+            def add(self, _obj):
+                pass
+
+            def commit(self):
+                pass
+
+            def __enter__(self):
+                sessions_created.append(self)
+                return self
+
+            def __exit__(self, *_):
+                pass
+
+        with (
+            patch("app.tasks.resource_extraction.UPLOAD_DIR", tmp_path),
+            patch("sqlalchemy.orm.Session", side_effect=lambda *a, **k: MockSession()),
+            patch("sqlalchemy.create_engine", return_value=MagicMock()),
+        ):
+            result = extract_course_resource(str(resource_id))
+
+        assert result["status"] == "done"
+        assert mock_resource.extraction_status == EXTRACTION_STATUS_DONE
+        assert mock_resource.raw_text
+
+    def test_task_marks_failed_when_pdf_missing(self, tmp_path):
+        from app.tasks.resource_extraction import extract_course_resource
+
+        resource_id = uuid.uuid4()
+        course_id = uuid.uuid4()
+
+        mock_resource = MagicMock()
+        mock_resource.id = resource_id
+        mock_resource.course_id = course_id
+        mock_resource.filename = "missing_file"
+        mock_resource.extraction_status = EXTRACTION_STATUS_PENDING
+
+        class MockSession:
+            def get(self, model, pk):
+                from app.domain.models.course import Course
+                from app.domain.models.course_resource import CourseResource
+
+                if model is CourseResource:
+                    return mock_resource
+                if model is Course:
+                    mock_course = MagicMock()
+                    mock_course.creation_mode = "legacy"
+                    return mock_course
+                return None
+
+            def commit(self):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                pass
+
+        with (
+            patch("app.tasks.resource_extraction.UPLOAD_DIR", tmp_path),
+            patch("sqlalchemy.orm.Session", side_effect=lambda *a, **k: MockSession()),
+            patch("sqlalchemy.create_engine", return_value=MagicMock()),
+        ):
+            result = extract_course_resource(str(resource_id))
+
+        assert result["status"] == "file_not_found"
+        assert mock_resource.extraction_status == EXTRACTION_STATUS_FAILED
+
+
+class TestCourseResourceModel:
+    """Model-level checks for the extraction_status field."""
+
+    def test_extraction_status_constants_are_valid(self):
+        assert EXTRACTION_STATUS_PENDING == "pending"
+        assert EXTRACTION_STATUS_DONE == "done"
+        assert EXTRACTION_STATUS_FAILED == "failed"
+
+    def test_model_has_extraction_status_column(self):
+        from app.domain.models.course_resource import CourseResource
+
+        columns = {c.name for c in CourseResource.__table__.columns}
+        assert "extraction_status" in columns

--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -721,6 +721,12 @@ export function AICourseWizard({
   }, [courseId, isIndexing, taskId, t, queryClient]);
 
   // ── Extraction polling (background PDF extraction) ─────────────────
+  // Depend on a stable key derived from file statuses, not the full files
+  // array — otherwise every setFiles call would re-run this effect and
+  // constantly tear down + restart the timeout.
+  const extractionKey = files
+    .map((f) => `${f.name}:${f.status}:${f.extraction_status ?? ""}`)
+    .join("|");
 
   useEffect(() => {
     const hasExtracting = files.some(
@@ -775,7 +781,10 @@ export function AICourseWizard({
     return () => {
       if (extractionPollRef.current) clearTimeout(extractionPollRef.current);
     };
-  }, [courseId, files, isIndexing]);
+    // extractionKey captures the meaningful shape of files for this effect;
+    // files is intentionally referenced inside but not a dep to avoid churn.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [courseId, extractionKey, isIndexing]);
 
   const cancelIndexation = useCallback(async () => {
     if (!courseId) return;

--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -62,6 +62,8 @@ import { getCourseTaxonomy, type TaxonomyItem } from "@/lib/api";
 import { SyllabusVisualEditor } from "@/components/admin/syllabus-visual-editor";
 import { LessonPreviewStep } from "@/components/admin/lesson-preview-step";
 
+const EXTRACTING_STATUSES = new Set(["pending", "extracting"]);
+
 // ── Step types ────────────────────────────────────────────────────────
 
 type AIWizardStep =
@@ -217,6 +219,9 @@ export function AICourseWizard({
   const [regenerateError, setRegenerateError] = useState<string | null>(null);
   const [showFreshConfirm, setShowFreshConfirm] = useState(false);
 
+  // Extraction polling state (tracks background PDF extraction)
+  const extractionPollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   // Indexation state
   const [taskId, setTaskId] = useState<string | null>(null);
   const [indexStatus, setIndexStatus] = useState<IndexStatus | null>(null);
@@ -324,6 +329,7 @@ export function AICourseWizard({
           name: f.name,
           size_bytes: f.size_bytes,
           status: "uploaded" as const,
+          extraction_status: f.extraction_status,
         }));
         setFiles((prev) => {
           const localNames = new Set(prev.map((f) => f.name));
@@ -353,24 +359,14 @@ export function AICourseWizard({
         return;
       }
       setFiles((prev) =>
-        prev.map((f) => (f.name === file.name ? { ...f, status: "uploaded" as const } : f))
+        prev.map((f) =>
+          f.name === file.name
+            ? { ...f, status: "uploaded" as const, extraction_status: "pending" as const }
+            : f
+        )
       );
-
-      // Check if backend auto-triggered indexation (AI-assisted mode)
-      if (!isIndexing) {
-        try {
-          const status = await getIndexStatusApi(courseId);
-          if (status.task && ["PENDING", "STARTED", "RETRY"].includes(status.task.state)) {
-            setTaskId(status.task.id ?? null);
-            setIsIndexing(true);
-            lastIndexProgressTimeRef.current = Date.now();
-          }
-        } catch {
-          // ignore — indexation check is best-effort
-        }
-      }
     },
-    [courseId, isIndexing]
+    [courseId]
   );
 
   const handleFiles = useCallback(
@@ -724,6 +720,63 @@ export function AICourseWizard({
     };
   }, [courseId, isIndexing, taskId, t, queryClient]);
 
+  // ── Extraction polling (background PDF extraction) ─────────────────
+
+  useEffect(() => {
+    const hasExtracting = files.some(
+      (f) => f.status === "uploaded" && f.extraction_status && EXTRACTING_STATUSES.has(f.extraction_status)
+    );
+    if (!courseId || !hasExtracting) {
+      if (extractionPollRef.current) clearTimeout(extractionPollRef.current);
+      return;
+    }
+
+    const poll = async () => {
+      try {
+        const data = await getCourseResources(courseId);
+        const byName: Record<string, string> = {};
+        for (const f of data.files ?? []) {
+          byName[f.name] = f.extraction_status ?? "done";
+        }
+        setFiles((prev) =>
+          prev.map((f) => {
+            const serverStatus = byName[f.name];
+            if (serverStatus !== undefined && serverStatus !== f.extraction_status) {
+              return { ...f, extraction_status: serverStatus as UploadedFile["extraction_status"] };
+            }
+            return f;
+          })
+        );
+        const stillExtracting = (data.files ?? []).some((f) =>
+          EXTRACTING_STATUSES.has(f.extraction_status ?? "done")
+        );
+        if (stillExtracting) {
+          extractionPollRef.current = setTimeout(poll, 3000);
+        } else {
+          if (!isIndexing) {
+            try {
+              const status = await getIndexStatusApi(courseId);
+              if (status.task && ["PENDING", "STARTED", "RETRY"].includes(status.task.state)) {
+                setTaskId(status.task.id ?? null);
+                setIsIndexing(true);
+                lastIndexProgressTimeRef.current = Date.now();
+              }
+            } catch {
+              // ignore
+            }
+          }
+        }
+      } catch {
+        extractionPollRef.current = setTimeout(poll, 5000);
+      }
+    };
+
+    extractionPollRef.current = setTimeout(poll, 2000);
+    return () => {
+      if (extractionPollRef.current) clearTimeout(extractionPollRef.current);
+    };
+  }, [courseId, files, isIndexing]);
+
   const cancelIndexation = useCallback(async () => {
     if (!courseId) return;
     if (pollRef.current) clearTimeout(pollRef.current);
@@ -986,7 +1039,18 @@ export function AICourseWizard({
                         {f.status === "uploading" && (
                           <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
                         )}
-                        {f.status === "uploaded" && <CheckCircle2 className="h-4 w-4 text-green-600" />}
+                        {f.status === "uploaded" && f.extraction_status && EXTRACTING_STATUSES.has(f.extraction_status) && (
+                          <span title={t("upload.extracting")} className="flex items-center gap-1 text-xs text-muted-foreground">
+                            <div className="h-3 w-3 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
+                            {t("upload.extracting")}
+                          </span>
+                        )}
+                        {f.status === "uploaded" && (!f.extraction_status || f.extraction_status === "done") && (
+                          <CheckCircle2 className="h-4 w-4 text-green-600" />
+                        )}
+                        {f.status === "uploaded" && f.extraction_status === "failed" && (
+                          <span title={t("upload.extractionFailed")}><AlertCircle className="h-4 w-4 text-destructive" /></span>
+                        )}
                         {f.status === "error" && (
                           <span title={f.error}><AlertCircle className="h-4 w-4 text-destructive" /></span>
                         )}

--- a/frontend/lib/api-course-admin.ts
+++ b/frontend/lib/api-course-admin.ts
@@ -7,11 +7,14 @@ import { authClient } from "@/lib/auth";
 
 // ── Shared types ──────────────────────────────────────────────────────
 
+export type ExtractionStatus = "pending" | "extracting" | "done" | "failed";
+
 export interface UploadedFile {
   name: string;
   size_bytes: number;
   status: "uploading" | "uploaded" | "error";
   error?: string;
+  extraction_status?: ExtractionStatus;
 }
 
 export interface CourseInfo {
@@ -137,7 +140,7 @@ export async function deleteCourseResource(
 
 export async function getCourseResources(
   courseId: string
-): Promise<{ files: Array<{ name: string; size_bytes: number }> }> {
+): Promise<{ files: Array<{ name: string; size_bytes: number; extraction_status?: ExtractionStatus }> }> {
   return apiFetch(`/api/v1/admin/courses/${courseId}/resources`);
 }
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1372,7 +1372,9 @@
         "uploadError": "Upload error",
         "remove": "Remove",
         "noFiles": "No resources uploaded",
-        "atLeastOne": "Upload at least one PDF before continuing."
+        "atLeastOne": "Upload at least one PDF before continuing.",
+        "extracting": "Extracting…",
+        "extractionFailed": "Extraction failed"
       },
       "info": {
         "title": "Course information",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1372,7 +1372,9 @@
         "uploadError": "Erreur lors du téléversement",
         "remove": "Supprimer",
         "noFiles": "Aucune ressource téléversée",
-        "atLeastOne": "Téléversez au moins un PDF avant de continuer."
+        "atLeastOne": "Téléversez au moins un PDF avant de continuer.",
+        "extracting": "Extraction en cours…",
+        "extractionFailed": "Échec de l'extraction"
       },
       "info": {
         "title": "Informations du cours",


### PR DESCRIPTION
## Summary

Merges dev into main to ship the async PDF extraction fix for issue #1570 (see #1573 for details):

- Upload endpoint returns 201 in <2 s and no longer blocks the asyncio event loop.
- PyMuPDF extraction + RAG indexation dispatch moved into a new Celery task `extract_course_resource`.
- Alembic migration 069 adds `extraction_status` column to `course_resources`.
- Frontend AI wizard polls extraction status and shows an "Extraction en cours…" indicator.
- Review-fix commit: module-level SQLAlchemy engine, narrow `autoretry_for=(OSError,)`, drop fragile integration test.

## Test plan

- [x] Backend CI green
- [x] Frontend CI green
- [ ] Deploy to production tenants after merge (manual until #1571 lands)

Closes #1570