### PR TITLE
fix(wizard): retry button when taxonomy fails to load (#1598)

### DIFF
--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -247,8 +247,10 @@ export function AICourseWizard({
 
   // ── Load taxonomy ──────────────────────────────────────────────────
 
-  useEffect(() => {
-    getCourseTaxonomy().then((tax) => {
+  const loadTaxonomy = useCallback(async () => {
+    setTaxonomyError(false);
+    try {
+      const tax = await getCourseTaxonomy();
       const domains = tax.domains ?? [];
       const levels = tax.levels ?? [];
       const audienceTypes = tax.audience_types ?? [];
@@ -258,11 +260,15 @@ export function AICourseWizard({
       if (domains.length === 0 && levels.length === 0 && audienceTypes.length === 0) {
         setTaxonomyError(true);
       }
-    }).catch((err) => {
+    } catch (err) {
       console.error("[ai-course-wizard] Failed to load taxonomy:", err);
       setTaxonomyError(true);
-    });
+    }
   }, []);
+
+  useEffect(() => {
+    loadTaxonomy();
+  }, [loadTaxonomy]);
 
   // ── Hydrate on resume ─────────────────────────────────────────────
 
@@ -1114,11 +1120,22 @@ export function AICourseWizard({
                   </div>
 
                   {taxonomyError && (
-                    <div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700">
-                      <AlertCircle className="h-4 w-4 shrink-0" />
-                      {locale === "fr"
-                        ? "Impossible de charger les catégories. Rechargez la page ou continuez sans."
-                        : "Could not load categories. Reload the page or continue without."}
+                    <div className="flex items-center justify-between gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700">
+                      <div className="flex items-center gap-2">
+                        <AlertCircle className="h-4 w-4 shrink-0" />
+                        {locale === "fr"
+                          ? "Impossible de charger les catégories. Réessayez ou continuez sans."
+                          : "Could not load categories. Retry or continue without."}
+                      </div>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="h-7 shrink-0"
+                        onClick={() => loadTaxonomy()}
+                      >
+                        {locale === "fr" ? "Réessayer" : "Retry"}
+                      </Button>
                     </div>
                   )}
 


### PR DESCRIPTION
## Summary

Adds a **Retry** button inside the existing amber warning block in the AI course wizard so users can recover without reloading the whole page when `/api/v1/courses/taxonomy` returns empty or errors.

## Why

Seen during the sira-reseller-console demo tenant repair work: a fresh tenant pre-repair could land on the wizard's Objectifs step and be told to "reload the page" with no in-flow retry. Even after the console's self-serve repair endpoint ships, a gracefully-retrying wizard means one less hard-block for any taxonomy drift.

## Scope (narrow on purpose)

Only `frontend/components/admin/ai-course-wizard.tsx`:
- Extract `loadTaxonomy` into a `useCallback` hook reused by mount effect and the Retry button.
- Reset `taxonomyError` at each attempt so success clears the warning.

`canGoNext()` at line 871 already doesn't gate on taxonomy, so Next stays clickable — no code change needed there.

Other callsites of `getCourseTaxonomy` (`course-form.tsx`, `course-wizard-client.tsx`, `courses/page.tsx`, `curriculum-detail-view.tsx`) swallow errors silently or use taxonomy for filtering only — out of scope.

## Test plan

- [ ] Block `/api/v1/courses/taxonomy` via DevTools Network → advance to Objectifs → warning shows with Retry button → unblock + click → fields populate, warning gone.
- [ ] With taxonomy empty, Next advances the wizard (smoke).

Fixes #1598