### PR TITLE
fix(images): always proxy lesson source images through backend (#1607)

### DIFF
--- a/backend/app/domain/services/image_service.py
+++ b/backend/app/domain/services/image_service.py
@@ -103,9 +103,7 @@ class ImageGenerationService:
             source_img = await self._find_source_image(lesson_id, session)
             if source_img is not None:
                 image_record.status = "ready"
-                image_record.image_url = (
-                    source_img.storage_url or f"/api/v1/source-images/{source_img.id}/data"
-                )
+                image_record.image_url = f"/api/v1/source-images/{source_img.id}/data"
                 image_record.alt_text_fr = source_img.alt_text_fr or (
                     f"Figure {source_img.figure_number}" if source_img.figure_number else concept
                 )

--- a/backend/tests/test_tutor_source_image.py
+++ b/backend/tests/test_tutor_source_image.py
@@ -516,7 +516,7 @@ class TestDallEFallbackOptimization:
                 mock_openai_cls.assert_not_called()
 
         assert result.status == "ready"
-        assert source_img.storage_url in (result.image_url or "")
+        assert result.image_url == f"/api/v1/source-images/{source_img.id}/data"
 
     async def test_dalle_called_when_no_source_image(
         self, service, mock_session, mock_claude_response
@@ -567,7 +567,7 @@ class TestDallEFallbackOptimization:
     async def test_source_image_url_used_when_available(
         self, service, mock_session, mock_claude_response
     ):
-        """Source image's storage_url must be used as image_url."""
+        """Source image resolves to the backend proxy URL — not the internal MinIO URL."""
         from app.domain.models.content import GeneratedContent
 
         source_img = _make_source_image(
@@ -604,7 +604,7 @@ class TestDallEFallbackOptimization:
                     session=mock_session,
                 )
 
-        assert result.image_url == "https://cdn.example.com/figures/fig1.webp"
+        assert result.image_url == f"/api/v1/source-images/{source_img.id}/data"
         assert result.format == "webp"
 
 


### PR DESCRIPTION
## Summary

- Drop the `source_img.storage_url or …` fallback in `image_service.py`; always return the backend proxy path `/api/v1/source-images/{id}/data`.

## Why

Browsers cannot reach MinIO directly in prod — it has no Traefik route (intentionally private). When `SourceImage.storage_url` is populated by the PDF extraction pipeline, it contains the internal Docker URL `http://etutor-minio:9000/...`. The short-circuit in the old code meant every lesson that matched a source image wrote that internal URL into `generated_images.image_url`, which the frontend then failed to fetch (broken-image icon).

Same class of bug as #1603 (qbank images). That PR fixed the qbank path only; lessons went through a separate code path and were missed.

## Data repair (separate, manual)

Existing rows already persisted the bad URL. Run on prod after deploy:

```sql
UPDATE generated_images
SET image_url = '/api/v1/source-images/' || source_image_id || '/data'
WHERE image_url LIKE 'http%minio%';
```

(Verify the FK column name `source_image_id` against the current migration / model first.)

## Test plan

- [ ] Build green in CI
- [ ] Deploy to demo tenant
- [ ] Run the SQL data repair
- [ ] Reload a lesson previously showing broken image — returns 200 `image/webp` from `/api/v1/source-images/<uuid>/data`
- [ ] Confirm DALL-E / reuse paths (image_service.py:87, 137) still render — those already use `/api/v1/images/{id}/data`

Fixes #1607

🤖 Generated with [Claude Code](https://claude.com/claude-code)