### PR TITLE
Merge dev → main: qbank audio player (#1663)

### DIFF
--- a/frontend/components/qbank/qbank-audio-player.tsx
+++ b/frontend/components/qbank/qbank-audio-player.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+import {
+  getQBankQuestionAudio,
+  type QBankAudioLanguage,
+  type QBankQuestionAudioStatus,
+} from '@/lib/api';
+
+const LANGUAGES: QBankAudioLanguage[] = ['fr', 'mos', 'dyu', 'bam'];
+const STORAGE_KEY = 'qbank-audio-lang';
+
+interface QBankAudioPlayerProps {
+  questionId: string;
+  /** Preferred default when nothing is in localStorage yet (e.g. bank.language). */
+  defaultLanguage?: QBankAudioLanguage;
+}
+
+/**
+ * Per-question audio player with a language picker (fr/mos/dyu/bam).
+ *
+ * Driving-school learners who can't read rely on this — the audio is
+ * the primary way they answer the question. We don't hide it behind a
+ * preferences toggle: the four language pills are always visible and
+ * the last selection persists across questions via localStorage (#1659).
+ */
+export function QBankAudioPlayer({ questionId, defaultLanguage }: QBankAudioPlayerProps) {
+  const t = useTranslations('qbank');
+  const tLang = useTranslations('qbank.audioLanguages');
+  const [language, setLanguage] = useState<QBankAudioLanguage>(() => {
+    if (typeof window === 'undefined') return defaultLanguage ?? 'fr';
+    const saved = window.localStorage.getItem(STORAGE_KEY) as QBankAudioLanguage | null;
+    if (saved && LANGUAGES.includes(saved)) return saved;
+    return defaultLanguage ?? 'fr';
+  });
+  const [status, setStatus] = useState<QBankQuestionAudioStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const audioRef = useRef<HTMLAudioElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setStatus(null);
+    setError(null);
+    getQBankQuestionAudio(questionId, language)
+      .then((s) => { if (!cancelled) setStatus(s); })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Audio fetch failed');
+      });
+    return () => { cancelled = true; };
+  }, [questionId, language]);
+
+  // Persist the learner's chosen language across questions.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(STORAGE_KEY, language);
+  }, [language]);
+
+  // Stop playback when we switch language; the new audio will mount a fresh <audio>.
+  useEffect(() => {
+    if (audioRef.current) audioRef.current.pause();
+  }, [language]);
+
+  return (
+    <div className="flex flex-col gap-2" aria-label={t('audio.label')}>
+      <div
+        role="radiogroup"
+        aria-label={t('audio.languagePickerLabel')}
+        className="flex flex-wrap gap-2"
+      >
+        {LANGUAGES.map((lang) => {
+          const isSelected = lang === language;
+          return (
+            <button
+              key={lang}
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              aria-label={t('audio.pillAriaLabel', { language: tLang(lang) })}
+              onClick={() => setLanguage(lang)}
+              className={cn(
+                'min-h-11 min-w-16 rounded-full border px-4 py-1.5 text-sm font-medium transition-colors',
+                isSelected
+                  ? 'border-primary bg-primary text-primary-foreground'
+                  : 'border-border bg-background hover:border-primary/50'
+              )}
+            >
+              {tLang(lang)}
+            </button>
+          );
+        })}
+      </div>
+
+      {error && (
+        <p className="text-xs text-destructive" role="alert">
+          {t('audio.error')}
+        </p>
+      )}
+
+      {!error && !status && (
+        <p className="text-xs text-muted-foreground">{t('audio.loading')}</p>
+      )}
+
+      {status && (status.status === 'pending' || status.status === 'generating') && (
+        <p className="text-xs text-muted-foreground">{t('audio.notReady')}</p>
+      )}
+
+      {status?.status === 'failed' && (
+        <p className="text-xs text-destructive" role="alert">{t('audio.failed')}</p>
+      )}
+
+      {status?.status === 'ready' && status.audio_url && (
+        <audio
+          ref={audioRef}
+          src={status.audio_url}
+          controls
+          preload="none"
+          className="w-full"
+        >
+          {t('audio.unsupported')}
+        </audio>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/qbank/qbank-image-question.tsx
+++ b/frontend/components/qbank/qbank-image-question.tsx
@@ -3,6 +3,7 @@
 import Image from 'next/image';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
+import { QBankAudioPlayer } from '@/components/qbank/qbank-audio-player';
 import type { QBankQuestion } from '@/lib/api';
 
 const OPTION_LABELS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
@@ -70,6 +71,8 @@ export function QBankImageQuestion({
           />
         </div>
       )}
+
+      <QBankAudioPlayer questionId={question.id} />
 
       <p className="text-base font-medium leading-relaxed">{question.question_text}</p>
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1569,6 +1569,33 @@ export async function getQBankTestReview(
   return apiFetch<QBankReviewResponse>(`/api/v1/qbank/tests/${testId}/review/${attemptId}`);
 }
 
+// Question audio — backend streams OGG/Opus from MinIO via a proxy (#1658).
+// The status poll returns `audio_url` only when `status === "ready"`.
+export type QBankAudioLanguage = "fr" | "mos" | "dyu" | "bam";
+
+export type QBankAudioReadiness =
+  | "pending"
+  | "generating"
+  | "ready"
+  | "failed";
+
+export interface QBankQuestionAudioStatus {
+  question_id: string;
+  language: QBankAudioLanguage;
+  status: QBankAudioReadiness;
+  audio_url: string | null;
+  duration_seconds: number | null;
+}
+
+export async function getQBankQuestionAudio(
+  questionId: string,
+  language: QBankAudioLanguage,
+): Promise<QBankQuestionAudioStatus> {
+  return apiFetch<QBankQuestionAudioStatus>(
+    `/api/v1/qbank/questions/${questionId}/audio?lang=${language}`,
+  );
+}
+
 // ---------------------------------------------------------------------------
 // QBank management (org admin) — #1504
 // ---------------------------------------------------------------------------

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2069,6 +2069,22 @@
     "uploadOnlyPdf": "Only PDF files are accepted.",
     "uploadExtracting": "Extracting…",
     "uploadExtractedCount": "Extracted {count} question(s){warnings}.",
-    "uploadWithWarnings": " with {count} warning(s)"
+    "uploadWithWarnings": " with {count} warning(s)",
+    "audio": {
+      "label": "Question audio",
+      "languagePickerLabel": "Audio language",
+      "pillAriaLabel": "Listen in {language}",
+      "loading": "Loading audio…",
+      "notReady": "Audio is being prepared for this language.",
+      "failed": "Audio generation failed for this language.",
+      "error": "Unable to load audio.",
+      "unsupported": "Your browser does not support the audio element."
+    },
+    "audioLanguages": {
+      "fr": "French",
+      "mos": "Mooré",
+      "dyu": "Dioula",
+      "bam": "Bambara"
+    }
   }
-}
+}\n

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -2069,6 +2069,22 @@
     "uploadOnlyPdf": "Seuls les fichiers PDF sont acceptés.",
     "uploadExtracting": "Extraction…",
     "uploadExtractedCount": "{count} question(s) extraite(s){warnings}.",
