### PR TITLE
feat(qbank): Meta MMS TTS Docker sidecar for Moore/Dioula/Bambara (#1503)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,10 @@ NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
 MINIO_ACCESS_KEY=minioadmin
 MINIO_SECRET_KEY=minioadmin123
 
+# Meta MMS TTS sidecar (Moore / Dioula / Bambara)
+# Local dev: docker compose brings this up automatically on port 5050.
+MMS_TTS_URL=http://mms-tts:5050
+
 # Rate Limiting & Security
 RATE_LIMIT_REQUESTS_PER_MINUTE=100
 RATE_LIMIT_TUTOR_MESSAGES_PER_DAY=50

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,6 +80,9 @@ jobs:
           - service: frontend
             context: ./frontend
             image: ghcr.io/benidrissa/etutor-digital-ph/frontend
+          - service: mms-tts
+            context: ./infrastructure/mms-tts
+            image: ghcr.io/benidrissa/etutor-digital-ph/mms-tts
     steps:
       - uses: actions/checkout@v6
 
@@ -104,6 +107,17 @@ jobs:
 
       - name: Build and push backend
         if: matrix.service == 'backend'
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ matrix.image }}:buildcache
+          cache-to: type=registry,ref=${{ matrix.image }}:buildcache,mode=max
+
+      - name: Build and push mms-tts sidecar
+        if: matrix.service == 'mms-tts'
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.context }}
@@ -212,7 +226,7 @@ jobs:
             EOF
 
             # Pull new images (only changed layers transferred)
-            docker compose pull backend frontend
+            docker compose pull backend frontend mms-tts
 
             # Restart services
             docker compose up -d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,21 @@ env:
   FRONTEND_IMAGE: ghcr.io/benidrissa/etutor-digital-ph/frontend
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      mms_tts: ${{ steps.filter.outputs.mms_tts }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            mms_tts:
+              - 'infrastructure/mms-tts/**'
+              - '.github/workflows/deploy.yml'
+
   test:
     name: Lint & Test
     runs-on: ubuntu-latest
@@ -64,6 +79,42 @@ jobs:
           npm run lint
           npm run build
 
+  build-mms-tts:
+    name: Build & Push mms-tts
+    needs: [test, changes]
+    if: needs.changes.outputs.mms_tts == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/benidrissa/etutor-digital-ph/mms-tts
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest
+      - name: Build and push mms-tts sidecar
+        uses: docker/build-push-action@v6
+        with:
+          context: ./infrastructure/mms-tts
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=ghcr.io/benidrissa/etutor-digital-ph/mms-tts:buildcache
+          cache-to: type=registry,ref=ghcr.io/benidrissa/etutor-digital-ph/mms-tts:buildcache,mode=max
+
   build-and-push:
     name: Build & Push (${{ matrix.service }})
     needs: test
@@ -80,9 +131,6 @@ jobs:
           - service: frontend
             context: ./frontend
             image: ghcr.io/benidrissa/etutor-digital-ph/frontend
-          - service: mms-tts
-            context: ./infrastructure/mms-tts
-            image: ghcr.io/benidrissa/etutor-digital-ph/mms-tts
     steps:
       - uses: actions/checkout@v6
 
@@ -107,17 +155,6 @@ jobs:
 
       - name: Build and push backend
         if: matrix.service == 'backend'
-        uses: docker/build-push-action@v6
-        with:
-          context: ${{ matrix.context }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ matrix.image }}:buildcache
-          cache-to: type=registry,ref=${{ matrix.image }}:buildcache,mode=max
-
-      - name: Build and push mms-tts sidecar
-        if: matrix.service == 'mms-tts'
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.context }}
@@ -156,7 +193,11 @@ jobs:
 
   deploy:
     name: Deploy to Server
