### PR TITLE
chore(deploy): sync deploy.yml on dev with main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,16 @@ name: Deploy
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment (production requires manual dispatch)"
+        required: true
+        default: staging
+        type: choice
+        options:
+          - staging
+          - production
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Dev's deploy.yml was missing the `workflow_dispatch` input block that main has. Copying main's version onto dev so routine dev→main PRs stop conflicting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)