### PR TITLE
fix: dynamic frontend URL for certificate PDF QR codes

### DIFF
--- a/backend/app/api/v1/certificates.py
+++ b/backend/app/api/v1/certificates.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
@@ -28,6 +28,23 @@ router = APIRouter(tags=["Certificates"])
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def frontend_url_from_request(request: Request) -> str:
+    """Derive the public frontend URL from the incoming request.
+
+    Prefers Traefik-set X-Forwarded-* headers, falls back to request.url,
+    then to settings.frontend_url. Returns URL without trailing slash.
+    """
+    from app.infrastructure.config.settings import settings
+
+    proto = request.headers.get("x-forwarded-proto")
+    host = request.headers.get("x-forwarded-host") or request.headers.get("host")
+    if proto and host:
+        return f"{proto}://{host}".rstrip("/")
+    if host:
+        return f"{request.url.scheme}://{host}".rstrip("/")
+    return settings.frontend_url.rstrip("/")
 
 
 def _template_to_response(t) -> CertificateTemplateResponse:
@@ -164,6 +181,7 @@ async def get_certificate_detail(
 @router.get("/certificates/{certificate_id}/download")
 async def download_certificate_pdf(
     certificate_id: uuid.UUID,
+    request: Request,
     db: AsyncSession = Depends(get_db_session),
     current_user: AuthenticatedUser = Depends(get_current_user),
 ):
@@ -210,7 +228,10 @@ async def download_certificate_pdf(
 
     pdf_svc = CertificatePDFService()
     language = current_user.preferred_language or "fr"
-    await pdf_svc.generate_and_store(cert, cert.template, cert.course, user, db, language)
+    frontend_url = frontend_url_from_request(request)
+    await pdf_svc.generate_and_store(
+        cert, cert.template, cert.course, user, db, language, frontend_url=frontend_url
+    )
 
     # Now download the freshly generated PDF
     from app.infrastructure.storage.s3 import S3StorageService

--- a/backend/app/api/v1/quiz.py
+++ b/backend/app/api/v1/quiz.py
@@ -5,7 +5,7 @@ import uuid
 from uuid import UUID
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -749,6 +749,7 @@ async def can_attempt_summative_assessment(
 )
 async def submit_summative_assessment_attempt(
     request: QuizAttemptRequest,
+    http_request: Request,
     session: AsyncSession = Depends(get_db),
     current_user: AuthenticatedUser = Depends(require_active_subscription),
 ) -> SummativeAssessmentResponse:
@@ -1032,6 +1033,10 @@ async def submit_summative_assessment_attempt(
 
                                 user_obj = await session.get(User, user_id)
                                 if user_obj and not cert.pdf_url:
+                                    from app.api.v1.certificates import (
+                                        frontend_url_from_request,
+                                    )
+
                                     pdf_svc = CertificatePDFService()
                                     await pdf_svc.generate_and_store(
                                         cert,
@@ -1040,6 +1045,7 @@ async def submit_summative_assessment_attempt(
                                         user_obj,
                                         session,
                                         language=current_user.preferred_language or "fr",
+                                        frontend_url=frontend_url_from_request(http_request),
                                     )
                             except Exception as pdf_err:
                                 logger.warning(

--- a/backend/app/domain/services/certificate_pdf_service.py
+++ b/backend/app/domain/services/certificate_pdf_service.py
@@ -60,6 +60,7 @@ def _render_pdf(
     course: Course,
     user: User,
     language: str,
+    frontend_url: str,
 ) -> bytes:
     """Synchronous PDF rendering using ReportLab canvas. Returns PDF bytes."""
     from reportlab.pdfgen.canvas import Canvas
@@ -192,7 +193,7 @@ def _render_pdf(
     c.line(60, y_bottom + 15, 250, y_bottom + 15)
 
     # ── QR code (right side) ───────────────────────────────────
-    verification_url = f"{settings.frontend_url}/verify/{certificate.verification_code}"
+    verification_url = f"{frontend_url.rstrip('/')}/verify/{certificate.verification_code}"
     try:
         import qrcode
 
@@ -238,9 +239,16 @@ class CertificatePDFService:
         course: Course,
         user: User,
         language: str = "fr",
+        frontend_url: str | None = None,
     ) -> bytes:
-        """Generate certificate PDF bytes. Runs ReportLab in a thread pool."""
-        return await asyncio.to_thread(_render_pdf, certificate, template, course, user, language)
+        """Generate certificate PDF bytes. Runs ReportLab in a thread pool.
+
+        If frontend_url is None, falls back to settings.frontend_url (for background jobs).
+        """
+        resolved_url = frontend_url or settings.frontend_url
+        return await asyncio.to_thread(
+            _render_pdf, certificate, template, course, user, language, resolved_url
+        )
 
     async def generate_and_store(
         self,
@@ -250,12 +258,15 @@ class CertificatePDFService:
         user: User,
         db: AsyncSession,
         language: str = "fr",
+        frontend_url: str | None = None,
     ) -> str:
         """Generate PDF, upload to MinIO, update certificate record.
 
         Returns the public URL of the stored PDF.
         """
-        pdf_bytes = await self.generate_pdf(certificate, template, course, user, language)
+        pdf_bytes = await self.generate_pdf(
+            certificate, template, course, user, language, frontend_url
+        )
 
         # Upload to MinIO
         storage = S3StorageService()


### PR DESCRIPTION
## Summary
- Certificate PDF QR codes now derive the frontend URL from the HTTP request (Traefik X-Forwarded-* headers → Host header → `settings.frontend_url` fallback)
- Fixes issue where QR codes pointed to `localhost:3000` on production deployments
- Works for multi-tenant setups without per-deployment env var fiddling

## Changes
- `certificate_pdf_service.py`: `generate_pdf()`, `generate_and_store()`, `_render_pdf()` accept `frontend_url` parameter
- `certificates.py`: new `frontend_url_from_request()` helper; download endpoint uses it
- `quiz.py`: auto-trigger for course completion uses the same helper via `http_request` param

## Test plan
- [x] 12 unit tests pass
- [ ] Regenerate test certificate via `/certificates/{id}/download` on staging — QR contains `https://etutor.elearning.portfolio2.kimbetien.com/...` not localhost
- [ ] Auto-trigger still works (summative submit doesn't crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)