### PR TITLE
fix(qbank): default question timer to 60s (#1689)

### DIFF
--- a/backend/app/api/v1/schemas/qbank.py
+++ b/backend/app/api/v1/schemas/qbank.py
@@ -17,7 +17,7 @@ class QuestionBankCreate(BaseModel):
     description: str | None = None
     bank_type: str = Field(..., pattern=r"^(driving|exam_prep|psychotechnic|general_culture)$")
     language: str = Field(default="fr", max_length=5)
-    time_per_question_sec: int = Field(default=25, ge=5, le=120)
+    time_per_question_sec: int = Field(default=60, ge=5, le=120)
     passing_score: float = Field(default=80.0, ge=0, le=100)
 
 

--- a/backend/app/domain/models/question_bank.py
+++ b/backend/app/domain/models/question_bank.py
@@ -72,7 +72,7 @@ class QuestionBank(Base):
         Enum(QuestionBankType, name="questionbanktype"), nullable=False
     )
     language: Mapped[str] = mapped_column(String(5), server_default="fr", default="fr")
-    time_per_question_sec: Mapped[int] = mapped_column(Integer, server_default="25", default=25)
+    time_per_question_sec: Mapped[int] = mapped_column(Integer, server_default="60", default=60)
     passing_score: Mapped[float] = mapped_column(Float, server_default="80.0", default=80.0)
     status: Mapped[QuestionBankStatus] = mapped_column(
         Enum(QuestionBankStatus, name="questionbankstatus"),

--- a/backend/app/domain/services/qbank_service.py
+++ b/backend/app/domain/services/qbank_service.py
@@ -64,7 +64,7 @@ class QBankService:
         created_by: uuid.UUID,
         description: str | None = None,
         language: str = "fr",
-        time_per_question_sec: int = 25,
+        time_per_question_sec: int = 60,
         passing_score: float = 80.0,
     ) -> QuestionBank:
         await _org_svc.require_org_role(


### PR DESCRIPTION
Fixes #1689 — 3-line default change, no migration, no frontend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)