### PR TITLE
fix(api): drop storage_url from response schemas to stop MinIO URL leaks (#1608)

### DIFF
--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -558,7 +558,6 @@ def _audio_response(row, question_id: uuid.UUID, language: str) -> AudioStatusRe
         question_id=str(question_id),
         language=language,
         status=row.status.value if hasattr(row.status, "value") else row.status,
-        storage_url=row.storage_url,
         duration_seconds=row.duration_seconds,
     )
 

--- a/backend/app/api/v1/schemas/content.py
+++ b/backend/app/api/v1/schemas/content.py
@@ -41,7 +41,6 @@ class SourceImageRef(BaseModel):
     image_type: str = Field(
         ..., description="Image type: diagram, photo, chart, formula, icon, unknown"
     )
-    storage_url: str | None = Field(None, description="CDN URL to the image")
     alt_text_fr: str | None = Field(None, description="French alt text")
     alt_text_en: str | None = Field(None, description="English alt text")
 

--- a/backend/app/api/v1/schemas/qbank.py
+++ b/backend/app/api/v1/schemas/qbank.py
@@ -276,7 +276,6 @@ class AudioStatusResponse(BaseModel):
     question_id: str
     language: str
     status: str
-    storage_url: str | None = None
     duration_seconds: int | None = None
 
 

--- a/backend/app/api/v1/schemas/source_images.py
+++ b/backend/app/api/v1/schemas/source_images.py
@@ -17,7 +17,6 @@ class SourceImageMetadataResponse(BaseModel):
     chapter: str | None = None
     width: int | None = None
     height: int | None = None
-    storage_url: str | None = None
     alt_text_fr: str | None = None
     alt_text_en: str | None = None
 

--- a/backend/app/domain/services/lesson_service.py
+++ b/backend/app/domain/services/lesson_service.py
@@ -787,7 +787,6 @@ class LessonGenerationService:
                         caption_en=img.get("caption"),
                         attribution=img.get("attribution"),
                         image_type=img.get("image_type") or "unknown",
-                        storage_url=img.get("storage_url"),
                         alt_text_fr=img.get("alt_text_fr"),
                         alt_text_en=img.get("alt_text_en"),
                     )

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -536,7 +536,6 @@ class TutorService:
                                                 "caption_en": meta.get("caption"),
                                                 "attribution": meta.get("attribution"),
                                                 "image_type": meta.get("image_type", "unknown"),
-                                                "storage_url": meta.get("storage_url"),
                                                 "alt_text_fr": meta.get("alt_text_fr"),
                                                 "alt_text_en": meta.get("alt_text_en"),
                                             }
@@ -646,7 +645,6 @@ class TutorService:
                                 "caption_en": meta.get("caption"),
                                 "attribution": meta.get("attribution"),
                                 "image_type": meta.get("image_type", "unknown"),
-                                "storage_url": meta.get("storage_url"),
                                 "alt_text_fr": meta.get("alt_text_fr"),
                                 "alt_text_en": meta.get("alt_text_en"),
                             }

--- a/backend/tests/test_source_image_injection.py
+++ b/backend/tests/test_source_image_injection.py
@@ -34,7 +34,6 @@ def _make_image_meta(
     figure_number="1.3",
     caption="Steps in the Marketing Process",
     image_type="diagram",
-    storage_url="https://cdn.example.com/img/test.webp",
     alt_text_fr="Diagramme",
     alt_text_en="Diagram",
 ):
@@ -43,7 +42,6 @@ def _make_image_meta(
         "figure_number": figure_number,
         "caption": caption,
         "image_type": image_type,
-        "storage_url": storage_url,
         "alt_text_fr": alt_text_fr,
         "alt_text_en": alt_text_en,
     }
@@ -146,7 +144,6 @@ class TestSourceImageRefSchema:
             figure_number="1.3",
             caption="Test caption",
             image_type="diagram",
-            storage_url="https://cdn.example.com/img.webp",
             alt_text_fr="Diagramme",
             alt_text_en="Diagram",
         )
@@ -156,7 +153,6 @@ class TestSourceImageRefSchema:
         ref = SourceImageRef(id=str(uuid.uuid4()), image_type="photo")
         assert ref.figure_number is None
         assert ref.caption is None
-        assert ref.storage_url is None
         assert ref.alt_text_fr is None
         assert ref.alt_text_en is None
 
@@ -265,7 +261,6 @@ class TestExtractSourceImageRefs:
             figure_number="3.1",
             caption="A diagram",
             image_type="diagram",
-            storage_url="https://cdn.example.com/x.webp",
             alt_text_fr="Diag FR",
             alt_text_en="Diag EN",
         )
@@ -274,6 +269,5 @@ class TestExtractSourceImageRefs:
         assert result[0].figure_number == "3.1"
         assert result[0].caption == "A diagram"
         assert result[0].image_type == "diagram"
-        assert result[0].storage_url == "https://cdn.example.com/x.webp"
         assert result[0].alt_text_fr == "Diag FR"
         assert result[0].alt_text_en == "Diag EN"


### PR DESCRIPTION
## Summary

Pure-deletion PR removing the `storage_url` field from three frontend-facing response schemas, plus the cascade in services and tests. No behavior preserved, no new endpoints — just stopping the leak.

## Why

MinIO is intentionally private in prod (no Traefik route in the console infra or tenant template). When `storage_url` is built from `MINIO_PUBLIC_URL`, it is the internal Docker hostname `http://etutor-minio:9000/...`, unreachable from the browser. Same root cause as #1603 (qbank images, fixed) and #1607 (lesson images, in flight).

## Changes

**Schemas (the actual leaks):**
- `SourceImageMetadataResponse.storage_url` removed (`schemas/source_images.py`)
- `SourceImageRef.storage_url` removed (`schemas/content.py`)
- `AudioStatusResponse.storage_url` removed (`schemas/qbank.py`)

**Cascade:**
- `tutor_service.py` — remove `"storage_url"` from both `source_image_refs` dicts
- `lesson_service.py` — remove `storage_url=` kwarg from `SourceImageRef(...)` ctor in `_extract_source_image_refs`
- `qbank.py` — remove `storage_url=` from `_audio_response` builder
- `tests/test_source_image_injection.py` — drop kwargs and assertions tied to the field

## Why no replacement field for qbank audio

Frontend has **no qbank audio consumer today** (verified by grep across `frontend/`). When a UI lands, a proxy endpoint mirroring `/api/v1/qbank/questions/{id}/image` (added in #1603) should be added at the same time. Tracked as a follow-up issue rather than a speculative endpoint here — keeps the PR small.

## Test plan

- [ ] Build green in CI (pytest + ruff)
- [ ] Deploy to staging
- [ ] Inspect responses for `/api/v1/source-images/{id}` and `/api/v1/source-images/by-source/{source}` — no `storage_url` key, no `http://*minio*` substring
- [ ] Tutor stream and lesson cache still resolve `source_image_refs` (frontend renders Figure refs unchanged — frontend `SourceImageMeta` interface in `frontend/lib/api.ts:659` never had this field)
- [ ] QBank audio status endpoint returns `{question_id, language, status, duration_seconds}` only

Fixes #1608
Related: #1603, #1607, #1610 (guardrail test to prevent recurrence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)