-    needs: build-and-push
+    needs: [build-and-push, build-mms-tts]
+    if: |
+      always()
+      && needs.build-and-push.result == 'success'
+      && (needs.build-mms-tts.result == 'success' || needs.build-mms-tts.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -77,6 +77,10 @@ class Settings(BaseSettings):
     upload_max_pdf_tokens: int = 5000
     upload_max_csv_rows: int = 20
 
+    # Meta MMS TTS sidecar (Moore / Dioula / Bambara)
+    mms_tts_url: str = "http://mms-tts:5050"
+    mms_tts_timeout_seconds: float = 60.0
+
     # MinIO / S3-compatible object storage
     minio_endpoint: str = "http://localhost:9000"
     minio_access_key: str = ""

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,6 +29,25 @@ services:
       timeout: 5s
       retries: 5
 
+  mms-tts:
+    image: ghcr.io/benidrissa/etutor-digital-ph/mms-tts:latest
+    container_name: etutor-mms-tts
+    volumes:
+      - mms_models:/models
+    networks:
+      - etutor-data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:5050/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 180s
+      retries: 3
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+
   backend:
     image: ghcr.io/benidrissa/etutor-digital-ph/backend:latest
     container_name: etutor-backend
@@ -48,6 +67,7 @@ services:
       MINIO_BUCKET_MEDIA: ${MINIO_BUCKET_MEDIA:-santepublique-media}
       SMS_RELAY_API_KEY: ${SMS_RELAY_API_KEY}
       SMS_RELAY_TRUSTED_SENDERS: ${SMS_RELAY_TRUSTED_SENDERS}
+      MMS_TTS_URL: ${MMS_TTS_URL:-http://mms-tts:5050}
     volumes:
       - ./config:/app/config
       - ./resources:/app/resources
@@ -126,6 +146,7 @@ services:
       MINIO_BUCKET_MEDIA: ${MINIO_BUCKET_MEDIA:-santepublique-media}
       SMS_RELAY_API_KEY: ${SMS_RELAY_API_KEY}
       SMS_RELAY_TRUSTED_SENDERS: ${SMS_RELAY_TRUSTED_SENDERS}
+      MMS_TTS_URL: ${MMS_TTS_URL:-http://mms-tts:5050}
     volumes:
       - ./config:/app/config
       - ./resources:/app/resources
@@ -161,6 +182,7 @@ volumes:
   redisdata:
   uploads:
   minio_data:
+  mms_models:
 
 networks:
   etutor-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,26 @@ services:
       timeout: 5s
       retries: 5
 
+  mms-tts:
+    build:
+      context: ./infrastructure/mms-tts
+      dockerfile: Dockerfile
+    container_name: santepublique-mms-tts
+    ports:
+      - "5050:5050"
+    volumes:
+      - mms_models:/models
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:5050/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 180s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+
   backend:
     build:
       context: ./backend
@@ -40,6 +60,7 @@ services:
       REDIS_URL: redis://redis:6379/0
       APP_ENV: development
       CORS_ORIGINS: http://localhost:3000
+      MMS_TTS_URL: http://mms-tts:5050
     ports:
       - "8000:8000"
     volumes:
@@ -61,3 +82,4 @@ volumes:
   pgdata:
   redisdata:
   uploads_data:
+  mms_models:

--- a/infrastructure/mms-tts/Dockerfile
+++ b/infrastructure/mms-tts/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    HF_HOME=/models \
+    TRANSFORMERS_CACHE=/models
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY server.py .
+
+EXPOSE 5050
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=3 \
+    CMD curl -fsS http://localhost:5050/health || exit 1
+
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "5050", "--workers", "1"]

--- a/infrastructure/mms-tts/requirements.txt
+++ b/infrastructure/mms-tts/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.115.6
+uvicorn[standard]==0.32.1
+transformers==4.47.1
+torch==2.5.1
+scipy==1.14.1
+numpy==1.26.4
+pydub==0.25.1

--- a/infrastructure/mms-tts/server.py
+++ b/infrastructure/mms-tts/server.py
@@ -1,0 +1,139 @@
+"""Meta MMS TTS HTTP server for Moore, Dioula, and Bambara.
+
+Preloads Hugging Face `facebook/mms-tts-{mos,dyu,bam}` VITS models on startup and
+serves synthesized speech as OGG/Opus over HTTP. Opus at ~24 kbps keeps a
+30-second clip under ~100 KB, which matters for 2G/3G West African networks.
+"""
+from __future__ import annotations
+
+import io
+import logging
+import os
+import time
+from contextlib import asynccontextmanager
+from typing import Literal
+
+import numpy as np
+import torch
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel, Field
+from pydub import AudioSegment
+from scipy.io import wavfile
+from transformers import AutoTokenizer, VitsModel
+
+SUPPORTED_LANGUAGES = ("mos", "dyu", "bam")
+Language = Literal["mos", "dyu", "bam"]
+
+MAX_TEXT_CHARS = 2000
+OPUS_BITRATE = "24k"
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("mms-tts")
+
+
+class _ModelBundle:
+    __slots__ = ("model", "tokenizer", "sample_rate")
+
+    def __init__(self, model: VitsModel, tokenizer: AutoTokenizer, sample_rate: int):
+        self.model = model
+        self.tokenizer = tokenizer
+        self.sample_rate = sample_rate
+
+
+_MODELS: dict[str, _ModelBundle] = {}
+
+
+def _load_model(lang: str) -> _ModelBundle:
+    model_id = f"facebook/mms-tts-{lang}"
+    logger.info("loading %s", model_id)
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
+    model = VitsModel.from_pretrained(model_id)
+    model.eval()
+    return _ModelBundle(model=model, tokenizer=tokenizer, sample_rate=model.config.sampling_rate)
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    langs = [l for l in os.getenv("MMS_LANGUAGES", ",".join(SUPPORTED_LANGUAGES)).split(",") if l]
+    for lang in langs:
+        if lang not in SUPPORTED_LANGUAGES:
+            logger.warning("skipping unsupported language: %s", lang)
+            continue
+        _MODELS[lang] = _load_model(lang)
+    logger.info("loaded models: %s", list(_MODELS.keys()))
+    yield
+    _MODELS.clear()
+
+
+app = FastAPI(title="MMS TTS Sidecar", version="1.0.0", lifespan=lifespan)
+
+
+class SynthesizeRequest(BaseModel):
+    text: str = Field(..., min_length=1, max_length=MAX_TEXT_CHARS)
+    language: Language
+
+
+def _synthesize_wav(text: str, bundle: _ModelBundle) -> tuple[int, np.ndarray]:
+    inputs = bundle.tokenizer(text, return_tensors="pt")
+    with torch.no_grad():
+        output = bundle.model(**inputs).waveform
+    waveform = output.squeeze().cpu().numpy()
+    waveform = np.clip(waveform, -1.0, 1.0)
+    pcm16 = (waveform * 32767).astype(np.int16)
+    return bundle.sample_rate, pcm16
+
+
+def _wav_to_opus(sample_rate: int, pcm16: np.ndarray) -> bytes:
+    wav_buf = io.BytesIO()
+    wavfile.write(wav_buf, sample_rate, pcm16)
+    wav_buf.seek(0)
+
+    audio = AudioSegment.from_file(wav_buf, format="wav")
+    opus_buf = io.BytesIO()
+    audio.export(
+        opus_buf,
+        format="ogg",
+        codec="libopus",
+        bitrate=OPUS_BITRATE,
+        parameters=["-application", "voip"],
+    )
+    return opus_buf.getvalue()
+
+
+@app.get("/health")
+async def health() -> JSONResponse:
+    return JSONResponse({"status": "ok", "languages": list(_MODELS.keys())})
+
+
+@app.post("/synthesize")
+async def synthesize(req: SynthesizeRequest) -> Response:
+    bundle = _MODELS.get(req.language)
+    if bundle is None:
+        raise HTTPException(status_code=400, detail=f"language not loaded: {req.language}")
+
+    started = time.monotonic()
+    try:
+        sample_rate, pcm16 = _synthesize_wav(req.text, bundle)
+        opus_bytes = _wav_to_opus(sample_rate, pcm16)
+    except Exception as exc:
+        logger.exception("synthesis failed for %s: %s", req.language, exc)
+        raise HTTPException(status_code=500, detail="synthesis failed") from exc
+
+    elapsed_ms = int((time.monotonic() - started) * 1000)
+    logger.info(
+        "synth lang=%s chars=%d bytes=%d elapsed_ms=%d",
+        req.language,
+        len(req.text),
+        len(opus_bytes),
+        elapsed_ms,
+    )
+    return Response(
+        content=opus_bytes,
+        media_type="audio/ogg",
+        headers={
+            "X-Audio-Codec": "opus",
+            "X-Audio-Sample-Rate": str(sample_rate),
+            "X-Synth-Elapsed-Ms": str(elapsed_ms),
+        },
+    )


### PR DESCRIPTION
## Summary
- New `infrastructure/mms-tts/` service: a small FastAPI app that wraps Hugging Face `facebook/mms-tts-{mos,dyu,bam}` VITS models and returns audio over HTTP.
- Audio is returned as **OGG/Opus @ 24 kbps** (Content-Type: `audio/ogg`) — a 30s clip stays under ~100 KB, which is essential on 2G/3G West African networks (compare WAV: ~5 MB, MP3: ~250 KB).
- Models are not baked into the image; they're cached in a `mms_models` volume so the image stays small and the server boots fast after the first run.

## Changes
- `infrastructure/mms-tts/{Dockerfile,requirements.txt,server.py}` — sidecar service
- `docker-compose.yml` — local `mms-tts` service on port 5050, shared `mms_models` volume, exposes `MMS_TTS_URL` to the backend
- `docker-compose.prod.yml` — prod service pulling from ghcr.io with the same healthcheck + resource limit
- `backend/app/infrastructure/config/settings.py` — `mms_tts_url`, `mms_tts_timeout_seconds`
- `.env.example` — document `MMS_TTS_URL`
- `.github/workflows/deploy.yml` — add `mms-tts` to the build-and-push matrix and to `docker compose pull` on deploy

## Test plan
- [ ] `docker compose build mms-tts` succeeds locally
- [ ] `docker compose up mms-tts` reaches healthy state (models take ~60–120s to download on first boot, then cached)
- [ ] `curl -X POST http://localhost:5050/synthesize -H "Content-Type: application/json" -d '{"text":"I ni ce","language":"dyu"}' -o test.ogg` returns a file < 100 KB
- [ ] `ffprobe test.ogg` reports `opus` codec and `audio/ogg` container
- [ ] `/health` returns `{"status":"ok","languages":["mos","dyu","bam"]}`
- [ ] `curl` with unsupported language returns 400
- [ ] Once merged, CI produces `ghcr.io/benidrissa/etutor-digital-ph/mms-tts:latest`

Fixes #1503

🤖 Generated with [Claude Code](https://claude.com/claude-code)