### PR TITLE
Merge dev \u2192 main: tutor conversation commit-before-yield (#1642)

### DIFF
--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -564,7 +564,6 @@ def _audio_response(row, question_id: uuid.UUID, language: str) -> AudioStatusRe
         question_id=str(question_id),
         language=language,
         status=row.status.value if hasattr(row.status, "value") else row.status,
-        storage_url=row.storage_url,
         duration_seconds=row.duration_seconds,
     )
 

--- a/backend/app/api/v1/schemas/qbank.py
+++ b/backend/app/api/v1/schemas/qbank.py
@@ -281,7 +281,6 @@ class AudioStatusResponse(BaseModel):
     question_id: str
     language: str
     status: str
-    storage_url: str | None = None
     duration_seconds: int | None = None
 
 

--- a/backend/app/api/v1/schemas/source_images.py
+++ b/backend/app/api/v1/schemas/source_images.py
@@ -17,7 +17,6 @@ class SourceImageMetadataResponse(BaseModel):
     chapter: str | None = None
     width: int | None = None
     height: int | None = None
-    storage_url: str | None = None
     alt_text_fr: str | None = None
     alt_text_en: str | None = None
 

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -287,7 +287,9 @@ class TutorService:
             ):
                 conversation.compacted_context = session_ctx.previous_compact
                 session.add(conversation)
-                await session.flush()
+                # Commit here too so the compacted_context is visible to the
+                # follow-up GET the frontend fires on the yielded id (#1625).
+                await session.commit()
 
             yield {
                 "type": "conversation_id",
@@ -885,7 +887,14 @@ class TutorService:
         conversation_id: uuid.UUID | None,
         session: AsyncSession,
     ) -> TutorConversation:
-        """Get existing conversation or create a new one."""
+        """Get existing conversation or create a new one.
+
+        Newly-created conversations are committed before the helper returns
+        so that the streaming endpoint can safely yield the `conversation_id`
+        to the client without racing a follow-up GET on a different session
+        (#1625). `expire_on_commit=False` on the session factory keeps the
+        Python object usable after commit.
+        """
         if isinstance(user_id, str):
             user_id = uuid.UUID(user_id)
 
@@ -907,7 +916,7 @@ class TutorService:
             created_at=datetime.utcnow(),
         )
         session.add(conversation)
-        await session.flush()
+        await session.commit()
 
         return conversation
 

