### PR TITLE
fix(flashcards): /upcoming returns 200 empty for non-subscribers, not 403

### DIFF
--- a/backend/app/api/v1/flashcards.py
+++ b/backend/app/api/v1/flashcards.py
@@ -14,7 +14,8 @@ from app.ai.claude_service import ClaudeService
 from app.ai.rag.embeddings import EmbeddingService
 from app.ai.rag.retriever import SemanticRetriever
 from app.api.deps import get_db
-from app.api.deps_local_auth import require_active_subscription
+from app.api.deps_local_auth import get_current_user, require_active_subscription
+from app.domain.services.subscription_service import SubscriptionService
 from app.api.v1.schemas.content import FlashcardSetResponse
 from app.api.v1.schemas.flashcards import (
     FlashcardDueResponse,
@@ -513,7 +514,7 @@ async def complete_flashcard_session(
     },
 )
 async def get_upcoming_reviews(
-    current_user: User = Depends(require_active_subscription),
+    current_user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> UpcomingReviewsResponse:
     """
@@ -521,6 +522,11 @@ async def get_upcoming_reviews(
 
     Returns the next 5 review sessions with module information and card counts.
     Used for the dashboard upcoming reviews widget.
+
+    **Subscription behaviour:** this endpoint is an informational dashboard
+    widget, not gated content. Non-subscribed users get a `200 []` empty
+    response so the dashboard renders a neutral empty state instead of a
+    red error banner (issue #1626).
 
     **Features:**
     - Groups cards by review date and module
@@ -534,6 +540,18 @@ async def get_upcoming_reviews(
     - Includes all info needed for widget display
     """
     try:
+        # Non-subscribed users see an empty state, not a 403.
+        subscription = await SubscriptionService().get_active_subscription(
+            current_user.id, session
+        )
+        if subscription is None:
+            return UpcomingReviewsResponse(
+                user_id=current_user.id,
+                today_due_count=0,
+                has_due_cards=False,
+                upcoming_sessions=[],
+            )
+
         logger.info("Fetching upcoming reviews", user_id=str(current_user.id))
 
         now = datetime.utcnow()

--- a/backend/app/api/v1/flashcards.py
+++ b/backend/app/api/v1/flashcards.py
@@ -15,7 +15,6 @@ from app.ai.rag.embeddings import EmbeddingService
 from app.ai.rag.retriever import SemanticRetriever
 from app.api.deps import get_db
 from app.api.deps_local_auth import get_current_user, require_active_subscription
-from app.domain.services.subscription_service import SubscriptionService
 from app.api.v1.schemas.content import FlashcardSetResponse
 from app.api.v1.schemas.flashcards import (
     FlashcardDueResponse,
@@ -32,6 +31,7 @@ from app.domain.models.user import User
 from app.domain.services.analytics_service import AnalyticsService
 from app.domain.services.flashcard_service import FlashcardGenerationService
 from app.domain.services.platform_settings_service import SettingsCache
+from app.domain.services.subscription_service import SubscriptionService
 from app.infrastructure.config.settings import get_settings
 
 logger = structlog.get_logger()
@@ -541,9 +541,7 @@ async def get_upcoming_reviews(
     """
     try:
         # Non-subscribed users see an empty state, not a 403.
-        subscription = await SubscriptionService().get_active_subscription(
-            current_user.id, session
-        )
+        subscription = await SubscriptionService().get_active_subscription(current_user.id, session)
         if subscription is None:
             return UpcomingReviewsResponse(
                 user_id=current_user.id,

--- a/backend/tests/test_flashcards_upcoming_no_sub.py
+++ b/backend/tests/test_flashcards_upcoming_no_sub.py
@@ -1,0 +1,112 @@
+"""Regression tests for issues #1626 / #1619 — /api/v1/flashcards/upcoming
+must return a 200 empty payload for users without an active subscription,
+not a 403. The dashboard widget renders a neutral empty state when the
+response is empty; it rendered a red error banner on the pre-fix 403.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import AsyncClient
+
+from app.main import app
+
+
+def _auth_headers() -> dict:
+    from app.domain.services.jwt_auth_service import JWTAuthService
+
+    svc = JWTAuthService()
+    token = svc.create_access_token(
+        user_id=str(uuid.uuid4()),
+        email="learner@example.com",
+        role="user",
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def test_upcoming_reviews_returns_200_empty_for_non_subscriber(
+    client: AsyncClient,
+) -> None:
+    """No active subscription → 200 with zeros + empty sessions list."""
+    fake_user = SimpleNamespace(
+        id=uuid.uuid4(),
+        email="learner@example.com",
+        name="Learner",
+    )
+
+    # No active subscription.
+    sub_svc = MagicMock()
+    sub_svc.get_active_subscription = AsyncMock(return_value=None)
+
+    with (
+        patch(
+            "app.api.v1.flashcards.get_current_user",
+            new=AsyncMock(return_value=fake_user),
+        ),
+        patch(
+            "app.api.v1.flashcards.SubscriptionService",
+            return_value=sub_svc,
+        ),
+    ):
+        from app.api.deps import get_db
+        from app.api.deps_local_auth import get_current_user
+
+        async def _noop_db():
+            yield MagicMock()
+
+        async def _fake_user_dep():
+            return fake_user
+
+        app.dependency_overrides[get_db] = _noop_db
+        app.dependency_overrides[get_current_user] = _fake_user_dep
+        try:
+            response = await client.get(
+                "/api/v1/flashcards/upcoming",
+                headers=_auth_headers(),
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["today_due_count"] == 0
+    assert body["has_due_cards"] is False
+    assert body["upcoming_sessions"] == []
+
+
+async def test_upcoming_reviews_never_403_for_non_subscriber(
+    client: AsyncClient,
+) -> None:
+    """Defence-in-depth: the pre-fix 403 must not come back."""
+    fake_user = SimpleNamespace(id=uuid.uuid4(), email="l@x", name="L")
+
+    sub_svc = MagicMock()
+    sub_svc.get_active_subscription = AsyncMock(return_value=None)
+
+    with patch(
+        "app.api.v1.flashcards.SubscriptionService",
+        return_value=sub_svc,
+    ):
+        from app.api.deps import get_db
+        from app.api.deps_local_auth import get_current_user
+
+        async def _noop_db():
+            yield MagicMock()
+
+        async def _fake_user_dep():
+            return fake_user
+
+        app.dependency_overrides[get_db] = _noop_db
+        app.dependency_overrides[get_current_user] = _fake_user_dep
+        try:
+            response = await client.get(
+                "/api/v1/flashcards/upcoming",
+                headers=_auth_headers(),
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+    assert response.status_code != 403


### PR DESCRIPTION
## Summary
Dashboard widget `upcoming-reviews` showed a red "Erreur lors du chargement des révisions" banner for every user without an active subscription on prod (including admin accounts). Root cause: `GET /api/v1/flashcards/upcoming` sat behind `require_active_subscription` and returned 403, which React Query treats as an error.

Swap the dependency to `get_current_user` and early-return an empty `UpcomingReviewsResponse` when there's no active subscription. Subscribed users follow the existing path unchanged.

The frontend widget already renders a neutral empty state when `upcoming_sessions` is empty — no UI change needed. The red banner is now reserved for genuine failures.

Fixes #1626 · Fixes #1619

## Test plan
- [x] 2 new pytest cases (patch SubscriptionService → None): asserts 200 empty + never 403
- [x] Ruff clean
- [ ] Post-deploy: admin (no sub) hitting dashboard → no red banner; neutral "no upcoming reviews" card instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)