### PR TITLE
feat(qbank): NLLB translation before MMS TTS (#1690)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       mms_tts: ${{ steps.filter.outputs.mms_tts }}
+      nllb: ${{ steps.filter.outputs.nllb }}
     steps:
       - uses: actions/checkout@v6
       - id: filter
@@ -33,6 +34,9 @@ jobs:
           filters: |
             mms_tts:
               - 'infrastructure/mms-tts/**'
+              - '.github/workflows/deploy.yml'
+            nllb:
+              - 'infrastructure/nllb/**'
               - '.github/workflows/deploy.yml'
 
   test:
@@ -125,6 +129,42 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/benidrissa/etutor-digital-ph/mms-tts:buildcache
           cache-to: type=registry,ref=ghcr.io/benidrissa/etutor-digital-ph/mms-tts:buildcache,mode=max
 
+  build-nllb:
+    name: Build & Push nllb
+    needs: [test, changes]
+    if: needs.changes.outputs.nllb == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/benidrissa/etutor-digital-ph/nllb
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest
+      - name: Build and push nllb sidecar
+        uses: docker/build-push-action@v6
+        with:
+          context: ./infrastructure/nllb
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=ghcr.io/benidrissa/etutor-digital-ph/nllb:buildcache
+          cache-to: type=registry,ref=ghcr.io/benidrissa/etutor-digital-ph/nllb:buildcache,mode=max
+
   build-and-push:
     name: Build & Push (${{ matrix.service }})
     needs: test
@@ -203,11 +243,12 @@ jobs:
 
   deploy:
     name: Deploy to Server
-    needs: [build-and-push, build-mms-tts]
+    needs: [build-and-push, build-mms-tts, build-nllb]
     if: |
       always()
       && needs.build-and-push.result == 'success'
       && (needs.build-mms-tts.result == 'success' || needs.build-mms-tts.result == 'skipped')
+      && (needs.build-nllb.result == 'success' || needs.build-nllb.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -289,6 +330,7 @@ jobs:
 
             # Pull new images (only changed layers transferred)
             docker compose pull backend frontend mms-tts
+            docker compose pull nllb || echo "::warning::nllb pull failed, continuing with existing image"
 
             # Restart services
             docker compose up -d
@@ -317,11 +359,12 @@ jobs:
 
   deploy-production:
     name: Deploy to Production
-    needs: [build-and-push, build-mms-tts]
+    needs: [build-and-push, build-mms-tts, build-nllb]
     if: |
       always()
       && needs.build-and-push.result == 'success'
       && (needs.build-mms-tts.result == 'success' || needs.build-mms-tts.result == 'skipped')
+      && (needs.build-nllb.result == 'success' || needs.build-nllb.result == 'skipped')
       && github.event_name == 'workflow_dispatch'
       && github.event.inputs.environment == 'production'
     runs-on: ubuntu-latest
@@ -428,6 +471,7 @@ jobs:
             # elsewhere. Don't let that block the backend/frontend rollout.
             docker compose pull backend frontend
             docker compose pull mms-tts || echo "::warning::mms-tts pull failed, continuing with existing image"
+            docker compose pull nllb || echo "::warning::nllb pull failed, continuing with existing image"
 
             docker compose up -d
 

--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -630,15 +630,65 @@ async def generate_bank_audio(
     current_user: AuthenticatedUser = Depends(get_current_user),
     db=Depends(get_db_session),
 ):
-    """Kick off a batch audio-generation task for every question in a bank."""
+    """Kick off a batch audio-generation task for every question in a bank.
+
+    For non-source languages (mos/dyu/bam/ful) chain translate→audio so
+    MMS TTS receives native-language text (#1690).
+    """
+    from celery import chain as celery_chain
+
     from app.domain.services.organization_service import OrganizationService
-    from app.tasks.qbank_processing import generate_qbank_audio_task
+    from app.domain.services.qbank_translation_service import TARGET_LANGUAGES
+    from app.tasks.qbank_processing import (
+        generate_qbank_audio_task,
+        translate_qbank_bank_task,
+    )
 
     bank = await _svc.get_bank(db, bank_id)
     await OrganizationService().require_org_role(
         db, bank.organization_id, uuid.UUID(current_user.id)
     )
-    task = generate_qbank_audio_task.delay(str(bank_id), language)
+    if language in TARGET_LANGUAGES:
+        task = celery_chain(
+            translate_qbank_bank_task.si(str(bank_id), language),
+            generate_qbank_audio_task.si(str(bank_id), language),
+        ).apply_async()
+    else:
+        task = generate_qbank_audio_task.delay(str(bank_id), language)
+    return AudioGenerateResponse(task_id=task.id, bank_id=str(bank_id), language=language)
+
+
+@router.post(
+    "/banks/{bank_id}/translations/backfill",
+    response_model=AudioGenerateResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def backfill_bank_translations(
+    bank_id: uuid.UUID,
+    language: str = Query(..., pattern=r"^(mos|dyu|bam|ful)$"),
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    """Backfill NLLB translations for an existing bank, then re-generate audio.
+
+    Idempotent: questions already translated are skipped (#1690).
+    """
+    from celery import chain as celery_chain
+
+    from app.domain.services.organization_service import OrganizationService
+    from app.tasks.qbank_processing import (
+        generate_qbank_audio_task,
+        translate_qbank_bank_task,
+    )
+
+    bank = await _svc.get_bank(db, bank_id)
+    await OrganizationService().require_org_role(
+        db, bank.organization_id, uuid.UUID(current_user.id)
+    )
+    task = celery_chain(
+        translate_qbank_bank_task.si(str(bank_id), language),
+        generate_qbank_audio_task.si(str(bank_id), language),
+    ).apply_async()
     return AudioGenerateResponse(task_id=task.id, bank_id=str(bank_id), language=language)
 
 

--- a/backend/app/domain/models/question_bank.py
+++ b/backend/app/domain/models/question_bank.py
@@ -149,6 +149,39 @@ class QBankQuestionAudio(Base):
     question: Mapped[QBankQuestion] = relationship(back_populates="audio_files")
 
 
+class QBankQuestionTranslation(Base):
+    """Native-language translation of a qbank question + its options.
+
+    NLLB-200 translates French source text to mos/dyu/bam/ful and stores
+    the result so audio regenerations don't re-bill translations and
+    admins can correct low-resource outputs without them being
+    overwritten (#1690). One row per ``(question_id, language)``.
+    """
+
+    __tablename__ = "qbank_question_translations"
+    __table_args__ = (
+        UniqueConstraint("question_id", "language", name="uq_qbank_question_translation_lang"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    question_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("qbank_questions.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+    language: Mapped[str] = mapped_column(String(10), nullable=False)
+    question_text: Mapped[str] = mapped_column(Text, nullable=False)
+    options: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    source_model: Mapped[str] = mapped_column(String(50), nullable=False)
+    edited_by_admin: Mapped[bool] = mapped_column(Boolean, server_default="false", default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
 class QBankTest(Base):
     __tablename__ = "qbank_tests"
 

--- a/backend/app/domain/services/qbank_audio_service.py
+++ b/backend/app/domain/services/qbank_audio_service.py
@@ -24,11 +24,13 @@ from app.domain.models.question_bank import (
     QBankAudioStatus,
     QBankQuestion,
     QBankQuestionAudio,
+    QBankQuestionTranslation,
     QuestionBank,
 )
 from app.infrastructure.config.settings import settings
 from app.infrastructure.storage.s3 import S3StorageService
 from app.integrations.mms_tts import MMSTTSClient, MMSTTSError
+from app.integrations.nllb_translate import NLLBTranslateError
 
 logger = structlog.get_logger(__name__)
 
@@ -43,11 +45,21 @@ OPUS_CONTENT_TYPE = "audio/ogg"
 OPUS_BYTES_PER_SECOND = 6 * 1024  # matches LessonAudioService._estimate_duration
 
 
-def build_audio_script(question: QBankQuestion, language: str) -> str:
+def build_audio_script(
+    question: QBankQuestion,
+    language: str,
+    translation: QBankQuestionTranslation | None = None,
+) -> str:
     """Return the text that should be spoken for a question.
 
     Prepends the option label in the speaker's language so the TTS reads
     "Option A: ..." in French and the native prefix in MMS languages.
+
+    When ``translation`` is provided (#1690), its translated question_text
+    and options are used instead of the source-language ones. Without it
+    the raw ``question.question_text`` falls through, which is correct
+    for ``fr`` (source) but produces gibberish if fed into an MMS model
+    for mos/dyu/bam/ful.
     """
     prefixes = {
         "fr": "Option",
@@ -57,8 +69,16 @@ def build_audio_script(question: QBankQuestion, language: str) -> str:
         "ful": "Suɓaande",  # Fulfulde: "choice"
     }
     prefix = prefixes.get(language, "Option")
-    parts = [question.question_text.strip()]
-    for idx, opt in enumerate(question.options or []):
+
+    if translation is not None:
+        q_text = (translation.question_text or "").strip()
+        options = list(translation.options or [])
+    else:
+        q_text = (question.question_text or "").strip()
+        options = list(question.options or [])
+
+    parts = [q_text]
+    for idx, opt in enumerate(options):
         letter = chr(ord("A") + idx)
         parts.append(f"{prefix} {letter}: {opt}")
     return ". ".join(p for p in parts if p).strip() + "."
@@ -136,6 +156,9 @@ class QBankAudioService:
     ) -> QBankQuestionAudio:
         """Generate audio for a single question in one language.
 
+        For non-source languages (mos/dyu/bam/ful), translates the
+        question + options via NLLB first so the MMS sidecar receives
+        native-language text and produces intelligible speech (#1690).
         Sets status ``generating`` while running and ``ready`` / ``failed``
         afterwards so the frontend poll endpoint can reflect progress.
         """
@@ -145,8 +168,33 @@ class QBankAudioService:
 
         await self._upsert_audio_row(db, question_id, language, status=QBankAudioStatus.generating)
 
+        # Translate FR → target before TTS for all non-source languages.
+        # Translation fetch is idempotent; on NLLB failure we mark audio
+        # as failed rather than falling back to French-in-MMS (the broken
+        # behavior that shipped in #1670 and was fixed by #1681/#1690).
+        translation: QBankQuestionTranslation | None = None
+        if language != "fr":
+            from app.domain.services.qbank_translation_service import (
+                QBankTranslationService,
+            )
+
+            try:
+                translation = await QBankTranslationService().ensure_translation(
+                    db, question_id, language
+                )
+            except NLLBTranslateError as exc:
+                logger.warning(
+                    "NLLB translation failed",
+                    question_id=str(question_id),
+                    language=language,
+                    error=str(exc),
+                )
+                return await self._upsert_audio_row(
+                    db, question_id, language, status=QBankAudioStatus.failed
+                )
+
         try:
-            script = build_audio_script(question, language)
+            script = build_audio_script(question, language, translation=translation)
             audio_bytes = await self._synthesize_bytes(script, language)
             key = self._storage_key(question.question_bank_id, question_id, language)
             url = await self._storage.upload_bytes(

--- a/backend/app/domain/services/qbank_service.py
+++ b/backend/app/domain/services/qbank_service.py
@@ -28,22 +28,40 @@ _org_svc = OrganizationService()
 def _enqueue_pregenerate_audio(bank_id: uuid.UUID) -> None:
     """Fire a Celery task per supported language to pregenerate audio.
 
+    For non-source languages (mos/dyu/bam/ful), chain
+    ``translate_qbank_bank_task`` → ``generate_qbank_audio_task`` so MMS
+    TTS receives native-language text rather than French (#1690). French
+    still runs audio-only since it's the source.
+
     Kept as a module-level helper so it can be called from ``update_bank``
     (publish transition) and ``update_question`` (text change) without
     creating a service cycle. Imports are local so this module stays
     safe to import in contexts where Celery isn't wired up (e.g. tests
     that patch the task).
     """
-    from app.domain.services.qbank_audio_service import SUPPORTED_LANGUAGES
-    from app.tasks.qbank_processing import generate_qbank_audio_task
+    from celery import chain as celery_chain
 
+    from app.domain.services.qbank_audio_service import SUPPORTED_LANGUAGES
+    from app.domain.services.qbank_translation_service import TARGET_LANGUAGES
+    from app.tasks.qbank_processing import (
+        generate_qbank_audio_task,
+        translate_qbank_bank_task,
+    )
+
+    bank_id_str = str(bank_id)
     for language in SUPPORTED_LANGUAGES:
         try:
-            generate_qbank_audio_task.delay(str(bank_id), language)
+            if language in TARGET_LANGUAGES:
+                celery_chain(
+                    translate_qbank_bank_task.si(bank_id_str, language),
+                    generate_qbank_audio_task.si(bank_id_str, language),
+                ).apply_async()
+            else:
+                generate_qbank_audio_task.delay(bank_id_str, language)
         except Exception as exc:
             logger.warning(
                 "failed to enqueue qbank audio pregeneration",
-                bank_id=str(bank_id),
+                bank_id=bank_id_str,
                 language=language,
                 error=str(exc),
             )
@@ -255,8 +273,16 @@ class QBankService:
 
         if should_invalidate_audio:
             from app.domain.services.qbank_audio_service import QBankAudioService
+            from app.domain.services.qbank_translation_service import (
+                QBankTranslationService,
+            )
 
+            # Stale audio + stale translations both need clearing. Admin-
+            # edited translations survive (preserved by the translation
+            # service's invalidate_question method). Next audio regen
+            # will trigger fresh NLLB calls for dropped rows (#1690).
             await QBankAudioService().invalidate_question(db, question_id)
+            await QBankTranslationService().invalidate_question(db, question_id)
             _enqueue_pregenerate_audio(question.question_bank_id)
 
         return question

--- a/backend/app/domain/services/qbank_translation_service.py
+++ b/backend/app/domain/services/qbank_translation_service.py
@@ -1,0 +1,209 @@
+"""Qbank translation service — translate French (or any source) questions
+into mos/dyu/bam/ful *before* MMS TTS synthesizes (#1690).
+
+MMS is monolingual TTS; feeding it raw French makes gibberish in target
+languages. This service calls the NLLB-200 sidecar, persists the result
+per ``(question_id, language)``, and short-circuits on re-runs so audio
+regeneration doesn't re-bill translations. Admin-edited rows
+(``edited_by_admin=True``) are never overwritten.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import structlog
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.models.question_bank import (
+    QBankQuestion,
+    QBankQuestionTranslation,
+    QuestionBank,
+)
+from app.integrations.nllb_translate import (
+    NLLBTranslateClient,
+    NLLBTranslateError,
+    resolve_source_code,
+)
+
+logger = structlog.get_logger(__name__)
+
+# Languages that need translation. French is the default source and is
+# never translated by this service; other bank.language values (e.g. en)
+# are mapped via resolve_source_code() in the NLLB client.
+TARGET_LANGUAGES: tuple[str, ...] = ("mos", "dyu", "bam", "ful")
+
+
+class QBankTranslationService:
+    """Persist and retrieve qbank question translations."""
+
+    def __init__(self, nllb_client: NLLBTranslateClient | None = None) -> None:
+        self._nllb = nllb_client or NLLBTranslateClient()
+
+    async def get_translation(
+        self,
+        db: AsyncSession,
+        question_id: uuid.UUID,
+        language: str,
+    ) -> QBankQuestionTranslation | None:
+        """Return the stored translation row or ``None``."""
+        result = await db.execute(
+            select(QBankQuestionTranslation).where(
+                QBankQuestionTranslation.question_id == question_id,
+                QBankQuestionTranslation.language == language,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def ensure_translation(
+        self,
+        db: AsyncSession,
+        question_id: uuid.UUID,
+        language: str,
+    ) -> QBankQuestionTranslation:
+        """Translate ``question_id`` into ``language`` if not already stored.
+
+        Idempotent: if a row exists (including admin-edited ones) it's
+        returned as-is. Raises ``HTTPException`` 404 for unknown questions
+        and ``NLLBTranslateError`` for transport failures — callers mark
+        the audio row ``failed`` in that case.
+        """
+        if language not in TARGET_LANGUAGES:
+            raise ValueError(f"ensure_translation called with non-target language: {language}")
+
+        existing = await self.get_translation(db, question_id, language)
+        if existing is not None:
+            return existing
+
+        question = await db.get(QBankQuestion, question_id)
+        if question is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Question not found.",
+            )
+
+        bank = await db.get(QuestionBank, question.question_bank_id)
+        source_code = resolve_source_code(bank.language if bank else None)
+
+        # Translate question_text + each option in one batch round-trip.
+        source_texts = [question.question_text or ""]
+        options = list(question.options or [])
+        source_texts.extend(options)
+
+        translations = await self._nllb.translate_batch(
+            texts=source_texts,
+            target=language,
+            source=source_code,
+        )
+
+        translated_question = translations[0] if translations else ""
+        translated_options = translations[1:] if len(translations) > 1 else []
+
+        row = QBankQuestionTranslation(
+            question_id=question_id,
+            language=language,
+            question_text=translated_question,
+            options=translated_options,
+            source_model=self._nllb_model_label(),
+            edited_by_admin=False,
+        )
+        db.add(row)
+        await db.commit()
+        await db.refresh(row)
+        logger.info(
+            "qbank translation stored",
+            question_id=str(question_id),
+            language=language,
+            source=source_code,
+            options_count=len(translated_options),
+        )
+        return row
+
+    async def batch_translate_bank(
+        self,
+        db: AsyncSession,
+        bank_id: uuid.UUID,
+        language: str,
+    ) -> dict:
+        """Translate every question in a bank into ``language``.
+
+        Intended for Celery. Idempotent — questions already translated are
+        skipped. Returns counters for observability.
+        """
+        if language not in TARGET_LANGUAGES:
+            return {"bank_id": str(bank_id), "language": language, "skipped_lang": True}
+
+        questions = (
+            (
+                await db.execute(
+                    select(QBankQuestion).where(QBankQuestion.question_bank_id == bank_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        existing_ids: set[uuid.UUID] = set()
+        if questions:
+            existing_rows = await db.execute(
+                select(QBankQuestionTranslation.question_id).where(
+                    QBankQuestionTranslation.question_id.in_([q.id for q in questions]),
+                    QBankQuestionTranslation.language == language,
+                )
+            )
+            existing_ids = {row for row in existing_rows.scalars()}
+
+        translated = 0
+        skipped = 0
+        failed = 0
+        for q in questions:
+            if q.id in existing_ids:
+                skipped += 1
+                continue
+            try:
+                await self.ensure_translation(db, q.id, language)
+                translated += 1
+            except NLLBTranslateError as exc:
+                failed += 1
+                logger.warning(
+                    "qbank translation failed",
+                    question_id=str(q.id),
+                    language=language,
+                    error=str(exc),
+                )
+
+        return {
+            "bank_id": str(bank_id),
+            "language": language,
+            "total": len(questions),
+            "translated": translated,
+            "skipped": skipped,
+            "failed": failed,
+        }
+
+    async def invalidate_question(
+        self,
+        db: AsyncSession,
+        question_id: uuid.UUID,
+    ) -> int:
+        """Drop non-admin-edited translation rows for a question.
+
+        Called when a question's text or options change — the stored
+        translation is stale. Admin-edited rows are preserved so manual
+        corrections survive re-ingestion.
+        """
+        result = await db.execute(
+            QBankQuestionTranslation.__table__.delete().where(
+                QBankQuestionTranslation.question_id == question_id,
+                QBankQuestionTranslation.edited_by_admin.is_(False),
+            )
+        )
+        await db.commit()
+        return result.rowcount or 0
+
+    def _nllb_model_label(self) -> str:
+        from app.infrastructure.config.settings import settings
+
+        return f"nllb-200-{settings.nllb_model}"

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -94,6 +94,12 @@ class Settings(BaseSettings):
     mms_tts_url: str = "http://mms-tts:5050"
     mms_tts_timeout_seconds: float = 60.0
 
+    # Meta NLLB-200 translation sidecar — translates French qbank text
+    # into mos/dyu/bam/ful before MMS TTS synthesizes (#1690).
+    nllb_url: str = "http://nllb:5060"
+    nllb_timeout_seconds: float = 60.0
+    nllb_model: str = "distilled-600M"
+
     # MinIO / S3-compatible object storage
     minio_endpoint: str = "http://localhost:9000"
     minio_access_key: str = ""

--- a/backend/app/integrations/nllb_translate.py
+++ b/backend/app/integrations/nllb_translate.py
@@ -1,0 +1,132 @@
+"""Async HTTP client for the Meta NLLB-200 translation sidecar.
+
+The sidecar (``infrastructure/nllb/``) wraps ``facebook/nllb-200-distilled-600M``
+and exposes ``POST /translate`` + ``GET /health``. We use it to translate
+French driving-school qbank questions and options into the West African
+target languages before the MMS TTS sidecar synthesizes speech (#1690).
+
+MMS is monolingual TTS and doesn't translate; feeding it raw French makes
+gibberish. NLLB fills that gap without touching the MMS pipeline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import structlog
+
+from app.infrastructure.config.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+# NLLB target codes keyed by the public qbank language code. French is
+# the default source and isn't translated back to itself. Fulfulde maps
+# to ``fuv_Latn`` (Nigerian) — explicitly listed in the NLLB-200
+# language set published with https://ai.meta.com/blog/nllb-200/.
+TARGET_CODES: dict[str, str] = {
+    "mos": "mos_Latn",
+    "dyu": "dyu_Latn",
+    "bam": "bam_Latn",
+    "ful": "fuv_Latn",
+}
+
+# Source language codes: public ISO 639-1 (as stored on QuestionBank.language)
+# → NLLB FLORES-200 code. Default source is French because driving-school
+# content ships in French, but banks authored in other languages can now
+# be translated too (per user request #1690).
+SOURCE_CODES: dict[str, str] = {
+    "fr": "fra_Latn",
+    "en": "eng_Latn",
+    "ar": "arb_Arab",
+    "pt": "por_Latn",
+    "es": "spa_Latn",
+}
+
+DEFAULT_SOURCE = "fra_Latn"
+
+
+def resolve_source_code(bank_language: str | None) -> str:
+    """Map ``QuestionBank.language`` (ISO-639-1) to the NLLB FLORES-200 code."""
+    if not bank_language:
+        return DEFAULT_SOURCE
+    return SOURCE_CODES.get(bank_language.lower(), DEFAULT_SOURCE)
+
+
+class NLLBTranslateError(Exception):
+    """Raised when the NLLB sidecar is unreachable or returns an error."""
+
+
+class NLLBTranslateClient:
+    """Thin async wrapper over the NLLB translation sidecar.
+
+    A module-level semaphore keeps concurrent forward passes bounded so
+    a batch pregeneration job doesn't overwhelm the single-worker sidecar.
+    """
+
+    _semaphore = asyncio.Semaphore(2)
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> None:
+        self._base_url = (base_url or settings.nllb_url).rstrip("/")
+        self._timeout = timeout_seconds or settings.nllb_timeout_seconds
+
+    @staticmethod
+    def supports(language: str) -> bool:
+        return language in TARGET_CODES
+
+    async def translate_batch(
+        self,
+        texts: list[str],
+        target: str,
+        source: str = DEFAULT_SOURCE,
+    ) -> list[str]:
+        """Translate a batch of short texts into ``target`` in one forward pass.
+
+        Raises ``NLLBTranslateError`` for transport / sidecar failures so
+        the caller can mark translation rows as failed and move on.
+        """
+        if target not in TARGET_CODES:
+            raise NLLBTranslateError(f"NLLB does not support target: {target}")
+        if not texts:
+            return []
+        if any(not t or not t.strip() for t in texts):
+            raise NLLBTranslateError("NLLB received empty text in batch")
+
+        tgt_code = TARGET_CODES[target]
+
+        async with self._semaphore:
+            try:
+                async with httpx.AsyncClient(timeout=self._timeout) as client:
+                    resp = await client.post(
+                        f"{self._base_url}/translate",
+                        json={"texts": texts, "src": source, "tgt": tgt_code},
+                    )
+            except httpx.HTTPError as exc:
+                raise NLLBTranslateError(f"NLLB sidecar unreachable: {exc}") from exc
+
+        if resp.status_code != 200:
+            raise NLLBTranslateError(f"NLLB sidecar returned {resp.status_code}: {resp.text[:200]}")
+        payload = resp.json()
+        translations = payload.get("translations")
+        if not isinstance(translations, list) or len(translations) != len(texts):
+            raise NLLBTranslateError("NLLB sidecar returned malformed translations array")
+
+        logger.info(
+            "NLLB translate",
+            target=target,
+            batch_size=len(texts),
+            elapsed_ms=payload.get("elapsed_ms"),
+        )
+        return translations
+
+    async def health(self) -> bool:
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.get(f"{self._base_url}/health")
+            return resp.status_code == 200
+        except httpx.HTTPError:
+            return False

--- a/backend/app/tasks/qbank_processing.py
+++ b/backend/app/tasks/qbank_processing.py
@@ -137,13 +137,24 @@ async def _process_pdf_async(task, bank_id: str, pdf_filename: str) -> dict:
 
     # Fire audio pregeneration for every supported language so the first
     # learner to take a test doesn't wait on the MMS sidecar (#1674).
-    # Skipped when no questions were added — nothing to synthesize.
+    # For non-source languages, chain translate→audio so MMS receives
+    # native-language text rather than French (#1690). Skipped when no
+    # questions were added — nothing to translate or synthesize.
     if created:
+        from celery import chain as celery_chain
+
         from app.domain.services.qbank_audio_service import SUPPORTED_LANGUAGES
+        from app.domain.services.qbank_translation_service import TARGET_LANGUAGES
 
         for language in SUPPORTED_LANGUAGES:
             try:
-                generate_qbank_audio_task.delay(bank_id, language)
+                if language in TARGET_LANGUAGES:
+                    celery_chain(
+                        translate_qbank_bank_task.si(bank_id, language),
+                        generate_qbank_audio_task.si(bank_id, language),
+                    ).apply_async()
+                else:
+                    generate_qbank_audio_task.delay(bank_id, language)
             except Exception as exc:
                 logger.warning(
                     "failed to enqueue post-extract audio pregeneration",
@@ -192,6 +203,53 @@ async def _generate_audio_async(bank_id: str, language: str) -> dict:
 
     logger.info(
         "qbank audio batch complete",
+        bank_id=bank_id,
+        language=language,
+        result=result,
+    )
+    return result
+
+
+@celery_app.task(
+    base=QBankTask,
+    bind=True,
+    name="qbank.translate",
+    max_retries=2,
+    default_retry_delay=60,
+    soft_time_limit=600,
+    time_limit=660,
+    rate_limit="5/m",
+)
+def translate_qbank_bank_task(self, bank_id: str, language: str) -> dict:
+    """Translate every question in a bank into ``language`` via NLLB (#1690).
+
+    Runs *before* ``generate_qbank_audio_task`` in the pregeneration chain
+    so MMS TTS receives native-language text and produces intelligible
+    audio rather than French-with-target-phonology gibberish.
+    """
+    return asyncio.run(_translate_bank_async(bank_id, language))
+
+
+async def _translate_bank_async(bank_id: str, language: str) -> dict:
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.domain.services.qbank_translation_service import (
+        QBankTranslationService,
+    )
+    from app.infrastructure.config.settings import settings
+
+    engine = create_async_engine(settings.database_url, echo=False)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    service = QBankTranslationService()
+
+    async with session_factory() as session:
+        try:
+            result = await service.batch_translate_bank(session, uuid.UUID(bank_id), language)
+        finally:
+            await engine.dispose()
+
+    logger.info(
+        "qbank translation batch complete",
         bank_id=bank_id,
         language=language,
         result=result,

--- a/backend/migrations/versions/070_add_qbank_question_translations.py
+++ b/backend/migrations/versions/070_add_qbank_question_translations.py
@@ -1,0 +1,65 @@
+"""Add qbank_question_translations table.
+
+Revision ID: 070
+Revises: 069
+Create Date: 2026-04-18
+
+Stores NLLB-200 translations of French qbank questions into the four
+West African target languages (mos/dyu/bam/ful) so MMS TTS receives
+native-language text and produces intelligible audio (#1690).
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "070"
+down_revision = "069"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "qbank_question_translations",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "question_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("qbank_questions.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("language", sa.String(10), nullable=False),
+        sa.Column("question_text", sa.Text(), nullable=False),
+        sa.Column("options", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("source_model", sa.String(50), nullable=False),
+        sa.Column(
+            "edited_by_admin",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "question_id",
+            "language",
+            name="uq_qbank_question_translation_lang",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("qbank_question_translations")

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -48,6 +48,28 @@ services:
         limits:
           memory: 4G
 
+  nllb:
+    # NLLB-200 translation sidecar (#1690). Loads facebook/nllb-200-
+    # distilled-600M (~2.4 GB RAM) and translates French qbank text to
+    # mos/dyu/bam/ful before the MMS sidecar synthesizes audio.
+    image: ghcr.io/benidrissa/etutor-digital-ph/nllb:latest
+    container_name: etutor-nllb
+    volumes:
+      - nllb_models:/models
+    networks:
+      - etutor-data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:5060/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 240s
+      retries: 3
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+
   backend:
     image: ghcr.io/benidrissa/etutor-digital-ph/backend:latest
     container_name: etutor-backend
@@ -68,6 +90,7 @@ services:
       SMS_RELAY_API_KEY: ${SMS_RELAY_API_KEY}
       SMS_RELAY_TRUSTED_SENDERS: ${SMS_RELAY_TRUSTED_SENDERS}
       MMS_TTS_URL: ${MMS_TTS_URL:-http://mms-tts:5050}
+      NLLB_URL: ${NLLB_URL:-http://nllb:5060}
     volumes:
       - ./config:/app/config
       - ./resources:/app/resources
@@ -147,6 +170,7 @@ services:
       SMS_RELAY_API_KEY: ${SMS_RELAY_API_KEY}
       SMS_RELAY_TRUSTED_SENDERS: ${SMS_RELAY_TRUSTED_SENDERS}
       MMS_TTS_URL: ${MMS_TTS_URL:-http://mms-tts:5050}
+      NLLB_URL: ${NLLB_URL:-http://nllb:5060}
     volumes:
       - ./config:/app/config
       - ./resources:/app/resources
@@ -183,6 +207,7 @@ volumes:
   uploads:
   minio_data:
   mms_models:
+  nllb_models:
 
 networks:
   etutor-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,29 @@ services:
         limits:
           memory: 4G
 
+  nllb:
+    # NLLB-200 translation sidecar. Translates French qbank text into
+    # mos/dyu/bam/ful before MMS TTS synthesizes audio (#1690). Loads
+    # facebook/nllb-200-distilled-600M once at startup (~2.4 GB in RAM).
+    build:
+      context: ./infrastructure/nllb
+      dockerfile: Dockerfile
+    container_name: santepublique-nllb
+    ports:
+      - "5060:5060"
+    volumes:
+      - nllb_models:/models
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:5060/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 240s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+
   backend:
     build:
       context: ./backend
@@ -83,3 +106,4 @@ volumes:
   redisdata:
   uploads_data:
   mms_models:
+  nllb_models:

--- a/frontend/components/qbank/qbank-audio-player.tsx
+++ b/frontend/components/qbank/qbank-audio-player.tsx
@@ -12,6 +12,35 @@ import {
 const LANGUAGES: QBankAudioLanguage[] = ['fr', 'mos', 'dyu', 'bam', 'ful'];
 const STORAGE_KEY = 'qbank-audio-lang';
 
+// Per-language pill colors so non-literate learners can identify the
+// active language by color instead of reading its name (#1690 follow-up).
+// Kept hue-distant to tolerate red/green color-blindness via saturation.
+// Active state uses the bg-* + text-white combo; inactive uses ring-*
+// on the border so the identity cue still shows through.
+const LANGUAGE_COLORS: Record<QBankAudioLanguage, { active: string; inactive: string }> = {
+  fr: {
+    active: 'border-blue-600 bg-blue-600 text-white',
+    inactive: 'border-blue-600/40 text-blue-700 hover:border-blue-600 dark:text-blue-300',
+  },
+  mos: {
+    active: 'border-red-600 bg-red-600 text-white',
+    inactive: 'border-red-600/40 text-red-700 hover:border-red-600 dark:text-red-300',
+  },
+  dyu: {
+    active: 'border-green-600 bg-green-600 text-white',
+    inactive: 'border-green-600/40 text-green-700 hover:border-green-600 dark:text-green-300',
+  },
+  bam: {
+    active: 'border-yellow-600 bg-yellow-600 text-white',
+    inactive: 'border-yellow-600/40 text-yellow-700 hover:border-yellow-600 dark:text-yellow-300',
+  },
+  ful: {
+    active: 'border-purple-600 bg-purple-600 text-white',
+    inactive:
+      'border-purple-600/40 text-purple-700 hover:border-purple-600 dark:text-purple-300',
+  },
+};
+
 interface QBankAudioPlayerProps {
   questionId: string;
   /** Preferred default when nothing is in localStorage yet (e.g. bank.language). */
@@ -123,10 +152,10 @@ export function QBankAudioPlayer({
               // language row fits next to the image; bumps to min-h-11
               // on sm+ where there is room for WCAG touch targets.
               className={cn(
-                'min-h-9 rounded-full border px-3 py-1 text-xs font-medium transition-colors sm:min-h-11 sm:px-4 sm:py-1.5 sm:text-sm',
+                'min-h-9 rounded-full border-2 bg-background px-3 py-1 text-xs font-medium transition-colors sm:min-h-11 sm:px-4 sm:py-1.5 sm:text-sm',
                 isSelected
-                  ? 'border-primary bg-primary text-primary-foreground'
-                  : 'border-border bg-background hover:border-primary/50'
+                  ? LANGUAGE_COLORS[lang].active
+                  : LANGUAGE_COLORS[lang].inactive,
               )}
             >
               {tLang(lang)}

--- a/infrastructure/nllb/Dockerfile
+++ b/infrastructure/nllb/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    HF_HOME=/models \
+    TRANSFORMERS_CACHE=/models
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY server.py .
+
+EXPOSE 5060
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=180s --retries=3 \
+    CMD curl -fsS http://localhost:5060/health || exit 1
+
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "5060", "--workers", "1"]

--- a/infrastructure/nllb/requirements.txt
+++ b/infrastructure/nllb/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.115.6
+uvicorn[standard]==0.32.1
+transformers==4.47.1
+torch==2.5.1
+sentencepiece==0.2.0

--- a/infrastructure/nllb/server.py
+++ b/infrastructure/nllb/server.py
@@ -1,0 +1,156 @@
+"""Meta NLLB-200 translation HTTP server.
+
+Translates short driving-school qbank texts from French to four low-resource
+West African languages: Mooré (mos_Latn), Dioula (dyu_Latn), Bambara
+(bam_Latn), and Fulfulde — Western Niger variant (fuh_Latn). Pairs with the
+MMS TTS sidecar: translate here first, synthesize audio there. MMS is
+monolingual TTS and will pronounce French syllables with the target
+phonology if fed raw French; this service fixes that (#1690).
+
+Model: ``facebook/nllb-200-distilled-600M`` (~2.4 GB RAM). Preloads the
+model once on startup and keeps it hot. Batch translate up to ~10 short
+texts in one forward pass.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+
+MAX_INPUT_CHARS = 2000
+MAX_TEXTS_PER_BATCH = 32
+MAX_NEW_TOKENS = 256
+
+# NLLB source/target codes for the qbank pipeline. The sidecar itself is
+# source-agnostic (NLLB-200 handles 200+ languages); the backend picks
+# the right source code per bank and sends it here. These constants are
+# only used for the ``/health`` payload and input validation reporting.
+DEFAULT_SOURCE = "fra_Latn"
+SUPPORTED_TARGETS = ("mos_Latn", "dyu_Latn", "bam_Latn", "fuv_Latn")
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("nllb")
+
+
+class _Bundle:
+    __slots__ = ("model", "tokenizer")
+
+    def __init__(self, model, tokenizer):
+        self.model = model
+        self.tokenizer = tokenizer
+
+
+_BUNDLE: _Bundle | None = None
+
+
+def _load_model() -> _Bundle:
+    model_id = os.getenv("NLLB_MODEL_ID", "facebook/nllb-200-distilled-600M")
+    logger.info("loading %s", model_id)
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
+    model = AutoModelForSeq2SeqLM.from_pretrained(model_id)
+    model.eval()
+    return _Bundle(model=model, tokenizer=tokenizer)
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    global _BUNDLE
+    # Per-language loading isn't a concept for NLLB — one model handles
+    # all 200+ target codes. If the model itself fails to download we
+    # log and keep the server alive so /health reflects the outage
+    # without taking the container into a crash loop (same resilience
+    # pattern as the MMS sidecar after #1681).
+    try:
+        _BUNDLE = _load_model()
+        logger.info("nllb model loaded")
+    except Exception as exc:
+        logger.exception("failed to load nllb model: %s", exc)
+        _BUNDLE = None
+    yield
+    _BUNDLE = None
+
+
+app = FastAPI(title="NLLB Translation Sidecar", version="1.0.0", lifespan=lifespan)
+
+
+class TranslateRequest(BaseModel):
+    texts: list[str] = Field(..., min_length=1, max_length=MAX_TEXTS_PER_BATCH)
+    src: str = Field(default=DEFAULT_SOURCE, min_length=3, max_length=16)
+    tgt: str = Field(..., min_length=3, max_length=16)
+
+
+class TranslateResponse(BaseModel):
+    translations: list[str]
+    elapsed_ms: int
+
+
+@app.get("/health")
+async def health() -> JSONResponse:
+    loaded = _BUNDLE is not None
+    return JSONResponse(
+        {
+            "status": "ok" if loaded else "degraded",
+            "model_loaded": loaded,
+            "supported_targets": list(SUPPORTED_TARGETS),
+            "default_source": DEFAULT_SOURCE,
+        },
+        status_code=200 if loaded else 503,
+    )
+
+
+@app.post("/translate", response_model=TranslateResponse)
+async def translate(req: TranslateRequest) -> TranslateResponse:
+    if _BUNDLE is None:
+        raise HTTPException(status_code=503, detail="model not loaded")
+
+    for text in req.texts:
+        if len(text) > MAX_INPUT_CHARS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"input text exceeds {MAX_INPUT_CHARS} characters",
+            )
+
+    tokenizer = _BUNDLE.tokenizer
+    model = _BUNDLE.model
+    tokenizer.src_lang = req.src
+
+    started = time.monotonic()
+    inputs = tokenizer(
+        req.texts,
+        return_tensors="pt",
+        padding=True,
+        truncation=True,
+        max_length=MAX_INPUT_CHARS,
+    )
+
+    # NLLB forced_bos_token_id selects the target language at generation
+    # time. ``convert_tokens_to_ids`` is the supported way to retrieve it
+    # across transformers versions.
+    tgt_id = tokenizer.convert_tokens_to_ids(req.tgt)
+    if tgt_id is None or tgt_id == tokenizer.unk_token_id:
+        raise HTTPException(status_code=400, detail=f"unknown target lang: {req.tgt}")
+
+    generated = model.generate(
+        **inputs,
+        forced_bos_token_id=tgt_id,
+        max_new_tokens=MAX_NEW_TOKENS,
+        num_beams=1,
+    )
+    translations = tokenizer.batch_decode(generated, skip_special_tokens=True)
+    elapsed_ms = int((time.monotonic() - started) * 1000)
+
+    logger.info(
+        "translate src=%s tgt=%s batch=%d elapsed_ms=%d",
+        req.src,
+        req.tgt,
+        len(req.texts),
+        elapsed_ms,
+    )
+    return TranslateResponse(translations=translations, elapsed_ms=elapsed_ms)


### PR DESCRIPTION
## Summary

Fixes the gibberish-audio bug (#1690) where MMS models pronounced French syllables with target-language phonology for mos/dyu/bam/ful. Adds an NLLB-200 translation sidecar that translates French → target before each MMS synthesis call, persists translations, and resiliently fails-closed on NLLB outage.

Covers both bugs this sprint plus the recent per-language pill color request. Timer bug was shipped as #1691.

## Highlights
- **NLLB-200 sidecar** (\`infrastructure/nllb/\`) loading \`facebook/nllb-200-distilled-600M\`, with resilient startup.
- **Translation client** (\`nllb_translate.py\`) with FLORES-200 codes: mos/dyu/bam direct, ful → fuv_Latn (Nigerian per NLLB language set), and SOURCE_CODES mapping so EN/AR/PT/ES banks also work.
- **\`QBankQuestionTranslation\`** model + migration 070 — one row per (question, language) with \`edited_by_admin\` preservation and \`source_model\` audit.
- **\`ensure_translation\`** — idempotent upsert, batches question + options in one NLLB round-trip; admin-edited rows never overwritten.
- **Celery chain** \`translate_qbank_bank_task → generate_qbank_audio_task\` wired into PDF extraction, publish transition, manual \`/audio/generate\`, and new \`/translations/backfill\` endpoint.
- **Failure mode**: NLLB outage marks audio \`failed\` (no regression to French-in-MMS gibberish).
- **Docker compose** (\`yml\` + \`prod.yml\`): new \`nllb\` service + \`nllb_models\` volume + \`NLLB_URL\` env.
- **CI**: \`build-nllb\` job + deploy pulls the new image with graceful warning.
- **Frontend**: per-language pill colors for non-literate accessibility — FR blue, mos red, dyu green, bam yellow, ful purple. Active/inactive states distinguishable by fill vs colored border.

## Test plan
- [x] \`uv run pytest backend/tests/test_qbank_audio_service.py test_qbank_slide_extractor.py test_qbank_analytics_service.py\` — 54 passed
- [x] \`uv run ruff check app/\` — clean
- [x] \`uv run ruff format --check app/\` — clean
- [ ] Deploy to staging (CI builds nllb image first run); \`GET /api/v1/health\` from sidecar reports all target codes.
- [ ] Republish bank 43fb7500-74b2-4c0f-bb1d-fbd3a8b85e19; translations populate, audio is native (no French syllables in non-FR audio).
- [ ] Mobile test-taker on iPhone 13: colored pills visible, FR blue active on load, tap Mooré → pill turns red + audio speaks Mooré.
- [ ] Edit a question's text via PATCH; non-admin-edited translations drop; next regen produces fresh NLLB calls.

Related: #1670 (ful language added), #1681 (MMS sidecar resilience), #1691 (60s timer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)