-    "uploadWithWarnings": " avec {count} avertissement(s)"
+    "uploadWithWarnings": " avec {count} avertissement(s)",
+    "audio": {
+      "label": "Audio de la question",
+      "languagePickerLabel": "Langue de l’audio",
+      "pillAriaLabel": "Écouter en {language}",
+      "loading": "Chargement de l’audio…",
+      "notReady": "L’audio est en cours de préparation pour cette langue.",
+      "failed": "La génération audio a échoué pour cette langue.",
+      "error": "Impossible de charger l’audio.",
+      "unsupported": "Votre navigateur ne prend pas en charge l’élément audio."
+    },
+    "audioLanguages": {
+      "fr": "Français",
+      "mos": "Mooré",
+      "dyu": "Dioula",
+      "bam": "Bambara"
+    }
   }
-}
+}\n


### PR DESCRIPTION
## Summary
Ships the frontend audio player so driving-school learners can actually play the fr/mos/dyu/bam clips served by #1658.

- #1663 — \`QBankAudioPlayer\` component + language pills + localStorage persistence

Will land on the staging server as soon as #1651 (GHCR denied) is resolved — most recent deploys have been failing on image pull, not on code.

## Test plan
- [ ] CI green
- [ ] After #1651 clears + successful deploy: driving-school test-taker shows language pills above each question; clicking plays the clip