### PR TITLE
feat(qbank): organization question bank management pages (#1504)

### DIFF
--- a/frontend/app/[locale]/org/[orgSlug]/qbank/[bankId]/client.tsx
+++ b/frontend/app/[locale]/org/[orgSlug]/qbank/[bankId]/client.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { useLocale } from "next-intl";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useOrg } from "@/components/org/org-context";
+import { QBankPdfUpload } from "@/components/qbank/qbank-pdf-upload";
+import { QBankQuestionEditor } from "@/components/qbank/qbank-question-editor";
+import { QBankTestConfigList } from "@/components/qbank/qbank-test-config";
+import {
+  getQBankBank,
+  listQBankQuestions,
+  updateQBankBank,
+  type QBankBank,
+  type QBankQuestionFull,
+} from "@/lib/api";
+
+interface Props {
+  bankId: string;
+}
+
+const PAGE_SIZE = 20;
+
+export function QBankDetailClient({ bankId }: Props) {
+  const locale = useLocale();
+  const { org } = useOrg();
+  const [bank, setBank] = useState<QBankBank | null>(null);
+  const [questions, setQuestions] = useState<QBankQuestionFull[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [categoryFilter, setCategoryFilter] = useState<string | "all">("all");
+  const [publishing, setPublishing] = useState(false);
+
+  async function loadQuestions(p: number = page) {
+    const result = await listQBankQuestions(bankId, p, PAGE_SIZE);
+    setQuestions(result.questions);
+    setTotal(result.total);
+    setPage(result.page);
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [b, q] = await Promise.all([
+          getQBankBank(bankId),
+          listQBankQuestions(bankId, 1, PAGE_SIZE),
+        ]);
+        if (cancelled) return;
+        setBank(b);
+        setQuestions(q.questions);
+        setTotal(q.total);
+      } catch (err: unknown) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Load failed");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [bankId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+      </div>
+    );
+  }
+  if (error) return <p className="text-sm text-red-700">{error}</p>;
+  if (!bank || !org) return null;
+
+  const base = `/${locale}/org/${org.slug}/qbank`;
+  const categories = Array.from(
+    new Set(questions.map((q) => q.category).filter((c): c is string => Boolean(c)))
+  ).sort();
+  const visibleQuestions =
+    categoryFilter === "all"
+      ? questions
+      : questions.filter((q) => q.category === categoryFilter);
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  async function togglePublished() {
+    if (!bank) return;
+    setPublishing(true);
+    try {
+      const updated = await updateQBankBank(bank.id, {
+        status: bank.status === "published" ? "draft" : "published",
+      });
+      setBank(updated);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Update failed");
+    } finally {
+      setPublishing(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <Link
+        href={base}
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-gray-900"
+      >
+        <ArrowLeft className="h-4 w-4" /> Back to banks
+      </Link>
+
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-semibold">{bank.title}</h1>
+            <Badge>{bank.status}</Badge>
+          </div>
+          {bank.description && (
+            <p className="mt-1 text-sm text-muted-foreground">{bank.description}</p>
+          )}
+          <p className="mt-2 text-xs text-muted-foreground">
+            {total} {total === 1 ? "question" : "questions"} · {bank.time_per_question_sec}s per Q · {bank.passing_score}% to pass · {bank.language.toUpperCase()}
+          </p>
+        </div>
+        <Button onClick={togglePublished} disabled={publishing} variant="outline">
+          {publishing && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          {bank.status === "published" ? "Unpublish" : "Publish"}
+        </Button>
+      </header>
+
+      <section className="space-y-3 rounded-lg border bg-white p-4">
+        <h2 className="text-lg font-medium">Add more questions</h2>
+        <QBankPdfUpload
+          bankId={bankId}
+          onProcessed={(res) => {
+            if (res.status === "success") void loadQuestions(1);
+          }}
+        />
+      </section>
+
+      <section className="space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h2 className="text-lg font-medium">Questions</h2>
+          {categories.length > 0 && (
+            <select
+              value={categoryFilter}
+              onChange={(e) => setCategoryFilter(e.target.value)}
+              className="rounded-md border px-3 py-1.5 text-sm"
+              aria-label="Filter by category"
+            >
+              <option value="all">All categories</option>
+              {categories.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+
+        {visibleQuestions.length === 0 ? (
+          <p className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+            No questions yet. Upload a PDF above to extract some.
+          </p>
+        ) : (
+          <ul className="space-y-4">
+            {visibleQuestions.map((q) => (
+              <li key={q.id}>
+                <QBankQuestionEditor
+                  question={q}
+                  onSaved={(updated) =>
+                    setQuestions((prev) => prev.map((p) => (p.id === updated.id ? updated : p)))
+                  }
+                  onDeleted={(id) => {
+                    setQuestions((prev) => prev.filter((p) => p.id !== id));
+                    setTotal((t) => Math.max(0, t - 1));
+                  }}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {totalPages > 1 && (
+          <div className="flex items-center justify-center gap-2 pt-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page === 1}
+              onClick={() => void loadQuestions(page - 1)}
+            >
+              Previous
+            </Button>
+            <span className="text-sm text-muted-foreground">
+              Page {page} / {totalPages}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page >= totalPages}
+              onClick={() => void loadQuestions(page + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        )}
+      </section>
+
+      <section className="rounded-lg border bg-white p-4">
+        <QBankTestConfigList bankId={bankId} />
+      </section>
+    </div>
+  );
+}

--- a/frontend/app/[locale]/org/[orgSlug]/qbank/[bankId]/page.tsx
+++ b/frontend/app/[locale]/org/[orgSlug]/qbank/[bankId]/page.tsx
@@ -1,0 +1,10 @@
+import { QBankDetailClient } from "./client";
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ bankId: string }>;
+}) {
+  const { bankId } = await params;
+  return <QBankDetailClient bankId={bankId} />;
+}

--- a/frontend/app/[locale]/org/[orgSlug]/qbank/client.tsx
+++ b/frontend/app/[locale]/org/[orgSlug]/qbank/client.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { useLocale } from "next-intl";
+import { ClipboardList, Loader2, Plus } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { useOrg } from "@/components/org/org-context";
+import { listQBankBanks, type QBankBank, type QBankStatus, type QBankType } from "@/lib/api";
+
+const TYPE_LABELS: Record<QBankType, string> = {
+  driving: "Driving school",
+  exam_prep: "Exam prep",
+  psychotechnic: "Psychotechnic",
+  general_culture: "General culture",
+};
+
+const STATUS_STYLES: Record<QBankStatus, string> = {
+  draft: "bg-gray-100 text-gray-700",
+  published: "bg-green-100 text-green-700",
+  archived: "bg-yellow-100 text-yellow-700",
+};
+
+export function QBankListClient() {
+  const locale = useLocale();
+  const { org, loading: orgLoading } = useOrg();
+  const [banks, setBanks] = useState<QBankBank[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [typeFilter, setTypeFilter] = useState<QBankType | "all">("all");
+
+  useEffect(() => {
+    if (!org) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await listQBankBanks(org.id);
+        if (!cancelled) setBanks(res);
+      } catch (err: unknown) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Load failed");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [org]);
+
+  if (orgLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+      </div>
+    );
+  }
+
+  if (!org) {
+    return <p className="text-muted-foreground">Organization not found.</p>;
+  }
+
+  const filtered = typeFilter === "all" ? banks : banks.filter((b) => b.bank_type === typeFilter);
+  const base = `/${locale}/org/${org.slug}/qbank`;
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-semibold">
+            <ClipboardList className="h-6 w-6" /> Question banks
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Image-based MCQ banks for your organization.
+          </p>
+        </div>
+        <Link
+          href={`${base}/create`}
+          className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-2.5 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/80"
+        >
+          <Plus className="h-4 w-4" /> New bank
+        </Link>
+      </header>
+
+      <div className="flex flex-wrap gap-2">
+        {(["all", ...Object.keys(TYPE_LABELS)] as const).map((key) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => setTypeFilter(key as QBankType | "all")}
+            className={`rounded-full px-3 py-1 text-sm ${
+              typeFilter === key
+                ? "bg-green-600 text-white"
+                : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+            }`}
+          >
+            {key === "all" ? "All types" : TYPE_LABELS[key as QBankType]}
+          </button>
+        ))}
+      </div>
+
+      {error && (
+        <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-10 text-center">
+          <p className="text-sm text-muted-foreground">
+            No question banks yet. Create one to get started.
+          </p>
+        </div>
+      ) : (
+        <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {filtered.map((bank) => (
+            <li key={bank.id}>
+              <Link
+                href={`${base}/${bank.id}`}
+                className="flex h-full flex-col gap-3 rounded-lg border bg-white p-4 transition hover:border-green-500 hover:shadow-sm"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <h2 className="font-medium">{bank.title}</h2>
+                  <Badge className={STATUS_STYLES[bank.status]}>{bank.status}</Badge>
+                </div>
+                {bank.description && (
+                  <p className="line-clamp-2 text-sm text-muted-foreground">{bank.description}</p>
+                )}
+                <div className="mt-auto flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                  <span>{TYPE_LABELS[bank.bank_type]}</span>
+                  <span>
+                    {bank.question_count} {bank.question_count === 1 ? "question" : "questions"}
+                  </span>
+                  <span>
+                    {bank.test_count} {bank.test_count === 1 ? "test" : "tests"}
+                  </span>
+                  <span>{bank.time_per_question_sec}s per Q</span>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/[locale]/org/[orgSlug]/qbank/create/client.tsx
+++ b/frontend/app/[locale]/org/[orgSlug]/qbank/create/client.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useState } from "react";
+import { useLocale } from "next-intl";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useOrg } from "@/components/org/org-context";
+import { QBankPdfUpload } from "@/components/qbank/qbank-pdf-upload";
+import { createQBankBank, type QBankBank, type QBankType } from "@/lib/api";
+
+const BANK_TYPES: { value: QBankType; label: string }[] = [
+  { value: "driving", label: "Driving school" },
+  { value: "exam_prep", label: "Exam prep" },
+  { value: "psychotechnic", label: "Psychotechnic" },
+  { value: "general_culture", label: "General culture" },
+];
+
+export function QBankCreateClient() {
+  const locale = useLocale();
+  const router = useRouter();
+  const { org } = useOrg();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [bank, setBank] = useState<QBankBank | null>(null);
+
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [bankType, setBankType] = useState<QBankType>("driving");
+  const [language, setLanguage] = useState("fr");
+  const [timePerQuestion, setTimePerQuestion] = useState(25);
+  const [passingScore, setPassingScore] = useState(80);
+
+  if (!org) return null;
+  const base = `/${locale}/org/${org.slug}/qbank`;
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    if (!org) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const created = await createQBankBank({
+        organization_id: org.id,
+        title,
+        description: description || null,
+        bank_type: bankType,
+        language,
+        time_per_question_sec: timePerQuestion,
+        passing_score: passingScore,
+      });
+      setBank(created);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to create bank");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <Link
+        href={base}
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-gray-900"
+      >
+        <ArrowLeft className="h-4 w-4" /> Back to banks
+      </Link>
+      <h1 className="text-2xl font-semibold">Create question bank</h1>
+
+      {!bank ? (
+        <form onSubmit={handleCreate} className="space-y-4 rounded-lg border bg-white p-5">
+          <div className="space-y-2">
+            <Label htmlFor="title">Title</Label>
+            <Input
+              id="title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              required
+              minLength={2}
+              maxLength={500}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="description">Description</Label>
+            <textarea
+              id="description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={3}
+              className="w-full rounded-md border px-3 py-2 text-sm"
+            />
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="type">Type</Label>
+              <select
+                id="type"
+                value={bankType}
+                onChange={(e) => setBankType(e.target.value as QBankType)}
+                className="w-full rounded-md border px-3 py-2 text-sm"
+              >
+                {BANK_TYPES.map((t) => (
+                  <option key={t.value} value={t.value}>
+                    {t.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="language">Language</Label>
+              <select
+                id="language"
+                value={language}
+                onChange={(e) => setLanguage(e.target.value)}
+                className="w-full rounded-md border px-3 py-2 text-sm"
+              >
+                <option value="fr">Français</option>
+                <option value="en">English</option>
+              </select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="time">Time per question (seconds)</Label>
+              <Input
+                id="time"
+                type="number"
+                min={5}
+                max={120}
+                value={timePerQuestion}
+                onChange={(e) => setTimePerQuestion(Number(e.target.value))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="passing">Passing score (%)</Label>
+              <Input
+                id="passing"
+                type="number"
+                min={0}
+                max={100}
+                value={passingScore}
+                onChange={(e) => setPassingScore(Number(e.target.value))}
+              />
+            </div>
+          </div>
+
+          {error && <p className="text-sm text-red-700">{error}</p>}
+
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => router.push(base)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Create bank
+            </Button>
+          </div>
+        </form>
+      ) : (
+        <div className="space-y-4 rounded-lg border bg-white p-5">
+          <p className="text-sm">
+            Bank <span className="font-medium">{bank.title}</span> created. Now upload a PDF to
+            extract questions.
+          </p>
+          <QBankPdfUpload
+            bankId={bank.id}
+            onProcessed={(res) => {
+              if (res.status === "success") {
+                setTimeout(() => router.push(`${base}/${bank.id}`), 1500);
+              }
+            }}
+          />
+          <div className="flex justify-end">
+            <Button onClick={() => router.push(`${base}/${bank.id}`)}>Open bank</Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/[locale]/org/[orgSlug]/qbank/create/page.tsx
+++ b/frontend/app/[locale]/org/[orgSlug]/qbank/create/page.tsx
@@ -1,0 +1,5 @@
+import { QBankCreateClient } from "./client";
+
+export default function Page() {
+  return <QBankCreateClient />;
+}

--- a/frontend/app/[locale]/org/[orgSlug]/qbank/page.tsx
+++ b/frontend/app/[locale]/org/[orgSlug]/qbank/page.tsx
@@ -1,0 +1,5 @@
+import { QBankListClient } from "./client";
+
+export default function Page() {
+  return <QBankListClient />;
+}

--- a/frontend/components/org/org-nav.tsx
+++ b/frontend/components/org/org-nav.tsx
@@ -12,6 +12,7 @@ import {
   BarChart3,
   Users,
   Library,
+  ClipboardList,
 } from "lucide-react";
 
 export function OrgNav() {
@@ -27,6 +28,7 @@ export function OrgNav() {
     { href: base, label: t("dashboard"), icon: LayoutDashboard },
     { href: `${base}/courses`, label: "Courses", icon: GraduationCap },
     { href: `${base}/curricula`, label: t("curricula"), icon: Library },
+    { href: `${base}/qbank`, label: "Question Banks", icon: ClipboardList },
     { href: `${base}/codes`, label: t("codes"), icon: QrCode },
     { href: `${base}/reports`, label: t("reports"), icon: BarChart3 },
     { href: `${base}/members`, label: t("members"), icon: Users },

--- a/frontend/components/qbank/qbank-pdf-upload.tsx
+++ b/frontend/components/qbank/qbank-pdf-upload.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { AlertCircle, CheckCircle2, FileText, Loader2, Upload } from "lucide-react";
+import {
+  getQBankProcessingStatus,
+  uploadQBankPdf,
+  type QBankProcessingStatus,
+} from "@/lib/api";
+
+interface Props {
+  bankId: string;
+  onProcessed?: (result: QBankProcessingStatus) => void;
+}
+
+type Phase = "idle" | "uploading" | "processing" | "done" | "error";
+
+const POLL_INTERVAL_MS = 3000;
+
+export function QBankPdfUpload({ bankId, onProcessed }: Props) {
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [taskId, setTaskId] = useState<string | null>(null);
+  const [filename, setFilename] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [status, setStatus] = useState<QBankProcessingStatus | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [dragActive, setDragActive] = useState(false);
+
+  const handleFile = useCallback(
+    async (file: File) => {
+      if (file.type !== "application/pdf") {
+        setPhase("error");
+        setMessage("Only PDF files are accepted.");
+        return;
+      }
+      setPhase("uploading");
+      setMessage(null);
+      setFilename(file.name);
+      try {
+        const res = await uploadQBankPdf(bankId, file);
+        setTaskId(res.task_id);
+        setPhase("processing");
+      } catch (err: unknown) {
+        setPhase("error");
+        setMessage(err instanceof Error ? err.message : "Upload failed");
+      }
+    },
+    [bankId]
+  );
+
+  useEffect(() => {
+    if (phase !== "processing" || !taskId) return;
+    let cancelled = false;
+
+    async function poll() {
+      try {
+        const s = await getQBankProcessingStatus(bankId, taskId!);
+        if (cancelled) return;
+        setStatus(s);
+        if (["success", "failure"].includes(s.status)) {
+          setPhase(s.status === "success" ? "done" : "error");
+          if (s.status === "failure") setMessage(s.error ?? "Processing failed");
+          onProcessed?.(s);
+          return;
+        }
+      } catch (err: unknown) {
+        if (cancelled) return;
+        setPhase("error");
+        setMessage(err instanceof Error ? err.message : "Polling failed");
+        return;
+      }
+      if (!cancelled) setTimeout(poll, POLL_INTERVAL_MS);
+    }
+
+    poll();
+    return () => {
+      cancelled = true;
+    };
+  }, [bankId, phase, taskId, onProcessed]);
+
+  const onDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      setDragActive(false);
+      const file = e.dataTransfer.files[0];
+      if (file) void handleFile(file);
+    },
+    [handleFile]
+  );
+
+  return (
+    <div className="space-y-3">
+      <div
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragActive(true);
+        }}
+        onDragLeave={() => setDragActive(false)}
+        onDrop={onDrop}
+        onClick={() => fileInputRef.current?.click()}
+        className={`flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed p-8 text-center transition ${
+          dragActive ? "border-green-500 bg-green-50" : "border-gray-300 hover:border-gray-400"
+        }`}
+      >
+        <Upload className="mb-2 h-8 w-8 text-gray-400" />
+        <p className="text-sm font-medium">Drop a PDF here or click to select</p>
+        <p className="text-xs text-muted-foreground">
+          Slides with an image + question + options per page
+        </p>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="application/pdf"
+          className="hidden"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) void handleFile(file);
+            e.target.value = "";
+          }}
+        />
+      </div>
+
+      {filename && (
+        <div className="flex items-center gap-2 rounded-md border bg-white px-3 py-2 text-sm">
+          <FileText className="h-4 w-4 text-gray-400" />
+          <span className="flex-1 truncate">{filename}</span>
+          {phase === "uploading" && <Loader2 className="h-4 w-4 animate-spin text-gray-400" />}
+          {phase === "processing" && (
+            <span className="flex items-center gap-1 text-xs text-blue-600">
+              <Loader2 className="h-3 w-3 animate-spin" /> Extracting…
+            </span>
+          )}
+          {phase === "done" && <CheckCircle2 className="h-4 w-4 text-green-600" />}
+          {phase === "error" && <AlertCircle className="h-4 w-4 text-red-600" />}
+        </div>
+      )}
+
+      {phase === "done" && status?.result && (
+        <p className="text-sm text-green-700">
+          Extracted {status.result.questions_created} question(s)
+          {Array.isArray(status.result.errors) && status.result.errors.length > 0
+            ? ` with ${status.result.errors.length} warning(s)`
+            : ""}
+          .
+        </p>
+      )}
+
+      {message && phase === "error" && (
+        <p className="text-sm text-red-700">{message}</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/qbank/qbank-question-editor.tsx
+++ b/frontend/components/qbank/qbank-question-editor.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useState } from "react";
+import { Loader2, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  deleteQBankQuestion,
+  updateQBankQuestion,
+  type QBankDifficulty,
+  type QBankQuestionFull,
+} from "@/lib/api";
+
+interface Props {
+  question: QBankQuestionFull;
+  onSaved: (updated: QBankQuestionFull) => void;
+  onDeleted: (id: string) => void;
+}
+
+const DIFFICULTIES: QBankDifficulty[] = ["easy", "medium", "hard"];
+
+export function QBankQuestionEditor({ question, onSaved, onDeleted }: Props) {
+  const [text, setText] = useState(question.question_text);
+  const [options, setOptions] = useState([...question.options]);
+  const [correct, setCorrect] = useState<number[]>([...question.correct_answer_indices]);
+  const [category, setCategory] = useState(question.category ?? "");
+  const [difficulty, setDifficulty] = useState<QBankDifficulty>(question.difficulty);
+  const [explanation, setExplanation] = useState(question.explanation ?? "");
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [dirty, setDirty] = useState(false);
+
+  useEffect(() => {
+    setText(question.question_text);
+    setOptions([...question.options]);
+    setCorrect([...question.correct_answer_indices]);
+    setCategory(question.category ?? "");
+    setDifficulty(question.difficulty);
+    setExplanation(question.explanation ?? "");
+    setDirty(false);
+  }, [question]);
+
+  function touch() {
+    setDirty(true);
+  }
+
+  function toggleCorrect(idx: number) {
+    setCorrect((prev) =>
+      prev.includes(idx) ? prev.filter((i) => i !== idx) : [...prev, idx].sort()
+    );
+    touch();
+  }
+
+  function updateOption(idx: number, value: string) {
+    setOptions((prev) => prev.map((o, i) => (i === idx ? value : o)));
+    touch();
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await updateQBankQuestion(question.id, {
+        question_text: text,
+        options,
+        correct_answer_indices: correct,
+        category: category || null,
+        difficulty,
+        explanation: explanation || null,
+      });
+      onSaved(updated);
+      setDirty(false);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!confirm("Delete this question? This cannot be undone.")) return;
+    setDeleting(true);
+    setError(null);
+    try {
+      await deleteQBankQuestion(question.id);
+      onDeleted(question.id);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Delete failed");
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4 rounded-lg border bg-white p-4">
+      {question.image_url && (
+        <div className="relative aspect-video w-full overflow-hidden rounded-md bg-gray-50">
+          <Image
+            src={question.image_url}
+            alt={`Question ${question.order_index}`}
+            fill
+            className="object-contain"
+            sizes="(max-width: 768px) 100vw, 60vw"
+            unoptimized
+          />
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label>Question</Label>
+        <textarea
+          value={text}
+          onChange={(e) => {
+            setText(e.target.value);
+            touch();
+          }}
+          rows={2}
+          className="w-full rounded-md border px-3 py-2 text-sm"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label>Options (check the correct one(s))</Label>
+        {options.map((opt, idx) => (
+          <div key={idx} className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={correct.includes(idx)}
+              onChange={() => toggleCorrect(idx)}
+              className="h-4 w-4"
+              aria-label={`Option ${String.fromCharCode(65 + idx)} correct`}
+            />
+            <span className="w-6 text-sm font-medium">{String.fromCharCode(65 + idx)}.</span>
+            <Input value={opt} onChange={(e) => updateOption(idx, e.target.value)} />
+          </div>
+        ))}
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor={`cat-${question.id}`}>Category</Label>
+          <Input
+            id={`cat-${question.id}`}
+            value={category}
+            onChange={(e) => {
+              setCategory(e.target.value);
+              touch();
+            }}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={`diff-${question.id}`}>Difficulty</Label>
+          <select
+            id={`diff-${question.id}`}
+            value={difficulty}
+            onChange={(e) => {
+              setDifficulty(e.target.value as QBankDifficulty);
+              touch();
+            }}
+            className="w-full rounded-md border px-3 py-2 text-sm"
+          >
+            {DIFFICULTIES.map((d) => (
+              <option key={d} value={d}>
+                {d}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`exp-${question.id}`}>Explanation (optional)</Label>
+        <textarea
+          id={`exp-${question.id}`}
+          value={explanation}
+          onChange={(e) => {
+            setExplanation(e.target.value);
+            touch();
+          }}
+          rows={2}
+          className="w-full rounded-md border px-3 py-2 text-sm"
+        />
+      </div>
+
+      {error && <p className="text-sm text-red-700">{error}</p>}
+
+      <div className="flex justify-between">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={handleDelete}
+          disabled={deleting || saving}
+        >
+          {deleting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Trash2 className="mr-2 h-4 w-4" />}
+          Delete
+        </Button>
+        <Button type="button" onClick={handleSave} disabled={!dirty || saving}>
+          {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          Save changes
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/qbank/qbank-test-config.tsx
+++ b/frontend/components/qbank/qbank-test-config.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  createQBankTest,
+  listQBankTests,
+  type QBankTestConfig,
+  type QBankTestMode,
+} from "@/lib/api";
+
+interface Props {
+  bankId: string;
+}
+
+const MODES: { value: QBankTestMode; label: string }[] = [
+  { value: "exam", label: "Exam (timed, no feedback)" },
+  { value: "training", label: "Training (feedback + review)" },
+  { value: "review", label: "Review (all answers visible)" },
+];
+
+export function QBankTestConfigList({ bankId }: Props) {
+  const [tests, setTests] = useState<QBankTestConfig[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const [title, setTitle] = useState("");
+  const [mode, setMode] = useState<QBankTestMode>("exam");
+  const [count, setCount] = useState<number | "">("");
+  const [shuffle, setShuffle] = useState(true);
+  const [timeOverride, setTimeOverride] = useState<number | "">("");
+  const [showFeedback, setShowFeedback] = useState(false);
+
+  useEffect(() => {
+    listQBankTests(bankId)
+      .then(setTests)
+      .catch((err: Error) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [bankId]);
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    setCreating(true);
+    setError(null);
+    try {
+      const created = await createQBankTest({
+        question_bank_id: bankId,
+        title,
+        mode,
+        question_count: count === "" ? null : Number(count),
+        shuffle_questions: shuffle,
+        time_per_question_sec: timeOverride === "" ? null : Number(timeOverride),
+        show_feedback: showFeedback,
+      });
+      setTests((prev) => [...prev, created]);
+      setTitle("");
+      setCount("");
+      setTimeOverride("");
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Create failed");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-medium">Tests</h2>
+      {loading ? (
+        <Loader2 className="h-5 w-5 animate-spin text-gray-400" />
+      ) : tests.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No tests configured yet.</p>
+      ) : (
+        <ul className="space-y-2">
+          {tests.map((t) => (
+            <li
+              key={t.id}
+              className="flex items-center justify-between gap-3 rounded-md border bg-white p-3 text-sm"
+            >
+              <div>
+                <span className="font-medium">{t.title}</span>
+                <span className="ml-2 text-xs uppercase text-muted-foreground">{t.mode}</span>
+              </div>
+              <span className="text-xs text-muted-foreground">
+                {t.question_count ?? "all"} q · {t.time_per_question_sec ?? "default"} s · {t.shuffle_questions ? "shuffled" : "ordered"}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <form onSubmit={handleCreate} className="space-y-3 rounded-md border bg-gray-50 p-4">
+        <h3 className="text-sm font-medium">New test</h3>
+
+        <div className="space-y-2">
+          <Label htmlFor="test-title">Title</Label>
+          <Input
+            id="test-title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            required
+            minLength={2}
+          />
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="test-mode">Mode</Label>
+            <select
+              id="test-mode"
+              value={mode}
+              onChange={(e) => setMode(e.target.value as QBankTestMode)}
+              className="w-full rounded-md border px-3 py-2 text-sm"
+            >
+              {MODES.map((m) => (
+                <option key={m.value} value={m.value}>
+                  {m.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="test-count">Question count (blank = all)</Label>
+            <Input
+              id="test-count"
+              type="number"
+              min={1}
+              max={500}
+              value={count}
+              onChange={(e) => setCount(e.target.value === "" ? "" : Number(e.target.value))}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="test-time">Override time/question (seconds)</Label>
+            <Input
+              id="test-time"
+              type="number"
+              min={5}
+              max={120}
+              value={timeOverride}
+              onChange={(e) =>
+                setTimeOverride(e.target.value === "" ? "" : Number(e.target.value))
+              }
+            />
+          </div>
+          <div className="flex flex-col justify-end gap-2">
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={shuffle}
+                onChange={(e) => setShuffle(e.target.checked)}
+              />
+              Shuffle questions
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={showFeedback}
+                onChange={(e) => setShowFeedback(e.target.checked)}
+              />
+              Show feedback after each answer
+            </label>
+          </div>
+        </div>
+
+        {error && <p className="text-sm text-red-700">{error}</p>}
+
+        <div className="flex justify-end">
+          <Button type="submit" disabled={creating}>
+            {creating ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Plus className="mr-2 h-4 w-4" />
+            )}
+            Create test
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1547,3 +1547,223 @@ export async function getQBankTestReview(
 ): Promise<QBankReviewResponse> {
   return apiFetch<QBankReviewResponse>(`/api/v1/qbank/tests/${testId}/review/${attemptId}`);
 }
+
+// ---------------------------------------------------------------------------
+// QBank management (org admin) — #1504
+// ---------------------------------------------------------------------------
+
+export type QBankType = "driving" | "exam_prep" | "psychotechnic" | "general_culture";
+export type QBankStatus = "draft" | "published" | "archived";
+export type QBankDifficulty = "easy" | "medium" | "hard";
+export type QBankTestMode = "exam" | "training" | "review";
+
+export interface QBankBank {
+  id: string;
+  organization_id: string;
+  title: string;
+  description: string | null;
+  bank_type: QBankType;
+  language: string;
+  time_per_question_sec: number;
+  passing_score: number;
+  status: QBankStatus;
+  question_count: number;
+  test_count: number;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface QBankBankCreate {
+  organization_id: string;
+  title: string;
+  description?: string | null;
+  bank_type: QBankType;
+  language?: string;
+  time_per_question_sec?: number;
+  passing_score?: number;
+}
+
+export interface QBankBankUpdate {
+  title?: string;
+  description?: string | null;
+  language?: string;
+  time_per_question_sec?: number;
+  passing_score?: number;
+  status?: QBankStatus;
+}
+
+export interface QBankQuestionFull {
+  id: string;
+  question_bank_id: string;
+  order_index: number;
+  image_url: string | null;
+  question_text: string;
+  options: string[];
+  correct_answer_indices: number[];
+  explanation: string | null;
+  source_page: number | null;
+  source_pdf_name: string | null;
+  category: string | null;
+  difficulty: QBankDifficulty;
+  created_at: string;
+}
+
+export interface QBankQuestionList {
+  questions: QBankQuestionFull[];
+  total: number;
+  page: number;
+  per_page: number;
+}
+
+export interface QBankQuestionUpdate {
+  question_text?: string;
+  options?: string[];
+  correct_answer_indices?: number[];
+  explanation?: string | null;
+  category?: string | null;
+  difficulty?: QBankDifficulty;
+}
+
+export interface QBankTestConfig {
+  id: string;
+  question_bank_id: string;
+  title: string;
+  mode: QBankTestMode;
+  question_count: number | null;
+  shuffle_questions: boolean;
+  time_per_question_sec: number | null;
+  show_feedback: boolean;
+  filter_categories: string[] | null;
+  filter_failed_only: boolean;
+  created_by: string;
+  created_at: string;
+}
+
+export interface QBankTestCreate {
+  question_bank_id: string;
+  title: string;
+  mode: QBankTestMode;
+  question_count?: number | null;
+  shuffle_questions?: boolean;
+  time_per_question_sec?: number | null;
+  show_feedback?: boolean;
+  filter_categories?: string[] | null;
+  filter_failed_only?: boolean;
+}
+
+export interface QBankProcessingStatus {
+  task_id: string;
+  bank_id: string;
+  status: string;
+  result?: { bank_id: string; questions_created: number; errors: unknown[] };
+  error?: string;
+}
+
+export async function listQBankBanks(orgId: string): Promise<QBankBank[]> {
+  return apiFetch<QBankBank[]>(`/api/v1/qbank/banks?org_id=${orgId}`);
+}
+
+export async function createQBankBank(body: QBankBankCreate): Promise<QBankBank> {
+  return apiFetch<QBankBank>(`/api/v1/qbank/banks`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function getQBankBank(bankId: string): Promise<QBankBank> {
+  return apiFetch<QBankBank>(`/api/v1/qbank/banks/${bankId}`);
+}
+
+export async function updateQBankBank(
+  bankId: string,
+  body: QBankBankUpdate
+): Promise<QBankBank> {
+  return apiFetch<QBankBank>(`/api/v1/qbank/banks/${bankId}`, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function deleteQBankBank(bankId: string): Promise<void> {
+  return apiFetch<void>(`/api/v1/qbank/banks/${bankId}`, { method: "DELETE" });
+}
+
+export async function listQBankQuestions(
+  bankId: string,
+  page = 1,
+  perPage = 50
+): Promise<QBankQuestionList> {
+  return apiFetch<QBankQuestionList>(
+    `/api/v1/qbank/banks/${bankId}/questions?page=${page}&per_page=${perPage}`
+  );
+}
+
+export async function updateQBankQuestion(
+  questionId: string,
+  body: QBankQuestionUpdate
+): Promise<QBankQuestionFull> {
+  return apiFetch<QBankQuestionFull>(`/api/v1/qbank/questions/${questionId}`, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function deleteQBankQuestion(questionId: string): Promise<void> {
+  return apiFetch<void>(`/api/v1/qbank/questions/${questionId}`, {
+    method: "DELETE",
+  });
+}
+
+export async function listQBankTests(bankId: string): Promise<QBankTestConfig[]> {
+  return apiFetch<QBankTestConfig[]>(`/api/v1/qbank/tests?bank_id=${bankId}`);
+}
+
+export async function createQBankTest(body: QBankTestCreate): Promise<QBankTestConfig> {
+  return apiFetch<QBankTestConfig>(`/api/v1/qbank/tests`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function uploadQBankPdf(
+  bankId: string,
+  file: File
+): Promise<{ task_id: string; bank_id: string; filename: string; status: string }> {
+  const formData = new FormData();
+  formData.append("file", file);
+  const headers: Record<string, string> = {};
+  if (typeof window !== "undefined") {
+    try {
+      const { authClient } = await import("./auth");
+      const token = await authClient.getValidToken();
+      headers["Authorization"] = `Bearer ${token}`;
+    } catch {
+      // no auth header if no token
+    }
+  }
+  const res = await fetch(`${API_BASE}/api/v1/qbank/banks/${bankId}/upload-pdf`, {
+    method: "POST",
+    headers,
+    body: formData,
+  });
+  if (!res.ok) {
+    let message = `API error: ${res.status}`;
+    try {
+      const body = await res.json();
+      if (typeof body?.detail === "string") message = body.detail;
+      else if (body?.detail?.message) message = body.detail.message;
+    } catch { /* ignore */ }
+    throw new ApiError(message, res.status);
+  }
+  return res.json();
+}
+
+export async function getQBankProcessingStatus(
+  bankId: string,
+  taskId: string
+): Promise<QBankProcessingStatus> {
+  return apiFetch<QBankProcessingStatus>(
+    `/api/v1/qbank/banks/${bankId}/processing-status?task_id=${taskId}`
+  );
+}


### PR DESCRIPTION
## Summary
- Full org-admin UI for question banks under `/org/{slug}/qbank`: list, create (with inline PDF upload), and detail page (publish toggle, add more PDFs, paginated editable questions, test configuration).
- New components: `qbank-pdf-upload` (drag-drop + 3s polling), `qbank-question-editor` (image + editable text/options/correct/category/difficulty), `qbank-test-config` (list + create new test).
- Extends `frontend/lib/api.ts` with the full QBank management surface (bank/question/test CRUD, multipart upload, processing status).
- Adds a "Question Banks" tab to the org nav.

No i18n keys in this PR — strings stay English-only until #1507 sweeps them.

## Changes
- `frontend/app/[locale]/org/[orgSlug]/qbank/page.tsx` + `client.tsx` — bank list
- `frontend/app/[locale]/org/[orgSlug]/qbank/create/page.tsx` + `client.tsx` — create + upload
- `frontend/app/[locale]/org/[orgSlug]/qbank/[bankId]/page.tsx` + `client.tsx` — detail
- `frontend/components/qbank/qbank-pdf-upload.tsx`
- `frontend/components/qbank/qbank-question-editor.tsx`
- `frontend/components/qbank/qbank-test-config.tsx`
- `frontend/components/org/org-nav.tsx` — new tab
- `frontend/lib/api.ts` — types + client fns

## Test plan
- [x] `npm run lint` — 0 errors (40 pre-existing warnings unchanged)
- [x] `npx tsc --noEmit` — no new type errors in qbank/
- [ ] Manual: create a bank, upload a PDF, watch extraction progress, edit a question, toggle publish, create a test
- [ ] Mobile layout at 320px (stacked grid, 44px touch targets)

Fixes #1504

🤖 Generated with [Claude Code](https://claude.com/claude-code)