### PR TITLE
feat(qbank): pregenerate audio on publish + preload on test start (#1674)

### DIFF
--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -358,6 +358,10 @@ async def start_test(
     current_user: AuthenticatedUser = Depends(get_current_user),
     db=Depends(get_db_session),
 ):
+    from sqlalchemy import select
+
+    from app.domain.models.question_bank import QBankAudioStatus, QBankQuestionAudio
+
     data = await _svc.start_test(db, test_id, uuid.UUID(current_user.id))
     test = data["test"]
     # Training mode with show_feedback relies on the client knowing the answer
@@ -378,6 +382,23 @@ async def start_test(
         for q in data["questions"]
     ]
 
+    # Preload ready audio URLs for every (question, language) pair so the
+    # client can warm its HTTP cache before the timer starts (#1674).
+    audio_map: dict[str, dict[str, str]] = {}
+    question_ids = [q.id for q in data["questions"]]
+    if question_ids:
+        audio_rows = await db.execute(
+            select(QBankQuestionAudio).where(
+                QBankQuestionAudio.question_id.in_(question_ids),
+                QBankQuestionAudio.status == QBankAudioStatus.ready,
+            )
+        )
+        for row in audio_rows.scalars():
+            url = _audio_url_for(request, row.question_id, row.language, row.storage_key)
+            if url is None:
+                continue
+            audio_map.setdefault(str(row.question_id), {})[row.language] = url
+
     return TestStartResponse(
         test_id=str(test.id),
         title=test.title,
@@ -386,6 +407,7 @@ async def start_test(
         show_feedback=test.show_feedback,
         questions=questions,
         total_questions=len(questions),
+        audio=audio_map,
     )
 
 

--- a/backend/app/api/v1/schemas/qbank.py
+++ b/backend/app/api/v1/schemas/qbank.py
@@ -154,6 +154,12 @@ class TestStartResponse(BaseModel):
     show_feedback: bool
     questions: list[TestStartQuestion]
     total_questions: int
+    # Pre-fetched audio URLs: ``{question_id: {language: url}}``. Only
+    # entries with ``status == "ready"`` are included; missing keys mean
+    # the client should fall back to polling ``/questions/{id}/audio``.
+    # Preloading these on the client lets the learner start hearing the
+    # question within the timer window without a per-question round-trip.
+    audio: dict[str, dict[str, str]] = Field(default_factory=dict)
 
 
 class TestSubmitRequest(BaseModel):

--- a/backend/app/domain/services/qbank_audio_service.py
+++ b/backend/app/domain/services/qbank_audio_service.py
@@ -33,6 +33,12 @@ from app.integrations.mms_tts import MMSTTSClient, MMSTTSError
 logger = structlog.get_logger(__name__)
 
 SupportedLanguage = Literal["fr", "mos", "dyu", "bam", "ful"]
+
+# Canonical list of languages audio is generated for. Pregeneration loops
+# over this tuple when a bank is published so every (question, language)
+# pair has a ready clip by the time a learner starts a test (#1674).
+SUPPORTED_LANGUAGES: tuple[str, ...] = ("fr", "mos", "dyu", "bam", "ful")
+
 OPUS_CONTENT_TYPE = "audio/ogg"
 OPUS_BYTES_PER_SECOND = 6 * 1024  # matches LessonAudioService._estimate_duration
 
@@ -180,8 +186,15 @@ class QBankAudioService:
         db: AsyncSession,
         bank_id: uuid.UUID,
         language: str,
+        *,
+        skip_ready: bool = True,
     ) -> dict:
-        """Generate audio for every question in a bank. Intended for Celery."""
+        """Generate audio for every question in a bank. Intended for Celery.
+
+        Idempotent by default: questions whose ``(question, language)`` row
+        is already ``ready`` are skipped so republishing or retrying a
+        bank doesn't re-bill TTS for clips that already exist (#1674).
+        """
         bank = await db.get(QuestionBank, bank_id)
         if bank is None:
             raise HTTPException(
@@ -199,9 +212,25 @@ class QBankAudioService:
             .all()
         )
 
+        ready_question_ids: set[uuid.UUID] = set()
+        if skip_ready and questions:
+            existing = await db.execute(
+                select(QBankQuestionAudio).where(
+                    QBankQuestionAudio.question_id.in_([q.id for q in questions]),
+                    QBankQuestionAudio.language == language,
+                    QBankQuestionAudio.status == QBankAudioStatus.ready,
+                )
+            )
+            ready_question_ids = {row.question_id for row in existing.scalars()}
+
         ready = 0
         failed = 0
+        skipped = 0
         for q in questions:
+            if q.id in ready_question_ids:
+                skipped += 1
+                ready += 1  # Already-ready clips still count as ready.
+                continue
             row = await self.generate_question_audio(db, q.id, language)
             if row.status == QBankAudioStatus.ready:
                 ready += 1
@@ -212,9 +241,27 @@ class QBankAudioService:
             "bank_id": str(bank_id),
             "language": language,
             "total": len(questions),
+            "skipped": skipped,
             "ready": ready,
             "failed": failed,
         }