--- a/backend/tests/test_no_minio_leaks_in_schemas.py
+++ b/backend/tests/test_no_minio_leaks_in_schemas.py
@@ -1,0 +1,63 @@
+"""Guardrail: no field on any v1 response schema may leak internal storage URLs.
+
+MinIO is private in prod (no Traefik route). Any field containing a raw
+storage URL or storage key serializes an internal Docker hostname to the
+browser. The fix pattern is to expose proxy URLs via /api/v1/.../data
+endpoints instead. This test fails any future schema that re-introduces
+the leak.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+
+import pydantic
+
+import app.api.v1.schemas as schemas_pkg
+
+FORBIDDEN_FIELD_NAMES = {"storage_url", "storage_key", "minio_url"}
+
+# Intentionally-allowed carry-overs: schemas where the field is kept on purpose.
+# Keyed by "module.ClassName" and accompanied by a comment explaining why. New
+# entries should be rare; prefer dropping the field and routing through a
+# /api/v1/.../data proxy endpoint (the pattern that closed #1603/#1628).
+ALLOWED_LEAKS: dict[str, set[str]] = {
+    # Retained per owner decision 2026-04-18: lesson output carries a CDN URL
+    # reference via SourceImageRef that the frontend renderer may consume
+    # directly. Byte streams still flow through /api/v1/source-images/{id}/data.
+    "app.api.v1.schemas.content.SourceImageRef": {"storage_url"},
+}
+
+
+def _walk_response_models() -> list[type[pydantic.BaseModel]]:
+    models: list[type[pydantic.BaseModel]] = []
+    pkg_path = schemas_pkg.__path__
+    pkg_name = schemas_pkg.__name__
+    for _, mod_name, _ in pkgutil.iter_modules(pkg_path, pkg_name + "."):
+        mod = importlib.import_module(mod_name)
+        for attr in vars(mod).values():
+            if (
+                isinstance(attr, type)
+                and issubclass(attr, pydantic.BaseModel)
+                and attr is not pydantic.BaseModel
+            ):
+                models.append(attr)
+    return models
+
+
+def test_no_storage_url_or_key_field_in_v1_schemas():
+    offenders = []
+    for model in _walk_response_models():
+        leaked = set(model.model_fields) & FORBIDDEN_FIELD_NAMES
+        key = f"{model.__module__}.{model.__name__}"
+        leaked -= ALLOWED_LEAKS.get(key, set())
+        if leaked:
+            offenders.append(f"{key}: {sorted(leaked)}")
+    assert not offenders, (
+        "Response schemas must not expose internal storage URLs or keys. "
+        "Use /api/v1/.../data proxy endpoints instead. If a field is "
+        "intentionally retained, add it to ALLOWED_LEAKS with a comment "
+        "explaining why.\n"
+        "Offenders:\n  " + "\n  ".join(offenders)
+    )

--- a/backend/tests/test_tutor_conversation_race.py
+++ b/backend/tests/test_tutor_conversation_race.py
@@ -1,0 +1,81 @@
+"""Regression tests for issue #1625 — the tutor chat endpoint must commit
+the new conversation row before yielding its `conversation_id` to the
+client, so a follow-up GET on that id (from a different HTTP/DB session)
+returns 200 instead of 404."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.domain.models.conversation import TutorConversation
+from app.domain.models.user import User, UserRole
+from app.domain.services.tutor_service import TutorService
+
+
+@pytest.fixture
+async def user(db_session) -> User:
+    u = User(
+        id=uuid.uuid4(),
+        email="learner@example.com",
+        name="Test Learner",
+        phone_number=None,
+        role=UserRole.user,
+        email_verified=True,
+        preferred_language="fr",
+    )
+    db_session.add(u)
+    await db_session.commit()
+    return u
+
+
+async def test_new_conversation_is_committed_before_returning(db_session, user) -> None:
+    """`_get_or_create_conversation` must commit newly-created rows so that
+    a fresh session (simulating a follow-up HTTP request) can see them."""
+    svc = TutorService()
+    conversation = await svc._get_or_create_conversation(
+        user_id=user.id,
+        module_id=None,
+        conversation_id=None,
+        session=db_session,
+    )
+    assert conversation.id is not None
+
+    # Read back through a different session to prove the row is committed.
+    from app.infrastructure.persistence.database import async_session_factory
+
+    async with async_session_factory() as fresh:
+        from sqlalchemy import select
+
+        result = await fresh.execute(
+            select(TutorConversation).where(TutorConversation.id == conversation.id)
+        )
+        fetched = result.scalar_one_or_none()
+
+    assert fetched is not None, (
+        "new conversation must be visible from a different session — "
+        "was previously only flushed, not committed (#1625)"
+    )
+    assert fetched.user_id == user.id
+
+
+async def test_existing_conversation_is_returned_unchanged(db_session, user) -> None:
+    """Helper must return an existing conversation without re-creating."""
+    existing = TutorConversation(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        module_id=None,
+        messages=[],
+    )
+    db_session.add(existing)
+    await db_session.commit()
+
+    svc = TutorService()
+    fetched = await svc._get_or_create_conversation(
+        user_id=user.id,
+        module_id=None,
+        conversation_id=existing.id,
+        session=db_session,
+    )
+    assert fetched.id == existing.id

--- a/backend/tests/test_tutor_conversation_race.py
+++ b/backend/tests/test_tutor_conversation_race.py
@@ -1,81 +1,121 @@
-"""Regression tests for issue #1625 — the tutor chat endpoint must commit
-the new conversation row before yielding its `conversation_id` to the
-client, so a follow-up GET on that id (from a different HTTP/DB session)
-returns 200 instead of 404."""
+"""Regression tests for issue #1625 — tutor chat must commit the new
+conversation row before yielding its `conversation_id` to the client,
+so a follow-up GET on that id (from a different HTTP/DB session)
+returns 200 instead of 404.
+
+Test approach: existing DB integration tests in this repo are all
+`@pytest.mark.skip` because conftest's `create_all` can't emit enum
+types that live behind `create_type=False`. So we verify the invariant
+with an AsyncMock session and assert that `_get_or_create_conversation`
+calls `session.commit()` (not just `session.flush()`) on the new-row path.
+"""
 
 from __future__ import annotations
 
 import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, call
 
-import pytest
-
-from app.domain.models.conversation import TutorConversation
-from app.domain.models.user import User, UserRole
 from app.domain.services.tutor_service import TutorService
 
 
-@pytest.fixture
-async def user(db_session) -> User:
-    u = User(
-        id=uuid.uuid4(),
-        email="learner@example.com",
-        name="Test Learner",
-        phone_number=None,
-        role=UserRole.user,
-        email_verified=True,
-        preferred_language="fr",
+class _NullResult:
+    def scalar_one_or_none(self):
+        return None
+
+
+class _FoundResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+async def test_new_conversation_is_committed_not_just_flushed() -> None:
+    """When creating a new conversation, the helper must `await session.commit()`."""
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_NullResult())
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+
+    svc = TutorService(
+        anthropic_client=MagicMock(),
+        semantic_retriever=MagicMock(),
+        embedding_service=MagicMock(),
     )
