### PR TITLE
Release: qbank audio pregeneration, mobile-first test-taker, Fulfulde, slide image crop

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -199,6 +199,9 @@ jobs:
       && needs.build-and-push.result == 'success'
       && (needs.build-mms-tts.result == 'success' || needs.build-mms-tts.result == 'skipped')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read       # needed for docker pull ghcr.io/... (#1651)
     steps:
       - uses: actions/checkout@v6
 
@@ -228,6 +231,8 @@ jobs:
       - name: Deploy on server
         uses: appleboy/ssh-action@v1
         env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -245,10 +250,16 @@ jobs:
           host: 167.86.115.58
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_KEY }}
-          envs: POSTGRES_PASSWORD,ANTHROPIC_API_KEY,OPENAI_API_KEY,GOOGLE_API_KEY,SENTRY_DSN,NEXT_PUBLIC_SENTRY_DSN,NEXT_PUBLIC_POSTHOG_KEY,NEXT_PUBLIC_POSTHOG_HOST,SMS_RELAY_API_KEY,SMS_RELAY_TRUSTED_SENDERS,MINIO_ACCESS_KEY,MINIO_SECRET_KEY,DEPLOY_SHA
+          envs: GHCR_USER,GHCR_TOKEN,POSTGRES_PASSWORD,ANTHROPIC_API_KEY,OPENAI_API_KEY,GOOGLE_API_KEY,SENTRY_DSN,NEXT_PUBLIC_SENTRY_DSN,NEXT_PUBLIC_POSTHOG_KEY,NEXT_PUBLIC_POSTHOG_HOST,SMS_RELAY_API_KEY,SMS_RELAY_TRUSTED_SENDERS,MINIO_ACCESS_KEY,MINIO_SECRET_KEY,DEPLOY_SHA
           script: |
             set -e
             cd ~/etutor
+
+            # Authenticate to GHCR with the runner's fresh GITHUB_TOKEN (#1651).
+            # Replaces the server-side cached credential that kept going stale —
+            # the old workflow silently assumed a one-time docker login set
+            # years ago and left us blind when the token rotated.
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
             # Write .env
             cat > .env << EOF
@@ -289,3 +300,7 @@ jobs:
 
             # Cleanup old images
             docker image prune -f
+
+            # Drop the GHCR credential so the server doesn't carry a stale
+            # token between deploys — the next run authenticates fresh.
+            docker logout ghcr.io

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -342,38 +342,53 @@ jobs:
 
       - name: Validate required prod secrets
         run: |
+          # PROD_DEPLOY_SSH_KEY is the only hard requirement — staging's
+          # DEPLOY_SSH_KEY can't reach 94.250.201.110. Everything else
+          # falls back to the staging secret if PROD_* isn't set.
           missing=""
-          [ -z "${{ secrets.PROD_ANTHROPIC_API_KEY }}" ] && missing="$missing PROD_ANTHROPIC_API_KEY"
-          [ -z "${{ secrets.PROD_OPENAI_API_KEY }}" ] && missing="$missing PROD_OPENAI_API_KEY"
-          [ -z "${{ secrets.PROD_GOOGLE_API_KEY }}" ] && missing="$missing PROD_GOOGLE_API_KEY"
           [ -z "${{ secrets.PROD_DEPLOY_SSH_KEY }}" ] && missing="$missing PROD_DEPLOY_SSH_KEY"
-          [ -z "${{ secrets.PROD_POSTGRES_PASSWORD }}" ] && missing="$missing PROD_POSTGRES_PASSWORD"
+          [ -z "${{ secrets.PROD_POSTGRES_PASSWORD || secrets.POSTGRES_PASSWORD }}" ] && missing="$missing POSTGRES_PASSWORD (set PROD_POSTGRES_PASSWORD or fallback POSTGRES_PASSWORD)"
+          [ -z "${{ secrets.PROD_ANTHROPIC_API_KEY || secrets.ANTHROPIC_API_KEY }}" ] && missing="$missing ANTHROPIC_API_KEY (set PROD_ANTHROPIC_API_KEY or fallback ANTHROPIC_API_KEY)"
+          [ -z "${{ secrets.PROD_OPENAI_API_KEY || secrets.OPENAI_API_KEY }}" ] && missing="$missing OPENAI_API_KEY (set PROD_OPENAI_API_KEY or fallback OPENAI_API_KEY)"
+          [ -z "${{ secrets.PROD_GOOGLE_API_KEY || secrets.GOOGLE_API_KEY }}" ] && missing="$missing GOOGLE_API_KEY (set PROD_GOOGLE_API_KEY or fallback GOOGLE_API_KEY)"
           if [ -n "$missing" ]; then
             echo "::error::Missing required production secrets:$missing"
             exit 1
           fi
+          echo "Prod secret pre-flight: OK"
+          # Soft-optional (observability, etc). Log a warning if absent.
+          [ -z "${{ secrets.PROD_SENTRY_DSN || secrets.SENTRY_DSN }}" ] && echo "::warning::SENTRY_DSN not set — backend Sentry disabled on prod"
+          [ -z "${{ secrets.PROD_NEXT_PUBLIC_POSTHOG_KEY || secrets.NEXT_PUBLIC_POSTHOG_KEY }}" ] && echo "::warning::POSTHOG_KEY not set — frontend analytics disabled on prod"
 
       - name: Deploy on production server
         uses: appleboy/ssh-action@v1
         env:
+          # PROD_* takes precedence; staging secret is the fallback so the
+          # deploy isn't blocked on key rotation day (see PR #1668 discussion).
+          # If you've issued dedicated prod keys, set the PROD_* variants and
+          # they'll override the staging values. Secrets with no PROD_*
+          # counterpart (SENTRY_DSN, NEXT_PUBLIC_*, POSTHOG_*) are left empty
+          # when absent — observability just degrades gracefully.
           GHCR_USER: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          POSTGRES_PASSWORD: ${{ secrets.PROD_POSTGRES_PASSWORD }}
-          ANTHROPIC_API_KEY: ${{ secrets.PROD_ANTHROPIC_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.PROD_OPENAI_API_KEY }}
-          GOOGLE_API_KEY: ${{ secrets.PROD_GOOGLE_API_KEY }}
-          SENTRY_DSN: ${{ secrets.PROD_SENTRY_DSN }}
-          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.PROD_NEXT_PUBLIC_SENTRY_DSN }}
-          NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.PROD_NEXT_PUBLIC_POSTHOG_KEY }}
-          NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.PROD_NEXT_PUBLIC_POSTHOG_HOST }}
-          SMS_RELAY_API_KEY: ${{ secrets.PROD_SMS_RELAY_API_KEY }}
-          SMS_RELAY_TRUSTED_SENDERS: ${{ secrets.PROD_SMS_RELAY_TRUSTED_SENDERS }}
-          MINIO_ACCESS_KEY: ${{ secrets.PROD_MINIO_ACCESS_KEY }}
-          MINIO_SECRET_KEY: ${{ secrets.PROD_MINIO_SECRET_KEY }}
+          POSTGRES_PASSWORD: ${{ secrets.PROD_POSTGRES_PASSWORD || secrets.POSTGRES_PASSWORD }}
+          ANTHROPIC_API_KEY: ${{ secrets.PROD_ANTHROPIC_API_KEY || secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.PROD_OPENAI_API_KEY || secrets.OPENAI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.PROD_GOOGLE_API_KEY || secrets.GOOGLE_API_KEY }}
+          SENTRY_DSN: ${{ secrets.PROD_SENTRY_DSN || secrets.SENTRY_DSN }}
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.PROD_NEXT_PUBLIC_SENTRY_DSN || secrets.NEXT_PUBLIC_SENTRY_DSN }}
+          NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.PROD_NEXT_PUBLIC_POSTHOG_KEY || secrets.NEXT_PUBLIC_POSTHOG_KEY }}
+          NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.PROD_NEXT_PUBLIC_POSTHOG_HOST || secrets.NEXT_PUBLIC_POSTHOG_HOST }}
+          SMS_RELAY_API_KEY: ${{ secrets.PROD_SMS_RELAY_API_KEY || secrets.SMS_RELAY_API_KEY }}
+          SMS_RELAY_TRUSTED_SENDERS: ${{ secrets.PROD_SMS_RELAY_TRUSTED_SENDERS || secrets.SMS_RELAY_TRUSTED_SENDERS }}
+          MINIO_ACCESS_KEY: ${{ secrets.PROD_MINIO_ACCESS_KEY || secrets.MINIO_ACCESS_KEY }}
+          MINIO_SECRET_KEY: ${{ secrets.PROD_MINIO_SECRET_KEY || secrets.MINIO_SECRET_KEY }}
           DEPLOY_SHA: ${{ github.sha }}
         with:
           host: 94.250.201.110
           username: deploy
+          # SSH key for the prod host — MUST be set explicitly as PROD_*
+          # (staging DEPLOY_SSH_KEY won't have access to 94.250.201.110).
           key: ${{ secrets.PROD_DEPLOY_SSH_KEY }}
           envs: GHCR_USER,GHCR_TOKEN,POSTGRES_PASSWORD,ANTHROPIC_API_KEY,OPENAI_API_KEY,GOOGLE_API_KEY,SENTRY_DSN,NEXT_PUBLIC_SENTRY_DSN,NEXT_PUBLIC_POSTHOG_KEY,NEXT_PUBLIC_POSTHOG_HOST,SMS_RELAY_API_KEY,SMS_RELAY_TRUSTED_SENDERS,MINIO_ACCESS_KEY,MINIO_SECRET_KEY,DEPLOY_SHA
           script: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -304,3 +304,152 @@ jobs:
             # Drop the GHCR credential so the server doesn't carry a stale
             # token between deploys — the next run authenticates fresh.
             docker logout ghcr.io
