### PR TITLE
fix(qbank): reject empty NLLB translations + sanitize + diagnostic (#1696)

### DIFF
--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -32,6 +32,7 @@ from app.api.v1.schemas.qbank import (
     TestStartResponse,
     TestSubmitRequest,
     TestUpdate,
+    TranslationResponse,
 )
 from app.domain.models.question_bank import QBankQuestion
 from app.domain.services.qbank_analytics_service import QBankAnalyticsService
@@ -690,6 +691,50 @@ async def backfill_bank_translations(
         generate_qbank_audio_task.si(str(bank_id), language),
     ).apply_async()
     return AudioGenerateResponse(task_id=task.id, bank_id=str(bank_id), language=language)
+
+
+@router.get(
+    "/questions/{question_id}/translations/{language}",
+    response_model=TranslationResponse,
+)
+async def get_question_translation(
+    question_id: uuid.UUID,
+    language: str,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    """Return the stored NLLB translation for a (question, language).
+
+    Diagnostic endpoint added in #1696 so we can verify whether stored
+    translations contain real native-language text or empty strings.
+    Returns 404 when no translation row exists (e.g. for ``lang=fr``
+    which is the source and never has a row, or for questions that
+    haven't been translated yet).
+    """
+    if language not in ("mos", "dyu", "bam", "ful"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsupported target language: {language}",
+        )
+
+    from app.domain.services.qbank_translation_service import QBankTranslationService
+
+    row = await QBankTranslationService().get_translation(db, question_id, language)
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No translation stored for this (question, language).",
+        )
+    return TranslationResponse(
+        question_id=str(row.question_id),
+        language=row.language,
+        question_text=row.question_text,
+        options=list(row.options or []),
+        source_model=row.source_model,
+        edited_by_admin=row.edited_by_admin,
+        created_at=row.created_at.isoformat(),
+        updated_at=row.updated_at.isoformat(),
+    )
 
 
 @router.post(

--- a/backend/app/api/v1/schemas/qbank.py
+++ b/backend/app/api/v1/schemas/qbank.py
@@ -300,3 +300,19 @@ class AudioGenerateResponse(BaseModel):
     bank_id: str
     language: str
     status: str = "processing"
+
+
+# ---------------------------------------------------------------------------
+# Translations (#1696 debug view)
+# ---------------------------------------------------------------------------
+
+
+class TranslationResponse(BaseModel):
+    question_id: str
+    language: str
+    question_text: str
+    options: list[str]
+    source_model: str
+    edited_by_admin: bool
+    created_at: str
+    updated_at: str

--- a/backend/app/domain/services/qbank_translation_service.py
+++ b/backend/app/domain/services/qbank_translation_service.py
@@ -65,17 +65,35 @@ class QBankTranslationService:
     ) -> QBankQuestionTranslation:
         """Translate ``question_id`` into ``language`` if not already stored.
 
-        Idempotent: if a row exists (including admin-edited ones) it's
-        returned as-is. Raises ``HTTPException`` 404 for unknown questions
-        and ``NLLBTranslateError`` for transport failures — callers mark
-        the audio row ``failed`` in that case.
+        Idempotent: if a non-empty row exists (including admin-edited ones)
+        it's returned as-is. Empty / whitespace-only stored rows are treated
+        as garbage (see #1696 — NLLB sometimes returns \"\") and dropped so
+        the retry produces real translations. Raises ``HTTPException`` 404
+        for unknown questions and ``NLLBTranslateError`` for transport
+        failures — callers mark the audio row ``failed`` in that case.
         """
         if language not in TARGET_LANGUAGES:
             raise ValueError(f"ensure_translation called with non-target language: {language}")
 
         existing = await self.get_translation(db, question_id, language)
         if existing is not None:
-            return existing
+            question_text_ok = bool((existing.question_text or "").strip())
+            options_ok = all(
+                isinstance(opt, str) and opt.strip() for opt in (existing.options or [])
+            )
+            if question_text_ok and options_ok:
+                return existing
+            if existing.edited_by_admin:
+                # Don't clobber manual overrides even if they look empty.
+                return existing
+            # Stale row from an NLLB glitch (#1696). Drop and re-translate.
+            logger.warning(
+                "dropping empty qbank translation row",
+                question_id=str(question_id),
+                language=language,
+            )
+            await db.delete(existing)
+            await db.commit()
 
         question = await db.get(QBankQuestion, question_id)
         if question is None:
@@ -88,9 +106,26 @@ class QBankTranslationService:
         source_code = resolve_source_code(bank.language if bank else None)
 
         # Translate question_text + each option in one batch round-trip.
-        source_texts = [question.question_text or ""]
+        # Sanitize the source text first: NLLB chokes on embedded newlines
+        # and trailing colons, sometimes returning "" for the whole entry
+        # (root cause of #1696). Replacing \\n with ". " and stripping
+        # trailing colons preserves meaning and avoids the edge case.
+        def _sanitize(text: str) -> str:
+            cleaned = (text or "").replace("\r\n", "\n").replace("\n", ". ")
+            cleaned = cleaned.strip().rstrip(":").strip()
+            return cleaned
+
+        source_texts = [_sanitize(question.question_text or "")]
         options = list(question.options or [])
-        source_texts.extend(options)
+        source_texts.extend(_sanitize(opt) for opt in options)
+
+        # Guard: NLLB rejects empty inputs and will trip our batch-level
+        # empty-check. If the sanitize dropped everything, there's nothing
+        # to translate — fail loudly so the caller marks audio failed.
+        if any(not t for t in source_texts):
+            raise NLLBTranslateError(
+                f"qbank question {question_id} has an empty field after sanitize; cannot translate."
+            )
 
         translations = await self._nllb.translate_batch(
             texts=source_texts,
@@ -148,12 +183,21 @@ class QBankTranslationService:
         existing_ids: set[uuid.UUID] = set()
         if questions:
             existing_rows = await db.execute(
-                select(QBankQuestionTranslation.question_id).where(
+                select(QBankQuestionTranslation).where(
                     QBankQuestionTranslation.question_id.in_([q.id for q in questions]),
                     QBankQuestionTranslation.language == language,
                 )
             )
-            existing_ids = {row for row in existing_rows.scalars()}
+            for row in existing_rows.scalars():
+                # Only treat a row as "done" if it actually has content
+                # or was explicitly edited by an admin. Empty auto-
+                # generated rows (#1696) must be re-translated.
+                has_text = bool((row.question_text or "").strip())
+                has_options = all(
+                    isinstance(opt, str) and opt.strip() for opt in (row.options or [])
+                )
+                if (has_text and has_options) or row.edited_by_admin:
+                    existing_ids.add(row.question_id)
 
         translated = 0
         skipped = 0

--- a/backend/app/integrations/nllb_translate.py
+++ b/backend/app/integrations/nllb_translate.py
@@ -115,6 +115,19 @@ class NLLBTranslateClient:
         if not isinstance(translations, list) or len(translations) != len(texts):
             raise NLLBTranslateError("NLLB sidecar returned malformed translations array")
 
+        # Guard against silently-broken output: NLLB occasionally returns
+        # empty strings for edge-case inputs (newlines, trailing colons,
+        # repeated punctuation). Persisting those as translations makes
+        # MMS TTS speak only the "Option A: Option B:" prefix padding
+        # and the bug looks identical to the original gibberish (#1696).
+        for idx, translated in enumerate(translations):
+            if not translated or not translated.strip():
+                raise NLLBTranslateError(
+                    f"NLLB returned empty translation for entry {idx} "
+                    f"(target={target}, input_snippet={texts[idx][:60]!r}); "
+                    f"full response: {payload!r}"
+                )
+
         logger.info(
             "NLLB translate",
             target=target,


### PR DESCRIPTION
Fixes #1696 — audio was still gibberish after #1693 because NLLB sometimes returned empty strings that we silently stored. MMS then synthesized only the 'Option A:' prefix padding.

- Reject empty/whitespace entries in client.translate_batch
- Sanitize `\n` → `. ` and strip trailing `:` before NLLB
- Re-translate stored rows that are empty (admin-edited preserved)
- New `GET /qbank/questions/{id}/translations/{lang}` diagnostic

🤖 Generated with [Claude Code](https://claude.com/claude-code)