### PR TITLE
feat(qbank): per-question TTS audio in FR / Moore / Dioula / Bambara (#1502)

### DIFF
--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -11,6 +11,8 @@ from fastapi import APIRouter, Depends, File, Query, UploadFile, status
 from app.api.deps import get_db_session
 from app.api.deps_local_auth import AuthenticatedUser, get_current_user
 from app.api.v1.schemas.qbank import (
+    AudioGenerateResponse,
+    AudioStatusResponse,
     BankAnalyticsResponse,
     BankStudentsResponse,
     QuestionBankCreate,
@@ -31,12 +33,14 @@ from app.api.v1.schemas.qbank import (
     TestUpdate,
 )
 from app.domain.services.qbank_analytics_service import QBankAnalyticsService
+from app.domain.services.qbank_audio_service import QBankAudioService
 from app.domain.services.qbank_service import QBankService
 
 router = APIRouter(prefix="/qbank", tags=["Question Bank"])
 
 _svc = QBankService()
 _analytics = QBankAnalyticsService()
+_audio = QBankAudioService()
 
 
 # ---------------------------------------------------------------------------
@@ -509,3 +513,86 @@ async def get_student_progress(
 ):
     """Individual student progress. Students may only view their own record."""
     return await _analytics.get_student_progress(db, bank_id, user_id, uuid.UUID(current_user.id))
+
+
+# ---------------------------------------------------------------------------
+# Audio generation
+# ---------------------------------------------------------------------------
+
+
+def _audio_response(row, question_id: uuid.UUID, language: str) -> AudioStatusResponse:
+    if row is None:
+        return AudioStatusResponse(
+            question_id=str(question_id),
+            language=language,
+            status="pending",
+        )
+    return AudioStatusResponse(
+        question_id=str(question_id),
+        language=language,
+        status=row.status.value if hasattr(row.status, "value") else row.status,
+        storage_url=row.storage_url,
+        duration_seconds=row.duration_seconds,
+    )
+
+
+@router.post(
+    "/banks/{bank_id}/audio/generate",
+    response_model=AudioGenerateResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def generate_bank_audio(
+    bank_id: uuid.UUID,
+    language: str = Query(..., pattern=r"^(fr|mos|dyu|bam)$"),
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    """Kick off a batch audio-generation task for every question in a bank."""
+    from app.domain.services.organization_service import OrganizationService
+    from app.tasks.qbank_processing import generate_qbank_audio_task
+
+    bank = await _svc.get_bank(db, bank_id)
+    await OrganizationService().require_org_role(
+        db, bank.organization_id, uuid.UUID(current_user.id)
+    )
+    task = generate_qbank_audio_task.delay(str(bank_id), language)
+    return AudioGenerateResponse(task_id=task.id, bank_id=str(bank_id), language=language)
+
+
+@router.post(
+    "/questions/{question_id}/audio",
+    response_model=AudioStatusResponse,
+)
+async def upload_question_audio(
+    question_id: uuid.UUID,
+    language: str = Query(..., pattern=r"^(fr|mos|dyu|bam)$"),
+    file: UploadFile = File(...),
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    """Manual fallback: org admin uploads a pre-recorded audio file."""
+    from fastapi import HTTPException
+
+    if not file.content_type or not file.content_type.startswith("audio/"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Expected an audio file.",
+        )
+    data = await file.read()
+    row = await _audio.store_uploaded_audio(db, question_id, language, data, file.content_type)
+    return _audio_response(row, question_id, language)
+
+
+@router.get(
+    "/questions/{question_id}/audio",
+    response_model=AudioStatusResponse,
+)
+async def get_question_audio(
+    question_id: uuid.UUID,
+    lang: str = Query(..., pattern=r"^(fr|mos|dyu|bam)$"),
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    """Return the audio URL + status for one question/language."""
+    row = await _audio.get_audio_status(db, question_id, lang)
+    return _audio_response(row, question_id, lang)

--- a/backend/app/api/v1/schemas/qbank.py
+++ b/backend/app/api/v1/schemas/qbank.py
@@ -265,3 +265,23 @@ class StudentProgressResponse(BaseModel):
     latest_score: float
     trend: str
     weakest_categories: list[CategoryPassRate]
+
+
+# ---------------------------------------------------------------------------
+# Audio
+# ---------------------------------------------------------------------------
+
+
+class AudioStatusResponse(BaseModel):
+    question_id: str
+    language: str
+    status: str
+    storage_url: str | None = None
+    duration_seconds: int | None = None
+
+
+class AudioGenerateResponse(BaseModel):
+    task_id: str
+    bank_id: str
+    language: str
+    status: str = "processing"

--- a/backend/app/domain/services/qbank_audio_service.py
+++ b/backend/app/domain/services/qbank_audio_service.py
@@ -1,0 +1,254 @@
+"""Question audio generation — French (OpenAI TTS) + Moore/Dioula/Bambara (MMS).
+
+Each qbank question gets an OGG/Opus audio clip per language it supports.
+French uses the same OpenAI gpt-4o-mini-tts path as LessonAudioService so
+audio quality and file size stay consistent. Moore / Dioula / Bambara go
+through the MMS sidecar (see app.integrations.mms_tts).
+
+The audio script is the question read aloud followed by its options, so the
+learner can take a test with eyes on the image while the text is read to
+them. File size target is ~50 KB per 30s clip (Opus @ 24 kbps).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Literal
+
+import structlog
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.models.question_bank import (
+    QBankAudioStatus,
+    QBankQuestion,
+    QBankQuestionAudio,
+    QuestionBank,
+)
+from app.infrastructure.config.settings import settings
+from app.infrastructure.storage.s3 import S3StorageService
+from app.integrations.mms_tts import MMSTTSClient, MMSTTSError
+
+logger = structlog.get_logger(__name__)
+
+SupportedLanguage = Literal["fr", "mos", "dyu", "bam"]
+OPUS_CONTENT_TYPE = "audio/ogg"
+OPUS_BYTES_PER_SECOND = 6 * 1024  # matches LessonAudioService._estimate_duration
+
+
+def build_audio_script(question: QBankQuestion, language: str) -> str:
+    """Return the text that should be spoken for a question.
+
+    Prepends the option label in the speaker's language so the TTS reads
+    "Option A: ..." in French and the native prefix in MMS languages.
+    """
+    prefixes = {
+        "fr": "Option",
+        "mos": "Tʋʋmde",  # Moore: "task/choice"
+        "dyu": "Sugandili",  # Dioula/Jula: "choice"
+        "bam": "Sugandili",  # Bambara: "choice"
+    }
+    prefix = prefixes.get(language, "Option")
+    parts = [question.question_text.strip()]
+    for idx, opt in enumerate(question.options or []):
+        letter = chr(ord("A") + idx)
+        parts.append(f"{prefix} {letter}: {opt}")
+    return ". ".join(p for p in parts if p).strip() + "."
+
+
+def estimate_duration_seconds(audio_bytes: int) -> int:
+    """Estimate OGG/Opus clip duration from byte size (speech @ ~48 kbps)."""
+    return max(1, audio_bytes // OPUS_BYTES_PER_SECOND)
+
+
+class QBankAudioService:
+    """Generate and store TTS audio for qbank questions."""
+
+    def __init__(self, mms_client: MMSTTSClient | None = None) -> None:
+        self._mms = mms_client or MMSTTSClient()
+        self._storage = S3StorageService()
+
+    def _storage_key(self, bank_id: uuid.UUID, question_id: uuid.UUID, language: str) -> str:
+        return f"qbank-audio/{bank_id}/{question_id}/{language}.opus"
+
+    async def _upsert_audio_row(
+        self,
+        db: AsyncSession,
+        question_id: uuid.UUID,
+        language: str,
+        **updates: object,
+    ) -> QBankQuestionAudio:
+        """Create or update the (question, language) audio row."""
+        existing = await db.execute(
+            select(QBankQuestionAudio).where(
+                QBankQuestionAudio.question_id == question_id,
+                QBankQuestionAudio.language == language,
+            )
+        )
+        row = existing.scalar_one_or_none()
+        if row is None:
+            row = QBankQuestionAudio(question_id=question_id, language=language)
+            db.add(row)
+        for field, value in updates.items():
+            setattr(row, field, value)
+        await db.commit()
+        await db.refresh(row)
+        return row
+
+    async def _synthesize_bytes(self, script: str, language: str) -> bytes:
+        """Dispatch to the right TTS backend and return OGG/Opus bytes."""
+        if language == "fr":
+            from openai import AsyncOpenAI
+
+            client = AsyncOpenAI(api_key=settings.openai_api_key)
+            response = await client.audio.speech.create(
+                model="gpt-4o-mini-tts",
+                voice="nova",
+                input=script,
+                response_format="opus",
+            )
+            audio = response.content
+            if not audio:
+                raise ValueError("OpenAI TTS returned empty audio")
+            return audio
+
+        if MMSTTSClient.supports(language):
+            return await self._mms.synthesize(script, language)
+
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsupported audio language: {language}",
+        )
+
+    async def generate_question_audio(
+        self,
+        db: AsyncSession,
+        question_id: uuid.UUID,
+        language: str,
+    ) -> QBankQuestionAudio:
+        """Generate audio for a single question in one language.
+
+        Sets status ``generating`` while running and ``ready`` / ``failed``
+        afterwards so the frontend poll endpoint can reflect progress.
+        """
+        question = await db.get(QBankQuestion, question_id)
+        if question is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Question not found.")
+
+        await self._upsert_audio_row(db, question_id, language, status=QBankAudioStatus.generating)
+
+        try:
+            script = build_audio_script(question, language)
+            audio_bytes = await self._synthesize_bytes(script, language)
+            key = self._storage_key(question.question_bank_id, question_id, language)
+            url = await self._storage.upload_bytes(
+                key=key, data=audio_bytes, content_type=OPUS_CONTENT_TYPE
+            )
+        except MMSTTSError as exc:
+            logger.warning("MMS synthesis failed", question_id=str(question_id), error=str(exc))
+            return await self._upsert_audio_row(
+                db,
+                question_id,
+                language,
+                status=QBankAudioStatus.failed,
+            )
+        except Exception as exc:
+            logger.exception(
+                "qbank audio generation failed",
+                question_id=str(question_id),
+                language=language,
+                error=str(exc),
+            )
+            return await self._upsert_audio_row(
+                db, question_id, language, status=QBankAudioStatus.failed
+            )
+
+        return await self._upsert_audio_row(
+            db,
+            question_id,
+            language,
+            storage_key=key,
+            storage_url=url,
+            duration_seconds=estimate_duration_seconds(len(audio_bytes)),
+            status=QBankAudioStatus.ready,
+        )
+
+    async def batch_generate(
+        self,
+        db: AsyncSession,
+        bank_id: uuid.UUID,
+        language: str,
+    ) -> dict:
+        """Generate audio for every question in a bank. Intended for Celery."""
+        bank = await db.get(QuestionBank, bank_id)
+        if bank is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Question bank not found.",
+            )
+
+        questions = (
+            (
+                await db.execute(
+                    select(QBankQuestion).where(QBankQuestion.question_bank_id == bank_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        ready = 0
+        failed = 0
+        for q in questions:
+            row = await self.generate_question_audio(db, q.id, language)
+            if row.status == QBankAudioStatus.ready:
+                ready += 1
+            else:
+                failed += 1
+
+        return {
+            "bank_id": str(bank_id),
+            "language": language,
+            "total": len(questions),
+            "ready": ready,
+            "failed": failed,
+        }
+
+    async def store_uploaded_audio(
+        self,
+        db: AsyncSession,
+        question_id: uuid.UUID,
+        language: str,
+        audio_bytes: bytes,
+        content_type: str,
+    ) -> QBankQuestionAudio:
+        """Handle the manual-upload fallback from the admin UI."""
+        question = await db.get(QBankQuestion, question_id)
+        if question is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Question not found.")
+        key = self._storage_key(question.question_bank_id, question_id, language)
+        url = await self._storage.upload_bytes(key=key, data=audio_bytes, content_type=content_type)
+        return await self._upsert_audio_row(
+            db,
+            question_id,
+            language,
+            storage_key=key,
+            storage_url=url,
+            duration_seconds=estimate_duration_seconds(len(audio_bytes)),
+            status=QBankAudioStatus.ready,
+        )
+
+    async def get_audio_status(
+        self,
+        db: AsyncSession,
+        question_id: uuid.UUID,
+        language: str,
+    ) -> QBankQuestionAudio | None:
+        result = await db.execute(
+            select(QBankQuestionAudio).where(
+                QBankQuestionAudio.question_id == question_id,
+                QBankQuestionAudio.language == language,
+            )
+        )
+        return result.scalar_one_or_none()

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -77,7 +77,7 @@ class Settings(BaseSettings):
     upload_max_pdf_tokens: int = 5000
     upload_max_csv_rows: int = 20
 
-    # Meta MMS TTS sidecar (Moore / Dioula / Bambara)
+    # Meta MMS TTS sidecar (Moore / Dioula / Bambara) — see #1503.
     mms_tts_url: str = "http://mms-tts:5050"
     mms_tts_timeout_seconds: float = 60.0
 

--- a/backend/app/integrations/mms_tts.py
+++ b/backend/app/integrations/mms_tts.py
@@ -1,0 +1,89 @@
+"""Async HTTP client for the Meta MMS TTS sidecar service.
+
+The sidecar is a separate Docker service (see infrastructure/mms-tts) that
+wraps facebook/mms-tts-{mos,dyu,bam} models and returns OGG/Opus audio. We
+call it over plain HTTP from the backend and the Celery worker.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import structlog
+
+from app.infrastructure.config.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+SUPPORTED_LANGUAGES = {"mos", "dyu", "bam"}
+
+
+class MMSTTSError(Exception):
+    """Raised when the MMS sidecar returns an error or is unreachable."""
+
+
+class MMSTTSClient:
+    """Thin async wrapper over the MMS TTS sidecar.
+
+    A module-level semaphore keeps concurrent CPU-bound synthesis calls
+    bounded so a batch job can't overwhelm the single-worker sidecar.
+    """
+
+    _semaphore = asyncio.Semaphore(2)
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> None:
+        self._base_url = (base_url or settings.mms_tts_url).rstrip("/")
+        self._timeout = timeout_seconds or settings.mms_tts_timeout_seconds
+
+    @staticmethod
+    def supports(language: str) -> bool:
+        return language in SUPPORTED_LANGUAGES
+
+    async def synthesize(self, text: str, language: str) -> bytes:
+        """Return OGG/Opus audio bytes for ``text`` in the given language.
+
+        Raises MMSTTSError for any transport or sidecar-side failure; the
+        caller is expected to mark the audio row ``failed`` and surface the
+        error in logs rather than crashing the whole batch.
+        """
+        if language not in SUPPORTED_LANGUAGES:
+            raise MMSTTSError(f"MMS TTS does not support language: {language}")
+        if not text or not text.strip():
+            raise MMSTTSError("MMS TTS received empty text")
+
+        async with self._semaphore:
+            try:
+                async with httpx.AsyncClient(timeout=self._timeout) as client:
+                    resp = await client.post(
+                        f"{self._base_url}/synthesize",
+                        json={"text": text, "language": language},
+                    )
+            except httpx.HTTPError as exc:
+                raise MMSTTSError(f"MMS sidecar unreachable: {exc}") from exc
+
+        if resp.status_code != 200:
+            raise MMSTTSError(f"MMS sidecar returned {resp.status_code}: {resp.text[:200]}")
+        audio = resp.content
+        if not audio:
+            raise MMSTTSError("MMS sidecar returned empty body")
+
+        logger.info(
+            "MMS TTS synthesis",
+            language=language,
+            text_chars=len(text),
+            audio_bytes=len(audio),
+        )
+        return audio
+
+    async def health(self) -> bool:
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.get(f"{self._base_url}/health")
+            return resp.status_code == 200
+        except httpx.HTTPError:
+            return False

--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -22,6 +22,7 @@ celery_app = Celery(
         "app.tasks.file_cleanup",
         "app.tasks.image_indexation",
         "app.tasks.preassessment_generation",
+        "app.tasks.qbank_processing",
         "app.tasks.rag_indexation",
         "app.tasks.resource_extraction",
         "app.tasks.syllabus_generation",

--- a/backend/app/tasks/qbank_processing.py
+++ b/backend/app/tasks/qbank_processing.py
@@ -142,3 +142,43 @@ async def _process_pdf_async(task, bank_id: str, pdf_filename: str) -> dict:
         "questions_created": created,
         "errors": errors,
     }
+
+
+@celery_app.task(
+    base=QBankTask,
+    bind=True,
+    name="qbank.generate_audio",
+    max_retries=2,
+    default_retry_delay=60,
+    soft_time_limit=900,
+    time_limit=960,
+    rate_limit="5/m",
+)
+def generate_qbank_audio_task(self, bank_id: str, language: str) -> dict:
+    """Generate TTS audio for every question in a bank, one language at a time."""
+    return asyncio.get_event_loop().run_until_complete(_generate_audio_async(bank_id, language))
+
+
+async def _generate_audio_async(bank_id: str, language: str) -> dict:
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.domain.services.qbank_audio_service import QBankAudioService
+    from app.infrastructure.config.settings import settings
+
+    engine = create_async_engine(settings.database_url, echo=False)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    service = QBankAudioService()
+
+    async with session_factory() as session:
+        try:
+            result = await service.batch_generate(session, uuid.UUID(bank_id), language)
+        finally:
+            await engine.dispose()
+
+    logger.info(
+        "qbank audio batch complete",
+        bank_id=bank_id,
+        language=language,
+        result=result,
+    )
+    return result

--- a/backend/tests/test_qbank_audio_service.py
+++ b/backend/tests/test_qbank_audio_service.py
@@ -1,0 +1,79 @@
+"""Unit tests for qbank audio helpers + TTS dispatch.
+
+DB/MinIO paths are intentionally out of scope — they're thin wrappers over
+already-tested primitives. These tests pin down the behaviors that matter:
+the spoken script format, size estimation, and the fact that unsupported
+languages don't hit any TTS backend.
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.domain.services.qbank_audio_service import (
+    QBankAudioService,
+    build_audio_script,
+    estimate_duration_seconds,
+)
+
+
+class _FakeQuestion:
+    def __init__(self, text: str, options: list[str]):
+        self.question_text = text
+        self.options = options
+
+
+def test_build_audio_script_french_prefix():
+    q = _FakeQuestion("Que signifie ce panneau ?", ["Stop", "Céder", "Danger"])
+    script = build_audio_script(q, "fr")
+    assert script.startswith("Que signifie ce panneau ?")
+    assert "Option A: Stop" in script
+    assert "Option B: Céder" in script
+    assert "Option C: Danger" in script
+    assert script.endswith(".")
+
+
+def test_build_audio_script_mms_languages_use_native_prefix():
+    q = _FakeQuestion("Question", ["A", "B"])
+    for lang, prefix in [("mos", "Tʋʋmde"), ("dyu", "Sugandili"), ("bam", "Sugandili")]:
+        script = build_audio_script(q, lang)
+        assert f"{prefix} A" in script
+        assert f"{prefix} B" in script
+
+
+def test_build_audio_script_handles_empty_options():
+    q = _FakeQuestion("Just a question", [])
+    script = build_audio_script(q, "fr")
+    assert script == "Just a question."
+
+
+def test_estimate_duration_seconds_opus_rate():
+    # 30s clip at ~48 kbps = ~180 KB
+    assert estimate_duration_seconds(180 * 1024) == 30
+    # Always returns at least 1 second for tiny blobs
+    assert estimate_duration_seconds(10) == 1
+
+
+@pytest.mark.asyncio
+async def test_synthesize_rejects_unsupported_language():
+    svc = QBankAudioService(
+        mms_client=types.SimpleNamespace(
+            synthesize=AsyncMock(side_effect=AssertionError("should not be called")),
+        )
+    )
+    with pytest.raises(HTTPException) as exc:
+        await svc._synthesize_bytes("hi", "en")
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_synthesize_dispatches_mms_languages_to_client():
+    fake_mms = types.SimpleNamespace(synthesize=AsyncMock(return_value=b"OGG"))
+    svc = QBankAudioService(mms_client=fake_mms)
+    out = await svc._synthesize_bytes("lakala", "dyu")
+    assert out == b"OGG"
+    fake_mms.synthesize.assert_awaited_once_with("lakala", "dyu")


### PR DESCRIPTION
## Summary
- Every qbank question can now be generated as an OGG/Opus audio clip **per language**. French reuses the OpenAI `gpt-4o-mini-tts` path from `LessonAudioService` (consistent voice + bitrate with lesson audio). Moore (`mos`), Dioula (`dyu`), and Bambara (`bam`) go through the new Meta MMS sidecar from #1503.
- Status machine (`pending` → `generating` → `ready` / `failed`) lets the admin UI poll progress without guessing.
- Manual upload fallback is included for org admins who prefer to record their own audio.

## Endpoints
| Method | Path | Purpose |
|---|---|---|
| POST | `/qbank/banks/{bank_id}/audio/generate?language=fr\|mos\|dyu\|bam` | Kick off a batch Celery task |
| POST | `/qbank/questions/{id}/audio?language=…` (multipart) | Manual upload fallback |
| GET  | `/qbank/questions/{id}/audio?lang=…` | Poll status + URL |

## Changes
- `backend/app/integrations/mms_tts.py` — async httpx client with bounded concurrency
- `backend/app/domain/services/qbank_audio_service.py` — QBankAudioService
- `backend/app/tasks/qbank_processing.py` — `qbank.generate_audio` Celery task
- `backend/app/tasks/celery_app.py` — include qbank_processing module so the worker registers both tasks
- `backend/app/api/v1/qbank.py` — three new endpoints
- `backend/app/api/v1/schemas/qbank.py` — new response models
- `backend/app/infrastructure/config/settings.py` — `mms_tts_url` + timeout (duplicates #1503 so this branch builds in isolation; rebase will collapse)
- `backend/tests/test_qbank_audio_service.py` — 6 unit tests

## Dependencies
- Needs **#1503** (MMS TTS sidecar) running for `mos/dyu/bam` at runtime. French works without it.

## Test plan
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run pytest tests/test_qbank_audio_service.py -q` — 6 passed
- [ ] Local: start sidecar, `POST /qbank/banks/{id}/audio/generate?language=dyu`, poll status, confirm opus file in MinIO
- [ ] Auth: non-admin member hitting `/audio/generate` gets 403
- [ ] Manual upload: multipart audio/ogg upload creates a `ready` row

Fixes #1502

🤖 Generated with [Claude Code](https://claude.com/claude-code)