+
+  deploy-production:
+    name: Deploy to Production
+    needs: [build-and-push, build-mms-tts]
+    if: |
+      always()
+      && needs.build-and-push.result == 'success'
+      && (needs.build-mms-tts.result == 'success' || needs.build-mms-tts.result == 'skipped')
+      && github.event_name == 'workflow_dispatch'
+      && github.event.inputs.environment == 'production'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Rsync compose file
+        env:
+          DEPLOY_KEY: ${{ secrets.PROD_DEPLOY_SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$DEPLOY_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H 94.250.201.110 >> ~/.ssh/known_hosts
+          # Prefer a prod-specific compose file if one exists in the repo,
+          # otherwise fall back to the shared one.
+          if [ -f docker-compose.prod.sira-donnia.yml ]; then
+            COMPOSE_SRC=docker-compose.prod.sira-donnia.yml
+          else
+            COMPOSE_SRC=docker-compose.prod.yml
+          fi
+          rsync -avz -e "ssh -i ~/.ssh/deploy_key" \
+            "$COMPOSE_SRC" \
+            deploy@94.250.201.110:~/etutor/docker-compose.yml
+
+      - name: Validate required prod secrets
+        run: |
+          missing=""
+          [ -z "${{ secrets.PROD_ANTHROPIC_API_KEY }}" ] && missing="$missing PROD_ANTHROPIC_API_KEY"
+          [ -z "${{ secrets.PROD_OPENAI_API_KEY }}" ] && missing="$missing PROD_OPENAI_API_KEY"
+          [ -z "${{ secrets.PROD_GOOGLE_API_KEY }}" ] && missing="$missing PROD_GOOGLE_API_KEY"
+          [ -z "${{ secrets.PROD_DEPLOY_SSH_KEY }}" ] && missing="$missing PROD_DEPLOY_SSH_KEY"
+          [ -z "${{ secrets.PROD_POSTGRES_PASSWORD }}" ] && missing="$missing PROD_POSTGRES_PASSWORD"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing required production secrets:$missing"
+            exit 1
+          fi
+
+      - name: Deploy on production server
+        uses: appleboy/ssh-action@v1
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          POSTGRES_PASSWORD: ${{ secrets.PROD_POSTGRES_PASSWORD }}
+          ANTHROPIC_API_KEY: ${{ secrets.PROD_ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.PROD_OPENAI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.PROD_GOOGLE_API_KEY }}
+          SENTRY_DSN: ${{ secrets.PROD_SENTRY_DSN }}
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.PROD_NEXT_PUBLIC_SENTRY_DSN }}
+          NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.PROD_NEXT_PUBLIC_POSTHOG_KEY }}
+          NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.PROD_NEXT_PUBLIC_POSTHOG_HOST }}
+          SMS_RELAY_API_KEY: ${{ secrets.PROD_SMS_RELAY_API_KEY }}
+          SMS_RELAY_TRUSTED_SENDERS: ${{ secrets.PROD_SMS_RELAY_TRUSTED_SENDERS }}
+          MINIO_ACCESS_KEY: ${{ secrets.PROD_MINIO_ACCESS_KEY }}
+          MINIO_SECRET_KEY: ${{ secrets.PROD_MINIO_SECRET_KEY }}
+          DEPLOY_SHA: ${{ github.sha }}
+        with:
+          host: 94.250.201.110
+          username: deploy
+          key: ${{ secrets.PROD_DEPLOY_SSH_KEY }}
+          envs: GHCR_USER,GHCR_TOKEN,POSTGRES_PASSWORD,ANTHROPIC_API_KEY,OPENAI_API_KEY,GOOGLE_API_KEY,SENTRY_DSN,NEXT_PUBLIC_SENTRY_DSN,NEXT_PUBLIC_POSTHOG_KEY,NEXT_PUBLIC_POSTHOG_HOST,SMS_RELAY_API_KEY,SMS_RELAY_TRUSTED_SENDERS,MINIO_ACCESS_KEY,MINIO_SECRET_KEY,DEPLOY_SHA
+          script: |
+            set -e
+            cd ~/etutor
+
+            # Fresh GHCR login every deploy, same pattern as staging (#1651).
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+
+            cat > .env << EOF
+            POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+            ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+            OPENAI_API_KEY=${OPENAI_API_KEY}
+            GOOGLE_API_KEY=${GOOGLE_API_KEY}
+            SENTRY_DSN=${SENTRY_DSN}
+            NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}
+            NEXT_PUBLIC_POSTHOG_KEY=${NEXT_PUBLIC_POSTHOG_KEY}
+            NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST}
+            SMS_RELAY_API_KEY=${SMS_RELAY_API_KEY}
+            SMS_RELAY_TRUSTED_SENDERS=${SMS_RELAY_TRUSTED_SENDERS}
+            MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
+            MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
+            EOF
+
+            # Pull new images. mms-tts is an optional sidecar (audio TTS);
+            # its pull currently fails on a ghcr permissions issue tracked
+            # elsewhere. Don't let that block the backend/frontend rollout.
+            docker compose pull backend frontend
+            docker compose pull mms-tts || echo "::warning::mms-tts pull failed, continuing with existing image"
+
+            docker compose up -d
+
+            sleep 10
+            echo "Running database migrations..."
+            docker compose exec -T -e PYTHONPATH=/app backend uv run alembic upgrade head
+            echo "Migrations completed successfully."
+            docker compose up -d --force-recreate backend
+            sleep 15
+
+            echo "${DEPLOY_SHA}" > .deploy-sha
+
+            sleep 15
+            docker compose ps
+
+            docker image prune -f
+            docker logout ghcr.io
+
+      - name: Rollout to existing prod tenants
+        if: success()
+        uses: appleboy/ssh-action@v1
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          host: 94.250.201.110
+          username: deploy
+          key: ${{ secrets.PROD_DEPLOY_SSH_KEY }}
+          envs: GHCR_USER,GHCR_TOKEN
+          script: |
+            set -e
+            # #1571 part 2: tenants pull `:latest` at provisioning time and
+            # then freeze. After a platform deploy, refresh every tenant so
+            # they pick up the new backend/frontend images.
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+            TENANT_ROOT="$HOME/tenants"
+            if [ ! -d "$TENANT_ROOT" ]; then
+              echo "::notice::No $TENANT_ROOT directory — skipping tenant rollout (no existing tenants)."
+              docker logout ghcr.io
+              exit 0
+            fi
+            for tenant_dir in "$TENANT_ROOT"/*/; do
+              [ -f "$tenant_dir/docker-compose.yml" ] || continue
+              slug=$(basename "$tenant_dir")
+              echo "--- Refreshing tenant: $slug ---"
+              (cd "$tenant_dir" && docker compose pull backend frontend && docker compose up -d) \
+                || echo "::warning::Tenant $slug rollout failed — continuing with others"
+            done
+            docker logout ghcr.io
+            echo "Tenant rollout complete."

--- a/backend/app/ai/qbank_slide_extractor.py
+++ b/backend/app/ai/qbank_slide_extractor.py
@@ -230,6 +230,80 @@ def _convert_to_webp(
     return buf.getvalue(), img.width, img.height
 
 
+# Fallback crop ratio when the page has no text layer (fully scanned slides).
+# Driving-school layouts reliably place the illustration in the top ~55%.
+DEFAULT_ILLUSTRATION_RATIO = 0.55
+
+# Clamp the crop ratio so we never cut off the illustration or keep too much
+# of the text block.
+MIN_ILLUSTRATION_RATIO = 0.3
+MAX_ILLUSTRATION_RATIO = 0.75
+
+# Text spans shorter than this are treated as headers (e.g. "Question 01")
+# and ignored when picking the question-text top boundary.
+HEADER_SPAN_MAX_LEN = 12
+
+# Skip spans whose top is in the first ~10% of the page height — those are
+# page headers, not the question block.
+TOP_MARGIN_IGNORE_RATIO = 0.1
+
+
+def _illustration_crop_ratio(page: pymupdf.Page) -> float:
+    """Return the fraction of the page height that contains the illustration.
+
+    For slides where the question/options text sits below the photo, this is
+    the y-coordinate of the topmost question-looking text span divided by
+    the page height. Falls back to ``DEFAULT_ILLUSTRATION_RATIO`` when no
+    text layer is present (scanned slides).
+    """
+    spans = _flatten_spans(page.get_text("dict"))
+    page_h = max(float(page.rect.height), 1.0)
+    if not spans:
+        return DEFAULT_ILLUSTRATION_RATIO
+
+    for span in spans:
+        text = span["text"].strip()
+        if len(text) < HEADER_SPAN_MAX_LEN:
+            continue
+        y0 = float(span["bbox"][1])
+        if y0 / page_h < TOP_MARGIN_IGNORE_RATIO:
+            continue
+        # Leave 2% padding above the text so we don't clip the illustration.
+        ratio = (y0 / page_h) - 0.02
+        return max(MIN_ILLUSTRATION_RATIO, min(MAX_ILLUSTRATION_RATIO, ratio))
+    return DEFAULT_ILLUSTRATION_RATIO
+
+
+def _crop_to_illustration(
+    image_bytes: bytes,
+    max_width: int = WEBP_MAX_WIDTH,
+    crop_ratio: float = DEFAULT_ILLUSTRATION_RATIO,
+) -> tuple[bytes, int, int]:
+    """Crop a full-slide raster to the illustration region and encode as WebP.
+
+    Driving-school PDFs frequently ship each slide as one image with the
+    question text and options baked in. The frontend renders the extracted
+    text separately, so keeping the text in the image duplicates the same
+    information twice (#1669). This helper drops the bottom of the image.
+    """
+    img = Image.open(io.BytesIO(image_bytes))
+    if img.mode not in ("RGB",):
+        img = img.convert("RGB")
+
+    crop_ratio = max(MIN_ILLUSTRATION_RATIO, min(MAX_ILLUSTRATION_RATIO, crop_ratio))
+    new_h = max(1, int(img.height * crop_ratio))
+    img = img.crop((0, 0, img.width, new_h))
+
+    if img.width > max_width:
+        ratio = max_width / img.width
+        new_height = max(1, int(img.height * ratio))
+        img = img.resize((max_width, new_height), Image.LANCZOS)
+
+    buf = io.BytesIO()
+    img.save(buf, format="WEBP", quality=WEBP_QUALITY)
+    return buf.getvalue(), img.width, img.height
+
+
 # -----------------------------------------------------------------------------
 # Tier 1 — PyMuPDF text + color extraction (free)
 # -----------------------------------------------------------------------------
@@ -401,13 +475,21 @@ def _tier1_confidence(
 
 def _find_largest_embedded_image(
     page: pymupdf.Page, doc: pymupdf.Document
-) -> tuple[bytes, int, int] | None:
-    """Return (png_bytes, width, height) of the largest embedded raster image on the page."""
+) -> tuple[bytes, int, int, bool] | None:
+    """Return ``(png_bytes, width, height, covers_full_page)`` for the largest
+    embedded raster image on the page, or ``None`` when the page has none.
+
+    ``covers_full_page`` is ``True`` when the image's placement on the page
+    covers at least 85% of the page area — a strong signal that this image
+    is a full-slide raster (with question text baked in) rather than a
+    standalone illustration photo.
+    """
     images = page.get_images(full=True)
     if not images:
         return None
 
-    best: tuple[bytes, int, int] | None = None
+    page_area = max(float(page.rect.width * page.rect.height), 1.0)
+    best: tuple[bytes, int, int, bool] | None = None
     best_area = 0
     for img_info in images:
         xref = img_info[0]
@@ -418,9 +500,17 @@ def _find_largest_embedded_image(
         width = extracted.get("width", 0)
         height = extracted.get("height", 0)
         area = width * height
-        if area > best_area and extracted.get("image"):
-            best = (extracted["image"], width, height)
-            best_area = area
+        if area <= best_area or not extracted.get("image"):
+            continue
+        covers_full_page = False
+        try:
+            bbox = page.get_image_bbox(img_info)
+            bbox_area = float(bbox.width * bbox.height)
+            covers_full_page = bbox_area / page_area >= 0.85
+        except Exception:
+            pass
+        best = (extracted["image"], width, height, covers_full_page)
+        best_area = area
     return best
 
 
@@ -449,15 +539,22 @@ def _extract_tier1(
         return [], 0.0
 
     # Get the situation image: prefer the largest embedded image.
+    crop_ratio = _illustration_crop_ratio(page)
     embedded = _find_largest_embedded_image(page, doc)
     if embedded is not None:
-        raw_bytes, _, _ = embedded
-        webp_bytes, width, height = _convert_to_webp(raw_bytes)
+        raw_bytes, _, _, covers_full_page = embedded
+        if covers_full_page:
+            # Embedded image IS the whole slide (text baked in) — crop it.
+            webp_bytes, width, height = _crop_to_illustration(raw_bytes, crop_ratio=crop_ratio)
+        else:
+            # Already a standalone illustration — keep as-is.
+            webp_bytes, width, height = _convert_to_webp(raw_bytes)
         has_image = True
     else:
-        # Fall back to rasterizing the whole page — the frontend gets the full slide.
+        # Fall back to rasterizing the whole page and cropping to the
+        # illustration region so baked-in question text is dropped (#1669).
         png_bytes = _rasterize_page(page)
-        webp_bytes, width, height = _convert_to_webp(png_bytes)
+        webp_bytes, width, height = _crop_to_illustration(png_bytes, crop_ratio=crop_ratio)
         has_image = False
 
     confidence = _tier1_confidence(parsed, has_image, cluster_count=len(clusters))
@@ -491,7 +588,11 @@ async def _extract_tier3_vision(
 ) -> list[ExtractedSlideQuestion]:
     """Tier 3: send the rasterized page to Claude Vision and parse the response."""
     png_bytes = _rasterize_page(page)
-    webp_bytes, width, height = _convert_to_webp(png_bytes)
+    # Vision needs the whole slide (question + options text) to read the page;
+    # the stored image is cropped to the illustration region so the test-taker
+    # doesn't duplicate the question text visually (#1669).
+    crop_ratio = _illustration_crop_ratio(page)
+    webp_bytes, width, height = _crop_to_illustration(png_bytes, crop_ratio=crop_ratio)
 
     b64_image = base64.b64encode(png_bytes).decode("utf-8")
     response = await claude.client.messages.create(

--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -77,8 +77,8 @@ def _audio_url_for(
 ) -> str | None:
     """Build a browser-reachable proxy URL for a question's audio clip.
 
-    Driving-school banks ship audio in fr/mos/dyu/bam (required so
-    learners who can't read can still take the test). The DB column
+    Driving-school banks ship audio in fr/mos/dyu/bam/ful (required
+    so learners who can't read can still take the test). The DB column
     stores ``http://minio:9000/...`` which the browser can't reach —
     same pattern as ``_image_url_for``. Returns ``None`` when the audio
     row has no bytes yet (pending/failed states).

--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -358,6 +358,10 @@ async def start_test(
     current_user: AuthenticatedUser = Depends(get_current_user),
     db=Depends(get_db_session),
 ):
+    from sqlalchemy import select
+
+    from app.domain.models.question_bank import QBankAudioStatus, QBankQuestionAudio
+
     data = await _svc.start_test(db, test_id, uuid.UUID(current_user.id))
     test = data["test"]
     # Training mode with show_feedback relies on the client knowing the answer
@@ -378,6 +382,23 @@ async def start_test(
         for q in data["questions"]
     ]
 
+    # Preload ready audio URLs for every (question, language) pair so the
+    # client can warm its HTTP cache before the timer starts (#1674).
+    audio_map: dict[str, dict[str, str]] = {}
+    question_ids = [q.id for q in data["questions"]]
+    if question_ids:
+        audio_rows = await db.execute(
+            select(QBankQuestionAudio).where(
+                QBankQuestionAudio.question_id.in_(question_ids),
+                QBankQuestionAudio.status == QBankAudioStatus.ready,
+            )
+        )
+        for row in audio_rows.scalars():
+            url = _audio_url_for(request, row.question_id, row.language, row.storage_key)
+            if url is None:
+                continue
+            audio_map.setdefault(str(row.question_id), {})[row.language] = url
+
     return TestStartResponse(
         test_id=str(test.id),
         title=test.title,
@@ -386,6 +407,7 @@ async def start_test(
         show_feedback=test.show_feedback,
         questions=questions,
         total_questions=len(questions),
+        audio=audio_map,
     )
 
 

--- a/backend/app/api/v1/schemas/qbank.py
+++ b/backend/app/api/v1/schemas/qbank.py
@@ -154,6 +154,12 @@ class TestStartResponse(BaseModel):
     show_feedback: bool
     questions: list[TestStartQuestion]
     total_questions: int
+    # Pre-fetched audio URLs: ``{question_id: {language: url}}``. Only
+    # entries with ``status == "ready"`` are included; missing keys mean
+    # the client should fall back to polling ``/questions/{id}/audio``.
+    # Preloading these on the client lets the learner start hearing the
+    # question within the timer window without a per-question round-trip.
+    audio: dict[str, dict[str, str]] = Field(default_factory=dict)
 
 
 class TestSubmitRequest(BaseModel):

--- a/backend/app/domain/services/qbank_audio_service.py
+++ b/backend/app/domain/services/qbank_audio_service.py
@@ -33,6 +33,12 @@ from app.integrations.mms_tts import MMSTTSClient, MMSTTSError
 logger = structlog.get_logger(__name__)
 
 SupportedLanguage = Literal["fr", "mos", "dyu", "bam", "ful"]
+
+# Canonical list of languages audio is generated for. Pregeneration loops
+# over this tuple when a bank is published so every (question, language)
+# pair has a ready clip by the time a learner starts a test (#1674).
+SUPPORTED_LANGUAGES: tuple[str, ...] = ("fr", "mos", "dyu", "bam", "ful")
+
 OPUS_CONTENT_TYPE = "audio/ogg"
 OPUS_BYTES_PER_SECOND = 6 * 1024  # matches LessonAudioService._estimate_duration
 
@@ -180,8 +186,15 @@ class QBankAudioService:
         db: AsyncSession,
         bank_id: uuid.UUID,
         language: str,
+        *,
+        skip_ready: bool = True,
     ) -> dict:
-        """Generate audio for every question in a bank. Intended for Celery."""
+        """Generate audio for every question in a bank. Intended for Celery.
+
+        Idempotent by default: questions whose ``(question, language)`` row
+        is already ``ready`` are skipped so republishing or retrying a
+        bank doesn't re-bill TTS for clips that already exist (#1674).
+        """
         bank = await db.get(QuestionBank, bank_id)
         if bank is None:
             raise HTTPException(
@@ -199,9 +212,25 @@ class QBankAudioService:
             .all()
         )
 
+        ready_question_ids: set[uuid.UUID] = set()
+        if skip_ready and questions:
+            existing = await db.execute(
+                select(QBankQuestionAudio).where(
+                    QBankQuestionAudio.question_id.in_([q.id for q in questions]),
+                    QBankQuestionAudio.language == language,
+                    QBankQuestionAudio.status == QBankAudioStatus.ready,
+                )
+            )
+            ready_question_ids = {row.question_id for row in existing.scalars()}
+
         ready = 0
         failed = 0
+        skipped = 0
         for q in questions:
+            if q.id in ready_question_ids:
+                skipped += 1
+                ready += 1  # Already-ready clips still count as ready.
+                continue
             row = await self.generate_question_audio(db, q.id, language)
             if row.status == QBankAudioStatus.ready:
                 ready += 1
@@ -212,9 +241,27 @@ class QBankAudioService:
             "bank_id": str(bank_id),
             "language": language,
             "total": len(questions),
+            "skipped": skipped,
             "ready": ready,
             "failed": failed,
         }
+
+    async def invalidate_question(
+        self,
+        db: AsyncSession,
+        question_id: uuid.UUID,
+    ) -> None:
+        """Drop every cached audio row for a question.
+
+        Called when a question's text or options change — the stored
+        clip no longer matches the script and must be regenerated.
+        """
+        await db.execute(
+            QBankQuestionAudio.__table__.delete().where(
+                QBankQuestionAudio.question_id == question_id,
+            )
+        )
+        await db.commit()
 
     async def store_uploaded_audio(
         self,

--- a/backend/app/domain/services/qbank_audio_service.py
+++ b/backend/app/domain/services/qbank_audio_service.py
@@ -32,7 +32,7 @@ from app.integrations.mms_tts import MMSTTSClient, MMSTTSError
 
 logger = structlog.get_logger(__name__)
 
-SupportedLanguage = Literal["fr", "mos", "dyu", "bam"]
+SupportedLanguage = Literal["fr", "mos", "dyu", "bam", "ful"]
 OPUS_CONTENT_TYPE = "audio/ogg"
 OPUS_BYTES_PER_SECOND = 6 * 1024  # matches LessonAudioService._estimate_duration
 
@@ -48,6 +48,7 @@ def build_audio_script(question: QBankQuestion, language: str) -> str:
         "mos": "Tʋʋmde",  # Moore: "task/choice"
         "dyu": "Sugandili",  # Dioula/Jula: "choice"
         "bam": "Sugandili",  # Bambara: "choice"
+        "ful": "Suɓaande",  # Fulfulde: "choice"
     }
     prefix = prefixes.get(language, "Option")
     parts = [question.question_text.strip()]

--- a/backend/app/domain/services/qbank_service.py
+++ b/backend/app/domain/services/qbank_service.py
@@ -25,6 +25,30 @@ logger = structlog.get_logger(__name__)
 _org_svc = OrganizationService()
 
 
+def _enqueue_pregenerate_audio(bank_id: uuid.UUID) -> None:
+    """Fire a Celery task per supported language to pregenerate audio.
+
+    Kept as a module-level helper so it can be called from ``update_bank``
+    (publish transition) and ``update_question`` (text change) without
+    creating a service cycle. Imports are local so this module stays
+    safe to import in contexts where Celery isn't wired up (e.g. tests
+    that patch the task).
+    """
+    from app.domain.services.qbank_audio_service import SUPPORTED_LANGUAGES
+    from app.tasks.qbank_processing import generate_qbank_audio_task
+
+    for language in SUPPORTED_LANGUAGES:
+        try:
+            generate_qbank_audio_task.delay(str(bank_id), language)
+        except Exception as exc:
+            logger.warning(
+                "failed to enqueue qbank audio pregeneration",
+                bank_id=str(bank_id),
+                language=language,
+                error=str(exc),
+            )
+
+
 class QBankService:
     # ------------------------------------------------------------------
     # Question Bank CRUD
@@ -125,11 +149,19 @@ class QBankService:
             "passing_score",
             "status",
         }
+        previous_status = bank.status.value if hasattr(bank.status, "value") else bank.status
         for key, value in fields.items():
             if key in allowed and value is not None:
                 setattr(bank, key, value)
         await db.commit()
         await db.refresh(bank)
+
+        # Publish transition fires audio pregeneration for every supported
+        # language so learners never wait on the timer for TTS (#1674).
+        new_status = bank.status.value if hasattr(bank.status, "value") else bank.status
+        if previous_status != "published" and new_status == "published":
+            _enqueue_pregenerate_audio(bank_id)
+
         return bank
 
     async def delete_bank(
@@ -208,11 +240,25 @@ class QBankService:
             "category",
             "difficulty",
         }
+        # Changes to the spoken text or option list make the cached TTS
+        # clips stale — drop them and re-enqueue generation downstream.
+        invalidating_keys = {"question_text", "options"}
+        should_invalidate_audio = any(
+            key in invalidating_keys and value is not None and value != getattr(question, key, None)
+            for key, value in fields.items()
+        )
         for key, value in fields.items():
             if key in allowed and value is not None:
                 setattr(question, key, value)
         await db.commit()
         await db.refresh(question)
+
+        if should_invalidate_audio:
+            from app.domain.services.qbank_audio_service import QBankAudioService
+
+            await QBankAudioService().invalidate_question(db, question_id)
+            _enqueue_pregenerate_audio(question.question_bank_id)
+
         return question
 
     async def delete_question(

--- a/backend/app/integrations/mms_tts.py
+++ b/backend/app/integrations/mms_tts.py
@@ -1,8 +1,10 @@
 """Async HTTP client for the Meta MMS TTS sidecar service.
 
 The sidecar is a separate Docker service (see infrastructure/mms-tts) that
-wraps facebook/mms-tts-{mos,dyu,bam} models and returns OGG/Opus audio. We
-call it over plain HTTP from the backend and the Celery worker.
+wraps facebook/mms-tts-{mos,dyu,bam,ffm} models and returns OGG/Opus audio.
+``ful`` is exposed to the backend and frontend; the sidecar maps it to the
+``ffm`` (Maasina Fulfulde) VITS model. We call it over plain HTTP from the
+backend and the Celery worker.
 """
 
 from __future__ import annotations
@@ -16,7 +18,7 @@ from app.infrastructure.config.settings import settings
 
 logger = structlog.get_logger(__name__)
 
-SUPPORTED_LANGUAGES = {"mos", "dyu", "bam"}
+SUPPORTED_LANGUAGES = {"mos", "dyu", "bam", "ful"}
 
 
 class MMSTTSError(Exception):

--- a/backend/app/tasks/qbank_processing.py
+++ b/backend/app/tasks/qbank_processing.py
@@ -134,6 +134,24 @@ async def _process_pdf_async(task, bank_id: str, pdf_filename: str) -> dict:
         questions_created=created,
         errors_count=len(errors),
     )
+
+    # Fire audio pregeneration for every supported language so the first
+    # learner to take a test doesn't wait on the MMS sidecar (#1674).
+    # Skipped when no questions were added — nothing to synthesize.
+    if created:
+        from app.domain.services.qbank_audio_service import SUPPORTED_LANGUAGES
+
+        for language in SUPPORTED_LANGUAGES:
+            try:
+                generate_qbank_audio_task.delay(bank_id, language)
+            except Exception as exc:
+                logger.warning(
+                    "failed to enqueue post-extract audio pregeneration",
+                    bank_id=bank_id,
+                    language=language,
+                    error=str(exc),
+                )
+
     return {
         "bank_id": bank_id,
         "questions_created": created,

--- a/backend/tests/test_qbank_audio_service.py
+++ b/backend/tests/test_qbank_audio_service.py
@@ -39,7 +39,12 @@ def test_build_audio_script_french_prefix():
 
 def test_build_audio_script_mms_languages_use_native_prefix():
     q = _FakeQuestion("Question", ["A", "B"])
-    for lang, prefix in [("mos", "Tʋʋmde"), ("dyu", "Sugandili"), ("bam", "Sugandili")]:
+    for lang, prefix in [
+        ("mos", "Tʋʋmde"),
+        ("dyu", "Sugandili"),
+        ("bam", "Sugandili"),
+        ("ful", "Suɓaande"),
+    ]:
         script = build_audio_script(q, lang)
         assert f"{prefix} A" in script
         assert f"{prefix} B" in script

--- a/backend/tests/test_qbank_audio_service.py
+++ b/backend/tests/test_qbank_audio_service.py
@@ -15,6 +15,7 @@ import pytest
 from fastapi import HTTPException
 
 from app.domain.services.qbank_audio_service import (
+    SUPPORTED_LANGUAGES,
     QBankAudioService,
     build_audio_script,
     estimate_duration_seconds,
@@ -82,3 +83,11 @@ async def test_synthesize_dispatches_mms_languages_to_client():
     out = await svc._synthesize_bytes("lakala", "dyu")
     assert out == b"OGG"
     fake_mms.synthesize.assert_awaited_once_with("lakala", "dyu")
+
+
+def test_supported_languages_is_non_empty_tuple():
+    # Pregeneration loops over this tuple, so it must stay iterable and
+    # contain at least French (the baseline).
+    assert isinstance(SUPPORTED_LANGUAGES, tuple)
+    assert "fr" in SUPPORTED_LANGUAGES
+    assert all(isinstance(lang, str) for lang in SUPPORTED_LANGUAGES)

--- a/backend/tests/test_qbank_slide_extractor.py
+++ b/backend/tests/test_qbank_slide_extractor.py
@@ -12,13 +12,19 @@ from unittest.mock import AsyncMock, patch
 
 import pymupdf
 import pytest
+from PIL import Image
 
 from app.ai.qbank_slide_extractor import (
     CONFIDENCE_THRESHOLD,
+    DEFAULT_ILLUSTRATION_RATIO,
+    MAX_ILLUSTRATION_RATIO,
+    MIN_ILLUSTRATION_RATIO,
     ExtractedSlideQuestion,
     _cluster_into_questions,
+    _crop_to_illustration,
     _extract_tier1,
     _flatten_spans,
+    _illustration_crop_ratio,
     _infer_category,
     _is_green,
     _parse_question_cluster,
@@ -420,3 +426,72 @@ class TestExtractQuestionsFromPdf:
     async def test_missing_pdf_raises(self, tmp_path: Path):
         with pytest.raises(FileNotFoundError):
             await extract_questions_from_pdf(tmp_path / "does-not-exist.pdf")
+
+
+def _solid_png_bytes(width: int, height: int) -> bytes:
+    import io
+
+    img = Image.new("RGB", (width, height), color=(255, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+class TestIllustrationCrop:
+    def test_crop_reduces_height_by_default_ratio(self):
+        src = _solid_png_bytes(400, 1000)
+        webp, w, h = _crop_to_illustration(src, crop_ratio=0.5)
+        assert w == 400
+        assert h == 500
+        assert webp[:4] == b"RIFF"  # WebP container magic
+
+    def test_crop_clamps_below_minimum(self):
+        src = _solid_png_bytes(200, 1000)
+        _webp, _w, h = _crop_to_illustration(src, crop_ratio=0.05)
+        # 0.05 is below MIN, so clamped to MIN_ILLUSTRATION_RATIO.
+        assert h == int(1000 * MIN_ILLUSTRATION_RATIO)
+
+    def test_crop_clamps_above_maximum(self):
+        src = _solid_png_bytes(200, 1000)
+        _webp, _w, h = _crop_to_illustration(src, crop_ratio=0.99)
+        assert h == int(1000 * MAX_ILLUSTRATION_RATIO)
+
+    def test_crop_respects_max_width(self):
+        # Wider than WEBP_MAX_WIDTH (1024): both crop and width cap apply.
+        src = _solid_png_bytes(2048, 1000)
+        _webp, w, h = _crop_to_illustration(src, crop_ratio=0.6)
+        assert w == 1024
+        # Height is cropped (0.6 * 1000 = 600), then scaled by 1024/2048 = 0.5
+        assert h == 300
+
+    def test_ratio_falls_back_when_page_has_no_text(self, tmp_path: Path):
+        doc = pymupdf.open()
+        doc.new_page(width=595, height=842)
+        ratio = _illustration_crop_ratio(doc[0])
+        doc.close()
+        assert ratio == DEFAULT_ILLUSTRATION_RATIO
+
+    def test_ratio_uses_topmost_question_span(self, tmp_path: Path):
+        # Page with a header near the top and a question block halfway down.
+        pdf = tmp_path / "slide.pdf"
+        doc = pymupdf.open()
+        page = doc.new_page(width=595, height=842)
+        # Header (short) — should be ignored.
+        page.insert_text((72, 30), "Question 01", fontsize=10, color=BLACK)
+        # Actual question at y=500 on a 842pt page → 500/842 ≈ 0.594
+        page.insert_text(
+            (72, 500),
+            "Je peux faire un arret ici ?",
+            fontsize=12,
+            color=BLACK,
+        )
+        doc.save(str(pdf))
+        doc.close()
+
+        doc = pymupdf.open(str(pdf))
+        ratio = _illustration_crop_ratio(doc[0])
+        doc.close()
+
+        # PyMuPDF baseline y differs from insert y by the font height; just
+        # assert the ratio falls in the expected middle band below the header.
+        assert 0.4 < ratio < 0.7

--- a/frontend/components/chat/chat-layout.tsx
+++ b/frontend/components/chat/chat-layout.tsx
@@ -12,12 +12,16 @@ function ChatUIComponents() {
     ? pathname.split('/modules/')[1]?.split('/')[0]
     : undefined;
 
-  // Hide floating button when already on the tutor page
+  // Hide floating button on screens where it would overlap the primary
+  // action (tutor page, qbank test-taker where the sticky footer already
+  // holds the Valider / Terminer button).
   const isOnTutorPage = pathname.endsWith('/tutor');
+  const isOnQbankTest = /\/qbank\/tests\/[^/]+$/.test(pathname);
+  const hideFab = isOnTutorPage || isOnQbankTest;
 
   return (
     <>
-      {!isOnTutorPage && <FloatingChatButton onClick={openChat} />}
+      {!hideFab && <FloatingChatButton onClick={openChat} />}
       <ChatPanel 
         isOpen={isOpen} 
         onClose={closeChat}

--- a/frontend/components/qbank/qbank-audio-player.tsx
+++ b/frontend/components/qbank/qbank-audio-player.tsx
@@ -72,11 +72,11 @@ export function QBankAudioPlayer({ questionId, defaultLanguage }: QBankAudioPlay
   }, [language]);
 
   return (
-    <div className="flex flex-col gap-2" aria-label={t('audio.label')}>
+    <div className="flex flex-col gap-1.5 sm:gap-2" aria-label={t('audio.label')}>
       <div
         role="radiogroup"
         aria-label={t('audio.languagePickerLabel')}
-        className="flex flex-wrap gap-2"
+        className="flex flex-wrap gap-1.5 sm:gap-2"
       >
         {LANGUAGES.map((lang) => {
           const isSelected = lang === language;
@@ -88,8 +88,11 @@ export function QBankAudioPlayer({ questionId, defaultLanguage }: QBankAudioPlay
               aria-checked={isSelected}
               aria-label={t('audio.pillAriaLabel', { language: tLang(lang) })}
               onClick={() => setLanguage(lang)}
+              // min-h-9 on mobile keeps the pills compact so the 4-5
+              // language row fits next to the image; bumps to min-h-11
+              // on sm+ where there is room for WCAG touch targets.
               className={cn(
-                'min-h-11 min-w-16 rounded-full border px-4 py-1.5 text-sm font-medium transition-colors',
+                'min-h-9 rounded-full border px-3 py-1 text-xs font-medium transition-colors sm:min-h-11 sm:px-4 sm:py-1.5 sm:text-sm',
                 isSelected
                   ? 'border-primary bg-primary text-primary-foreground'
                   : 'border-border bg-background hover:border-primary/50'
@@ -107,14 +110,6 @@ export function QBankAudioPlayer({ questionId, defaultLanguage }: QBankAudioPlay
         </p>
       )}
 
-      {!error && !status && (
-        <p className="text-xs text-muted-foreground">{t('audio.loading')}</p>
-      )}
-
-      {status && (status.status === 'pending' || status.status === 'generating') && (
-        <p className="text-xs text-muted-foreground">{t('audio.notReady')}</p>
-      )}
-
       {status?.status === 'failed' && (
         <p className="text-xs text-destructive" role="alert">{t('audio.failed')}</p>
       )}
@@ -125,11 +120,16 @@ export function QBankAudioPlayer({ questionId, defaultLanguage }: QBankAudioPlay
           src={status.audio_url}
           controls
           preload="none"
-          className="w-full"
+          className="h-9 w-full sm:h-10"
         >
           {t('audio.unsupported')}
         </audio>
       )}
+
+      {/* The "loading" and "notReady" states are intentionally silent on
+          the test-taker to avoid eating vertical space while the learner
+          is under a timer. Audio availability is communicated by whether
+          the <audio> element renders at all. */}
     </div>
   );
 }