+
+    async def invalidate_question(
+        self,
+        db: AsyncSession,
+        question_id: uuid.UUID,
+    ) -> None:
+        """Drop every cached audio row for a question.
+
+        Called when a question's text or options change — the stored
+        clip no longer matches the script and must be regenerated.
+        """
+        await db.execute(
+            QBankQuestionAudio.__table__.delete().where(
+                QBankQuestionAudio.question_id == question_id,
+            )
+        )
+        await db.commit()
 
     async def store_uploaded_audio(
         self,

--- a/backend/app/domain/services/qbank_service.py
+++ b/backend/app/domain/services/qbank_service.py
@@ -25,6 +25,30 @@ logger = structlog.get_logger(__name__)
 _org_svc = OrganizationService()
 
 
+def _enqueue_pregenerate_audio(bank_id: uuid.UUID) -> None:
+    """Fire a Celery task per supported language to pregenerate audio.
+
+    Kept as a module-level helper so it can be called from ``update_bank``
+    (publish transition) and ``update_question`` (text change) without
+    creating a service cycle. Imports are local so this module stays
+    safe to import in contexts where Celery isn't wired up (e.g. tests
+    that patch the task).
+    """
+    from app.domain.services.qbank_audio_service import SUPPORTED_LANGUAGES
+    from app.tasks.qbank_processing import generate_qbank_audio_task
+
+    for language in SUPPORTED_LANGUAGES:
+        try:
+            generate_qbank_audio_task.delay(str(bank_id), language)
+        except Exception as exc:
+            logger.warning(
+                "failed to enqueue qbank audio pregeneration",
+                bank_id=str(bank_id),
+                language=language,
+                error=str(exc),
+            )
+
+
 class QBankService:
     # ------------------------------------------------------------------
     # Question Bank CRUD
@@ -125,11 +149,19 @@ class QBankService:
             "passing_score",
             "status",
         }
+        previous_status = bank.status.value if hasattr(bank.status, "value") else bank.status
         for key, value in fields.items():
             if key in allowed and value is not None:
                 setattr(bank, key, value)
         await db.commit()
         await db.refresh(bank)
+
+        # Publish transition fires audio pregeneration for every supported
+        # language so learners never wait on the timer for TTS (#1674).
+        new_status = bank.status.value if hasattr(bank.status, "value") else bank.status
+        if previous_status != "published" and new_status == "published":
+            _enqueue_pregenerate_audio(bank_id)
+
         return bank
 
     async def delete_bank(
@@ -208,11 +240,25 @@ class QBankService:
             "category",
             "difficulty",
         }
+        # Changes to the spoken text or option list make the cached TTS
+        # clips stale — drop them and re-enqueue generation downstream.
+        invalidating_keys = {"question_text", "options"}
+        should_invalidate_audio = any(
+            key in invalidating_keys and value is not None and value != getattr(question, key, None)
+            for key, value in fields.items()
+        )
         for key, value in fields.items():
             if key in allowed and value is not None:
                 setattr(question, key, value)
         await db.commit()
         await db.refresh(question)