-    db_session.add(u)
-    await db_session.commit()
-    return u
-
-
-async def test_new_conversation_is_committed_before_returning(db_session, user) -> None:
-    """`_get_or_create_conversation` must commit newly-created rows so that
-    a fresh session (simulating a follow-up HTTP request) can see them."""
-    svc = TutorService()
-    conversation = await svc._get_or_create_conversation(
-        user_id=user.id,
+    result = await svc._get_or_create_conversation(
+        user_id=uuid.uuid4(),
         module_id=None,
         conversation_id=None,
-        session=db_session,
+        session=session,
     )
-    assert conversation.id is not None
 
-    # Read back through a different session to prove the row is committed.
-    from app.infrastructure.persistence.database import async_session_factory
-
-    async with async_session_factory() as fresh:
-        from sqlalchemy import select
-
-        result = await fresh.execute(
-            select(TutorConversation).where(TutorConversation.id == conversation.id)
-        )
-        fetched = result.scalar_one_or_none()
-
-    assert fetched is not None, (
-        "new conversation must be visible from a different session — "
-        "was previously only flushed, not committed (#1625)"
+    assert result is not None
+    assert session.add.call_count == 1, "new conversation must be staged"
+    # The fix for #1625: commit (not just flush) so a fresh session sees it.
+    assert session.commit.await_count >= 1, (
+        "new conversation must be committed before the helper returns "
+        "(#1625) — a bare flush() left the row invisible to follow-up GETs"
     )
-    assert fetched.user_id == user.id
 
 
-async def test_existing_conversation_is_returned_unchanged(db_session, user) -> None:
-    """Helper must return an existing conversation without re-creating."""
-    existing = TutorConversation(
+async def test_existing_conversation_is_fetched_not_recreated() -> None:
+    """When passed an existing conversation_id, helper must fetch and
+    return without creating a new row (no add/commit)."""
+    existing = SimpleNamespace(
         id=uuid.uuid4(),
-        user_id=user.id,
+        user_id=uuid.uuid4(),
         module_id=None,
-        messages=[],
     )
-    db_session.add(existing)
-    await db_session.commit()
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_FoundResult(existing))
+    session.add = MagicMock()
+    session.commit = AsyncMock()
 
-    svc = TutorService()
+    svc = TutorService(
+        anthropic_client=MagicMock(),
+        semantic_retriever=MagicMock(),
+        embedding_service=MagicMock(),
+    )
     fetched = await svc._get_or_create_conversation(
-        user_id=user.id,
+        user_id=existing.user_id,
         module_id=None,
         conversation_id=existing.id,
-        session=db_session,
+        session=session,
     )
-    assert fetched.id == existing.id
+
+    assert fetched is existing
+    assert session.add.call_count == 0, "existing conversation must not be re-added"
+    assert session.commit.await_count == 0, "existing path must not commit"
+
+
+# Guard against a silent regression back to `flush()` without commit.
+async def test_create_path_does_not_only_flush() -> None:
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_NullResult())
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+
+    svc = TutorService(
+        anthropic_client=MagicMock(),
+        semantic_retriever=MagicMock(),
+        embedding_service=MagicMock(),
+    )
+    await svc._get_or_create_conversation(
+        user_id=uuid.uuid4(),
+        module_id=None,
+        conversation_id=None,
+        session=session,
+    )
+
+    # flush() alone would be the pre-fix bug. commit() is the fix.
+    assert session.commit.await_count >= 1
+
+    # Ensure we don't accidentally re-introduce a bare flush-without-commit
+    # by checking commit() ran *at some point* — not the specific ordering
+    # (the helper may refresh/flush internally if extended later).
+    assert session.method_calls  # sanity: the session was exercised
+    _ = call  # silence unused-import check if lints tighten


### PR DESCRIPTION
## Summary
- **#1642** — `_get_or_create_conversation` commits the new TutorConversation before streaming its id. Unblocks the AI tutor's response round-trip — the frontend's follow-up GET on the yielded id no longer 404s due to a cross-session read-committed race.

Note: this is a latent race bug, not a tenant regression per se (staging's faster stream timing happens to hide it). Ships alongside the demo-tenant fixes since it was caught during production review.

## Test plan
- [x] CI green on dev (mock-based regression tests pin the commit-vs-flush invariant)
- [ ] Post-deploy: send a tutor message on demo tenant, assistant reply appears, conversation persists on reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)