### PR TITLE
Merge dev \u2192 main: html lang from locale (#1650)

### DIFF
--- a/frontend/app/[locale]/layout.tsx
+++ b/frontend/app/[locale]/layout.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from "next";
+import { Inter, JetBrains_Mono } from "next/font/google";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
 import { notFound } from "next/navigation";
@@ -7,6 +9,52 @@ import { SettingsProvider } from "@/lib/settings-context";
 import { InstallPrompt } from "@/components/pwa/install-prompt";
 import { ServiceWorkerRegister } from "@/components/pwa/service-worker-register";
 import { PostHogProvider } from "@/lib/posthog-provider";
+import { getServerBranding } from "@/lib/branding";
+import "../globals.css";
+import "katex/dist/katex.min.css";
+
+const inter = Inter({
+  variable: "--font-sans",
+  subsets: ["latin"],
+  display: "swap",
+  weight: ["400", "500", "600", "700"],
+  preload: true,
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-mono",
+  subsets: ["latin"],
+  display: "swap",
+  weight: ["400", "500"],
+  preload: false,
+});
+
+export async function generateMetadata(): Promise<Metadata> {
+  const branding = await getServerBranding();
+  return {
+    title: {
+      default: branding.app_name,
+      template: `%s · ${branding.app_name}`,
+    },
+    description: branding.app_description_en,
+    manifest: "/manifest.webmanifest",
+    appleWebApp: {
+      capable: true,
+      statusBarStyle: "default",
+      title: branding.app_short_name,
+    },
+    formatDetection: {
+      telephone: false,
+    },
+    themeColor: branding.theme_color,
+    viewport: {
+      width: "device-width",
+      initialScale: 1,
+      maximumScale: 1,
+      userScalable: false,
+    },
+  };
+}
 
 export default async function LocaleLayout({
   children,
@@ -22,18 +70,32 @@ export default async function LocaleLayout({
   }
 
   const messages = await getMessages();
+  const branding = await getServerBranding();
 
   return (
-    <NextIntlClientProvider messages={messages}>
-      <PostHogProvider>
-        <QueryProvider>
-          <SettingsProvider>
-            {children}
-            <InstallPrompt />
-            <ServiceWorkerRegister />
-          </SettingsProvider>
-        </QueryProvider>
-      </PostHogProvider>
-    </NextIntlClientProvider>
+    <html
+      lang={locale}
+      className={`${inter.variable} ${jetbrainsMono.variable}`}
+    >
+      <head>
+        <link rel="apple-touch-startup-image" href="/icon-512x512.svg" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+        <meta name="apple-mobile-web-app-title" content={branding.app_short_name} />
+      </head>
+      <body className="min-h-dvh bg-background font-sans text-foreground antialiased">
+        <NextIntlClientProvider messages={messages}>
+          <PostHogProvider>
+            <QueryProvider>
+              <SettingsProvider>
+                {children}
+                <InstallPrompt />
+                <ServiceWorkerRegister />
+              </SettingsProvider>
+            </QueryProvider>
+          </PostHogProvider>
+        </NextIntlClientProvider>
+      </body>
+    </html>
   );
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,69 +1,13 @@
-import type { Metadata } from "next";
-import { Inter, JetBrains_Mono } from "next/font/google";
-import "./globals.css";
-import "katex/dist/katex.min.css";
-import { getServerBranding } from "@/lib/branding";
+// Root layout is intentionally a pass-through. The real <html>/<body> and
+// `generateMetadata` live in app/[locale]/layout.tsx so we can set
+// `<html lang={locale}>` from the URL segment (issue #1617). Next.js 15
+// accepts this arrangement as long as exactly one layout in the tree
+// emits <html>/<body>.
 
-const inter = Inter({
-  variable: "--font-sans",
-  subsets: ["latin"],
-  display: "swap",
-  weight: ["400", "500", "600", "700"],
-  preload: true,
-});
-
-const jetbrainsMono = JetBrains_Mono({
-  variable: "--font-mono",
-  subsets: ["latin"],
-  display: "swap",
-  weight: ["400", "500"],
-  preload: false,
-});
-
-export async function generateMetadata(): Promise<Metadata> {
-  const branding = await getServerBranding();
-  return {
-    title: {
-      default: branding.app_name,
-      template: `%s · ${branding.app_name}`,
-    },
-    description: branding.app_description_en,
-    manifest: "/manifest.webmanifest",
-    appleWebApp: {
-      capable: true,
-      statusBarStyle: "default",
-      title: branding.app_short_name,
-    },
-    formatDetection: {
-      telephone: false,
-    },
-    themeColor: branding.theme_color,
-    viewport: {
-      width: "device-width",
-      initialScale: 1,
-      maximumScale: 1,
-      userScalable: false,
-    },
-  };
-}
-
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const branding = await getServerBranding();
-  return (
-    <html className={`${inter.variable} ${jetbrainsMono.variable}`}>
-      <head>
-        <link rel="apple-touch-startup-image" href="/icon-512x512.svg" />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-        <meta name="apple-mobile-web-app-title" content={branding.app_short_name} />
-      </head>
-      <body className="min-h-dvh bg-background font-sans text-foreground antialiased">
-        {children}
-      </body>
-    </html>
-  );
+  return children;
 }

--- a/frontend/e2e/html-lang.spec.ts
+++ b/frontend/e2e/html-lang.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Regression guard for issue #1617 — every rendered page must carry the
+ * right `<html lang>`. Pre-fix, it was always empty (WCAG A failure).
+ */
+test.describe("html lang attribute", () => {
+  test("/fr/* pages set lang='fr'", async ({ page }) => {
+    await page.goto("/fr/courses");
+    const lang = await page.locator("html").getAttribute("lang");
+    expect(lang).toBe("fr");
+  });
+
+  test("/en/* pages set lang='en'", async ({ page }) => {
+    await page.goto("/en/courses");
+    const lang = await page.locator("html").getAttribute("lang");
+    expect(lang).toBe("en");
+  });
+});


### PR DESCRIPTION
## Summary
- **#1650** — `<html lang={locale}>` now renders correctly on every page. WCAG A compliance restored.

## Test plan
- [x] CI green
- [ ] Post-deploy: `document.documentElement.lang === 'fr'` on /fr pages, `'en'` on /en pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)