### PR TITLE
fix(qbank): move sync setStates out of audio-player useEffect body

### DIFF
--- a/frontend/components/qbank/qbank-audio-player.tsx
+++ b/frontend/components/qbank/qbank-audio-player.tsx
@@ -41,12 +41,20 @@ export function QBankAudioPlayer({ questionId, defaultLanguage }: QBankAudioPlay
 
   useEffect(() => {
     let cancelled = false;
-    setStatus(null);
-    setError(null);
+    // Old-state resets moved into the callbacks: sync setStates inside an
+    // effect body cascade re-renders and trip the no-sync-set-state lint
+    // rule. The brief flicker of stale status on question/language change
+    // is acceptable — it's replaced atomically when the fetch resolves.
     getQBankQuestionAudio(questionId, language)
-      .then((s) => { if (!cancelled) setStatus(s); })
+      .then((s) => {
+        if (cancelled) return;
+        setError(null);
+        setStatus(s);
+      })
       .catch((err) => {
-        if (!cancelled) setError(err instanceof Error ? err.message : 'Audio fetch failed');
+        if (cancelled) return;
+        setStatus(null);
+        setError(err instanceof Error ? err.message : 'Audio fetch failed');
       });
     return () => { cancelled = true; };
   }, [questionId, language]);


### PR DESCRIPTION
## Summary
Unblocks the dev branch lint. After #1663 merged, every PR branched from \`dev\` now fails \`Frontend (Next.js)\` CI on:

\`\`\`
components/qbank/qbank-audio-player.tsx
  44:5  error  Error: Calling setState synchronously within an effect can trigger cascading renders
  react-you-might-not-need-an-effect/no-sync-set-state
\`\`\`

#1663's CI appears to have passed somehow (possibly the rule was upgraded to error between branch creation and now), but it's red for everyone else now.

## Change
Move the \`setStatus(null)\` and \`setError(null)\` resets out of the \`useEffect\` body into the \`.then/.catch\` callbacks. Same visible behaviour — briefly stale status on question/language switch, then atomic replacement when the fetch resolves — minus the synchronous-setState-in-effect anti-pattern.

## Test plan
- [ ] Frontend lint green on this PR
- [ ] Manual: open a qbank test-taker, switch language pills — no regression in the pending/ready/failed state transitions

Related: #1663, #1665 (the deploy.yml PR currently blocked behind this lint)