### PR TITLE
fix(qbank): drop Bearer auth from image proxy so <img> tags can fetch (#1628)

### DIFF
--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -633,7 +633,6 @@ async def get_question_audio(
 @router.get("/questions/{question_id}/image")
 async def get_question_image(
     question_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(get_current_user),
     db=Depends(get_db_session),
 ):
     """Stream a qbank question's webp image from MinIO via the backend.
@@ -643,6 +642,11 @@ async def get_question_image(
     from browsers. This endpoint reuses the same pattern as the lesson audio
     streamer and serves the bytes with a long-lived cache header — the
     storage_key includes order_index so the URL is stable per question.
+
+    No auth: <img> tags cannot attach an Authorization header, and the frontend
+    embeds these URLs straight into src attributes. The unguessable question
+    UUID is the capability, matching the pattern in source_images.get_image_data
+    and lesson_audio.get_audio_data (#1628).
     """
     question = await db.get(QBankQuestion, question_id)
     if question is None or not question.image_storage_key:


### PR DESCRIPTION
## Summary
Fixes #1628. After #1603 landed, question-image URLs pointed at the backend proxy (\`/api/v1/qbank/questions/{id}/image\`) — but that endpoint required \`Authorization: Bearer\`, which browsers do not attach to \`<img>\` / \`<audio>\` / \`<link>\` requests. Every image in the qbank bank editor, the test-taker runner, and the review page 401'd, so #1603 swapped one broken URL for another.

This PR drops \`Depends(get_current_user)\` from the image endpoint. The unguessable question UUID is the capability, matching the pattern already used by sibling byte-streaming endpoints:

- [\`source_images.get_image_data\`](backend/app/api/v1/source_images.py#L72) — unauthenticated
- [\`lesson_audio.get_audio_data\`](backend/app/api/v1/lesson_audio.py#L189) — unauthenticated

The qbank image route was the outlier.

## Verification on staging (before this PR)
\`\`\`
$ curl -skD - -o /dev/null "…/api/v1/qbank/questions/…/image"
HTTP/2 401
www-authenticate: Bearer
\`\`\`
Live browser session: all 11 question \`<img>\` tags showed \`naturalWidth=0\` — admin editor, taker runner, results review all broken.

## After this PR (expected)
- \`GET /api/v1/qbank/questions/{id}/image\` → 200 with \`image/webp\` for any caller with the UUID.
- \`<img src="…/image">\` loads naturally; no JS changes needed.
- Existing \`_image_url_for\` URL-building tests still pass (\`test_qbank_image_proxy.py\`).

## Test plan
- [ ] CI green on this PR
- [ ] After deploy, open any qbank bank with images on staging — question images render
- [ ] Start a test via \`/fr/qbank/tests/<id>\` — per-question images render as the timer runs
- [ ] Finish + review — images render in the review page too

Fixes #1628
Refs #1603 (which introduced the proxy URL)