### PR TITLE
fix(api): drop remaining storage_url fields + land guardrail test (#1639)

### DIFF
--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -564,7 +564,6 @@ def _audio_response(row, question_id: uuid.UUID, language: str) -> AudioStatusRe
         question_id=str(question_id),
         language=language,
         status=row.status.value if hasattr(row.status, "value") else row.status,
-        storage_url=row.storage_url,
         duration_seconds=row.duration_seconds,
     )
 

--- a/backend/app/api/v1/schemas/qbank.py
+++ b/backend/app/api/v1/schemas/qbank.py
@@ -281,7 +281,6 @@ class AudioStatusResponse(BaseModel):
     question_id: str
     language: str
     status: str
-    storage_url: str | None = None
     duration_seconds: int | None = None
 
 

--- a/backend/app/api/v1/schemas/source_images.py
+++ b/backend/app/api/v1/schemas/source_images.py
@@ -17,7 +17,6 @@ class SourceImageMetadataResponse(BaseModel):
     chapter: str | None = None
     width: int | None = None
     height: int | None = None
-    storage_url: str | None = None
     alt_text_fr: str | None = None
     alt_text_en: str | None = None
 

--- a/backend/tests/test_no_minio_leaks_in_schemas.py
+++ b/backend/tests/test_no_minio_leaks_in_schemas.py
@@ -1,0 +1,63 @@
+"""Guardrail: no field on any v1 response schema may leak internal storage URLs.
+
+MinIO is private in prod (no Traefik route). Any field containing a raw
+storage URL or storage key serializes an internal Docker hostname to the
+browser. The fix pattern is to expose proxy URLs via /api/v1/.../data
+endpoints instead. This test fails any future schema that re-introduces
+the leak.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+
+import pydantic
+
+import app.api.v1.schemas as schemas_pkg
+
+FORBIDDEN_FIELD_NAMES = {"storage_url", "storage_key", "minio_url"}
+
+# Intentionally-allowed carry-overs: schemas where the field is kept on purpose.
+# Keyed by "module.ClassName" and accompanied by a comment explaining why. New
+# entries should be rare; prefer dropping the field and routing through a
+# /api/v1/.../data proxy endpoint (the pattern that closed #1603/#1628).
+ALLOWED_LEAKS: dict[str, set[str]] = {
+    # Retained per owner decision 2026-04-18: lesson output carries a CDN URL
+    # reference via SourceImageRef that the frontend renderer may consume
+    # directly. Byte streams still flow through /api/v1/source-images/{id}/data.
+    "app.api.v1.schemas.content.SourceImageRef": {"storage_url"},
+}
+
+
+def _walk_response_models() -> list[type[pydantic.BaseModel]]:
+    models: list[type[pydantic.BaseModel]] = []
+    pkg_path = schemas_pkg.__path__
+    pkg_name = schemas_pkg.__name__
+    for _, mod_name, _ in pkgutil.iter_modules(pkg_path, pkg_name + "."):
+        mod = importlib.import_module(mod_name)
+        for attr in vars(mod).values():
+            if (
+                isinstance(attr, type)
+                and issubclass(attr, pydantic.BaseModel)
+                and attr is not pydantic.BaseModel
+            ):
+                models.append(attr)
+    return models
+
+
+def test_no_storage_url_or_key_field_in_v1_schemas():
+    offenders = []
+    for model in _walk_response_models():
+        leaked = set(model.model_fields) & FORBIDDEN_FIELD_NAMES
+        key = f"{model.__module__}.{model.__name__}"
+        leaked -= ALLOWED_LEAKS.get(key, set())
+        if leaked:
+            offenders.append(f"{key}: {sorted(leaked)}")
+    assert not offenders, (
+        "Response schemas must not expose internal storage URLs or keys. "
+        "Use /api/v1/.../data proxy endpoints instead. If a field is "
+        "intentionally retained, add it to ALLOWED_LEAKS with a comment "
+        "explaining why.\n"
+        "Offenders:\n  " + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
## Summary
Fixes #1639. #1608 was supposed to close out \`storage_url\` leaks on v1 response schemas and add a guardrail test, but three schemas slipped through and the test file itself never made it onto \`dev\` — it was living as an untracked local file, so CI couldn't enforce anything. Every consumer of those responses was receiving unreachable \`http://minio:9000/...\` URLs and silently ignoring them.

## Changes
### Schemas cleaned
- **\`AudioStatusResponse\`** ([backend/app/api/v1/schemas/qbank.py](backend/app/api/v1/schemas/qbank.py)) — drops \`storage_url\`. The \`_audio_response\` helper in [qbank.py:556](backend/app/api/v1/qbank.py#L556) stops populating it from the ORM. No frontend reads the field; clients poll for \`status\` + \`duration_seconds\` only.
- **\`SourceImageMetadataResponse\`** ([backend/app/api/v1/schemas/source_images.py](backend/app/api/v1/schemas/source_images.py)) — drops \`storage_url\`. The route builds the response via \`.model_validate(orm_obj)\`, so removing the field is safe — Pydantic ignores the extra ORM attribute. Byte streams still come from \`/api/v1/source-images/{id}/data\` (which the frontend already calls).

### Schema retained on purpose
- **\`SourceImageRef.storage_url\`** ([backend/app/api/v1/schemas/content.py](backend/app/api/v1/schemas/content.py)) — **kept** per owner direction (lesson output references a CDN URL the renderer consumes directly). Added to an \`ALLOWED_LEAKS\` allowlist in the guardrail test with an inline comment explaining the exemption. New entries should require a similar rationale.

### Guardrail landed
- \`backend/tests/test_no_minio_leaks_in_schemas.py\` added to the tree. Same iteration-over-\`app.api.v1.schemas\` logic as the untracked local version, with the allowlist extension and a clearer failure message pointing future authors at the proxy pattern.

## Test plan
- [ ] CI green (\`pytest tests/test_no_minio_leaks_in_schemas.py\` now passes)
- [ ] After deploy, \`GET /api/v1/qbank/questions/{id}/audio?lang=fr\` returns a response without a \`storage_url\` field
- [ ] \`GET /api/v1/source-images\` returns items without \`storage_url\`
- [ ] Lesson generation still emits \`source_image_refs\` with \`storage_url\` populated (verified via the allowlist entry)

Fixes #1639