### PR TITLE
ci(deploy): surface rsync failure reason in action log (#1613)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -206,11 +206,16 @@ jobs:
         env:
           DEPLOY_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
         run: |
+          set -o pipefail
           mkdir -p ~/.ssh
           echo "$DEPLOY_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H 167.86.115.58 >> ~/.ssh/known_hosts
-          rsync -avz -e "ssh -i ~/.ssh/deploy_key" \
+          # -T bounds the scan; otherwise a stalled sshd banner hangs until action timeout.
+          ssh-keyscan -T 10 -H 167.86.115.58 >> ~/.ssh/known_hosts
+          # -v on rsync + ConnectTimeout on ssh ensure the stderr reason (timeout, auth,
+          # host key) lands in the action log instead of a bare "exit code 1" (see #1613).
+          rsync -avvz \
+            -e "ssh -i ~/.ssh/deploy_key -o ConnectTimeout=15 -o ServerAliveInterval=10" \
             docker-compose.prod.yml \
             deploy@167.86.115.58:~/etutor/docker-compose.yml
 


### PR DESCRIPTION
## Summary
- Fixes the opacity described in #1613: the `Rsync compose file` step has been dying with `Process completed with exit code 1` and no stderr, so we can't tell if it's an SSH banner timeout, host-key mismatch, or auth failure.
- Adds `rsync -avvz` (was `-avz`) so ssh stderr makes it into the action log.
- Wraps the ssh inner command with `-o ConnectTimeout=15 -o ServerAliveInterval=10` so the step fails fast on a stalled sshd banner (which is what the staging host appears to be doing — TCP 22 accepts but banner exchange times out) and keeps long transfers alive.
- Bounds `ssh-keyscan` with `-T 10` so the pre-flight doesn't silently pin the step open.
- `set -o pipefail` so keyscan errors actually fail the step.

Does not restart the staging host — that's still blocked on someone with SSH access running `uptime && df -h && docker ps && docker compose logs` on `deploy@167.86.115.58`. See #1613 for the triage checklist.

## Test plan
- [ ] CI green on this PR.
- [ ] Once staging is reachable again, the next deploy either succeeds, or fails with a diagnostic line (`ssh: connect to host … port 22: Connection timed out`, `Permission denied (publickey)`, etc.) instead of a bare exit 1.

Refs #1613