### PR TITLE
fix(images): bypass Next.js optimizer for API-proxied lesson images

### DIFF
--- a/frontend/components/learning/lesson-image.tsx
+++ b/frontend/components/learning/lesson-image.tsx
@@ -102,6 +102,7 @@ export function LessonImage({ lessonId, language }: LessonImageProps) {
             height={512}
             loading="lazy"
             sizes="(max-width: 640px) 100vw, 512px"
+            unoptimized
             className={`w-full h-auto object-cover rounded-lg transition-opacity duration-300 ${
               isVisible ? 'opacity-100' : 'opacity-0'
             }`}
@@ -134,6 +135,7 @@ export function LessonImage({ lessonId, language }: LessonImageProps) {
             width={512}
             height={512}
             sizes="(max-width: 640px) 100vw, 512px"
+            unoptimized
             className="max-w-full max-h-full object-contain rounded-lg"
             onClick={(e) => e.stopPropagation()}
           />

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -49,6 +49,14 @@ const nextConfig: NextConfig = {
         hostname: "api.elearning.portfolio2.kimbetien.com",
         pathname: "/api/**",
       },
+      // Production wildcard for tenants provisioned under *.sira-donnia.org.
+      // Covers same-origin `<tenant>.tenant.sira-donnia.org/api/**` *and*
+      // the direct `api.<tenant>.tenant.sira-donnia.org` subdomain.
+      {
+        protocol: "https",
+        hostname: "**.sira-donnia.org",
+        pathname: "/**",
+      },
     ],
   },
 


### PR DESCRIPTION
## Summary
- `unoptimized` on both `<Image>` instances in `LessonImage`. Backend already ships immutable WebP; the optimizer roundtrip only added latency and, on prod, hard-failed (400).
- Add wildcard `**.sira-donnia.org` in `images.remotePatterns` so any reseller-provisioned tenant is covered without a code change. Kept the pre-existing entries intact for dev/staging back-compat.

Fixes #1616

## Regression context
The only hostname whitelisted was `api.elearning.portfolio2.kimbetien.com` (staging). Prod tenants under `*.sira-donnia.org` were not in the list, so the Next optimizer rejected the same-origin `/api/v1/images/<uuid>/data` URL with HTTP 400. Every lesson image on every prod tenant looked broken (`<img>.naturalWidth === 0`), even though the backend served the bytes correctly.

## Test plan
- [x] TypeScript clean on changed files
- [ ] Post-deploy: open a lesson on demo tenant; confirm images render and DevTools shows 200s on `/api/v1/images/<uuid>/data` (direct) and no `/_next/image?url=/api/…` 400s.
- [ ] Regression: a non-API image (e.g. course cover from MinIO) still renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)