### PR TITLE
ci(deploy): auth to GHCR per-deploy with runner GITHUB_TOKEN (#1651)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -199,6 +199,9 @@ jobs:
       && needs.build-and-push.result == 'success'
       && (needs.build-mms-tts.result == 'success' || needs.build-mms-tts.result == 'skipped')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read       # needed for docker pull ghcr.io/... (#1651)
     steps:
       - uses: actions/checkout@v6
 
@@ -228,6 +231,8 @@ jobs:
       - name: Deploy on server
         uses: appleboy/ssh-action@v1
         env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -245,10 +250,16 @@ jobs:
           host: 167.86.115.58
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_KEY }}
-          envs: POSTGRES_PASSWORD,ANTHROPIC_API_KEY,OPENAI_API_KEY,GOOGLE_API_KEY,SENTRY_DSN,NEXT_PUBLIC_SENTRY_DSN,NEXT_PUBLIC_POSTHOG_KEY,NEXT_PUBLIC_POSTHOG_HOST,SMS_RELAY_API_KEY,SMS_RELAY_TRUSTED_SENDERS,MINIO_ACCESS_KEY,MINIO_SECRET_KEY,DEPLOY_SHA
+          envs: GHCR_USER,GHCR_TOKEN,POSTGRES_PASSWORD,ANTHROPIC_API_KEY,OPENAI_API_KEY,GOOGLE_API_KEY,SENTRY_DSN,NEXT_PUBLIC_SENTRY_DSN,NEXT_PUBLIC_POSTHOG_KEY,NEXT_PUBLIC_POSTHOG_HOST,SMS_RELAY_API_KEY,SMS_RELAY_TRUSTED_SENDERS,MINIO_ACCESS_KEY,MINIO_SECRET_KEY,DEPLOY_SHA
           script: |
             set -e
             cd ~/etutor
+
+            # Authenticate to GHCR with the runner's fresh GITHUB_TOKEN (#1651).
+            # Replaces the server-side cached credential that kept going stale —
+            # the old workflow silently assumed a one-time docker login set
+            # years ago and left us blind when the token rotated.
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
             # Write .env
             cat > .env << EOF
@@ -289,3 +300,7 @@ jobs:
 
             # Cleanup old images
             docker image prune -f
+
+            # Drop the GHCR credential so the server doesn't carry a stale
+            # token between deploys — the next run authenticates fresh.
+            docker logout ghcr.io


### PR DESCRIPTION
## Summary
Fixes #1651. The last three+ \`Deploy\` runs on \`main\` have died at the SSH'd server step with:

\`\`\`
Image ghcr.io/benidrissa/etutor-digital-ph/frontend:latest
  Error error from registry: denied
\`\`\`

Root cause: the deploy job SSHs into \`deploy@167.86.115.58\` and runs \`docker compose pull\` without a prior \`docker login\`, relying on whatever token was cached in \`~/.docker/config.json\` from an undocumented one-time setup. That cached token has since expired or been rotated. Meanwhile the \`build-and-push\` job succeeds because it authenticates through \`docker/login-action@v3\` with the per-run \`GITHUB_TOKEN\`.

Six merged PRs (#1630 #1633 #1643 #1648 #1658 #1663) are built but not serving traffic — main has been drifting from staging all afternoon.

## What changed
Only [.github/workflows/deploy.yml](.github/workflows/deploy.yml):

1. **\`permissions: packages: read\` on the deploy job** — scopes the per-job \`GITHUB_TOKEN\` so \`docker pull ghcr.io/...\` is allowed.
2. **\`GHCR_USER\` / \`GHCR_TOKEN\` env vars** threaded through to the SSH script via \`appleboy/ssh-action\`'s \`envs:\` CSV.
3. **\`docker login ghcr.io -u \"\$GHCR_USER\" --password-stdin\`** at the top of the script. \`--password-stdin\` keeps the token off the process list.
4. **\`docker logout ghcr.io\`** at the end. No stale token survives between deploys — we re-auth fresh every run, so the \"server credential rotated and we didn't notice\" failure class can't silently return.

Same pattern as the build-and-push side ([deploy.yml:137-142](.github/workflows/deploy.yml#L137-L142)), just reissued per deploy on the remote host instead of once, on the build runner.

## Test plan
- [ ] CI green on this PR
- [ ] After merge → dev → main, the auto-triggered Deploy run succeeds
- [ ] In the \"Deploy on server\" step log, look for \`Login Succeeded\` — indicates GHCR accepted the runner's token
- [ ] \`docker compose pull\` completes without \`error from registry: denied\`
- [ ] \`docker compose ps\` at the end shows backend + frontend \`Up\` (healthy)
- [ ] Smoke on staging:
  - \`curl -sk -o /dev/null -w \"%{http_code}\\n\" https://etutor.elearning.portfolio2.kimbetien.com/fr/login\` → 200
  - Open qbank test-taker → question images render (validates #1630 finally live)
  - Qbank test-taker shows the language pills from #1663

## Out of scope
- Pinning \`:latest\` to SHA tags in \`docker-compose.prod.yml\` — separate issue.
- The unused \`:tenant\` frontend build artifact — separate issue.
- Applying the same fix to any prod deploy pipeline (\`94.250.201.110\`) — this workflow only targets staging.

Fixes #1651