### PR TITLE
fix(admin): translate sub_admin role + replace hardcoded W. African country filter

### DIFF
--- a/frontend/components/admin/user-list-client.tsx
+++ b/frontend/components/admin/user-list-client.tsx
@@ -303,17 +303,16 @@ export function UserListClient() {
           />
         </div>
 
-        <select
+        {/* Free-text country filter — the former hardcoded W. African list
+            was tenant-inappropriate for the generalised platform (#1620). */}
+        <input
+          type="text"
           className="min-h-11 rounded-md border border-input bg-background px-3 py-2 text-sm"
           value={country}
           onChange={(e) => { setCountry(e.target.value); setOffset(0); }}
+          placeholder={t("filterCountry")}
           aria-label={t("filterCountry")}
-        >
-          <option value="">{t("allCountries")}</option>
-          {["benin", "burkina-faso", "cote-divoire", "ghana", "mali", "niger", "nigeria", "senegal", "togo"].map((c) => (
-            <option key={c} value={c}>{c}</option>
-          ))}
-        </select>
+        />
 
         <select
           className="min-h-11 rounded-md border border-input bg-background px-3 py-2 text-sm"
@@ -336,6 +335,7 @@ export function UserListClient() {
           <option value="">{t("allRoles")}</option>
           <option value="user">{tRoles("user")}</option>
           <option value="expert">{tRoles("expert")}</option>
+          <option value="sub_admin">{tRoles("sub_admin")}</option>
           <option value="admin">{tRoles("admin")}</option>
         </select>
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -932,7 +932,8 @@
   "Roles": {
     "user": "User",
     "expert": "Expert",
-    "admin": "Administrator"
+    "admin": "Administrator",
+    "sub_admin": "Sub-administrator"
   },
   "Admin": {
     "courses": {

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -932,7 +932,8 @@
   "Roles": {
     "user": "Utilisateur",
     "expert": "Expert",
-    "admin": "Administrateur"
+    "admin": "Administrateur",
+    "sub_admin": "Sous-administrateur"
   },
   "Admin": {
     "courses": {


### PR DESCRIPTION
## Summary
- Add `Roles.sub_admin` i18n key to both locales. Fixes the admin user list showing literal \`Roles.sub_admin\` for sub-admin accounts.
- Replace hardcoded nine-West-African-country dropdown with a free-text country filter input. Backend still supports `country=` query param unchanged.
- Role filter dropdown gains a \`sub_admin\` option.

Fixes #1620

## Test plan
- [x] TS clean
- [ ] Post-deploy: admin users page shows "Sous-administrateur" / "Sub-administrator" instead of "Roles.sub_admin"
- [ ] Country filter accepts free-text and filters correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)