### PR TITLE
Merge dev \u2192 main: PWA serwist wiring (#1634)

### DIFF
--- a/frontend/app/[locale]/layout.tsx
+++ b/frontend/app/[locale]/layout.tsx
@@ -5,6 +5,7 @@ import { routing } from "@/i18n/routing";
 import { QueryProvider } from "@/lib/query-provider";
 import { SettingsProvider } from "@/lib/settings-context";
 import { InstallPrompt } from "@/components/pwa/install-prompt";
+import { ServiceWorkerRegister } from "@/components/pwa/service-worker-register";
 import { PostHogProvider } from "@/lib/posthog-provider";
 
 export default async function LocaleLayout({
@@ -29,6 +30,7 @@ export default async function LocaleLayout({
           <SettingsProvider>
             {children}
             <InstallPrompt />
+            <ServiceWorkerRegister />
           </SettingsProvider>
         </QueryProvider>
       </PostHogProvider>

--- a/frontend/components/pwa/service-worker-register.tsx
+++ b/frontend/components/pwa/service-worker-register.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Registers /sw.js (built by @serwist/next from frontend/sw.ts) on mount.
+ *
+ * Mounted once inside the locale layout. The SW is the only path to offline
+ * content caching + background sync — see issue #1615 for the regression this
+ * fixes (the standalone build shipped without an SW registration call).
+ */
+export function ServiceWorkerRegister() {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!("serviceWorker" in navigator)) return;
+    // Don't register in dev — @serwist/next disables the build there too.
+    if (process.env.NODE_ENV === "development") return;
+
+    navigator.serviceWorker
+      .register("/sw.js", { scope: "/" })
+      .catch((err) => {
+        // Log but don't fail the page — offline mode degrades gracefully.
+        console.warn("[sw] registration failed:", err);
+      });
+  }, []);
+
+  return null;
+}

--- a/frontend/e2e/pwa.spec.ts
+++ b/frontend/e2e/pwa.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Regression guard for issue #1615 — without @serwist/next wiring in
+ * next.config.ts, `/sw.js` returns Next's 404 HTML and `getRegistrations()`
+ * is empty. If either drifts back to that state this test fails in CI.
+ */
+test.describe("PWA service worker", () => {
+  test("/sw.js is served as JavaScript", async ({ request }) => {
+    const res = await request.get("/sw.js");
+    expect(res.status()).toBe(200);
+    const contentType = res.headers()["content-type"] || "";
+    expect(contentType).toMatch(/javascript/);
+    // Sanity: the file should actually look like an SW (registers some handler).
+    const body = await res.text();
+    expect(body).toMatch(/self\.|serviceWorker|workbox|serwist/i);
+  });
+
+  test("service worker registers on page load", async ({ page }) => {
+    await page.goto("/fr/courses");
+    // Wait for the ServiceWorkerRegister effect to fire + SW to install.
+    await page.waitForFunction(
+      async () => {
+        if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) {
+          return false;
+        }
+        const regs = await navigator.serviceWorker.getRegistrations();
+        return regs.length >= 1;
+      },
+      null,
+      { timeout: 10_000 },
+    );
+    const count = await page.evaluate(async () => {
+      const regs = await navigator.serviceWorker.getRegistrations();
+      return regs.length;
+    });
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,10 +2,21 @@ import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 import { withSentryConfig } from "@sentry/nextjs";
 import createBundleAnalyzer from "@next/bundle-analyzer";
+import withSerwistInit from "@serwist/next";
 
 const withNextIntl = createNextIntlPlugin("./i18n/request.ts");
 const withBundleAnalyzer = createBundleAnalyzer({
   enabled: process.env.ANALYZE === "true",
+});
+
+// Wires sw.ts → /public/sw.js at build time. Required for PWA registration;
+// without this the standalone build ships with no service worker and offline
+// mode silently fails (see issue #1615).
+const withSerwist = withSerwistInit({
+  swSrc: "sw.ts",
+  swDest: "public/sw.js",
+  reloadOnOnline: true,
+  disable: process.env.NODE_ENV === "development",
 });
 
 const nextConfig: NextConfig = {
@@ -108,7 +119,7 @@ const nextConfig: NextConfig = {
 };
 
 export default withSentryConfig(
-  withBundleAnalyzer(withNextIntl(nextConfig)),
+  withSerwist(withBundleAnalyzer(withNextIntl(nextConfig))),
   {
     org: process.env.SENTRY_ORG,
     project: process.env.SENTRY_PROJECT,


### PR DESCRIPTION
## Summary
Fixes the PWA regression on all tenants: `/sw.js` is now emitted by Serwist during the standalone build and registered on mount via a new client component. Offline-first is restored.

Fixes sira #1615 on deploy.

## Test plan
- [x] Backend CI green on dev
- [x] Frontend build CI green on dev (Serwist plugin compiles)
- [ ] Post-deploy: `curl https://demo.tenant.sira-donnia.org/sw.js` → 200 `application/javascript`
- [ ] Post-deploy: in browser, `navigator.serviceWorker.getRegistrations().length >= 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)