### PR TITLE
Merge dev \u2192 main: flashcards /upcoming 200 empty for non-subs (#1647)

### DIFF
--- a/backend/app/api/v1/flashcards.py
+++ b/backend/app/api/v1/flashcards.py
@@ -14,7 +14,8 @@ from app.ai.claude_service import ClaudeService
 from app.ai.rag.embeddings import EmbeddingService
 from app.ai.rag.retriever import SemanticRetriever
 from app.api.deps import get_db
-from app.api.deps_local_auth import require_active_subscription
+from app.api.deps_local_auth import get_current_user, require_active_subscription
+from app.domain.services.subscription_service import SubscriptionService
 from app.api.v1.schemas.content import FlashcardSetResponse
 from app.api.v1.schemas.flashcards import (
     FlashcardDueResponse,
@@ -513,7 +514,7 @@ async def complete_flashcard_session(
     },
 )
 async def get_upcoming_reviews(
-    current_user: User = Depends(require_active_subscription),
+    current_user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> UpcomingReviewsResponse:
     """
@@ -521,6 +522,11 @@ async def get_upcoming_reviews(
 
     Returns the next 5 review sessions with module information and card counts.
     Used for the dashboard upcoming reviews widget.
+
+    **Subscription behaviour:** this endpoint is an informational dashboard
+    widget, not gated content. Non-subscribed users get a `200 []` empty
+    response so the dashboard renders a neutral empty state instead of a
+    red error banner (issue #1626).
 
     **Features:**
     - Groups cards by review date and module
@@ -534,6 +540,18 @@ async def get_upcoming_reviews(
     - Includes all info needed for widget display
     """
     try:
+        # Non-subscribed users see an empty state, not a 403.
+        subscription = await SubscriptionService().get_active_subscription(
+            current_user.id, session
+        )
+        if subscription is None:
+            return UpcomingReviewsResponse(
+                user_id=current_user.id,
+                today_due_count=0,
+                has_due_cards=False,
+                upcoming_sessions=[],
+            )
+
         logger.info("Fetching upcoming reviews", user_id=str(current_user.id))
 
         now = datetime.utcnow()

--- a/backend/app/api/v1/flashcards.py
+++ b/backend/app/api/v1/flashcards.py
@@ -14,7 +14,7 @@ from app.ai.claude_service import ClaudeService
 from app.ai.rag.embeddings import EmbeddingService
 from app.ai.rag.retriever import SemanticRetriever
 from app.api.deps import get_db
-from app.api.deps_local_auth import require_active_subscription
+from app.api.deps_local_auth import get_current_user, require_active_subscription
 from app.api.v1.schemas.content import FlashcardSetResponse
 from app.api.v1.schemas.flashcards import (
     FlashcardDueResponse,
@@ -31,6 +31,7 @@ from app.domain.models.user import User
 from app.domain.services.analytics_service import AnalyticsService
 from app.domain.services.flashcard_service import FlashcardGenerationService
 from app.domain.services.platform_settings_service import SettingsCache
+from app.domain.services.subscription_service import SubscriptionService
 from app.infrastructure.config.settings import get_settings
 
 logger = structlog.get_logger()
@@ -513,7 +514,7 @@ async def complete_flashcard_session(
     },
 )
 async def get_upcoming_reviews(
-    current_user: User = Depends(require_active_subscription),
+    current_user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> UpcomingReviewsResponse:
     """
@@ -521,6 +522,11 @@ async def get_upcoming_reviews(
 
     Returns the next 5 review sessions with module information and card counts.
     Used for the dashboard upcoming reviews widget.
+
+    **Subscription behaviour:** this endpoint is an informational dashboard
+    widget, not gated content. Non-subscribed users get a `200 []` empty
+    response so the dashboard renders a neutral empty state instead of a
+    red error banner (issue #1626).
 
     **Features:**
     - Groups cards by review date and module
@@ -534,6 +540,16 @@ async def get_upcoming_reviews(
     - Includes all info needed for widget display
     """
     try:
+        # Non-subscribed users see an empty state, not a 403.
+        subscription = await SubscriptionService().get_active_subscription(current_user.id, session)
+        if subscription is None:
+            return UpcomingReviewsResponse(
+                user_id=current_user.id,
+                today_due_count=0,
+                has_due_cards=False,
+                upcoming_sessions=[],
+            )
+
         logger.info("Fetching upcoming reviews", user_id=str(current_user.id))
 
         now = datetime.utcnow()

--- a/backend/app/api/v1/flashcards.py
+++ b/backend/app/api/v1/flashcards.py
@@ -15,7 +15,6 @@ from app.ai.rag.embeddings import EmbeddingService
 from app.ai.rag.retriever import SemanticRetriever
 from app.api.deps import get_db
 from app.api.deps_local_auth import get_current_user, require_active_subscription
-from app.domain.services.subscription_service import SubscriptionService
 from app.api.v1.schemas.content import FlashcardSetResponse
 from app.api.v1.schemas.flashcards import (
     FlashcardDueResponse,
@@ -32,6 +31,7 @@ from app.domain.models.user import User
 from app.domain.services.analytics_service import AnalyticsService
 from app.domain.services.flashcard_service import FlashcardGenerationService
 from app.domain.services.platform_settings_service import SettingsCache
+from app.domain.services.subscription_service import SubscriptionService
 from app.infrastructure.config.settings import get_settings
 
 logger = structlog.get_logger()
@@ -541,9 +541,7 @@ async def get_upcoming_reviews(
     """
     try:
         # Non-subscribed users see an empty state, not a 403.
-        subscription = await SubscriptionService().get_active_subscription(
-            current_user.id, session
-        )
+        subscription = await SubscriptionService().get_active_subscription(current_user.id, session)
         if subscription is None:
             return UpcomingReviewsResponse(
                 user_id=current_user.id,

--- a/backend/tests/test_flashcards_upcoming_no_sub.py
+++ b/backend/tests/test_flashcards_upcoming_no_sub.py
@@ -1,0 +1,112 @@
+"""Regression tests for issues #1626 / #1619 — /api/v1/flashcards/upcoming
+must return a 200 empty payload for users without an active subscription,
+not a 403. The dashboard widget renders a neutral empty state when the
+response is empty; it rendered a red error banner on the pre-fix 403.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import AsyncClient
+
+from app.main import app
+
+
+def _auth_headers() -> dict:
+    from app.domain.services.jwt_auth_service import JWTAuthService
+
+    svc = JWTAuthService()
+    token = svc.create_access_token(
+        user_id=str(uuid.uuid4()),
+        email="learner@example.com",
+        role="user",
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def test_upcoming_reviews_returns_200_empty_for_non_subscriber(
+    client: AsyncClient,
+) -> None:
+    """No active subscription → 200 with zeros + empty sessions list."""
+    fake_user = SimpleNamespace(
+        id=uuid.uuid4(),
+        email="learner@example.com",
+        name="Learner",
+    )
+
+    # No active subscription.
+    sub_svc = MagicMock()
+    sub_svc.get_active_subscription = AsyncMock(return_value=None)
+
+    with (
+        patch(
+            "app.api.v1.flashcards.get_current_user",
+            new=AsyncMock(return_value=fake_user),
+        ),
+        patch(
+            "app.api.v1.flashcards.SubscriptionService",
+            return_value=sub_svc,
+        ),
+    ):
+        from app.api.deps import get_db
+        from app.api.deps_local_auth import get_current_user
+
+        async def _noop_db():
+            yield MagicMock()
+
+        async def _fake_user_dep():
+            return fake_user
+
+        app.dependency_overrides[get_db] = _noop_db
+        app.dependency_overrides[get_current_user] = _fake_user_dep
+        try:
+            response = await client.get(
+                "/api/v1/flashcards/upcoming",
+                headers=_auth_headers(),
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["today_due_count"] == 0
+    assert body["has_due_cards"] is False
+    assert body["upcoming_sessions"] == []
+
+
+async def test_upcoming_reviews_never_403_for_non_subscriber(
+    client: AsyncClient,
+) -> None:
+    """Defence-in-depth: the pre-fix 403 must not come back."""
+    fake_user = SimpleNamespace(id=uuid.uuid4(), email="l@x", name="L")
+
+    sub_svc = MagicMock()
+    sub_svc.get_active_subscription = AsyncMock(return_value=None)
+
+    with patch(
+        "app.api.v1.flashcards.SubscriptionService",
+        return_value=sub_svc,
+    ):
+        from app.api.deps import get_db
+        from app.api.deps_local_auth import get_current_user
+
+        async def _noop_db():
+            yield MagicMock()
+
+        async def _fake_user_dep():
+            return fake_user
+
+        app.dependency_overrides[get_db] = _noop_db
+        app.dependency_overrides[get_current_user] = _fake_user_dep
+        try:
+            response = await client.get(
+                "/api/v1/flashcards/upcoming",
+                headers=_auth_headers(),
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+    assert response.status_code != 403

--- a/frontend/components/learning/source-image.tsx
+++ b/frontend/components/learning/source-image.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useState } from 'react';
+import Image from 'next/image';
 import { useTranslations } from 'next-intl';
 import { X } from 'lucide-react';
-/* eslint-disable @next/next/no-img-element */
 import { API_BASE } from '@/lib/api';
 import type { SourceImageMeta } from '@/lib/api';
 
@@ -45,9 +45,16 @@ export function SourceImage({
           aria-label={t('viewFullscreen')}
           onClick={() => setIsFullscreen(true)}
         >
-          <img
+          <Image
             src={imageUrl}
             alt={altText}
+            // Upstream WebP dimensions vary per figure; 1024×768 is the ceiling
+            // for the source library. Next uses this to compute the srcset
+            // ladder (deviceSizes in next.config.ts); CSS (w-full h-auto)
+            // lets the browser size it against the 768px max-width container.
+            width={1024}
+            height={768}
+            sizes="(max-width: 768px) 100vw, 768px"
             loading="lazy"
             className={`w-full h-auto object-contain rounded-lg transition-opacity duration-300 ${
               isVisible ? 'opacity-100' : 'opacity-0'
@@ -86,11 +93,15 @@ export function SourceImage({
             <X className="w-5 h-5" aria-hidden="true" />
           </button>
 
-          <img
+          <Image
             src={imageUrl}
             alt={altText}
-            className="max-w-full max-h-[80vh] object-contain rounded-lg"
+            width={1920}
+            height={1080}
+            sizes="100vw"
+            className="max-w-full max-h-[80vh] w-auto h-auto object-contain rounded-lg"
             onClick={(e) => e.stopPropagation()}
+            priority
           />
 
           {figureLabel && (

--- a/frontend/components/qbank/qbank-image-question.tsx
+++ b/frontend/components/qbank/qbank-image-question.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Image from 'next/image';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 import type { QBankQuestion } from '@/lib/api';
@@ -56,13 +57,16 @@ export function QBankImageQuestion({
   return (
     <div className="flex flex-col gap-4">
       {question.image_url && (
-        <div className="relative w-full overflow-hidden rounded-lg bg-muted">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
+        <div className="relative h-[300px] w-full overflow-hidden rounded-lg bg-muted">
+          <Image
             src={question.image_url}
             alt={question.question_text}
-            className="w-full h-auto max-h-[300px] object-contain"
+            fill
+            // Player container tops out at max-w-2xl (42rem = 672px).
+            sizes="(max-width: 768px) 100vw, 42rem"
+            className="object-contain"
             onLoad={onImageLoad}
+            priority
           />
         </div>
       )}


### PR DESCRIPTION
## Summary
- **#1647** — `/api/v1/flashcards/upcoming` returns 200 with an empty payload for users without an active subscription. Removes the red error banner on every dashboard.

## Test plan
- [x] CI green on dev
- [ ] Post-deploy: admin (no sub) dashboard loads with neutral "no upcoming reviews" card — no red banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)