### PR TITLE
feat(qbank): add Fulfulde (ful) audio language (#1670)

### DIFF
--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -77,8 +77,8 @@ def _audio_url_for(
 ) -> str | None:
     """Build a browser-reachable proxy URL for a question's audio clip.
 
-    Driving-school banks ship audio in fr/mos/dyu/bam (required so
-    learners who can't read can still take the test). The DB column
+    Driving-school banks ship audio in fr/mos/dyu/bam/ful (required
+    so learners who can't read can still take the test). The DB column
     stores ``http://minio:9000/...`` which the browser can't reach —
     same pattern as ``_image_url_for``. Returns ``None`` when the audio
     row has no bytes yet (pending/failed states).

--- a/backend/app/domain/services/qbank_audio_service.py
+++ b/backend/app/domain/services/qbank_audio_service.py
@@ -32,7 +32,7 @@ from app.integrations.mms_tts import MMSTTSClient, MMSTTSError
 
 logger = structlog.get_logger(__name__)
 
-SupportedLanguage = Literal["fr", "mos", "dyu", "bam"]
+SupportedLanguage = Literal["fr", "mos", "dyu", "bam", "ful"]
 OPUS_CONTENT_TYPE = "audio/ogg"
 OPUS_BYTES_PER_SECOND = 6 * 1024  # matches LessonAudioService._estimate_duration
 
@@ -48,6 +48,7 @@ def build_audio_script(question: QBankQuestion, language: str) -> str:
         "mos": "Tʋʋmde",  # Moore: "task/choice"
         "dyu": "Sugandili",  # Dioula/Jula: "choice"
         "bam": "Sugandili",  # Bambara: "choice"
+        "ful": "Suɓaande",  # Fulfulde: "choice"
     }
     prefix = prefixes.get(language, "Option")
     parts = [question.question_text.strip()]

--- a/backend/app/integrations/mms_tts.py
+++ b/backend/app/integrations/mms_tts.py
@@ -1,8 +1,10 @@
 """Async HTTP client for the Meta MMS TTS sidecar service.
 
 The sidecar is a separate Docker service (see infrastructure/mms-tts) that
-wraps facebook/mms-tts-{mos,dyu,bam} models and returns OGG/Opus audio. We
-call it over plain HTTP from the backend and the Celery worker.
+wraps facebook/mms-tts-{mos,dyu,bam,ffm} models and returns OGG/Opus audio.
+``ful`` is exposed to the backend and frontend; the sidecar maps it to the
+``ffm`` (Maasina Fulfulde) VITS model. We call it over plain HTTP from the
+backend and the Celery worker.
 """
 
 from __future__ import annotations
@@ -16,7 +18,7 @@ from app.infrastructure.config.settings import settings
 
 logger = structlog.get_logger(__name__)
 
-SUPPORTED_LANGUAGES = {"mos", "dyu", "bam"}
+SUPPORTED_LANGUAGES = {"mos", "dyu", "bam", "ful"}
 
 
 class MMSTTSError(Exception):

--- a/backend/tests/test_qbank_audio_service.py
+++ b/backend/tests/test_qbank_audio_service.py
@@ -39,7 +39,12 @@ def test_build_audio_script_french_prefix():
 
 def test_build_audio_script_mms_languages_use_native_prefix():
     q = _FakeQuestion("Question", ["A", "B"])
-    for lang, prefix in [("mos", "Tʋʋmde"), ("dyu", "Sugandili"), ("bam", "Sugandili")]:
+    for lang, prefix in [
+        ("mos", "Tʋʋmde"),
+        ("dyu", "Sugandili"),
+        ("bam", "Sugandili"),
+        ("ful", "Suɓaande"),
+    ]:
         script = build_audio_script(q, lang)
         assert f"{prefix} A" in script
         assert f"{prefix} B" in script

--- a/frontend/components/qbank/qbank-audio-player.tsx
+++ b/frontend/components/qbank/qbank-audio-player.tsx
@@ -9,7 +9,7 @@ import {
   type QBankQuestionAudioStatus,
 } from '@/lib/api';
 
-const LANGUAGES: QBankAudioLanguage[] = ['fr', 'mos', 'dyu', 'bam'];
+const LANGUAGES: QBankAudioLanguage[] = ['fr', 'mos', 'dyu', 'bam', 'ful'];
 const STORAGE_KEY = 'qbank-audio-lang';
 
 interface QBankAudioPlayerProps {
@@ -19,12 +19,12 @@ interface QBankAudioPlayerProps {
 }
 
 /**
- * Per-question audio player with a language picker (fr/mos/dyu/bam).
+ * Per-question audio player with a language picker (fr/mos/dyu/bam/ful).
  *
  * Driving-school learners who can't read rely on this — the audio is
  * the primary way they answer the question. We don't hide it behind a
- * preferences toggle: the four language pills are always visible and
- * the last selection persists across questions via localStorage (#1659).
+ * preferences toggle: the language pills are always visible and the
+ * last selection persists across questions via localStorage (#1659, #1670).
  */
 export function QBankAudioPlayer({ questionId, defaultLanguage }: QBankAudioPlayerProps) {
   const t = useTranslations('qbank');

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1571,7 +1571,7 @@ export async function getQBankTestReview(
 
 // Question audio — backend streams OGG/Opus from MinIO via a proxy (#1658).
 // The status poll returns `audio_url` only when `status === "ready"`.
-export type QBankAudioLanguage = "fr" | "mos" | "dyu" | "bam";
+export type QBankAudioLanguage = "fr" | "mos" | "dyu" | "bam" | "ful";
 
 export type QBankAudioReadiness =
   | "pending"

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2084,7 +2084,8 @@
       "fr": "French",
       "mos": "Mooré",
       "dyu": "Dioula",
-      "bam": "Bambara"
+      "bam": "Bambara",
+      "ful": "Fulfulde"
     }
   }
 }\n

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -2084,7 +2084,8 @@
       "fr": "Français",
       "mos": "Mooré",
       "dyu": "Dioula",
-      "bam": "Bambara"
+      "bam": "Bambara",
+      "ful": "Fulfulde"
     }
   }
 }\n

--- a/infrastructure/mms-tts/server.py
+++ b/infrastructure/mms-tts/server.py
@@ -1,8 +1,13 @@
-"""Meta MMS TTS HTTP server for Moore, Dioula, and Bambara.
+"""Meta MMS TTS HTTP server for Moore, Dioula, Bambara, and Fulfulde.
 
-Preloads Hugging Face `facebook/mms-tts-{mos,dyu,bam}` VITS models on startup and
-serves synthesized speech as OGG/Opus over HTTP. Opus at ~24 kbps keeps a
-30-second clip under ~100 KB, which matters for 2G/3G West African networks.
+Preloads Hugging Face `facebook/mms-tts-{mos,dyu,bam,ffm}` VITS models on
+startup and serves synthesized speech as OGG/Opus over HTTP. Opus at
+~24 kbps keeps a 30-second clip under ~100 KB, which matters for 2G/3G
+West African networks.
+
+``ful`` is exposed as the public language code for Fulfulde; internally
+we load Meta's ``ffm`` (Maasina Fulfulde) VITS model, which matches the
+variant spoken in Burkina Faso / Mali — our primary audience.
 """
 from __future__ import annotations
 
@@ -22,8 +27,18 @@ from pydub import AudioSegment
 from scipy.io import wavfile
 from transformers import AutoTokenizer, VitsModel
 
-SUPPORTED_LANGUAGES = ("mos", "dyu", "bam")
-Language = Literal["mos", "dyu", "bam"]
+SUPPORTED_LANGUAGES = ("mos", "dyu", "bam", "ful")
+Language = Literal["mos", "dyu", "bam", "ful"]
+
+# Map public language codes to the Hugging Face model suffix. Meta ships
+# Fulfulde as variant-specific checkpoints (ffm, fuv, fuh, ...); we pick
+# ``ffm`` (Maasina) for the West African driving-school audience.
+MODEL_SUFFIX: dict[str, str] = {
+    "mos": "mos",
+    "dyu": "dyu",
+    "bam": "bam",
+    "ful": "ffm",
+}
 
 MAX_TEXT_CHARS = 2000
 OPUS_BITRATE = "24k"
@@ -45,8 +60,9 @@ _MODELS: dict[str, _ModelBundle] = {}
 
 
 def _load_model(lang: str) -> _ModelBundle:
-    model_id = f"facebook/mms-tts-{lang}"
-    logger.info("loading %s", model_id)
+    suffix = MODEL_SUFFIX.get(lang, lang)
+    model_id = f"facebook/mms-tts-{suffix}"
+    logger.info("loading %s (public code=%s)", model_id, lang)
     tokenizer = AutoTokenizer.from_pretrained(model_id)
     model = VitsModel.from_pretrained(model_id)
     model.eval()


### PR DESCRIPTION
## Summary
- Add `ful` (Fulfulde) as a 5th qbank audio language alongside fr/mos/dyu/bam
- MMS sidecar maps `ful` → `facebook/mms-tts-ffm` (Maasina Fulfulde — Burkina Faso / Mali variant)
- Frontend: type, language pill, i18n labels (FR & EN)
- Backend: `SupportedLanguage` literal, `SUPPORTED_LANGUAGES` set, native \"Option\" prefix, doc comment
- Tests: extend `test_build_audio_script_mms_languages_use_native_prefix` to cover `ful`

Fixes #1670

## Test plan
- [ ] Frontend renders 5 pills (FR, Mooré, Dioula, Bambara, Fulfulde)
- [ ] `GET /api/v1/qbank/questions/{id}/audio?lang=ful` returns `{status: "pending"}` before generation
- [ ] `POST /api/v1/qbank/banks/{id}/audio/generate` with `language=ful` kicks off Celery task
- [ ] Sidecar loads `facebook/mms-tts-ffm` successfully on startup (verify `GET /health` includes `ful`)
- [ ] Existing fr/mos/dyu/bam flows still work — no regression
- [ ] `uv run pytest backend/tests/test_qbank_audio_service.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)