+
+        if should_invalidate_audio:
+            from app.domain.services.qbank_audio_service import QBankAudioService
+
+            await QBankAudioService().invalidate_question(db, question_id)
+            _enqueue_pregenerate_audio(question.question_bank_id)
+
         return question
 
     async def delete_question(

--- a/backend/app/tasks/qbank_processing.py
+++ b/backend/app/tasks/qbank_processing.py
@@ -134,6 +134,24 @@ async def _process_pdf_async(task, bank_id: str, pdf_filename: str) -> dict:
         questions_created=created,
         errors_count=len(errors),
     )
+
+    # Fire audio pregeneration for every supported language so the first
+    # learner to take a test doesn't wait on the MMS sidecar (#1674).
+    # Skipped when no questions were added — nothing to synthesize.
+    if created:
+        from app.domain.services.qbank_audio_service import SUPPORTED_LANGUAGES
+
+        for language in SUPPORTED_LANGUAGES:
+            try:
+                generate_qbank_audio_task.delay(bank_id, language)
+            except Exception as exc:
+                logger.warning(
+                    "failed to enqueue post-extract audio pregeneration",
+                    bank_id=bank_id,
+                    language=language,
+                    error=str(exc),
+                )
+
     return {
         "bank_id": bank_id,
         "questions_created": created,

--- a/backend/tests/test_qbank_audio_service.py
+++ b/backend/tests/test_qbank_audio_service.py
@@ -15,6 +15,7 @@ import pytest
 from fastapi import HTTPException
 
 from app.domain.services.qbank_audio_service import (
+    SUPPORTED_LANGUAGES,
     QBankAudioService,
     build_audio_script,
     estimate_duration_seconds,
@@ -82,3 +83,11 @@ async def test_synthesize_dispatches_mms_languages_to_client():
     out = await svc._synthesize_bytes("lakala", "dyu")
     assert out == b"OGG"
     fake_mms.synthesize.assert_awaited_once_with("lakala", "dyu")
+
+
+def test_supported_languages_is_non_empty_tuple():
+    # Pregeneration loops over this tuple, so it must stay iterable and
+    # contain at least French (the baseline).
+    assert isinstance(SUPPORTED_LANGUAGES, tuple)
+    assert "fr" in SUPPORTED_LANGUAGES
+    assert all(isinstance(lang, str) for lang in SUPPORTED_LANGUAGES)

--- a/frontend/components/qbank/qbank-audio-player.tsx
+++ b/frontend/components/qbank/qbank-audio-player.tsx
@@ -16,6 +16,13 @@ interface QBankAudioPlayerProps {
   questionId: string;
   /** Preferred default when nothing is in localStorage yet (e.g. bank.language). */
   defaultLanguage?: QBankAudioLanguage;
+  /**
+   * Pre-fetched audio URLs keyed by language. When a URL exists here
+   * we mount the <audio> element directly instead of polling the
+   * status endpoint — saves a round-trip per question/language switch
+   * and is the fast path once pregeneration has run (#1674).
+   */
+  preloadedUrls?: Record<string, string>;
 }
 
 /**
@@ -26,7 +33,11 @@ interface QBankAudioPlayerProps {
  * preferences toggle: the language pills are always visible and the
  * last selection persists across questions via localStorage (#1659, #1670).
  */
-export function QBankAudioPlayer({ questionId, defaultLanguage }: QBankAudioPlayerProps) {
+export function QBankAudioPlayer({
+  questionId,
+  defaultLanguage,
+  preloadedUrls,
+}: QBankAudioPlayerProps) {
   const t = useTranslations('qbank');
   const tLang = useTranslations('qbank.audioLanguages');
   const [language, setLanguage] = useState<QBankAudioLanguage>(() => {
@@ -39,7 +50,14 @@ export function QBankAudioPlayer({ questionId, defaultLanguage }: QBankAudioPlay
   const [error, setError] = useState<string | null>(null);
   const audioRef = useRef<HTMLAudioElement>(null);
 
+  const preloadedUrl = preloadedUrls?.[language];
+
   useEffect(() => {
+    // Fast path: test-start gave us a ready URL for this language, so
+    // we derive the status in render and skip the network call entirely
+    // (#1674). No setState here — the derived status below covers it.
+    if (preloadedUrl) return;
+
     let cancelled = false;
     // Old-state resets moved into the callbacks: sync setStates inside an
     // effect body cascade re-renders and trip the no-sync-set-state lint
@@ -58,7 +76,20 @@ export function QBankAudioPlayer({ questionId, defaultLanguage }: QBankAudioPlay
         setError(err instanceof Error ? err.message : 'Audio fetch failed');
       });
     return () => { cancelled = true; };
-  }, [questionId, language]);
+  }, [questionId, language, preloadedUrl]);
+
+  // Derived status: preloaded URL wins over any cached fetch result so
+  // the <audio> element mounts synchronously on the first render.
+  const effectiveStatus: QBankQuestionAudioStatus | null = preloadedUrl
+    ? {
+        question_id: questionId,
+        language,
+        status: 'ready',
+        audio_url: preloadedUrl,
+        duration_seconds: null,
+      }
+    : status;
+  const effectiveError = preloadedUrl ? null : error;
 
   // Persist the learner's chosen language across questions.
   useEffect(() => {
@@ -104,22 +135,22 @@ export function QBankAudioPlayer({ questionId, defaultLanguage }: QBankAudioPlay
         })}
       </div>
 
-      {error && (
+      {effectiveError && (
         <p className="text-xs text-destructive" role="alert">
           {t('audio.error')}
         </p>
       )}
 
-      {status?.status === 'failed' && (
+      {effectiveStatus?.status === 'failed' && (
         <p className="text-xs text-destructive" role="alert">{t('audio.failed')}</p>
       )}
 
-      {status?.status === 'ready' && status.audio_url && (
+      {effectiveStatus?.status === 'ready' && effectiveStatus.audio_url && (
         <audio
           ref={audioRef}
-          src={status.audio_url}
+          src={effectiveStatus.audio_url}
           controls
-          preload="none"
+          preload="auto"
           className="h-9 w-full sm:h-10"
         >
           {t('audio.unsupported')}

--- a/frontend/components/qbank/qbank-image-question.tsx
+++ b/frontend/components/qbank/qbank-image-question.tsx
@@ -10,6 +10,12 @@ const OPTION_LABELS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
 
 interface QBankImageQuestionProps {
   question: QBankQuestion;
+  /**
+   * Pre-fetched audio URLs keyed by language. Populated from
+   * TestStartResponse.audio so the player can mount the <audio>
+   * element without a per-question round-trip (#1674).
+   */
+  preloadedAudio?: Record<string, string>;
   selectedIndices: number[];
   onToggle: (index: number) => void;
   showFeedback: boolean;
@@ -31,6 +37,7 @@ function selectionIsCorrect(
 
 export function QBankImageQuestion({
   question,
+  preloadedAudio,
   selectedIndices,
   onToggle,
   showFeedback,
@@ -75,7 +82,10 @@ export function QBankImageQuestion({
         </div>
       )}
 
-      <QBankAudioPlayer questionId={question.id} />
+      <QBankAudioPlayer
+        questionId={question.id}
+        preloadedUrls={preloadedAudio}
+      />
 
       <p className="text-sm font-medium leading-snug sm:text-base">
         {question.question_text}

--- a/frontend/components/qbank/qbank-test-player.tsx
+++ b/frontend/components/qbank/qbank-test-player.tsx
@@ -29,6 +29,24 @@ const AUTO_ADVANCE_MS = 700;
 // correct answer and the explanation before moving on.
 const AUTO_ADVANCE_FEEDBACK_MS = 2000;
 
+const AUDIO_PREF_STORAGE_KEY = 'qbank-audio-lang';
+const DEFAULT_AUDIO_LANG = 'fr';
+
+function preloadAudioClips(data: QBankTestStartResponse): void {
+  if (typeof window === 'undefined') return;
+  const audioMap = data.audio ?? {};
+  const saved = window.localStorage.getItem(AUDIO_PREF_STORAGE_KEY);
+  const activeLang = saved && saved.length > 0 ? saved : DEFAULT_AUDIO_LANG;
+  for (const question of data.questions) {
+    const url = audioMap[question.id]?.[activeLang];
+    if (!url) continue;
+    const preloader = new Audio();
+    preloader.preload = 'auto';
+    preloader.src = url;
+    preloader.load();
+  }
+}
+
 export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
   const t = useTranslations('qbank');
   const [phase, setPhase] = useState<Phase>('loading');
@@ -52,6 +70,10 @@ export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
         if (data.mode === 'exam') {
           setTimerRunning(true);
         }
+        // Warm the browser's HTTP cache for the active-language audio of
+        // every question so playback starts within the timer window
+        // regardless of network speed (#1674).
+        preloadAudioClips(data);
       })
       .catch((err) => {
         setError(err.message || 'Failed to load test');
@@ -307,6 +329,7 @@ export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
       <div className="min-h-0 flex-1 overflow-y-auto">
         <QBankImageQuestion
           question={currentQuestion}
+          preloadedAudio={testData.audio?.[currentQuestion.id]}
           selectedIndices={selectedIndices}
           onToggle={handleToggle}
           showFeedback={showingFeedback || testData.mode === 'review'}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1510,6 +1510,13 @@ export interface QBankTestStartResponse {
   show_feedback: boolean;
   questions: QBankQuestion[];
   total_questions: number;
+  /**
+   * Pre-fetched audio URLs: {question_id: {language: url}}. Only
+   * (question, language) pairs whose TTS clip is ready are populated.
+   * Missing entries mean the client should fall back to polling
+   * /api/v1/qbank/questions/{id}/audio (#1674).
+   */
+  audio?: Record<string, Record<string, string>>;
 }
 
 export interface QBankTestAttemptResponse {


### PR DESCRIPTION
## Summary

### Pregeneration (backend)
- Add `SUPPORTED_LANGUAGES: tuple[str, ...]` canonical list in `qbank_audio_service`.
- `update_bank` detects a `draft → published` transition and enqueues `generate_qbank_audio_task.delay(bank_id, lang)` for every supported language.
- `process_qbank_pdf` (Celery) enqueues the same after the first successful extraction so freshly-created banks get audio queued up in one shot.
- `update_question` detects `question_text` / `options` changes and drops the cached audio rows via `QBankAudioService.invalidate_question` before re-enqueuing — stops stale clips from playing the old script.
- `batch_generate` is now idempotent: a single prefetch query finds rows already `status=ready` and skips them, so republishing or retrying never re-bills TTS.
- Celery enqueue failures are caught and logged so broker hiccups don't block the user-facing publish response.

### Preload (test start + client)
- `TestStartResponse` returns `audio: {question_id: {language: url}}` with every `status=ready` clip for the test's questions, resolved via the same proxy URL helper as the per-question endpoint.
- `QBankTestPlayer` warms the browser's HTTP cache on test-start by creating detached `Audio` elements with `preload=\"auto\"` for every question's active-language clip (using the localStorage-stored language preference).
- `QBankAudioPlayer` accepts `preloadedUrls` and derives status in render from that prop when present, skipping the status round-trip entirely. Falls back to the existing polling endpoint when a language is still pregenerating.

Fixes #1674

## Test plan
- [x] `uv run pytest backend/tests/test_qbank_audio_service.py backend/tests/test_qbank_slide_extractor.py` — 42 passed
- [x] Backend ruff clean
- [x] Frontend `tsc --noEmit` clean
- [x] Frontend ESLint clean
- [ ] Publishing a draft bank with N questions enqueues N × len(SUPPORTED_LANGUAGES) audio rows and each reaches `status=ready`
- [ ] `GET /api/v1/qbank/tests/{id}/start` includes an `audio` map with the pregenerated URLs
- [ ] Client: on a throttled Fast-3G connection, the audio element is interactive before the timer expires on question 1
- [ ] Editing a question's `question_text` via PATCH wipes its audio rows and re-enqueues generation
- [ ] Republishing an already-published bank skips rows already `ready` (check Celery logs: `skipped > 0`)
- [ ] Language switch mid-test falls back to polling when the new language isn't in `preloadedUrls` yet

## Related
- #1670 — Fulfulde (ful). Once that lands, ful automatically joins `SUPPORTED_LANGUAGES` and the pregeneration loop.
- #1669 — slide image crop
- #1671 — mobile-first test-taker

🤖 Generated with [Claude Code](https://claude.com/claude-code)