### PR TITLE
Merge dev → main: qbank training feedback + multi-answer taker (#1633)

### DIFF
--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -337,6 +337,11 @@ async def start_test(
 ):
     data = await _svc.start_test(db, test_id, uuid.UUID(current_user.id))
     test = data["test"]
+    # Training mode with show_feedback relies on the client knowing the answer
+    # key so it can show per-question "Correct/Incorrect" without an extra
+    # round-trip. In exam mode the key stays server-side (#1632).
+    mode_value = test.mode.value if hasattr(test.mode, "value") else test.mode
+    expose_answers = mode_value == "training" and test.show_feedback
     questions = [
         TestStartQuestion(
             id=str(q.id),
@@ -345,6 +350,7 @@ async def start_test(
             options=q.options,
             category=q.category,
             difficulty=q.difficulty.value if hasattr(q.difficulty, "value") else q.difficulty,
+            correct_answer_indices=q.correct_answer_indices if expose_answers else None,
         )
         for q in data["questions"]
     ]
@@ -352,7 +358,7 @@ async def start_test(
     return TestStartResponse(
         test_id=str(test.id),
         title=test.title,
-        mode=test.mode.value if hasattr(test.mode, "value") else test.mode,
+        mode=mode_value,
         time_per_question_sec=data["time_per_question_sec"],
         show_feedback=test.show_feedback,
         questions=questions,

--- a/backend/app/api/v1/schemas/qbank.py
+++ b/backend/app/api/v1/schemas/qbank.py
@@ -139,6 +139,11 @@ class TestStartQuestion(BaseModel):
     options: list[str]
     category: str | None = None
     difficulty: str
+    # Populated only when the test is in training mode with show_feedback=True,
+    # so the client can draw a "Correct"/"Incorrect" banner without a round-trip
+    # per answer. Kept None for exam mode so network-tab inspection doesn't leak
+    # the answer key (#1632).
+    correct_answer_indices: list[int] | None = None
 
 
 class TestStartResponse(BaseModel):

--- a/frontend/app/[locale]/(app)/qbank/tests/[testId]/results/client.tsx
+++ b/frontend/app/[locale]/(app)/qbank/tests/[testId]/results/client.tsx
@@ -120,8 +120,8 @@ export function QBankTestResultsPage({ testId, attemptId }: QBankTestResultsPage
                   category: currentQuestion.category,
                   difficulty: '',
                 }}
-                selectedOption={currentQuestion.user_selected?.[0] ?? null}
-                onSelect={() => {}}
+                selectedIndices={currentQuestion.user_selected ?? []}
+                onToggle={() => {}}
                 showFeedback={true}
                 correctIndices={currentQuestion.correct_answer_indices}
               />

--- a/frontend/components/qbank/qbank-image-question.tsx
+++ b/frontend/components/qbank/qbank-image-question.tsx
@@ -8,33 +8,46 @@ const OPTION_LABELS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
 
 interface QBankImageQuestionProps {
   question: QBankQuestion;
-  selectedOption: number | null;
-  onSelect: (index: number) => void;
+  selectedIndices: number[];
+  onToggle: (index: number) => void;
   showFeedback: boolean;
   correctIndices?: number[];
   onImageLoad?: () => void;
 }
 
+// Multi-answer questions are scored as an exact set match — the picks equal
+// the correct set, order-agnostic (#1632).
+function selectionIsCorrect(
+  selected: readonly number[],
+  correct: readonly number[] | undefined
+): boolean {
+  if (!correct) return false;
+  if (selected.length !== correct.length) return false;
+  const correctSet = new Set(correct);
+  return selected.every((i) => correctSet.has(i));
+}
+
 export function QBankImageQuestion({
   question,
-  selectedOption,
-  onSelect,
+  selectedIndices,
+  onToggle,
   showFeedback,
   correctIndices,
   onImageLoad,
 }: QBankImageQuestionProps) {
   const t = useTranslations('qbank');
+  const hasSelection = selectedIndices.length > 0;
+  const isAnswerCorrect = selectionIsCorrect(selectedIndices, correctIndices);
 
   const getOptionStyle = (index: number) => {
-    if (!showFeedback || selectedOption === null) {
-      return selectedOption === index
+    const isSelected = selectedIndices.includes(index);
+    if (!showFeedback) {
+      return isSelected
         ? 'border-primary bg-primary/10 ring-2 ring-primary'
         : 'border-border hover:border-primary/50 hover:bg-muted/50';
     }
 
     const isCorrect = correctIndices?.includes(index);
-    const isSelected = selectedOption === index;
-
     if (isCorrect) return 'border-green-500 bg-green-50 dark:bg-green-950/30';
     if (isSelected && !isCorrect) return 'border-red-500 bg-red-50 dark:bg-red-950/30';
     return 'border-border opacity-60';
@@ -56,40 +69,43 @@ export function QBankImageQuestion({
 
       <p className="text-base font-medium leading-relaxed">{question.question_text}</p>
 
-      {showFeedback && selectedOption !== null && (
+      {showFeedback && hasSelection && (
         <div className={cn(
           'rounded-lg px-3 py-2 text-sm font-medium',
-          correctIndices?.includes(selectedOption)
+          isAnswerCorrect
             ? 'bg-green-100 text-green-800 dark:bg-green-950/50 dark:text-green-300'
             : 'bg-red-100 text-red-800 dark:bg-red-950/50 dark:text-red-300'
         )}>
-          {correctIndices?.includes(selectedOption) ? t('correct') : t('incorrect')}
+          {isAnswerCorrect ? t('correct') : t('incorrect')}
         </div>
       )}
 
       <div className="flex flex-col gap-2">
-        {question.options.map((option, index) => (
-          <button
-            key={index}
-            onClick={() => onSelect(index)}
-            disabled={showFeedback && selectedOption !== null}
-            className={cn(
-              'flex min-h-[44px] items-center gap-3 rounded-lg border-2 px-4 py-3 text-left transition-colors',
-              getOptionStyle(index),
-              'disabled:cursor-default'
-            )}
-          >
-            <span className={cn(
-              'flex h-8 w-8 shrink-0 items-center justify-center rounded-full border text-sm font-semibold',
-              selectedOption === index
-                ? 'border-primary bg-primary text-primary-foreground'
-                : 'border-muted-foreground/30'
-            )}>
-              {OPTION_LABELS[index]}
-            </span>
-            <span className="text-sm">{option}</span>
-          </button>
-        ))}
+        {question.options.map((option, index) => {
+          const isSelected = selectedIndices.includes(index);
+          return (
+            <button
+              key={index}
+              onClick={() => onToggle(index)}
+              disabled={showFeedback}
+              className={cn(
+                'flex min-h-[44px] items-center gap-3 rounded-lg border-2 px-4 py-3 text-left transition-colors',
+                getOptionStyle(index),
+                'disabled:cursor-default'
+              )}
+            >
+              <span className={cn(
+                'flex h-8 w-8 shrink-0 items-center justify-center rounded-full border text-sm font-semibold',
+                isSelected
+                  ? 'border-primary bg-primary text-primary-foreground'
+                  : 'border-muted-foreground/30'
+              )}>
+                {OPTION_LABELS[index]}
+              </span>
+              <span className="text-sm">{option}</span>
+            </button>
+          );
+        })}
       </div>
     </div>
   );

--- a/frontend/components/qbank/qbank-test-player.tsx
+++ b/frontend/components/qbank/qbank-test-player.tsx
@@ -68,34 +68,64 @@ export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
     }
   }, [testData, currentIndex]);
 
-  const handleSelect = useCallback((optionIndex: number) => {
+  // Toggle an option in the current question's selection. Multi-answer questions
+  // need to accumulate picks before scoring — training-mode feedback is deferred
+  // to an explicit "Valider" step rather than firing on first click (#1632).
+  const handleToggle = useCallback((optionIndex: number) => {
     if (!currentQuestion || showingFeedback) return;
 
     const timeSec = recordTime();
-    setAnswers((prev) => ({
-      ...prev,
-      [currentQuestion.id]: { selected: [optionIndex], time_sec: timeSec },
-    }));
+    setAnswers((prev) => {
+      const existing = prev[currentQuestion.id]?.selected ?? [];
+      const next = existing.includes(optionIndex)
+        ? existing.filter((i) => i !== optionIndex)
+        : [...existing, optionIndex];
+      return {
+        ...prev,
+        [currentQuestion.id]: { selected: next, time_sec: timeSec },
+      };
+    });
+  }, [currentQuestion, showingFeedback, recordTime]);
 
-    if (testData?.mode === 'training' && testData.show_feedback) {
-      setTimerRunning(false);
-      setShowingFeedback(true);
-    }
-  }, [currentQuestion, showingFeedback, recordTime, testData]);
+  // Commit the training-mode answer: stop the timer and reveal the correct set.
+  // "Question suivante" then unlocks normally via the existing flow.
+  const handleValidate = useCallback(() => {
+    if (!currentQuestion) return;
+    const timeSec = recordTime();
+    setAnswers((prev) => {
+      const existing = prev[currentQuestion.id];
+      if (!existing) return prev;
+      return {
+        ...prev,
+        [currentQuestion.id]: { ...existing, time_sec: timeSec },
+      };
+    });
+    setTimerRunning(false);
+    setShowingFeedback(true);
+  }, [currentQuestion, recordTime]);
 
   const handleTimerExpire = useCallback(() => {
     if (!currentQuestion) return;
     const timeSec = recordTime();
+    const hadAnswer = Boolean(answers[currentQuestion.id]);
     setAnswers((prev) => {
       if (prev[currentQuestion.id]) return prev;
       return { ...prev, [currentQuestion.id]: { selected: [], time_sec: timeSec } };
     });
     setTimerRunning(false);
 
+    // In training+feedback mode, if the learner had already picked something,
+    // lock in what they have and reveal the correct set instead of skipping.
+    // Otherwise (no pick, or exam mode) advance like before.
+    if (testData?.mode === 'training' && testData.show_feedback && hadAnswer) {
+      setShowingFeedback(true);
+      return;
+    }
+
     if (testData && currentIndex < testData.questions.length - 1) {
       setTimeout(() => goToNext(), 500);
     }
-  }, [currentQuestion, recordTime, testData, currentIndex, goToNext]);
+  }, [currentQuestion, recordTime, testData, currentIndex, goToNext, answers]);
 
   const handleSubmit = useCallback(async () => {
     if (!testData) return;
@@ -162,10 +192,18 @@ export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
 
   const totalQuestions = testData.questions.length;
   const progressPercent = ((currentIndex + 1) / totalQuestions) * 100;
-  const selectedOption = answers[currentQuestion.id]?.selected[0] ?? null;
+  const selectedIndices = answers[currentQuestion.id]?.selected ?? [];
+  const hasSelection = selectedIndices.length > 0;
   const isLastQuestion = currentIndex === totalQuestions - 1;
   const isExamMode = testData.mode === 'exam';
+  const isTrainingWithFeedback =
+    testData.mode === 'training' && testData.show_feedback;
   const hasTimer = testData.time_per_question_sec > 0 && testData.mode !== 'review';
+  // correct_answer_indices is only on the payload in training+feedback mode.
+  // Review mode doesn't need it (that page fetches its own review data).
+  const correctIndices = isTrainingWithFeedback
+    ? (currentQuestion.correct_answer_indices ?? undefined)
+    : undefined;
 
   return (
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 px-4 py-4">
@@ -193,10 +231,10 @@ export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
 
       <QBankImageQuestion
         question={currentQuestion}
-        selectedOption={selectedOption}
-        onSelect={handleSelect}
+        selectedIndices={selectedIndices}
+        onToggle={handleToggle}
         showFeedback={showingFeedback || testData.mode === 'review'}
-        correctIndices={testData.mode === 'review' ? [] : undefined}
+        correctIndices={correctIndices}
         onImageLoad={() => {
           if (hasTimer && !showingFeedback) {
             setTimerRunning(true);
@@ -216,6 +254,17 @@ export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
           </Button>
         )}
 
+        {/* Training + show_feedback: commit the selection explicitly before advancing.
+            Lets the learner pick every correct option on multi-answer questions. */}
+        {isTrainingWithFeedback && !showingFeedback && hasSelection && (
+          <Button
+            className="min-h-[44px] flex-1"
+            onClick={handleValidate}
+          >
+            {t('validate')}
+          </Button>
+        )}
+
         {showingFeedback && !isLastQuestion && (
           <Button
             className="min-h-[44px] flex-1"
@@ -225,7 +274,7 @@ export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
           </Button>
         )}
 
-        {!showingFeedback && !isExamMode && selectedOption !== null && !isLastQuestion && (
+        {!showingFeedback && !isExamMode && !isTrainingWithFeedback && hasSelection && !isLastQuestion && (
           <Button
             className="min-h-[44px] flex-1"
             onClick={goToNext}
@@ -234,7 +283,7 @@ export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
           </Button>
         )}
 
-        {isExamMode && !isLastQuestion && selectedOption !== null && (
+        {isExamMode && !isLastQuestion && hasSelection && (
           <Button
             className="min-h-[44px] flex-1"
             onClick={goToNext}
@@ -243,7 +292,7 @@ export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
           </Button>
         )}
 
-        {((isLastQuestion && selectedOption !== null && !showingFeedback) ||
+        {((isLastQuestion && hasSelection && !showingFeedback && !isTrainingWithFeedback) ||
           (isLastQuestion && showingFeedback)) && (
           <Button
             className={cn('min-h-[44px]', isExamMode ? 'w-full' : 'flex-1')}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1494,6 +1494,12 @@ export interface QBankQuestion {
   options: string[];
   category: string | null;
   difficulty: string;
+  /**
+   * Populated only when the test is in training mode with show_feedback=true.
+   * Lets the player draw "Correct"/"Incorrect" without a per-click round-trip.
+   * Undefined in exam mode so devtools users can't peek the answer key. (#1632)
+   */
+  correct_answer_indices?: number[] | null;
 }
 
 export interface QBankTestStartResponse {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1990,6 +1990,7 @@
     "question": "Question {current} of {total}",
     "timeRemaining": "{seconds}s",
     "submitTest": "Finish Test",
+    "validate": "Check answer",
     "nextQuestion": "Next Question",
     "previousQuestion": "Previous Question",
     "score": "Score",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1990,6 +1990,7 @@
     "question": "Question {current} sur {total}",
     "timeRemaining": "{seconds}s",
     "submitTest": "Terminer le test",
+    "validate": "Valider",
     "nextQuestion": "Question suivante",
     "previousQuestion": "Question précédente",
     "score": "Score",


### PR DESCRIPTION
## Summary
Rolling these dev-side fixes up to main so they deploy:
- #1633 — training-mode feedback banner + multi-answer taker UX (fixes #1632)
- Includes recent dev-only additions: PWA serwist wiring (#1615), branding runtime fetch follow-ups

## Test plan
- [ ] CI green on this merge PR
- [ ] After deploy, open a training-mode test with \`show_feedback=true\` on a multi-correct question → pick all correct options → "Valider" → banner reads Correct
- [ ] Exam-mode \`/tests/{id}/start\` response in devtools does not include \`correct_answer_indices\`