### PR TITLE
fix(chat): skip enrollments + tutor-stats fetches when user isn't logged in

### DIFF
--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -89,9 +89,7 @@ def _audio_url_for(
     host = request.headers.get("x-forwarded-host") or request.headers.get("host")
     if not host:
         return None
-    return (
-        f"{proto}://{host}/api/v1/qbank/questions/{question_id}/audio/{language}/data"
-    )
+    return f"{proto}://{host}/api/v1/qbank/questions/{question_id}/audio/{language}/data"
 
 
 def _bank_response(bank, question_count: int = 0, test_count: int = 0):

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -121,8 +121,11 @@ export function ChatPanel({
     }
   }, [activeCourseId]);
 
-  // Fetch enrolled courses for course selector
+  // Fetch enrolled courses for course selector. Skip for anonymous visitors
+  // so /courses (public catalog) doesn't fire a 401 into every visitor's
+  // console (#1622) — there's nothing to enroll-list for logged-out users.
   useEffect(() => {
+    if (!authClient.isAuthenticated()) return;
     getMyEnrollments({ orderBy: 'last_accessed', limit: 3 })
       .then((courses) => {
         setEnrolledCourses(courses);
@@ -135,6 +138,9 @@ export function ChatPanel({
   }, []);  // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
+    // Same reasoning as the enrollments fetch above — anonymous visitors
+    // shouldn't see a 401 in console for a tutor stats call they can't use.
+    if (!authClient.isAuthenticated()) return;
     fetchTutorStats()
       .then((stats) => {
         setMaxDailyUsage(stats.daily_messages_limit);


### PR DESCRIPTION
## Summary
ChatPanel mounts inside the `(app)` route group layout, which covers the public /courses catalog too. Anonymous visitors saw a 401 in the browser console on every catalog page view (from `getMyEnrollments` and `fetchTutorStats`).

Gate both useEffect fetches on `authClient.isAuthenticated()`. No more anon 401 noise; no UX change for logged-in users.

Fixes #1622

## Test plan
- [x] TS clean
- [ ] Post-deploy: open /fr/courses in incognito, confirm no 401 on /my-enrollments or /tutor/stats in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)