--- a/frontend/components/qbank/qbank-audio-player.tsx
+++ b/frontend/components/qbank/qbank-audio-player.tsx
@@ -9,7 +9,7 @@ import {
   type QBankQuestionAudioStatus,
 } from '@/lib/api';
 
-const LANGUAGES: QBankAudioLanguage[] = ['fr', 'mos', 'dyu', 'bam'];
+const LANGUAGES: QBankAudioLanguage[] = ['fr', 'mos', 'dyu', 'bam', 'ful'];
 const STORAGE_KEY = 'qbank-audio-lang';
 
 interface QBankAudioPlayerProps {
@@ -19,12 +19,12 @@ interface QBankAudioPlayerProps {
 }
 
 /**
- * Per-question audio player with a language picker (fr/mos/dyu/bam).
+ * Per-question audio player with a language picker (fr/mos/dyu/bam/ful).
  *
  * Driving-school learners who can't read rely on this — the audio is
  * the primary way they answer the question. We don't hide it behind a
- * preferences toggle: the four language pills are always visible and
- * the last selection persists across questions via localStorage (#1659).
+ * preferences toggle: the language pills are always visible and the
+ * last selection persists across questions via localStorage (#1659, #1670).
  */
 export function QBankAudioPlayer({ questionId, defaultLanguage }: QBankAudioPlayerProps) {
   const t = useTranslations('qbank');

--- a/frontend/components/qbank/qbank-audio-player.tsx
+++ b/frontend/components/qbank/qbank-audio-player.tsx
@@ -41,12 +41,20 @@ export function QBankAudioPlayer({ questionId, defaultLanguage }: QBankAudioPlay
 
   useEffect(() => {
     let cancelled = false;
-    setStatus(null);
-    setError(null);
+    // Old-state resets moved into the callbacks: sync setStates inside an
+    // effect body cascade re-renders and trip the no-sync-set-state lint
+    // rule. The brief flicker of stale status on question/language change
+    // is acceptable — it's replaced atomically when the fetch resolves.
     getQBankQuestionAudio(questionId, language)
-      .then((s) => { if (!cancelled) setStatus(s); })
+      .then((s) => {
+        if (cancelled) return;
+        setError(null);
+        setStatus(s);
+      })
       .catch((err) => {
-        if (!cancelled) setError(err instanceof Error ? err.message : 'Audio fetch failed');
+        if (cancelled) return;
+        setStatus(null);
+        setError(err instanceof Error ? err.message : 'Audio fetch failed');
       });
     return () => { cancelled = true; };
   }, [questionId, language]);

--- a/frontend/components/qbank/qbank-audio-player.tsx
+++ b/frontend/components/qbank/qbank-audio-player.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+import {
+  getQBankQuestionAudio,
+  type QBankAudioLanguage,
+  type QBankQuestionAudioStatus,
+} from '@/lib/api';
+
+const LANGUAGES: QBankAudioLanguage[] = ['fr', 'mos', 'dyu', 'bam'];
+const STORAGE_KEY = 'qbank-audio-lang';
+
+interface QBankAudioPlayerProps {
+  questionId: string;
+  /** Preferred default when nothing is in localStorage yet (e.g. bank.language). */
+  defaultLanguage?: QBankAudioLanguage;
+}
+
+/**
+ * Per-question audio player with a language picker (fr/mos/dyu/bam).
+ *
+ * Driving-school learners who can't read rely on this — the audio is
+ * the primary way they answer the question. We don't hide it behind a
+ * preferences toggle: the four language pills are always visible and
+ * the last selection persists across questions via localStorage (#1659).
+ */
+export function QBankAudioPlayer({ questionId, defaultLanguage }: QBankAudioPlayerProps) {
+  const t = useTranslations('qbank');
+  const tLang = useTranslations('qbank.audioLanguages');
+  const [language, setLanguage] = useState<QBankAudioLanguage>(() => {
+    if (typeof window === 'undefined') return defaultLanguage ?? 'fr';
+    const saved = window.localStorage.getItem(STORAGE_KEY) as QBankAudioLanguage | null;
+    if (saved && LANGUAGES.includes(saved)) return saved;
+    return defaultLanguage ?? 'fr';
+  });
+  const [status, setStatus] = useState<QBankQuestionAudioStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const audioRef = useRef<HTMLAudioElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setStatus(null);
+    setError(null);
+    getQBankQuestionAudio(questionId, language)
+      .then((s) => { if (!cancelled) setStatus(s); })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Audio fetch failed');
+      });
+    return () => { cancelled = true; };
+  }, [questionId, language]);
+
+  // Persist the learner's chosen language across questions.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(STORAGE_KEY, language);
+  }, [language]);
+
+  // Stop playback when we switch language; the new audio will mount a fresh <audio>.
+  useEffect(() => {
+    if (audioRef.current) audioRef.current.pause();
+  }, [language]);
+
+  return (
+    <div className="flex flex-col gap-2" aria-label={t('audio.label')}>
+      <div
+        role="radiogroup"
+        aria-label={t('audio.languagePickerLabel')}
+        className="flex flex-wrap gap-2"
+      >
+        {LANGUAGES.map((lang) => {
+          const isSelected = lang === language;
+          return (
+            <button
+              key={lang}
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              aria-label={t('audio.pillAriaLabel', { language: tLang(lang) })}
+              onClick={() => setLanguage(lang)}
+              className={cn(
+                'min-h-11 min-w-16 rounded-full border px-4 py-1.5 text-sm font-medium transition-colors',
+                isSelected
+                  ? 'border-primary bg-primary text-primary-foreground'
+                  : 'border-border bg-background hover:border-primary/50'
+              )}
+            >
+              {tLang(lang)}
+            </button>
+          );
+        })}
+      </div>
+
+      {error && (
+        <p className="text-xs text-destructive" role="alert">
+          {t('audio.error')}
+        </p>
+      )}
+
+      {!error && !status && (
+        <p className="text-xs text-muted-foreground">{t('audio.loading')}</p>
+      )}
+
+      {status && (status.status === 'pending' || status.status === 'generating') && (
+        <p className="text-xs text-muted-foreground">{t('audio.notReady')}</p>
+      )}
+
+      {status?.status === 'failed' && (
+        <p className="text-xs text-destructive" role="alert">{t('audio.failed')}</p>
+      )}
+
+      {status?.status === 'ready' && status.audio_url && (
+        <audio
+          ref={audioRef}
+          src={status.audio_url}
+          controls
+          preload="none"
+          className="w-full"
+        >
+          {t('audio.unsupported')}
+        </audio>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/qbank/qbank-audio-player.tsx
+++ b/frontend/components/qbank/qbank-audio-player.tsx
@@ -16,6 +16,13 @@ interface QBankAudioPlayerProps {
   questionId: string;
   /** Preferred default when nothing is in localStorage yet (e.g. bank.language). */
   defaultLanguage?: QBankAudioLanguage;
+  /**
+   * Pre-fetched audio URLs keyed by language. When a URL exists here
+   * we mount the <audio> element directly instead of polling the
+   * status endpoint — saves a round-trip per question/language switch
+   * and is the fast path once pregeneration has run (#1674).
+   */
+  preloadedUrls?: Record<string, string>;
 }
 
 /**
@@ -26,7 +33,11 @@ interface QBankAudioPlayerProps {
  * preferences toggle: the language pills are always visible and the
  * last selection persists across questions via localStorage (#1659, #1670).
  */
-export function QBankAudioPlayer({ questionId, defaultLanguage }: QBankAudioPlayerProps) {
+export function QBankAudioPlayer({
+  questionId,
+  defaultLanguage,
+  preloadedUrls,
+}: QBankAudioPlayerProps) {
   const t = useTranslations('qbank');
   const tLang = useTranslations('qbank.audioLanguages');
   const [language, setLanguage] = useState<QBankAudioLanguage>(() => {
@@ -39,7 +50,14 @@ export function QBankAudioPlayer({ questionId, defaultLanguage }: QBankAudioPlay
   const [error, setError] = useState<string | null>(null);
   const audioRef = useRef<HTMLAudioElement>(null);
 
+  const preloadedUrl = preloadedUrls?.[language];
+
   useEffect(() => {
+    // Fast path: test-start gave us a ready URL for this language, so
+    // we derive the status in render and skip the network call entirely
+    // (#1674). No setState here — the derived status below covers it.
+    if (preloadedUrl) return;
+
     let cancelled = false;
     // Old-state resets moved into the callbacks: sync setStates inside an
     // effect body cascade re-renders and trip the no-sync-set-state lint
@@ -58,7 +76,20 @@ export function QBankAudioPlayer({ questionId, defaultLanguage }: QBankAudioPlay
         setError(err instanceof Error ? err.message : 'Audio fetch failed');
       });
     return () => { cancelled = true; };
-  }, [questionId, language]);
+  }, [questionId, language, preloadedUrl]);
+
+  // Derived status: preloaded URL wins over any cached fetch result so
+  // the <audio> element mounts synchronously on the first render.
+  const effectiveStatus: QBankQuestionAudioStatus | null = preloadedUrl
+    ? {
+        question_id: questionId,
+        language,
+        status: 'ready',
+        audio_url: preloadedUrl,
+        duration_seconds: null,
+      }
+    : status;
+  const effectiveError = preloadedUrl ? null : error;
 
   // Persist the learner's chosen language across questions.
   useEffect(() => {
@@ -104,22 +135,22 @@ export function QBankAudioPlayer({ questionId, defaultLanguage }: QBankAudioPlay
         })}
       </div>
 
-      {error && (
+      {effectiveError && (
         <p className="text-xs text-destructive" role="alert">
           {t('audio.error')}
         </p>
       )}
 
-      {status?.status === 'failed' && (
+      {effectiveStatus?.status === 'failed' && (
         <p className="text-xs text-destructive" role="alert">{t('audio.failed')}</p>
       )}
 
-      {status?.status === 'ready' && status.audio_url && (
+      {effectiveStatus?.status === 'ready' && effectiveStatus.audio_url && (
         <audio
           ref={audioRef}
-          src={status.audio_url}
+          src={effectiveStatus.audio_url}
           controls
-          preload="none"
+          preload="auto"
           className="h-9 w-full sm:h-10"
         >
           {t('audio.unsupported')}

--- a/frontend/components/qbank/qbank-image-question.tsx
+++ b/frontend/components/qbank/qbank-image-question.tsx
@@ -3,6 +3,7 @@
 import Image from 'next/image';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
+import { QBankAudioPlayer } from '@/components/qbank/qbank-audio-player';
 import type { QBankQuestion } from '@/lib/api';
 
 const OPTION_LABELS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
@@ -70,6 +71,8 @@ export function QBankImageQuestion({
           />
         </div>
       )}
+
+      <QBankAudioPlayer questionId={question.id} />
 
       <p className="text-base font-medium leading-relaxed">{question.question_text}</p>
 

--- a/frontend/components/qbank/qbank-image-question.tsx
+++ b/frontend/components/qbank/qbank-image-question.tsx
@@ -10,6 +10,12 @@ const OPTION_LABELS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
 
 interface QBankImageQuestionProps {
   question: QBankQuestion;
+  /**
+   * Pre-fetched audio URLs keyed by language. Populated from
+   * TestStartResponse.audio so the player can mount the <audio>
+   * element without a per-question round-trip (#1674).
+   */
+  preloadedAudio?: Record<string, string>;
   selectedIndices: number[];
   onToggle: (index: number) => void;
   showFeedback: boolean;
@@ -31,6 +37,7 @@ function selectionIsCorrect(
 
 export function QBankImageQuestion({
   question,
+  preloadedAudio,
   selectedIndices,
   onToggle,
   showFeedback,
@@ -75,7 +82,10 @@ export function QBankImageQuestion({
         </div>
       )}
 
-      <QBankAudioPlayer questionId={question.id} />
+      <QBankAudioPlayer
+        questionId={question.id}
+        preloadedUrls={preloadedAudio}
+      />
 
       <p className="text-sm font-medium leading-snug sm:text-base">
         {question.question_text}

--- a/frontend/components/qbank/qbank-image-question.tsx
+++ b/frontend/components/qbank/qbank-image-question.tsx
@@ -56,9 +56,12 @@ export function QBankImageQuestion({
   };
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-2 sm:gap-3">
       {question.image_url && (
-        <div className="relative h-[300px] w-full overflow-hidden rounded-lg bg-muted">
+        // Height is capped to a fraction of the viewport so the options
+        // stay in view on phones (iPhone SE → 813px desktop). object-contain
+        // keeps the full illustration visible regardless of aspect ratio.
+        <div className="relative h-[30dvh] max-h-[360px] min-h-[160px] w-full overflow-hidden rounded-lg bg-muted sm:h-[38dvh]">
           <Image
             src={question.image_url}
             alt={question.question_text}
@@ -74,11 +77,13 @@ export function QBankImageQuestion({
 
       <QBankAudioPlayer questionId={question.id} />
 
-      <p className="text-base font-medium leading-relaxed">{question.question_text}</p>
+      <p className="text-sm font-medium leading-snug sm:text-base">
+        {question.question_text}
+      </p>
 
       {showFeedback && hasSelection && (
         <div className={cn(
-          'rounded-lg px-3 py-2 text-sm font-medium',
+          'rounded-lg px-3 py-1.5 text-sm font-medium',
           isAnswerCorrect
             ? 'bg-green-100 text-green-800 dark:bg-green-950/50 dark:text-green-300'
             : 'bg-red-100 text-red-800 dark:bg-red-950/50 dark:text-red-300'
@@ -87,7 +92,7 @@ export function QBankImageQuestion({
         </div>
       )}
 
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-1.5 sm:gap-2">
         {question.options.map((option, index) => {
           const isSelected = selectedIndices.includes(index);
           return (
@@ -96,13 +101,13 @@ export function QBankImageQuestion({
               onClick={() => onToggle(index)}
               disabled={showFeedback}
               className={cn(
-                'flex min-h-[44px] items-center gap-3 rounded-lg border-2 px-4 py-3 text-left transition-colors',
+                'flex min-h-11 items-center gap-3 rounded-lg border-2 px-3 py-2 text-left transition-colors sm:px-4 sm:py-3',
                 getOptionStyle(index),
                 'disabled:cursor-default'
               )}
             >
               <span className={cn(
-                'flex h-8 w-8 shrink-0 items-center justify-center rounded-full border text-sm font-semibold',
+                'flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-sm font-semibold sm:h-8 sm:w-8',
                 isSelected
                   ? 'border-primary bg-primary text-primary-foreground'
                   : 'border-muted-foreground/30'

--- a/frontend/components/qbank/qbank-test-player.tsx
+++ b/frontend/components/qbank/qbank-test-player.tsx
@@ -29,6 +29,24 @@ const AUTO_ADVANCE_MS = 700;
 // correct answer and the explanation before moving on.
 const AUTO_ADVANCE_FEEDBACK_MS = 2000;
 
+const AUDIO_PREF_STORAGE_KEY = 'qbank-audio-lang';
+const DEFAULT_AUDIO_LANG = 'fr';
+
+function preloadAudioClips(data: QBankTestStartResponse): void {
+  if (typeof window === 'undefined') return;
+  const audioMap = data.audio ?? {};
+  const saved = window.localStorage.getItem(AUDIO_PREF_STORAGE_KEY);
+  const activeLang = saved && saved.length > 0 ? saved : DEFAULT_AUDIO_LANG;
+  for (const question of data.questions) {
+    const url = audioMap[question.id]?.[activeLang];
+    if (!url) continue;
+    const preloader = new Audio();
+    preloader.preload = 'auto';
+    preloader.src = url;
+    preloader.load();
+  }
+}
+
 export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
   const t = useTranslations('qbank');
   const [phase, setPhase] = useState<Phase>('loading');
@@ -52,6 +70,10 @@ export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
         if (data.mode === 'exam') {
           setTimerRunning(true);
         }
+        // Warm the browser's HTTP cache for the active-language audio of
+        // every question so playback starts within the timer window
+        // regardless of network speed (#1674).
+        preloadAudioClips(data);
       })
       .catch((err) => {
         setError(err.message || 'Failed to load test');
@@ -307,6 +329,7 @@ export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
       <div className="min-h-0 flex-1 overflow-y-auto">
         <QBankImageQuestion
           question={currentQuestion}
+          preloadedAudio={testData.audio?.[currentQuestion.id]}
           selectedIndices={selectedIndices}
           onToggle={handleToggle}
           showFeedback={showingFeedback || testData.mode === 'review'}

--- a/frontend/components/qbank/qbank-test-player.tsx
+++ b/frontend/components/qbank/qbank-test-player.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useTranslations } from 'next-intl';
+import { ArrowLeft, ArrowRight, Check } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
@@ -21,6 +22,13 @@ interface QBankTestPlayerProps {
   testId: string;
 }
 
+// Delay before auto-advancing after a committed answer. Enough for the
+// learner to register what they picked without hand-holding them to click.
+const AUTO_ADVANCE_MS = 700;
+// Longer delay in training+feedback mode so the learner can read the
+// correct answer and the explanation before moving on.
+const AUTO_ADVANCE_FEEDBACK_MS = 2000;
+
 export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
   const t = useTranslations('qbank');
   const [phase, setPhase] = useState<Phase>('loading');
@@ -33,6 +41,7 @@ export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
   const [showingFeedback, setShowingFeedback] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const questionStartTime = useRef<number>(0);
+  const autoAdvanceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     startQBankTest(testId)
@@ -49,14 +58,26 @@ export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
       });
   }, [testId]);
 
+  useEffect(() => () => {
+    if (autoAdvanceTimer.current) clearTimeout(autoAdvanceTimer.current);
+  }, []);
+
   const currentQuestion = testData?.questions[currentIndex] ?? null;
 
   const recordTime = useCallback(() => {
     return Math.round((Date.now() - questionStartTime.current) / 1000);
   }, []);
 
+  const cancelAutoAdvance = useCallback(() => {
+    if (autoAdvanceTimer.current) {
+      clearTimeout(autoAdvanceTimer.current);
+      autoAdvanceTimer.current = null;
+    }
+  }, []);
+
   const goToNext = useCallback(() => {
     if (!testData) return;
+    cancelAutoAdvance();
     setShowingFeedback(false);
     if (currentIndex < testData.questions.length - 1) {
       setCurrentIndex((prev) => prev + 1);
@@ -66,29 +87,76 @@ export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
         setTimerRunning(true);
       }
     }
-  }, [testData, currentIndex]);
+  }, [testData, currentIndex, cancelAutoAdvance]);
 
-  // Toggle an option in the current question's selection. Multi-answer questions
-  // need to accumulate picks before scoring — training-mode feedback is deferred
-  // to an explicit "Valider" step rather than firing on first click (#1632).
+  const handleSubmit = useCallback(async () => {
+    if (!testData) return;
+    cancelAutoAdvance();
+    setPhase('submitting');
+    try {
+      const res = await submitQBankTest(testId, answers);
+      setResult(res);
+      setPhase('done');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Submit failed');
+      setPhase('playing');
+    }
+  }, [testId, testData, answers, cancelAutoAdvance]);
+
+  // Commit an answer and either advance or submit after a short delay so
+  // the learner isn't forced to click a separate "Next" button on every
+  // question while the timer is ticking (#1671).
+  const scheduleAutoAdvance = useCallback((delay: number) => {
+    cancelAutoAdvance();
+    autoAdvanceTimer.current = setTimeout(() => {
+      autoAdvanceTimer.current = null;
+      if (!testData) return;
+      const isLast = currentIndex === testData.questions.length - 1;
+      if (isLast) {
+        void handleSubmit();
+      } else {
+        goToNext();
+      }
+    }, delay);
+  }, [cancelAutoAdvance, testData, currentIndex, goToNext, handleSubmit]);
+
+  // Toggle an option in the current question's selection. Multi-answer
+  // questions accumulate picks and commit via Valider; single-answer
+  // modes auto-advance on the first tap.
   const handleToggle = useCallback((optionIndex: number) => {
     if (!currentQuestion || showingFeedback) return;
 
     const timeSec = recordTime();
+    const optionCount = currentQuestion.options.length;
+    const isMultiAnswer = optionCount > 2;
+    const isTrainingWithFeedback =
+      testData?.mode === 'training' && testData.show_feedback;
+
     setAnswers((prev) => {
       const existing = prev[currentQuestion.id]?.selected ?? [];
-      const next = existing.includes(optionIndex)
-        ? existing.filter((i) => i !== optionIndex)
-        : [...existing, optionIndex];
+      // For binary questions (OUI/NON style) treat each tap as a fresh
+      // single-answer pick so the UI behaves like a radio group.
+      const next = isMultiAnswer
+        ? (existing.includes(optionIndex)
+            ? existing.filter((i) => i !== optionIndex)
+            : [...existing, optionIndex])
+        : [optionIndex];
       return {
         ...prev,
         [currentQuestion.id]: { selected: next, time_sec: timeSec },
       };
     });
-  }, [currentQuestion, showingFeedback, recordTime]);
 
-  // Commit the training-mode answer: stop the timer and reveal the correct set.
-  // "Question suivante" then unlocks normally via the existing flow.
+    // Auto-advance only for the simple cases: non-multi questions in
+    // exam or no-feedback training. Multi-answer questions still need
+    // Valider so the learner can pick every correct option.
+    if (isMultiAnswer) return;
+    if (isTrainingWithFeedback) return;
+    scheduleAutoAdvance(AUTO_ADVANCE_MS);
+  }, [currentQuestion, showingFeedback, recordTime, testData, scheduleAutoAdvance]);
+
+  // Commit the training-mode answer: stop the timer, reveal the correct
+  // set, then auto-advance after a feedback-reading delay.
   const handleValidate = useCallback(() => {
     if (!currentQuestion) return;
     const timeSec = recordTime();
@@ -102,7 +170,8 @@ export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
     });
     setTimerRunning(false);
     setShowingFeedback(true);
-  }, [currentQuestion, recordTime]);
+    scheduleAutoAdvance(AUTO_ADVANCE_FEEDBACK_MS);
+  }, [currentQuestion, recordTime, scheduleAutoAdvance]);
 
   const handleTimerExpire = useCallback(() => {
     if (!currentQuestion) return;
@@ -119,29 +188,20 @@ export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
     // Otherwise (no pick, or exam mode) advance like before.
     if (testData?.mode === 'training' && testData.show_feedback && hadAnswer) {
       setShowingFeedback(true);
+      scheduleAutoAdvance(AUTO_ADVANCE_FEEDBACK_MS);
       return;
     }
 
     if (testData && currentIndex < testData.questions.length - 1) {
-      setTimeout(() => goToNext(), 500);
+      scheduleAutoAdvance(500);
+    } else if (testData) {
+      scheduleAutoAdvance(500);
     }
-  }, [currentQuestion, recordTime, testData, currentIndex, goToNext, answers]);
-
-  const handleSubmit = useCallback(async () => {
-    if (!testData) return;
-    setPhase('submitting');
-    try {
-      const res = await submitQBankTest(testId, answers);
-      setResult(res);
-      setPhase('done');
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Submit failed');
-      setPhase('playing');
-    }
-  }, [testId, testData, answers]);
+  }, [currentQuestion, recordTime, testData, currentIndex, answers, scheduleAutoAdvance]);
 
   const handlePrevious = useCallback(() => {
     if (currentIndex > 0) {
+      cancelAutoAdvance();
       setShowingFeedback(false);
       setCurrentIndex((prev) => prev - 1);
       setTimerResetKey((prev) => prev + 1);
@@ -150,7 +210,7 @@ export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
         setTimerRunning(true);
       }
     }
-  }, [currentIndex, testData]);
+  }, [currentIndex, testData, cancelAutoAdvance]);
 
   if (error) {
     return (
@@ -198,6 +258,7 @@ export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
   const isExamMode = testData.mode === 'exam';
   const isTrainingWithFeedback =
     testData.mode === 'training' && testData.show_feedback;
+  const isMultiAnswer = currentQuestion.options.length > 2;
   const hasTimer = testData.time_per_question_sec > 0 && testData.mode !== 'review';
   // correct_answer_indices is only on the payload in training+feedback mode.
   // Review mode doesn't need it (that page fetches its own review data).
@@ -205,14 +266,28 @@ export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
     ? (currentQuestion.correct_answer_indices ?? undefined)
     : undefined;
 
+  // Multi-answer questions need Valider to commit every correct pick
+  // before scoring; binary questions auto-advance on the first tap.
+  const showValidate =
+    isTrainingWithFeedback && !showingFeedback && isMultiAnswer && hasSelection;
+  // Show Submit only on the last question — intermediate submits are covered
+  // by the auto-advance timer kicking through to handleSubmit.
+  const showSubmit =
+    isLastQuestion &&
+    ((isExamMode && hasSelection) || showingFeedback || (isMultiAnswer && hasSelection));
+
   return (
-    <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 px-4 py-4">
-      <div className="space-y-2">
-        <div className="flex items-center justify-between text-sm text-muted-foreground">
+    <div className="mx-auto flex h-[calc(100dvh-var(--header-offset,0px))] w-full max-w-2xl flex-col gap-3 px-3 pb-3 pt-3 sm:gap-4 sm:px-4 sm:pt-4">
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between text-xs text-muted-foreground sm:text-sm">
           <span>{t('question', { current: currentIndex + 1, total: totalQuestions })}</span>
-          {testData.title && <span className="truncate ml-2 font-medium text-foreground">{testData.title}</span>}
+          {testData.title && (
+            <span className="ml-2 truncate font-medium text-foreground">
+              {testData.title}
+            </span>
+          )}
         </div>
-        <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+        <div className="h-1 w-full overflow-hidden rounded-full bg-muted sm:h-1.5">
           <div
             className="h-full rounded-full bg-primary transition-all duration-300"
             style={{ width: `${progressPercent}%` }}
@@ -229,77 +304,76 @@ export function QBankTestPlayer({ testId }: QBankTestPlayerProps) {
         />
       )}
 
-      <QBankImageQuestion
-        question={currentQuestion}
-        selectedIndices={selectedIndices}
-        onToggle={handleToggle}
-        showFeedback={showingFeedback || testData.mode === 'review'}
-        correctIndices={correctIndices}
-        onImageLoad={() => {
-          if (hasTimer && !showingFeedback) {
-            setTimerRunning(true);
-          }
-        }}
-      />
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <QBankImageQuestion
+          question={currentQuestion}
+          selectedIndices={selectedIndices}
+          onToggle={handleToggle}
+          showFeedback={showingFeedback || testData.mode === 'review'}
+          correctIndices={correctIndices}
+          onImageLoad={() => {
+            if (hasTimer && !showingFeedback) {
+              setTimerRunning(true);
+            }
+          }}
+        />
+      </div>
 
-      <div className="flex items-center gap-3 pt-2">
+      <div
+        className="sticky bottom-0 -mx-3 flex items-center gap-2 border-t border-border bg-background/95 px-3 py-2 backdrop-blur sm:-mx-4 sm:px-4"
+        style={{ paddingBottom: 'max(0.5rem, env(safe-area-inset-bottom))' }}
+      >
         {!isExamMode && (
           <Button
             variant="outline"
-            className="min-h-[44px] flex-1"
+            size="icon"
+            className="h-11 w-11 shrink-0"
             onClick={handlePrevious}
             disabled={currentIndex === 0}
+            aria-label={t('previousQuestion')}
+            title={t('previousQuestion')}
           >
-            {t('previousQuestion')}
+            <ArrowLeft className="h-5 w-5" />
           </Button>
         )}
 
-        {/* Training + show_feedback: commit the selection explicitly before advancing.
-            Lets the learner pick every correct option on multi-answer questions. */}
-        {isTrainingWithFeedback && !showingFeedback && hasSelection && (
+        {showValidate && (
           <Button
-            className="min-h-[44px] flex-1"
+            className="h-11 flex-1"
             onClick={handleValidate}
           >
+            <Check className="h-5 w-5" />
             {t('validate')}
           </Button>
         )}
 
-        {showingFeedback && !isLastQuestion && (
+        {showSubmit && !showValidate && (
           <Button
-            className="min-h-[44px] flex-1"
-            onClick={goToNext}
-          >
-            {t('nextQuestion')}
-          </Button>
-        )}
-
-        {!showingFeedback && !isExamMode && !isTrainingWithFeedback && hasSelection && !isLastQuestion && (
-          <Button
-            className="min-h-[44px] flex-1"
-            onClick={goToNext}
-          >
-            {t('nextQuestion')}
-          </Button>
-        )}
-
-        {isExamMode && !isLastQuestion && hasSelection && (
-          <Button
-            className="min-h-[44px] flex-1"
-            onClick={goToNext}
-          >
-            {t('nextQuestion')}
-          </Button>
-        )}
-
-        {((isLastQuestion && hasSelection && !showingFeedback && !isTrainingWithFeedback) ||
-          (isLastQuestion && showingFeedback)) && (
-          <Button
-            className={cn('min-h-[44px]', isExamMode ? 'w-full' : 'flex-1')}
+            className={cn('h-11', isExamMode ? 'flex-1' : 'flex-1')}
             onClick={handleSubmit}
           >
             {t('submitTest')}
           </Button>
+        )}
+
+        {!showValidate && !showSubmit && !isExamMode && (
+          <Button
+            variant="outline"
+            size="icon"
+            className="ml-auto h-11 w-11 shrink-0"
+            onClick={goToNext}
+            disabled={isLastQuestion}
+            aria-label={t('nextQuestion')}
+            title={t('nextQuestion')}
+          >
+            <ArrowRight className="h-5 w-5" />
+          </Button>
+        )}
+
+        {/* Exam mode has no prev/next text labels — auto-advance handles
+            the flow and manual skip would let learners cheat the timer. */}
+        {isExamMode && !showSubmit && (
+          <div className="flex-1" aria-hidden="true" />
         )}
       </div>
     </div>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1571,7 +1571,7 @@ export async function getQBankTestReview(
 
 // Question audio — backend streams OGG/Opus from MinIO via a proxy (#1658).
 // The status poll returns `audio_url` only when `status === "ready"`.
-export type QBankAudioLanguage = "fr" | "mos" | "dyu" | "bam";
+export type QBankAudioLanguage = "fr" | "mos" | "dyu" | "bam" | "ful";
 
 export type QBankAudioReadiness =
   | "pending"

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1510,6 +1510,13 @@ export interface QBankTestStartResponse {
   show_feedback: boolean;
   questions: QBankQuestion[];
   total_questions: number;
+  /**
+   * Pre-fetched audio URLs: {question_id: {language: url}}. Only
+   * (question, language) pairs whose TTS clip is ready are populated.
+   * Missing entries mean the client should fall back to polling
+   * /api/v1/qbank/questions/{id}/audio (#1674).
+   */
+  audio?: Record<string, Record<string, string>>;
 }
 
 export interface QBankTestAttemptResponse {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1569,6 +1569,33 @@ export async function getQBankTestReview(
   return apiFetch<QBankReviewResponse>(`/api/v1/qbank/tests/${testId}/review/${attemptId}`);
 }
 
+// Question audio — backend streams OGG/Opus from MinIO via a proxy (#1658).
+// The status poll returns `audio_url` only when `status === "ready"`.
+export type QBankAudioLanguage = "fr" | "mos" | "dyu" | "bam";
+
+export type QBankAudioReadiness =
+  | "pending"
+  | "generating"
+  | "ready"
+  | "failed";
+
+export interface QBankQuestionAudioStatus {
+  question_id: string;
+  language: QBankAudioLanguage;
+  status: QBankAudioReadiness;
+  audio_url: string | null;
+  duration_seconds: number | null;
+}
+
+export async function getQBankQuestionAudio(
+  questionId: string,
+  language: QBankAudioLanguage,
+): Promise<QBankQuestionAudioStatus> {
+  return apiFetch<QBankQuestionAudioStatus>(
+    `/api/v1/qbank/questions/${questionId}/audio?lang=${language}`,
+  );
+}
+
 // ---------------------------------------------------------------------------
 // QBank management (org admin) — #1504
 // ---------------------------------------------------------------------------

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2069,6 +2069,22 @@
     "uploadOnlyPdf": "Only PDF files are accepted.",
     "uploadExtracting": "Extracting…",
     "uploadExtractedCount": "Extracted {count} question(s){warnings}.",
-    "uploadWithWarnings": " with {count} warning(s)"
+    "uploadWithWarnings": " with {count} warning(s)",
+    "audio": {
+      "label": "Question audio",
+      "languagePickerLabel": "Audio language",
+      "pillAriaLabel": "Listen in {language}",
+      "loading": "Loading audio…",
+      "notReady": "Audio is being prepared for this language.",
+      "failed": "Audio generation failed for this language.",
+      "error": "Unable to load audio.",
+      "unsupported": "Your browser does not support the audio element."
+    },
+    "audioLanguages": {
+      "fr": "French",
+      "mos": "Mooré",
+      "dyu": "Dioula",
+      "bam": "Bambara"
+    }
   }
-}
+}\n

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2084,7 +2084,8 @@
       "fr": "French",
       "mos": "Mooré",
       "dyu": "Dioula",
-      "bam": "Bambara"
+      "bam": "Bambara",
+      "ful": "Fulfulde"
     }
   }
 }\n

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -2084,7 +2084,8 @@
       "fr": "Français",
       "mos": "Mooré",
       "dyu": "Dioula",
-      "bam": "Bambara"
+      "bam": "Bambara",
+      "ful": "Fulfulde"
     }
   }
 }\n

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -2069,6 +2069,22 @@
     "uploadOnlyPdf": "Seuls les fichiers PDF sont acceptés.",
     "uploadExtracting": "Extraction…",
     "uploadExtractedCount": "{count} question(s) extraite(s){warnings}.",
-    "uploadWithWarnings": " avec {count} avertissement(s)"
+    "uploadWithWarnings": " avec {count} avertissement(s)",
+    "audio": {
+      "label": "Audio de la question",
+      "languagePickerLabel": "Langue de l’audio",
+      "pillAriaLabel": "Écouter en {language}",
+      "loading": "Chargement de l’audio…",
+      "notReady": "L’audio est en cours de préparation pour cette langue.",
+      "failed": "La génération audio a échoué pour cette langue.",
+      "error": "Impossible de charger l’audio.",
+      "unsupported": "Votre navigateur ne prend pas en charge l’élément audio."
+    },
+    "audioLanguages": {
+      "fr": "Français",
+      "mos": "Mooré",
+      "dyu": "Dioula",
+      "bam": "Bambara"
+    }
   }
-}
+}\n

--- a/infrastructure/mms-tts/server.py
+++ b/infrastructure/mms-tts/server.py
@@ -1,8 +1,13 @@
-"""Meta MMS TTS HTTP server for Moore, Dioula, and Bambara.
+"""Meta MMS TTS HTTP server for Moore, Dioula, Bambara, and Fulfulde.
 
-Preloads Hugging Face `facebook/mms-tts-{mos,dyu,bam}` VITS models on startup and
-serves synthesized speech as OGG/Opus over HTTP. Opus at ~24 kbps keeps a
-30-second clip under ~100 KB, which matters for 2G/3G West African networks.
+Preloads Hugging Face `facebook/mms-tts-{mos,dyu,bam,ffm}` VITS models on
+startup and serves synthesized speech as OGG/Opus over HTTP. Opus at
+~24 kbps keeps a 30-second clip under ~100 KB, which matters for 2G/3G
+West African networks.
+
+``ful`` is exposed as the public language code for Fulfulde; internally
+we load Meta's ``ffm`` (Maasina Fulfulde) VITS model, which matches the
+variant spoken in Burkina Faso / Mali — our primary audience.
 """
 from __future__ import annotations
 
@@ -22,8 +27,18 @@ from pydub import AudioSegment
 from scipy.io import wavfile
 from transformers import AutoTokenizer, VitsModel
 
-SUPPORTED_LANGUAGES = ("mos", "dyu", "bam")
-Language = Literal["mos", "dyu", "bam"]
+SUPPORTED_LANGUAGES = ("mos", "dyu", "bam", "ful")
+Language = Literal["mos", "dyu", "bam", "ful"]
+
+# Map public language codes to the Hugging Face model suffix. Meta ships
+# Fulfulde as variant-specific checkpoints (ffm, fuv, fuh, ...); we pick
+# ``ffm`` (Maasina) for the West African driving-school audience.
+MODEL_SUFFIX: dict[str, str] = {
+    "mos": "mos",
+    "dyu": "dyu",
+    "bam": "bam",
+    "ful": "ffm",
+}
 
 MAX_TEXT_CHARS = 2000
 OPUS_BITRATE = "24k"
@@ -45,8 +60,9 @@ _MODELS: dict[str, _ModelBundle] = {}
 
 
 def _load_model(lang: str) -> _ModelBundle:
-    model_id = f"facebook/mms-tts-{lang}"
-    logger.info("loading %s", model_id)
+    suffix = MODEL_SUFFIX.get(lang, lang)
+    model_id = f"facebook/mms-tts-{suffix}"
+    logger.info("loading %s (public code=%s)", model_id, lang)
     tokenizer = AutoTokenizer.from_pretrained(model_id)
     model = VitsModel.from_pretrained(model_id)
     model.eval()


### PR DESCRIPTION
## Summary

Batched release of the 4 qbank improvements plus the queued CI/deploy work:

- #1669 / #1673 — crop slide images to the illustration frame (removes duplicate question text from the image)
- #1670 / #1672 — add Fulfulde (ful) as a 5th audio language (MMS \`ffm\` model)
- #1671 / #1675 — mobile-first test-taker with auto-advance, icon-only prev/next, sticky footer
- #1674 / #1679 — pregenerate audio on publish + preload on test start

Plus queued infra commits already on dev: production deploy path, GHCR per-deploy auth, mobile-first mobile-nav fixes, audio-player sync-setState fix.

## Test plan
- [ ] Prod-dispatch staging deploy first; verify MMS sidecar boots with ful/ffm model.
- [ ] Publish a test bank; confirm all 5 language audio rows reach \`ready\`.
- [ ] Open a test on iPhone SE viewport; verify no-scroll, auto-advance, prev/next icons.
- [ ] Re-extract one existing bank; verify images now crop to the illustration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)