### PR TITLE
feat(qbank): incorrect-only filter + attempt history on review/results (#1506)

### DIFF
--- a/frontend/app/[locale]/(app)/qbank/tests/[testId]/results/client.tsx
+++ b/frontend/app/[locale]/(app)/qbank/tests/[testId]/results/client.tsx
@@ -22,12 +22,15 @@ export function QBankTestResultsPage({ testId, attemptId }: QBankTestResultsPage
   const [review, setReview] = useState<QBankReviewResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [incorrectOnly, setIncorrectOnly] = useState(false);
 
   useEffect(() => {
     if (!attemptId) return;
+    let cancelled = false;
     getQBankTestReview(testId, attemptId)
-      .then(setReview)
-      .catch((err) => setError(err.message || 'Failed to load review'));
+      .then((r) => { if (!cancelled) setReview(r); })
+      .catch((err) => { if (!cancelled) setError(err.message || 'Failed to load review'); });
+    return () => { cancelled = true; };
   }, [testId, attemptId]);
 
   if (!attemptId) {
@@ -55,28 +58,50 @@ export function QBankTestResultsPage({ testId, attemptId }: QBankTestResultsPage
     );
   }
 
-  const currentQuestion = review.questions[currentIndex];
-  const totalQuestions = review.questions.length;
+  const filteredQuestions = incorrectOnly
+    ? review.questions.filter((q) => q.is_correct === false)
+    : review.questions;
+  const totalQuestions = filteredQuestions.length;
+  const safeIndex = Math.min(currentIndex, Math.max(0, totalQuestions - 1));
+  const currentQuestion = filteredQuestions[safeIndex];
 
   return (
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 px-4 py-4">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <Badge variant={review.passed ? 'default' : 'destructive'}>
           {review.passed ? t('passed') : t('failed')} — {Math.round(review.score)}%
         </Badge>
+        <label className="flex cursor-pointer items-center gap-2 text-sm text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={incorrectOnly}
+            onChange={(e) => {
+              setIncorrectOnly(e.target.checked);
+              setCurrentIndex(0);
+            }}
+            className="h-4 w-4"
+          />
+          {t('showIncorrectOnly')}
+        </label>
       </div>
 
+      {totalQuestions === 0 ? (
+        <p className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+          {t('noIncorrect')}
+        </p>
+      ) : (
       <div className="space-y-2">
         <div className="flex items-center justify-between text-sm text-muted-foreground">
-          <span>{t('question', { current: currentIndex + 1, total: totalQuestions })}</span>
+          <span>{t('question', { current: safeIndex + 1, total: totalQuestions })}</span>
         </div>
         <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
           <div
             className="h-full rounded-full bg-primary transition-all duration-300"
-            style={{ width: `${((currentIndex + 1) / totalQuestions) * 100}%` }}
+            style={{ width: `${((safeIndex + 1) / totalQuestions) * 100}%` }}
           />
         </div>
       </div>
+      )}
 
       {currentQuestion && (
         <>
@@ -113,11 +138,11 @@ export function QBankTestResultsPage({ testId, attemptId }: QBankTestResultsPage
               variant="outline"
               className="min-h-[44px] flex-1"
               onClick={() => setCurrentIndex((prev) => Math.max(0, prev - 1))}
-              disabled={currentIndex === 0}
+              disabled={safeIndex === 0}
             >
               {t('previousQuestion')}
             </Button>
-            {currentIndex < totalQuestions - 1 ? (
+            {safeIndex < totalQuestions - 1 ? (
               <Button
                 className="min-h-[44px] flex-1"
                 onClick={() => setCurrentIndex((prev) => prev + 1)}

--- a/frontend/components/qbank/qbank-test-results.tsx
+++ b/frontend/components/qbank/qbank-test-results.tsx
@@ -1,12 +1,16 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import type { QBankTestAttemptResponse } from '@/lib/api';
+import {
+  getQBankTestHistory,
+  type QBankTestAttemptResponse,
+} from '@/lib/api';
 
 interface QBankTestResultsProps {
   attempt: QBankTestAttemptResponse;
@@ -16,8 +20,18 @@ interface QBankTestResultsProps {
 export function QBankTestResults({ attempt, testId }: QBankTestResultsProps) {
   const t = useTranslations('qbank');
   const router = useRouter();
+  const [history, setHistory] = useState<QBankTestAttemptResponse[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getQBankTestHistory(testId)
+      .then((h) => { if (!cancelled) setHistory(h); })
+      .catch(() => { if (!cancelled) setHistory([]); });
+    return () => { cancelled = true; };
+  }, [testId]);
 
   const scorePercent = Math.round(attempt.score);
+  const priorAttempts = (history ?? []).filter((a) => a.id !== attempt.id);
 
   return (
     <div className="mx-auto flex w-full max-w-lg flex-col items-center gap-6 px-4 py-6">
@@ -76,6 +90,36 @@ export function QBankTestResults({ attempt, testId }: QBankTestResultsProps) {
                 </div>
               );
             })}
+          </CardContent>
+        </Card>
+      )}
+
+      {priorAttempts.length > 0 && (
+        <Card className="w-full">
+          <CardHeader>
+            <CardTitle>{t('attemptHistory')}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {priorAttempts
+              .slice()
+              .sort((a, b) => b.attempt_number - a.attempt_number)
+              .slice(0, 5)
+              .map((a) => (
+                <div
+                  key={a.id}
+                  className="flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-sm"
+                >
+                  <span className="text-muted-foreground">
+                    #{a.attempt_number} · {new Date(a.attempted_at).toLocaleDateString()}
+                  </span>
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium">{Math.round(a.score)}%</span>
+                    <Badge variant={a.passed ? 'default' : 'destructive'}>
+                      {a.passed ? t('passed') : t('failed')}
+                    </Badge>
+                  </div>
+                </div>
+              ))}
           </CardContent>
         </Card>
       )}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1998,6 +1998,9 @@
     "reviewAnswers": "Review Answers",
     "categoryBreakdown": "Results by Category",
     "timeTaken": "Total time: {seconds}s",
-    "noQuestions": "No questions available"
+    "noQuestions": "No questions available",
+    "showIncorrectOnly": "Show incorrect only",
+    "noIncorrect": "No incorrect answers to review.",
+    "attemptHistory": "Previous attempts"
   }
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1998,6 +1998,9 @@
     "reviewAnswers": "Revoir les réponses",
     "categoryBreakdown": "Résultats par catégorie",
     "timeTaken": "Temps total : {seconds}s",
-    "noQuestions": "Aucune question disponible"
+    "noQuestions": "Aucune question disponible",
+    "showIncorrectOnly": "Afficher uniquement les erreurs",
+    "noIncorrect": "Aucune réponse incorrecte à revoir.",
+    "attemptHistory": "Tentatives précédentes"
   }
 }


### PR DESCRIPTION
## Summary
Fills the remaining review / results gaps that #1552 left behind. The existing code already had the score, category breakdown, and per-question navigation; this adds the two missing pieces called out by #1506:

- **Review page** — "Show incorrect only" checkbox filters the question list to `is_correct === false`. Navigation indices stay sane when the filter flips mid-review; empty state handled when an attempt has no incorrect answers.
- **Results component** — now loads attempt history via `getQBankTestHistory` and renders the last five prior attempts (score + pass/fail badge) below the main score block.

Plus FR + EN i18n keys for the new strings (`showIncorrectOnly`, `noIncorrect`, `attemptHistory`).

## Scope caveats
- No backend changes. Time-per-question in review is not added here because the current review endpoint does not surface per-answer timings; that is a follow-up.

## Changes
- `frontend/app/[locale]/(app)/qbank/tests/[testId]/results/client.tsx`
- `frontend/components/qbank/qbank-test-results.tsx`
- `frontend/messages/{en,fr}.json`

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npx tsc --noEmit` — no qbank-related errors
- [ ] Manual: finish a test, toggle "show incorrect only" — list shrinks, navigation still works, empty state renders when nothing to review
- [ ] Manual: run the same test twice, second run shows the first attempt in history
- [ ] FR locale — new strings are translated

Fixes #1506

🤖 Generated with [Claude Code](https://claude.com/claude-code)