### PR TITLE
release: qbank Tier 1 category inference + partial-parse confidence penalty

### DIFF
--- a/backend/app/ai/qbank_slide_extractor.py
+++ b/backend/app/ai/qbank_slide_extractor.py
@@ -357,8 +357,20 @@ def _parse_question_cluster(cluster: list[dict]) -> tuple[str, list[str], list[i
     return question_text, options, correct_indices
 
 
-def _tier1_confidence(questions: list[tuple[str, list[str], list[int]]], has_image: bool) -> float:
-    """Score how confident we are in the Tier 1 extraction (0.0 - 1.0)."""
+def _tier1_confidence(
+    questions: list[tuple[str, list[str], list[int]]],
+    has_image: bool,
+    cluster_count: int | None = None,
+) -> float:
+    """Score how confident we are in the Tier 1 extraction (0.0 - 1.0).
+
+    If cluster_count is provided and exceeds the number of successfully parsed
+    questions, the score is halved — this guards against the case where the
+    slide has 2 question clusters but only 1 parses cleanly (irregular second
+    question). Without the penalty, the "looks perfect" score from the single
+    surviving question could keep Tier 1 above the threshold and silently drop
+    the second question.
+    """
     if not questions:
         return 0.0
 
@@ -378,6 +390,12 @@ def _tier1_confidence(questions: list[tuple[str, list[str], list[int]]], has_ima
     # Options within a question have consistent length (not single-char OCR junk)
     if all(all(len(o) >= 2 for o in opts) for _, opts, _ in questions):
         score += 0.1
+
+    # Penalty: if the cluster scanner found more question-shaped blocks than we
+    # successfully parsed, halve the score to force a Vision escalation.
+    if cluster_count is not None and cluster_count > len(questions):
+        score *= 0.5
+
     return min(score, 1.0)
 
 
@@ -442,7 +460,7 @@ def _extract_tier1(
         webp_bytes, width, height = _convert_to_webp(png_bytes)
         has_image = False
 
-    confidence = _tier1_confidence(parsed, has_image)
+    confidence = _tier1_confidence(parsed, has_image, cluster_count=len(clusters))
 
     questions = [
         ExtractedSlideQuestion(

--- a/backend/app/ai/qbank_slide_extractor.py
+++ b/backend/app/ai/qbank_slide_extractor.py
@@ -23,6 +23,7 @@ import base64
 import io
 import json
 import re
+import unicodedata
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -49,6 +50,95 @@ QUESTION_CLUSTER_GAP_PT = 40.0
 
 # Regex for option labels: "A.", "A)", "a.", "1.", "1)"
 OPTION_LABEL_RE = re.compile(r"^\s*([A-Da-d]|[1-4])[\.\)]\s+")
+
+# FR keyword hints per category. Matched case- and diacritic-insensitively so
+# "priorité" and "priorite" both match the "priorite" key. Used by Tier 1 to
+# set a best-guess category without an AI call. Tier 3 (Vision) still classifies
+# via the model prompt.
+CATEGORY_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "signalisation": (
+        "panneau",
+        "signal",
+        "feu",
+        "feux",
+        "stop",
+        "ceder",
+        "marquage",
+        "ligne continue",
+        "ligne discontinue",
+    ),
+    "priorite": (
+        "priorite",
+        "ceder le passage",
+        "intersection",
+        "carrefour",
+        "rond-point",
+        "rond point",
+        "giratoire",
+    ),
+    "securite": (
+        "ceinture",
+        "casque",
+        "airbag",
+        "securite",
+        "distance de securite",
+        "alcool",
+        "telephone",
+        "fatigue",
+    ),
+    "stationnement": (
+        "stationner",
+        "stationnement",
+        "garer",
+        "parking",
+        "arret",
+    ),
+    "vitesse": (
+        "vitesse",
+        "km/h",
+        "kilometres",
+        "ralentir",
+        "acceler",
+        "freinage",
+    ),
+    "pieton": (
+        "pieton",
+        "passage pieton",
+        "trottoir",
+    ),
+    "cycliste": (
+        "cycliste",
+        "velo",
+        "piste cyclable",
+        "bicyclette",
+    ),
+}
+
+
+def _normalize_for_match(text: str) -> str:
+    """Lowercase + strip diacritics for substring matching."""
+    nfkd = unicodedata.normalize("NFKD", text.lower())
+    return "".join(ch for ch in nfkd if not unicodedata.combining(ch))
+
+
+def _infer_category(question_text: str, options: list[str]) -> str:
+    """Heuristic category classifier for Tier 1.
+
+    Scans the question text and option texts for keyword hits from
+    CATEGORY_KEYWORDS. Returns the category with the most hits, or "general" if
+    no keywords match. Matching is case- and diacritic-insensitive.
+    """
+    haystack = _normalize_for_match(" ".join([question_text, *options]))
+
+    best_category = "general"
+    best_hits = 0
+    for category, keywords in CATEGORY_KEYWORDS.items():
+        hits = sum(1 for kw in keywords if kw in haystack)
+        if hits > best_hits:
+            best_hits = hits
+            best_category = category
+    return best_category
+
 
 EXTRACTION_SYSTEM_PROMPT = """You are analyzing a driving school exam or test preparation slide.
 Extract ALL questions from this slide image. Each slide may contain 1 or 2 questions.
@@ -360,7 +450,7 @@ def _extract_tier1(
             options=opts,
             correct_indices=ci,
             explanation=None,  # Tier 1 does not generate explanations
-            category=None,  # Tier 1 does not classify categories
+            category=_infer_category(qt, opts),
             page_number=page_number,
             image_bytes=webp_bytes,
             image_width=width,

--- a/backend/tests/test_qbank_slide_extractor.py
+++ b/backend/tests/test_qbank_slide_extractor.py
@@ -19,6 +19,7 @@ from app.ai.qbank_slide_extractor import (
     _cluster_into_questions,
     _extract_tier1,
     _flatten_spans,
+    _infer_category,
     _is_green,
     _parse_question_cluster,
     _tier1_confidence,
@@ -200,6 +201,80 @@ class TestParseQuestionCluster:
         assert correct == [1]
 
 
+class TestInferCategory:
+    """Keyword-based category classification used by Tier 1."""
+
+    def test_signalisation_panneau_stop(self):
+        assert (
+            _infer_category("Que signifie ce panneau STOP ?", ["Je passe", "Je m'arrête"])
+            == "signalisation"
+        )
+
+    def test_priorite_carrefour(self):
+        assert (
+            _infer_category(
+                "Au carrefour, qui a la priorité ?",
+                ["Le véhicule de droite", "Moi"],
+            )
+            == "priorite"
+        )
+
+    def test_securite_ceinture(self):
+        assert (
+            _infer_category(
+                "La ceinture de sécurité est-elle obligatoire ?",
+                ["Oui", "Non"],
+            )
+            == "securite"
+        )
+
+    def test_stationnement_parking(self):
+        assert (
+            _infer_category(
+                "Où puis-je stationner ?",
+                ["Sur le trottoir", "Dans un parking"],
+            )
+            == "stationnement"
+        )
+
+    def test_vitesse_km_h(self):
+        assert (
+            _infer_category(
+                "Quelle est la vitesse maximale en ville ?",
+                ["30 km/h", "50 km/h"],
+            )
+            == "vitesse"
+        )
+
+    def test_pieton_passage(self):
+        assert (
+            _infer_category(
+                "Un piéton s'engage sur le passage, que faites-vous ?",
+                ["Je le laisse passer", "Je klaxonne"],
+            )
+            == "pieton"
+        )
+
+    def test_cycliste_velo(self):
+        assert (
+            _infer_category(
+                "Vous doublez un cycliste, quelle distance latérale ?",
+                ["1 mètre", "50 cm"],
+            )
+            == "cycliste"
+        )
+
+    def test_unknown_falls_back_to_general(self):
+        assert _infer_category("Quelle est la capitale ?", ["Paris", "Lyon"]) == "general"
+
+    def test_diacritic_insensitive(self):
+        # No diacritics on "priorite" → still matches "priorité" in input
+        assert _infer_category("Priorité à droite", ["Oui", "Non"]) == "priorite"
+
+    def test_uppercase_insensitive(self):
+        assert _infer_category("PANNEAU STOP", ["A", "B"]) == "signalisation"
+
+
 class TestTier1Confidence:
     def test_no_questions_is_zero(self):
         assert _tier1_confidence([], has_image=True) == 0.0
@@ -243,6 +318,8 @@ class TestExtractTier1EndToEnd:
         assert "stop sign" in q.question_text.lower()
         assert len(q.options) == 2
         assert q.correct_indices == [1]
+        # "stop" is a signalisation keyword → category should be set, not None
+        assert q.category == "signalisation"
         assert confidence >= CONFIDENCE_THRESHOLD
 
     def test_blank_page_has_zero_confidence(self, tmp_path: Path):

--- a/backend/tests/test_qbank_slide_extractor.py
+++ b/backend/tests/test_qbank_slide_extractor.py
@@ -290,6 +290,21 @@ class TestTier1Confidence:
         # Missing the "exactly one correct answer" +0.3 bonus
         assert score < CONFIDENCE_THRESHOLD + 0.2
 
+    def test_partial_parse_is_penalized(self):
+        """Cluster scanner saw 2 blocks but only 1 parsed → halve the score."""
+        questions = [("What should you do?", ["Option A long", "Option B long"], [1])]
+        full = _tier1_confidence(questions, has_image=True)
+        partial = _tier1_confidence(questions, has_image=True, cluster_count=2)
+        assert partial == pytest.approx(full * 0.5)
+        # The halving must drop a "perfect" slide below the escalation threshold
+        assert partial < CONFIDENCE_THRESHOLD
+
+    def test_matching_cluster_count_is_not_penalized(self):
+        questions = [("What should you do?", ["Option A long", "Option B long"], [1])]
+        baseline = _tier1_confidence(questions, has_image=True)
+        same = _tier1_confidence(questions, has_image=True, cluster_count=1)
+        assert baseline == pytest.approx(same)
+
 
 class TestExtractTier1EndToEnd:
     """Drive the whole Tier 1 path with a real synthetic PDF."""


### PR DESCRIPTION
## Summary
Release of follow-ups to #1501.

## Included
- #1581 — feat(qbank): keyword-based category inference for Tier 1 (Fixes #1579)
- #1584 — feat(qbank): penalize Tier 1 confidence when clusters outnumber parsed questions (Fixes #1580)

## Test plan
- [x] CI green on both source PRs
- [x] qbank tests pass end-to-end after both merges on dev
- [ ] Deploy completes, `/health` green on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)