### PR TITLE
fix(wizard): RAG auto-chain silently drops; wizard publishes with 0 chunks

### DIFF
--- a/backend/app/tasks/resource_extraction.py
+++ b/backend/app/tasks/resource_extraction.py
@@ -208,6 +208,7 @@ def extract_course_resource(self, resource_id: str) -> dict:
 
                     task = index_course_resources.delay(course_id, course.rag_collection_id)
                     course.indexation_task_id = task.id
+                    course.creation_step = "indexing"
                     session.commit()
                     logger.info(
                         "extract_course_resource: chained indexation",

--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -311,7 +311,31 @@ export function AICourseWizard({
             setStep("generate");
           }
         } else if (resumeCreationStep === "indexing" || resumeCreationStep === "indexed") {
-          setStep("publish");
+          // creation_step alone is not trustworthy — the auto-chain may have
+          // dispatched but silently failed, leaving chunks_indexed=0. Fetch
+          // actual status and route based on real state.
+          try {
+            const status = await getIndexStatusApi(resumeCourseId);
+            setIndexStatus({
+              indexed: status.indexed,
+              chunks_indexed: status.chunks_indexed,
+              images_indexed: status.images_indexed,
+              task: status.task,
+            });
+            const taskState = status.task?.state;
+            if (taskState && ["PENDING", "STARTED", "RETRY"].includes(taskState)) {
+              setTaskId(status.task?.id ?? null);
+              setIsIndexing(true);
+              lastIndexProgressTimeRef.current = Date.now();
+              setStep("syllabus_edit");
+            } else if (status.chunks_indexed > 0) {
+              setStep("publish");
+            } else {
+              setStep("syllabus_edit");
+            }
+          } catch {
+            setStep("syllabus_edit");
+          }
         } else if (resumeCreationStep === "published") {
           setStep("publish");
         }
@@ -822,7 +846,7 @@ export function AICourseWizard({
   // ── Publish ───────────────────────────────────────────────────────
 
   useEffect(() => {
-    if (step !== "publish" || !courseId) return;
+    if (step !== "publish" || !courseId || isIndexing) return;
     setIsFetchingPublishSummary(true);
     Promise.all([
       getAdminCourse(courseId),
@@ -838,7 +862,7 @@ export function AICourseWizard({
       })
       .catch(() => {})
       .finally(() => setIsFetchingPublishSummary(false));
-  }, [step, courseId]);
+  }, [step, courseId, isIndexing]);
 
   const publishCourse = useCallback(async () => {
     if (!courseId) return;
@@ -1545,7 +1569,39 @@ export function AICourseWizard({
                         {publishError}
                       </div>
                     )}
-                    <Button onClick={publishCourse} className="w-full min-h-11" disabled={isPublishing}>
+                    {!isFetchingPublishSummary && (publishSummaryIndexStatus?.chunks_indexed ?? 0) === 0 && (
+                      <div className="rounded-lg border border-amber-300 bg-amber-50 p-3 space-y-3 text-sm text-amber-900 dark:border-amber-600/40 dark:bg-amber-950/30 dark:text-amber-200">
+                        <div className="flex items-start gap-2">
+                          <AlertCircle className="h-4 w-4 shrink-0 mt-0.5" />
+                          <p>{tAi("publish.ragMissing")}</p>
+                        </div>
+                        {isIndexing ? (
+                          <div className="space-y-2">
+                            <div className="flex items-center gap-2">
+                              <div className="h-4 w-4 animate-spin rounded-full border-2 border-amber-700 border-t-transparent shrink-0" />
+                              <p className="text-sm">
+                                {taskProg ? getStepLabel(taskProg.step) : t("index.taskPending")}
+                              </p>
+                            </div>
+                            <Progress value={progressValue} className="h-2" />
+                          </div>
+                        ) : (
+                          <Button onClick={startIndexation} className="w-full min-h-11" variant="outline">
+                            <Database className="mr-2 h-4 w-4" />
+                            {t("index.button")}
+                          </Button>
+                        )}
+                      </div>
+                    )}
+                    <Button
+                      onClick={publishCourse}
+                      className="w-full min-h-11"
+                      disabled={
+                        isPublishing ||
+                        isIndexing ||
+                        (publishSummaryIndexStatus?.chunks_indexed ?? 0) === 0
+                      }
+                    >
                       {isPublishing ? (
                         <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent mr-2" />
                       ) : (

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1580,6 +1580,9 @@
         "description": "Generate lesson previews, review content, and edit before publishing. Edited lessons will be locked and served from cache.",
         "skipHint": "This step is optional. Click Next to skip to publishing."
       },
+      "publish": {
+        "ragMissing": "RAG indexation has not completed — 0 content fragments indexed. Run indexation before publishing so the AI tutor can cite your resources."
+      },
       "skipToPublish": "Skip to Publish"
     },
     "syllabusEditor": {

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1580,6 +1580,9 @@
         "description": "Générez des aperçus de leçons, vérifiez le contenu et modifiez avant la publication. Les leçons modifiées seront verrouillées et servies depuis le cache.",
         "skipHint": "Cette étape est optionnelle. Cliquez sur Suivant pour passer à la publication."
       },
+      "publish": {
+        "ragMissing": "L'indexation RAG n'est pas terminée — 0 fragment de contenu indexé. Lancez l'indexation avant de publier afin que le tuteur IA puisse citer vos ressources."
+      },
       "skipToPublish": "Passer à la publication"
     },
     "syllabusEditor": {


### PR DESCRIPTION
## Summary
- Backend auto-chain now sets `creation_step='indexing'` so `RAGTask.on_failure` rollback and the 409 guard in the manual trigger endpoint actually fire.
- Wizard resume handler stops blindly jumping to Publish on `indexing`/`indexed`; it now fetches `/index-status` and routes based on real state (live task, chunks>0, or stale/dead → syllabus_edit with retry).
- Publish step disables the Publier button and surfaces a **Run indexation** retry when `chunks_indexed=0` (previously the 400 came back from the backend with no inline recovery).

Fixes #1601

## Test plan
- [ ] Fresh AI course: upload PDF → proceed through wizard → confirm Publier is only enabled once `Fragments RAG > 0`.
- [ ] Simulate chain drop: during extraction, `docker compose restart celery-worker`; reopen wizard from course list → should land on `syllabus_edit` with "Lancer l'indexation" button, not on Publier.
- [ ] Silent-failure repro: manually `DELETE FROM document_chunks WHERE source=<rag_collection_id>`; close + reopen wizard → should route to `syllabus_edit` with retry button.
- [ ] Click retry on Publish step (chunks=0) → indexation runs inline, Publier button re-enables after completion.
- [ ] Verify FR + EN copy for `admin.aiCourseWizard.publish.ragMissing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)