### PR TITLE
feat(qbank): penalize Tier 1 confidence on partial multi-question parses (#1580)

### DIFF
--- a/backend/app/ai/qbank_slide_extractor.py
+++ b/backend/app/ai/qbank_slide_extractor.py
@@ -267,8 +267,20 @@ def _parse_question_cluster(cluster: list[dict]) -> tuple[str, list[str], list[i
     return question_text, options, correct_indices
 
 
-def _tier1_confidence(questions: list[tuple[str, list[str], list[int]]], has_image: bool) -> float:
-    """Score how confident we are in the Tier 1 extraction (0.0 - 1.0)."""
+def _tier1_confidence(
+    questions: list[tuple[str, list[str], list[int]]],
+    has_image: bool,
+    cluster_count: int | None = None,
+) -> float:
+    """Score how confident we are in the Tier 1 extraction (0.0 - 1.0).
+
+    If cluster_count is provided and exceeds the number of successfully parsed
+    questions, the score is halved — this guards against the case where the
+    slide has 2 question clusters but only 1 parses cleanly (irregular second
+    question). Without the penalty, the "looks perfect" score from the single
+    surviving question could keep Tier 1 above the threshold and silently drop
+    the second question.
+    """
     if not questions:
         return 0.0
 
@@ -288,6 +300,12 @@ def _tier1_confidence(questions: list[tuple[str, list[str], list[int]]], has_ima
     # Options within a question have consistent length (not single-char OCR junk)
     if all(all(len(o) >= 2 for o in opts) for _, opts, _ in questions):
         score += 0.1
+
+    # Penalty: if the cluster scanner found more question-shaped blocks than we
+    # successfully parsed, halve the score to force a Vision escalation.
+    if cluster_count is not None and cluster_count > len(questions):
+        score *= 0.5
+
     return min(score, 1.0)
 
 
@@ -352,7 +370,7 @@ def _extract_tier1(
         webp_bytes, width, height = _convert_to_webp(png_bytes)
         has_image = False
 
-    confidence = _tier1_confidence(parsed, has_image)
+    confidence = _tier1_confidence(parsed, has_image, cluster_count=len(clusters))
 
     questions = [
         ExtractedSlideQuestion(

--- a/backend/tests/test_qbank_slide_extractor.py
+++ b/backend/tests/test_qbank_slide_extractor.py
@@ -215,6 +215,21 @@ class TestTier1Confidence:
         # Missing the "exactly one correct answer" +0.3 bonus
         assert score < CONFIDENCE_THRESHOLD + 0.2
 
+    def test_partial_parse_is_penalized(self):
+        """Cluster scanner saw 2 blocks but only 1 parsed → halve the score."""
+        questions = [("What should you do?", ["Option A long", "Option B long"], [1])]
+        full = _tier1_confidence(questions, has_image=True)
+        partial = _tier1_confidence(questions, has_image=True, cluster_count=2)
+        assert partial == pytest.approx(full * 0.5)
+        # The halving must drop a "perfect" slide below the escalation threshold
+        assert partial < CONFIDENCE_THRESHOLD
+
+    def test_matching_cluster_count_is_not_penalized(self):
+        questions = [("What should you do?", ["Option A long", "Option B long"], [1])]
+        baseline = _tier1_confidence(questions, has_image=True)
+        same = _tier1_confidence(questions, has_image=True, cluster_count=1)
+        assert baseline == pytest.approx(same)
+
 
 class TestExtractTier1EndToEnd:
     """Drive the whole Tier 1 path with a real synthetic PDF."""


### PR DESCRIPTION
## Summary

- \`_tier1_confidence\` now accepts an optional \`cluster_count\`. When the cluster scanner saw more question-shaped blocks than we successfully parsed, the score is **halved** — forcing a Vision escalation.
- \`_extract_tier1\` passes \`len(clusters)\` so the penalty fires automatically in real runs.
- Prevents silent data loss: a 2-question slide where only one question parses cleanly (irregular formatting on the other) no longer passes Tier 1 with a misleadingly-high score from the single survivor.

## Test plan

- [x] 2 new unit tests:
  - \`test_partial_parse_is_penalized\` — cluster_count=2 + 1 parsed question → score halved, drops below threshold
  - \`test_matching_cluster_count_is_not_penalized\` — cluster_count=1 + 1 parsed question → no penalty
- [x] 25/25 qbank tests pass (23 original + 2 new)
- [x] Ruff clean

Fixes #1580

🤖 Generated with [Claude Code](https://claude.com/claude-code)