### PR TITLE
feat(qbank): NLLB translation for driving-school audio in mos/dyu/bam

### DIFF
--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -643,6 +643,34 @@ async def generate_bank_audio(
 
 
 @router.post(
+    "/banks/{bank_id}/translate",
+    response_model=AudioGenerateResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def translate_bank(
+    bank_id: uuid.UUID,
+    language: str = Query(..., pattern=r"^(mos|dyu|bam)$"),
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    """Translate every question in a bank to ``language`` via NLLB (#1694).
+
+    Cached per (question, language) with a content-hash invalidator so
+    republishing an unchanged bank is free. Returns the Celery task id
+    — reuses ``AudioGenerateResponse`` since the shape is the same.
+    """
+    from app.domain.services.organization_service import OrganizationService
+    from app.tasks.qbank_processing import translate_qbank_task
+
+    bank = await _svc.get_bank(db, bank_id)
+    await OrganizationService().require_org_role(
+        db, bank.organization_id, uuid.UUID(current_user.id)
+    )
+    task = translate_qbank_task.delay(str(bank_id), language)
+    return AudioGenerateResponse(task_id=task.id, bank_id=str(bank_id), language=language)
+
+
+@router.post(
     "/questions/{question_id}/audio",
     response_model=AudioStatusResponse,
 )

--- a/backend/app/domain/models/question_bank.py
+++ b/backend/app/domain/models/question_bank.py
@@ -213,9 +213,7 @@ class QBankQuestionTranslation(Base):
 
     __tablename__ = "qbank_question_translations"
     __table_args__ = (
-        UniqueConstraint(
-            "question_id", "language", name="uq_qbank_question_translation_lang"
-        ),
+        UniqueConstraint("question_id", "language", name="uq_qbank_question_translation_lang"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
@@ -229,15 +227,11 @@ class QBankQuestionTranslation(Base):
     question_text: Mapped[str] = mapped_column(Text, nullable=False)
     options: Mapped[list] = mapped_column(JSON, nullable=False)
     explanation: Mapped[str | None] = mapped_column(Text, nullable=True)
-    translator: Mapped[str] = mapped_column(
-        String(64), server_default="nllb-200-distilled-600M"
-    )
+    translator: Mapped[str] = mapped_column(String(64), server_default="nllb-200-distilled-600M")
     reviewed_by: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("users.id", ondelete="SET NULL"), nullable=True
     )
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )

--- a/backend/app/domain/models/question_bank.py
+++ b/backend/app/domain/models/question_bank.py
@@ -123,6 +123,9 @@ class QBankQuestion(Base):
     audio_files: Mapped[list[QBankQuestionAudio]] = relationship(
         back_populates="question", cascade="all, delete-orphan"
     )
+    translations: Mapped[list[QBankQuestionTranslation]] = relationship(
+        back_populates="question", cascade="all, delete-orphan"
+    )
 
 
 class QBankQuestionAudio(Base):
@@ -196,3 +199,47 @@ class QBankTestAttempt(Base):
 
     test: Mapped[QBankTest] = relationship(back_populates="attempts")
     user: Mapped[User] = relationship(foreign_keys=[user_id])
+
+
+class QBankQuestionTranslation(Base):
+    """Cached NLLB-200 translations of qbank question content (#1694).
+
+    One row per (question_id, language). ``source_hash`` is a sha256 of
+    the concatenated source question_text + options + explanation, used
+    to detect when the source has changed and the cached translation is
+    stale. ``reviewed_by`` is set when a human admin has approved the
+    machine translation for publication.
+    """
+
+    __tablename__ = "qbank_question_translations"
+    __table_args__ = (
+        UniqueConstraint(
+            "question_id", "language", name="uq_qbank_question_translation_lang"
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    question_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("qbank_questions.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+    language: Mapped[str] = mapped_column(String(10), nullable=False)
+    source_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    question_text: Mapped[str] = mapped_column(Text, nullable=False)
+    options: Mapped[list] = mapped_column(JSON, nullable=False)
+    explanation: Mapped[str | None] = mapped_column(Text, nullable=True)
+    translator: Mapped[str] = mapped_column(
+        String(64), server_default="nllb-200-distilled-600M"
+    )
+    reviewed_by: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    question: Mapped[QBankQuestion] = relationship(back_populates="translations")

--- a/backend/app/domain/services/qbank_audio_service.py
+++ b/backend/app/domain/services/qbank_audio_service.py
@@ -28,8 +28,8 @@ from app.domain.models.question_bank import (
     QuestionBank,
 )
 from app.domain.services.qbank_translation_service import (
-    QBankTranslationService,
     TRANSLATE_LANGUAGES,
+    QBankTranslationService,
 )
 from app.infrastructure.config.settings import settings
 from app.infrastructure.storage.s3 import S3StorageService

--- a/backend/app/domain/services/qbank_audio_service.py
+++ b/backend/app/domain/services/qbank_audio_service.py
@@ -24,7 +24,12 @@ from app.domain.models.question_bank import (
     QBankAudioStatus,
     QBankQuestion,
     QBankQuestionAudio,
+    QBankQuestionTranslation,
     QuestionBank,
+)
+from app.domain.services.qbank_translation_service import (
+    QBankTranslationService,
+    TRANSLATE_LANGUAGES,
 )
 from app.infrastructure.config.settings import settings
 from app.infrastructure.storage.s3 import S3StorageService
@@ -43,11 +48,18 @@ OPUS_CONTENT_TYPE = "audio/ogg"
 OPUS_BYTES_PER_SECOND = 6 * 1024  # matches LessonAudioService._estimate_duration
 
 
-def build_audio_script(question: QBankQuestion, language: str) -> str:
+def build_audio_script(
+    question: QBankQuestion,
+    language: str,
+    translation: QBankQuestionTranslation | None = None,
+) -> str:
     """Return the text that should be spoken for a question.
 
-    Prepends the option label in the speaker's language so the TTS reads
-    "Option A: ..." in French and the native prefix in MMS languages.
+    When ``translation`` is supplied (for mos/dyu/bam under #1694), the
+    translated question_text and options are read instead of the French
+    source, so the TTS voice actually says local-language content rather
+    than French phonemes. The option prefix ("Tʋʋmde A: ...") is still
+    prepended in the speaker's language.
     """
     prefixes = {
         "fr": "Option",
@@ -57,8 +69,14 @@ def build_audio_script(question: QBankQuestion, language: str) -> str:
         "ful": "Suɓaande",  # Fulfulde: "choice"
     }
     prefix = prefixes.get(language, "Option")
-    parts = [question.question_text.strip()]
-    for idx, opt in enumerate(question.options or []):
+    if translation is not None:
+        question_text = translation.question_text
+        options = list(translation.options or [])
+    else:
+        question_text = question.question_text
+        options = list(question.options or [])
+    parts = [question_text.strip()]
+    for idx, opt in enumerate(options):
         letter = chr(ord("A") + idx)
         parts.append(f"{prefix} {letter}: {opt}")
     return ". ".join(p for p in parts if p).strip() + "."
@@ -72,9 +90,14 @@ def estimate_duration_seconds(audio_bytes: int) -> int:
 class QBankAudioService:
     """Generate and store TTS audio for qbank questions."""
 
-    def __init__(self, mms_client: MMSTTSClient | None = None) -> None:
+    def __init__(
+        self,
+        mms_client: MMSTTSClient | None = None,
+        translation_service: QBankTranslationService | None = None,
+    ) -> None:
         self._mms = mms_client or MMSTTSClient()
         self._storage = S3StorageService()
+        self._translation = translation_service or QBankTranslationService()
 
     def _storage_key(self, bank_id: uuid.UUID, question_id: uuid.UUID, language: str) -> str:
         return f"qbank-audio/{bank_id}/{question_id}/{language}.opus"
@@ -138,6 +161,12 @@ class QBankAudioService:
 
         Sets status ``generating`` while running and ``ready`` / ``failed``
         afterwards so the frontend poll endpoint can reflect progress.
+
+        For mos/dyu/bam (languages listed in
+        :data:`qbank_translation_service.TRANSLATE_LANGUAGES`) the question
+        is first translated from the bank's source language via NLLB (#1694).
+        If NLLB is unreachable the translation step returns ``None`` and we
+        fall back to synthesizing the source text — degraded but not broken.
         """
         question = await db.get(QBankQuestion, question_id)
         if question is None:
@@ -145,8 +174,16 @@ class QBankAudioService:
 
         await self._upsert_audio_row(db, question_id, language, status=QBankAudioStatus.generating)
 
+        translation = None
+        if language in TRANSLATE_LANGUAGES:
+            bank = await db.get(QuestionBank, question.question_bank_id)
+            if bank is not None and bank.language != language:
+                translation = await self._translation.ensure_question_translation(
+                    db, question, target_language=language, source_language=bank.language
+                )
+
         try:
-            script = build_audio_script(question, language)
+            script = build_audio_script(question, language, translation)
             audio_bytes = await self._synthesize_bytes(script, language)
             key = self._storage_key(question.question_bank_id, question_id, language)
             url = await self._storage.upload_bytes(

--- a/backend/app/domain/services/qbank_service.py
+++ b/backend/app/domain/services/qbank_service.py
@@ -255,8 +255,15 @@ class QBankService:
 
         if should_invalidate_audio:
             from app.domain.services.qbank_audio_service import QBankAudioService
+            from app.domain.services.qbank_translation_service import (
+                QBankTranslationService,
+            )
 
             await QBankAudioService().invalidate_question(db, question_id)
+            # Also drop cached NLLB translations — the source text has
+            # changed, so the translated question_text/options no longer
+            # match what the audio pipeline will synthesize (#1694).
+            await QBankTranslationService().invalidate_question(db, question_id)
             _enqueue_pregenerate_audio(question.question_bank_id)
 
         return question

--- a/backend/app/domain/services/qbank_translation_service.py
+++ b/backend/app/domain/services/qbank_translation_service.py
@@ -1,0 +1,208 @@
+"""NLLB-backed QBank question translation (#1694).
+
+Translates the ``question_text``, ``options``, and ``explanation`` of a
+QBankQuestion from the bank's source language to a target language
+(currently driving-school only: fr → mos/dyu/bam) so audio generation
+can read real local-language content instead of French phonemes played
+by a Moore/Dyula/Bambara TTS voice.
+
+Results are cached in ``qbank_question_translations`` keyed by
+(question_id, language) with a content hash on the source fields so
+edits invalidate stale translations automatically.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.models.question_bank import (
+    QBankQuestion,
+    QBankQuestionTranslation,
+    QuestionBank,
+)
+from app.integrations.nllb import NLLBClient, NLLBError
+
+logger = structlog.get_logger(__name__)
+
+
+# Languages the driving-school flow translates into. We deliberately keep
+# this small in v1 — NLLB-200 supports 200 languages but only these four
+# have MMS-TTS voices, so translating to e.g. swh_Latn would produce a
+# translation with no downstream audio consumer.
+TRANSLATE_LANGUAGES: tuple[str, ...] = ("mos", "dyu", "bam")
+
+
+def source_hash(question: QBankQuestion) -> str:
+    """Content hash for (question_text, options, explanation).
+
+    Used to detect when a cached translation is stale because the
+    source question has been edited. sha256 over a canonical JSON
+    representation — any field change flips the hash.
+    """
+    payload = json.dumps(
+        {
+            "t": question.question_text or "",
+            "o": list(question.options or []),
+            "e": question.explanation or "",
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+class QBankTranslationService:
+    """Translate and cache qbank question content per target language."""
+
+    def __init__(self, nllb_client: NLLBClient | None = None) -> None:
+        self._nllb = nllb_client or NLLBClient()
+
+    async def get_translation(
+        self,
+        db: AsyncSession,
+        question_id: uuid.UUID,
+        language: str,
+    ) -> QBankQuestionTranslation | None:
+        """Return the cached translation row for (question, language) if any."""
+        result = await db.execute(
+            select(QBankQuestionTranslation).where(
+                QBankQuestionTranslation.question_id == question_id,
+                QBankQuestionTranslation.language == language,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def ensure_question_translation(
+        self,
+        db: AsyncSession,
+        question: QBankQuestion,
+        target_language: str,
+        source_language: str,
+    ) -> QBankQuestionTranslation | None:
+        """Return a cached or freshly-generated translation for one question.
+
+        Returns ``None`` if NLLB is unreachable — the caller should fall
+        back to source-language synthesis rather than crashing the whole
+        audio-gen batch.
+        """
+        if source_language == target_language:
+            return None
+
+        current_hash = source_hash(question)
+        existing = await self.get_translation(db, question.id, target_language)
+        if existing is not None and existing.source_hash == current_hash:
+            return existing
+
+        texts = [question.question_text] + list(question.options or [])
+        if question.explanation:
+            texts.append(question.explanation)
+
+        try:
+            translated = await self._nllb.translate_batch(
+                texts, source_language, target_language
+            )
+        except NLLBError as exc:
+            logger.warning(
+                "NLLB translation failed; downstream will use source text",
+                question_id=str(question.id),
+                target=target_language,
+                error=str(exc),
+            )
+            return None
+
+        new_question_text = translated[0]
+        opt_count = len(question.options or [])
+        new_options = list(translated[1 : 1 + opt_count])
+        new_explanation = (
+            translated[1 + opt_count]
+            if question.explanation and len(translated) > 1 + opt_count
+            else None
+        )
+
+        if existing is None:
+            existing = QBankQuestionTranslation(
+                question_id=question.id,
+                language=target_language,
+            )
+            db.add(existing)
+        existing.source_hash = current_hash
+        existing.question_text = new_question_text
+        existing.options = new_options
+        existing.explanation = new_explanation
+        existing.translator = "nllb-200-distilled-600M"
+        await db.commit()
+        await db.refresh(existing)
+        return existing
+
+    async def translate_bank(
+        self,
+        db: AsyncSession,
+        bank_id: uuid.UUID,
+        target_language: str,
+    ) -> dict:
+        """Translate every question in a bank into ``target_language``.
+
+        Idempotent — questions whose source hash matches the cached row
+        are skipped so republishing a bank doesn't re-bill the sidecar.
+        """
+        bank = await db.get(QuestionBank, bank_id)
+        if bank is None:
+            return {
+                "bank_id": str(bank_id),
+                "language": target_language,
+                "total": 0,
+                "translated": 0,
+                "skipped": 0,
+                "failed": 0,
+            }
+
+        questions = (
+            await db.execute(
+                select(QBankQuestion).where(QBankQuestion.question_bank_id == bank_id)
+            )
+        ).scalars().all()
+
+        translated = 0
+        skipped = 0
+        failed = 0
+        for question in questions:
+            current_hash = source_hash(question)
+            existing = await self.get_translation(db, question.id, target_language)
+            if existing is not None and existing.source_hash == current_hash:
+                skipped += 1
+                continue
+            row = await self.ensure_question_translation(
+                db, question, target_language, bank.language
+            )
+            if row is None:
+                failed += 1
+            else:
+                translated += 1
+
+        return {
+            "bank_id": str(bank_id),
+            "language": target_language,
+            "total": len(questions),
+            "translated": translated,
+            "skipped": skipped,
+            "failed": failed,
+        }
+
+    async def invalidate_question(
+        self,
+        db: AsyncSession,
+        question_id: uuid.UUID,
+    ) -> None:
+        """Drop every cached translation for a question (on edit)."""
+        await db.execute(
+            QBankQuestionTranslation.__table__.delete().where(
+                QBankQuestionTranslation.question_id == question_id,
+            )
+        )
+        await db.commit()

--- a/backend/app/domain/services/qbank_translation_service.py
+++ b/backend/app/domain/services/qbank_translation_service.py
@@ -104,9 +104,7 @@ class QBankTranslationService:
             texts.append(question.explanation)
 
         try:
-            translated = await self._nllb.translate_batch(
-                texts, source_language, target_language
-            )
+            translated = await self._nllb.translate_batch(texts, source_language, target_language)
         except NLLBError as exc:
             logger.warning(
                 "NLLB translation failed; downstream will use source text",
@@ -163,10 +161,14 @@ class QBankTranslationService:
             }
 
         questions = (
-            await db.execute(
-                select(QBankQuestion).where(QBankQuestion.question_bank_id == bank_id)
+            (
+                await db.execute(
+                    select(QBankQuestion).where(QBankQuestion.question_bank_id == bank_id)
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
 
         translated = 0
         skipped = 0

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -94,6 +94,13 @@ class Settings(BaseSettings):
     mms_tts_url: str = "http://mms-tts:5050"
     mms_tts_timeout_seconds: float = 60.0
 
+    # Meta NLLB-200-distilled-600M shared translation sidecar (#1694).
+    # Translates QBank question_text/options from fr -> mos/dyu/bam before
+    # MMS-TTS synthesis so local-language audio is actually local-language
+    # content, not French phonemes played by a Moore/Dyula/Bambara voice.
+    nllb_url: str = "http://nllb:8000"
+    nllb_timeout_seconds: float = 60.0
+
     # MinIO / S3-compatible object storage
     minio_endpoint: str = "http://localhost:9000"
     minio_access_key: str = ""

--- a/backend/app/integrations/nllb.py
+++ b/backend/app/integrations/nllb.py
@@ -94,9 +94,7 @@ class NLLBClient:
                 raise NLLBError(f"NLLB sidecar unreachable: {exc}") from exc
 
         if resp.status_code != 200:
-            raise NLLBError(
-                f"NLLB sidecar returned {resp.status_code}: {resp.text[:200]}"
-            )
+            raise NLLBError(f"NLLB sidecar returned {resp.status_code}: {resp.text[:200]}")
         data = resp.json()
         translation = data.get("translation")
         if not translation:
@@ -111,9 +109,7 @@ class NLLBClient:
         )
         return translation
 
-    async def translate_batch(
-        self, texts: list[str], src: str, tgt: str
-    ) -> list[str]:
+    async def translate_batch(self, texts: list[str], src: str, tgt: str) -> list[str]:
         """Translate multiple strings in one call — preferred for bulk jobs
         since the sidecar does NLLB tokenization + beam search once.
         """
@@ -144,18 +140,15 @@ class NLLBClient:
                 raise NLLBError(f"NLLB sidecar unreachable: {exc}") from exc
 
         if resp.status_code != 200:
-            raise NLLBError(
-                f"NLLB sidecar returned {resp.status_code}: {resp.text[:200]}"
-            )
+            raise NLLBError(f"NLLB sidecar returned {resp.status_code}: {resp.text[:200]}")
         translations = resp.json().get("translations", [])
         if len(translations) != len(indexed):
             raise NLLBError(
-                f"NLLB batch returned {len(translations)} items for "
-                f"{len(indexed)} inputs"
+                f"NLLB batch returned {len(translations)} items for {len(indexed)} inputs"
             )
 
         out = list(texts)
-        for (i, _), translated in zip(indexed, translations):
+        for (i, _), translated in zip(indexed, translations, strict=True):
             out[i] = translated
         return out
 

--- a/backend/app/integrations/nllb.py
+++ b/backend/app/integrations/nllb.py
@@ -1,0 +1,168 @@
+"""Async HTTP client for the shared NLLB-200 translation sidecar (#1694).
+
+The sidecar is a separate Docker service (see infrastructure/nllb) that wraps
+facebook/nllb-200-distilled-600M. Called over plain HTTP from the backend and
+the Celery worker to translate QBank question text from French to Moore /
+Dyula / Bambara before MMS-TTS synthesis.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import structlog
+
+from app.infrastructure.config.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+
+# Map ISO-639-1 (and our internal 3-letter codes for local languages) to
+# NLLB flores-200 codes. Driving-school v1 only needs the four below;
+# callers can also pass flores codes directly via translate() and we'll
+# pass them through unchanged.
+ISO_TO_FLORES: dict[str, str] = {
+    "fr": "fra_Latn",
+    "en": "eng_Latn",
+    "mos": "mos_Latn",
+    "dyu": "dyu_Latn",
+    "bam": "bam_Latn",
+}
+
+
+def to_flores(code: str) -> str:
+    """Translate a short ISO code to NLLB flores-200, or pass through if
+    it already looks like a flores code (``xxx_Latn`` / ``xxx_Cyrl`` etc)."""
+    if "_" in code:
+        return code
+    try:
+        return ISO_TO_FLORES[code]
+    except KeyError as exc:
+        raise NLLBError(f"unsupported language code: {code}") from exc
+
+
+class NLLBError(Exception):
+    """Raised when the NLLB sidecar returns an error or is unreachable."""
+
+
+class NLLBClient:
+    """Thin async wrapper over the NLLB translation sidecar.
+
+    Shared concurrency bound across all callers in the same process — a
+    tenant's bulk translate job can't swamp the single-worker sidecar and
+    starve interactive callers. Sized conservatively because each request
+    occupies one worker thread on the sidecar for the full generate() call.
+    """
+
+    _semaphore = asyncio.Semaphore(2)
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> None:
+        self._base_url = (base_url or settings.nllb_url).rstrip("/")
+        self._timeout = timeout_seconds or settings.nllb_timeout_seconds
+
+    async def translate(self, text: str, src: str, tgt: str) -> str:
+        """Translate one string. ``src``/``tgt`` may be ISO codes or flores-200.
+
+        Raises NLLBError on any transport/sidecar failure. The caller is
+        expected to catch and degrade gracefully (e.g. skip translation
+        and fall back to source-language TTS, or mark the row ``failed``).
+        """
+        if not text or not text.strip():
+            raise NLLBError("NLLB received empty text")
+        src_flores = to_flores(src)
+        tgt_flores = to_flores(tgt)
+        if src_flores == tgt_flores:
+            return text
+
+        async with self._semaphore:
+            try:
+                async with httpx.AsyncClient(timeout=self._timeout) as client:
+                    resp = await client.post(
+                        f"{self._base_url}/translate",
+                        json={
+                            "text": text,
+                            "src_lang": src_flores,
+                            "tgt_lang": tgt_flores,
+                        },
+                    )
+            except httpx.HTTPError as exc:
+                raise NLLBError(f"NLLB sidecar unreachable: {exc}") from exc
+
+        if resp.status_code != 200:
+            raise NLLBError(
+                f"NLLB sidecar returned {resp.status_code}: {resp.text[:200]}"
+            )
+        data = resp.json()
+        translation = data.get("translation")
+        if not translation:
+            raise NLLBError("NLLB sidecar returned empty translation")
+
+        logger.info(
+            "NLLB translate",
+            src=src_flores,
+            tgt=tgt_flores,
+            chars=len(text),
+            elapsed_ms=data.get("elapsed_ms"),
+        )
+        return translation
+
+    async def translate_batch(
+        self, texts: list[str], src: str, tgt: str
+    ) -> list[str]:
+        """Translate multiple strings in one call — preferred for bulk jobs
+        since the sidecar does NLLB tokenization + beam search once.
+        """
+        if not texts:
+            return []
+        src_flores = to_flores(src)
+        tgt_flores = to_flores(tgt)
+        if src_flores == tgt_flores:
+            return list(texts)
+        # Filter empty inputs so the sidecar validator doesn't reject the
+        # whole batch if one option is blank.
+        indexed = [(i, t) for i, t in enumerate(texts) if t and t.strip()]
+        if not indexed:
+            return list(texts)
+
+        async with self._semaphore:
+            try:
+                async with httpx.AsyncClient(timeout=self._timeout) as client:
+                    resp = await client.post(
+                        f"{self._base_url}/translate/batch",
+                        json={
+                            "texts": [t for _, t in indexed],
+                            "src_lang": src_flores,
+                            "tgt_lang": tgt_flores,
+                        },
+                    )
+            except httpx.HTTPError as exc:
+                raise NLLBError(f"NLLB sidecar unreachable: {exc}") from exc
+
+        if resp.status_code != 200:
+            raise NLLBError(
+                f"NLLB sidecar returned {resp.status_code}: {resp.text[:200]}"
+            )
+        translations = resp.json().get("translations", [])
+        if len(translations) != len(indexed):
+            raise NLLBError(
+                f"NLLB batch returned {len(translations)} items for "
+                f"{len(indexed)} inputs"
+            )
+
+        out = list(texts)
+        for (i, _), translated in zip(indexed, translations):
+            out[i] = translated
+        return out
+
+    async def health(self) -> bool:
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.get(f"{self._base_url}/health")
+            return resp.status_code == 200
+        except httpx.HTTPError:
+            return False

--- a/backend/app/tasks/qbank_processing.py
+++ b/backend/app/tasks/qbank_processing.py
@@ -232,9 +232,7 @@ async def _translate_bank_async(bank_id: str, target_language: str) -> dict:
 
     async with session_factory() as session:
         try:
-            result = await service.translate_bank(
-                session, uuid.UUID(bank_id), target_language
-            )
+            result = await service.translate_bank(session, uuid.UUID(bank_id), target_language)
         finally:
             await engine.dispose()
 

--- a/backend/app/tasks/qbank_processing.py
+++ b/backend/app/tasks/qbank_processing.py
@@ -197,3 +197,51 @@ async def _generate_audio_async(bank_id: str, language: str) -> dict:
         result=result,
     )
     return result
+
+
+@celery_app.task(
+    base=QBankTask,
+    bind=True,
+    name="qbank.translate_bank",
+    max_retries=2,
+    default_retry_delay=60,
+    soft_time_limit=900,
+    time_limit=960,
+    rate_limit="5/m",
+)
+def translate_qbank_task(self, bank_id: str, target_language: str) -> dict:
+    """Translate every question in a bank into ``target_language`` via NLLB (#1694).
+
+    Kept separate from the audio task so admins can pre-translate and
+    review before audio synthesis if they want. The audio task also
+    translates lazily on demand, so this task is optional for the happy
+    path — run it to front-load the NLLB cost during authoring.
+    """
+    return asyncio.run(_translate_bank_async(bank_id, target_language))
+
+
+async def _translate_bank_async(bank_id: str, target_language: str) -> dict:
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.domain.services.qbank_translation_service import QBankTranslationService
+    from app.infrastructure.config.settings import settings
+
+    engine = create_async_engine(settings.database_url, echo=False)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    service = QBankTranslationService()
+
+    async with session_factory() as session:
+        try:
+            result = await service.translate_bank(
+                session, uuid.UUID(bank_id), target_language
+            )
+        finally:
+            await engine.dispose()
+
+    logger.info(
+        "qbank translate batch complete",
+        bank_id=bank_id,
+        language=target_language,
+        result=result,
+    )
+    return result

--- a/backend/migrations/versions/071_add_qbank_question_translations.py
+++ b/backend/migrations/versions/071_add_qbank_question_translations.py
@@ -1,0 +1,69 @@
+"""Add qbank_question_translations table for NLLB-cached translations.
+
+Revision ID: 071
+Revises: 069
+Create Date: 2026-04-18
+
+Caches NLLB-200 per-question, per-language translations (#1694) so the
+audio pregen pipeline doesn't call the sidecar for the same text every
+time a bank is republished. Content hash lets us invalidate when a
+question is edited.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "071"
+down_revision = "069"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "qbank_question_translations",
+        sa.Column("id", sa.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "question_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("qbank_questions.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("language", sa.String(10), nullable=False),
+        sa.Column("source_hash", sa.String(64), nullable=False),
+        sa.Column("question_text", sa.Text(), nullable=False),
+        sa.Column("options", sa.JSON(), nullable=False),
+        sa.Column("explanation", sa.Text(), nullable=True),
+        sa.Column(
+            "translator",
+            sa.String(64),
+            nullable=False,
+            server_default="nllb-200-distilled-600M",
+        ),
+        sa.Column(
+            "reviewed_by",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "question_id", "language", name="uq_qbank_question_translation_lang"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("qbank_question_translations")

--- a/backend/migrations/versions/071_add_qbank_question_translations.py
+++ b/backend/migrations/versions/071_add_qbank_question_translations.py
@@ -59,9 +59,7 @@ def upgrade() -> None:
             server_default=sa.text("now()"),
             nullable=False,
         ),
-        sa.UniqueConstraint(
-            "question_id", "language", name="uq_qbank_question_translation_lang"
-        ),
+        sa.UniqueConstraint("question_id", "language", name="uq_qbank_question_translation_lang"),
     )
 
 

--- a/backend/tests/test_nllb_client.py
+++ b/backend/tests/test_nllb_client.py
@@ -1,0 +1,124 @@
+"""Unit tests for the NLLB client (#1694).
+
+Stubs httpx so we don't spin the 2.4 GB model locally — these pin down
+the protocol shape (flores-200 code mapping, empty-text guard, batch
+reconstruction with gapped empty inputs, error conversion).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from app.integrations.nllb import NLLBClient, NLLBError, to_flores
+
+
+def test_to_flores_maps_iso_codes():
+    assert to_flores("fr") == "fra_Latn"
+    assert to_flores("en") == "eng_Latn"
+    assert to_flores("mos") == "mos_Latn"
+    assert to_flores("dyu") == "dyu_Latn"
+    assert to_flores("bam") == "bam_Latn"
+
+
+def test_to_flores_passes_through_flores_codes():
+    assert to_flores("fra_Latn") == "fra_Latn"
+    assert to_flores("swh_Latn") == "swh_Latn"
+
+
+def test_to_flores_raises_on_unknown_iso():
+    with pytest.raises(NLLBError):
+        to_flores("xx")
+
+
+@pytest.mark.asyncio
+async def test_translate_same_language_is_passthrough():
+    """Translating fr -> fr must not call the sidecar."""
+    client = NLLBClient(base_url="http://nllb:8000")
+    with patch("httpx.AsyncClient") as ac:
+        out = await client.translate("Bonjour", "fr", "fra_Latn")
+    assert out == "Bonjour"
+    ac.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_translate_rejects_empty_text():
+    client = NLLBClient(base_url="http://nllb:8000")
+    with pytest.raises(NLLBError):
+        await client.translate("", "fr", "mos")
+    with pytest.raises(NLLBError):
+        await client.translate("   ", "fr", "mos")
+
+
+@pytest.mark.asyncio
+async def test_translate_posts_flores_codes_and_parses_response():
+    """End-to-end shape: ISO in, flores on the wire, translation out."""
+    resp = httpx.Response(
+        200,
+        json={
+            "translation": "Ne y yiibu?",
+            "src_lang": "fra_Latn",
+            "tgt_lang": "mos_Latn",
+            "elapsed_ms": 42,
+        },
+    )
+    mock_post = AsyncMock(return_value=resp)
+    with patch("httpx.AsyncClient") as ac:
+        ac.return_value.__aenter__.return_value.post = mock_post
+        client = NLLBClient(base_url="http://nllb:8000")
+        out = await client.translate("Comment allez-vous ?", "fr", "mos")
+
+    assert out == "Ne y yiibu?"
+    mock_post.assert_awaited_once()
+    url, kwargs = mock_post.await_args.args, mock_post.await_args.kwargs
+    assert url[0] == "http://nllb:8000/translate"
+    assert kwargs["json"] == {
+        "text": "Comment allez-vous ?",
+        "src_lang": "fra_Latn",
+        "tgt_lang": "mos_Latn",
+    }
+
+
+@pytest.mark.asyncio
+async def test_translate_batch_preserves_empty_gaps():
+    """Empty options must stay empty in the output rather than
+    misaligning the translated list (regression guard)."""
+    # Empty strings get filtered on send, so the sidecar only sees the
+    # two non-empty inputs and returns two translations.
+    resp = httpx.Response(
+        200,
+        json={
+            "translations": ["T_question", "T_opt2"],
+            "src_lang": "fra_Latn",
+            "tgt_lang": "mos_Latn",
+            "elapsed_ms": 5,
+        },
+    )
+    mock_post = AsyncMock(return_value=resp)
+    with patch("httpx.AsyncClient") as ac:
+        ac.return_value.__aenter__.return_value.post = mock_post
+        client = NLLBClient(base_url="http://nllb:8000")
+        # Index 1 is an empty option — must be filtered on send and
+        # restored as "" in the output so option letter mapping holds.
+        out = await client.translate_batch(
+            ["question text", "", "opt2"], "fr", "mos"
+        )
+        # Confirm the wire request excluded the empty string.
+        _, kwargs = mock_post.await_args.args, mock_post.await_args.kwargs
+        assert kwargs["json"]["texts"] == ["question text", "opt2"]
+    assert out == ["T_question", "", "T_opt2"]
+
+
+@pytest.mark.asyncio
+async def test_translate_error_becomes_nllberror():
+    """Sidecar 503 must surface as NLLBError so callers can degrade."""
+    resp = httpx.Response(503, text="model loading")
+    mock_post = AsyncMock(return_value=resp)
+    with patch("httpx.AsyncClient") as ac:
+        ac.return_value.__aenter__.return_value.post = mock_post
+        client = NLLBClient(base_url="http://nllb:8000")
+        with pytest.raises(NLLBError) as exc:
+            await client.translate("salut", "fr", "mos")
+    assert "503" in str(exc.value)

--- a/backend/tests/test_nllb_client.py
+++ b/backend/tests/test_nllb_client.py
@@ -102,9 +102,7 @@ async def test_translate_batch_preserves_empty_gaps():
         client = NLLBClient(base_url="http://nllb:8000")
         # Index 1 is an empty option — must be filtered on send and
         # restored as "" in the output so option letter mapping holds.
-        out = await client.translate_batch(
-            ["question text", "", "opt2"], "fr", "mos"
-        )
+        out = await client.translate_batch(["question text", "", "opt2"], "fr", "mos")
         # Confirm the wire request excluded the empty string.
         _, kwargs = mock_post.await_args.args, mock_post.await_args.kwargs
         assert kwargs["json"]["texts"] == ["question text", "opt2"]

--- a/backend/tests/test_qbank_audio_service.py
+++ b/backend/tests/test_qbank_audio_service.py
@@ -91,3 +91,43 @@ def test_supported_languages_is_non_empty_tuple():
     assert isinstance(SUPPORTED_LANGUAGES, tuple)
     assert "fr" in SUPPORTED_LANGUAGES
     assert all(isinstance(lang, str) for lang in SUPPORTED_LANGUAGES)
+
+
+class _FakeTranslation:
+    def __init__(self, text: str, options: list[str]):
+        self.question_text = text
+        self.options = options
+
+
+def test_build_audio_script_uses_translation_when_provided():
+    """With a translation row, question_text and options come from the
+    translated content — the option PREFIX still stays in the speaker's
+    language so "Tʋʋmde A: ..." reads as a Moore sentence (#1694)."""
+    q = _FakeQuestion(
+        "Que signifie ce panneau ?",
+        ["Stop", "Céder le passage", "Danger"],
+    )
+    translation = _FakeTranslation(
+        "Tagem sɛbga bʋko la bʋgo?",
+        ["Zĩigi", "Kõ sori", "Yɛlga"],
+    )
+    script = build_audio_script(q, "mos", translation=translation)
+    # French source must NOT appear — the whole point of translation is
+    # that MMS-TTS pronounces Moore words, not French transliterations.
+    assert "Que signifie" not in script
+    assert "Stop" not in script
+    assert "Céder" not in script
+    # Translated content must appear, with Moore prefix.
+    assert script.startswith("Tagem sɛbga")
+    assert "Tʋʋmde A: Zĩigi" in script
+    assert "Tʋʋmde B: Kõ sori" in script
+    assert "Tʋʋmde C: Yɛlga" in script
+
+
+def test_build_audio_script_falls_back_to_source_when_translation_none():
+    """When NLLB is unreachable the translation is None — we must still
+    produce a playable script in the source language rather than crash."""
+    q = _FakeQuestion("Question source", ["A", "B"])
+    script = build_audio_script(q, "mos", translation=None)
+    assert script.startswith("Question source")
+    assert "Tʋʋmde A: A" in script

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,30 @@ services:
         limits:
           memory: 4G
 
+  # Shared multi-tenant translation service (#1694) — one container serves
+  # every tenant. Drives qbank question-text translation from fr → mos/dyu/bam
+  # before TTS synthesis so driving-school audio is real Moore/Dyula/Bambara,
+  # not French phonemes played by a local-language voice.
+  nllb:
+    build:
+      context: ./infrastructure/nllb
+      dockerfile: Dockerfile
+    container_name: santepublique-nllb
+    ports:
+      - "8001:8000"
+    volumes:
+      - nllb_models:/models
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 300s  # first boot downloads the 600M model (~2 min)
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          memory: 3G
+
   backend:
     build:
       context: ./backend
@@ -61,6 +85,7 @@ services:
       APP_ENV: development
       CORS_ORIGINS: http://localhost:3000
       MMS_TTS_URL: http://mms-tts:5050
+      NLLB_URL: http://nllb:8000
     ports:
       - "8000:8000"
     volumes:
@@ -83,3 +108,4 @@ volumes:
   redisdata:
   uploads_data:
   mms_models:
+  nllb_models:

--- a/infrastructure/nllb/Dockerfile
+++ b/infrastructure/nllb/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    HF_HOME=/models \
+    TRANSFORMERS_CACHE=/models
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY server.py .
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=300s --retries=3 \
+    CMD curl -fsS http://localhost:8000/health || exit 1
+
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1"]

--- a/infrastructure/nllb/requirements.txt
+++ b/infrastructure/nllb/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.115.6
+uvicorn[standard]==0.32.1
+transformers==4.47.1
+torch==2.5.1
+sentencepiece==0.2.0

--- a/infrastructure/nllb/server.py
+++ b/infrastructure/nllb/server.py
@@ -1,0 +1,168 @@
+"""Meta NLLB-200-distilled-600M translation server (#1694).
+
+Shared multi-tenant inference service. Loads Meta's
+``facebook/nllb-200-distilled-600M`` once (~2.4 GB RAM) and serves
+translations over HTTP — every tenant points at this same container
+instead of running its own 2.4 GB copy.
+
+Target language pairs for driving-school QBank v1: French source →
+``{fra_Latn, mos_Latn, dyu_Latn, bam_Latn}`` targets. The model supports
+200 languages; we don't restrict the endpoint, but document that
+low-resource language quality (mos/dyu/bam) is notably worse than
+fr↔en and callers should review translations before publishing.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from contextlib import asynccontextmanager
+
+import torch
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+
+MODEL_ID = os.getenv("NLLB_MODEL_ID", "facebook/nllb-200-distilled-600M")
+MAX_TEXT_CHARS = 4000
+MAX_NEW_TOKENS = 512
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("nllb")
+
+
+class _Bundle:
+    __slots__ = ("model", "tokenizer")
+
+    def __init__(self, model, tokenizer):
+        self.model = model
+        self.tokenizer = tokenizer
+
+
+_STATE: dict[str, _Bundle] = {}
+
+
+def _load() -> _Bundle:
+    logger.info("loading %s", MODEL_ID)
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+    model = AutoModelForSeq2SeqLM.from_pretrained(MODEL_ID)
+    model.eval()
+    logger.info("loaded %s", MODEL_ID)
+    return _Bundle(model=model, tokenizer=tokenizer)
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    try:
+        _STATE["bundle"] = _load()
+    except Exception:
+        # Don't crash lifespan — /translate will 503 until retry/restart.
+        # Matches the resilience pattern in infrastructure/mms-tts/server.py.
+        logger.exception("failed to load NLLB model")
+    yield
+    _STATE.clear()
+
+
+app = FastAPI(title="NLLB Translation Sidecar", version="1.0.0", lifespan=lifespan)
+
+
+class TranslateRequest(BaseModel):
+    text: str = Field(..., min_length=1, max_length=MAX_TEXT_CHARS)
+    src_lang: str = Field(..., description="NLLB flores-200 code, e.g. fra_Latn")
+    tgt_lang: str = Field(..., description="NLLB flores-200 code, e.g. mos_Latn")
+
+
+class TranslateResponse(BaseModel):
+    translation: str
+    src_lang: str
+    tgt_lang: str
+    elapsed_ms: int
+
+
+class BatchTranslateRequest(BaseModel):
+    texts: list[str] = Field(..., min_length=1, max_length=64)
+    src_lang: str
+    tgt_lang: str
+
+
+class BatchTranslateResponse(BaseModel):
+    translations: list[str]
+    src_lang: str
+    tgt_lang: str
+    elapsed_ms: int
+
+
+@app.get("/health")
+async def health() -> JSONResponse:
+    return JSONResponse({"status": "ok" if "bundle" in _STATE else "loading", "model": MODEL_ID})
+
+
+def _translate(texts: list[str], src_lang: str, tgt_lang: str) -> list[str]:
+    bundle = _STATE.get("bundle")
+    if bundle is None:
+        raise HTTPException(status_code=503, detail="model not loaded")
+    tokenizer = bundle.tokenizer
+    model = bundle.model
+
+    # NLLB requires src_lang on the tokenizer so the BOS token is right.
+    # We assign then restore in a try/finally to keep the tokenizer safe
+    # under concurrent requests (uvicorn workers=1 but FastAPI still runs
+    # handlers concurrently via threadpool).
+    prev_src = tokenizer.src_lang
+    tokenizer.src_lang = src_lang
+    try:
+        inputs = tokenizer(texts, return_tensors="pt", padding=True, truncation=True)
+        forced_bos = tokenizer.convert_tokens_to_ids(tgt_lang)
+        if forced_bos == tokenizer.unk_token_id:
+            raise HTTPException(status_code=400, detail=f"unknown tgt_lang: {tgt_lang}")
+        with torch.no_grad():
+            generated = model.generate(
+                **inputs,
+                forced_bos_token_id=forced_bos,
+                max_new_tokens=MAX_NEW_TOKENS,
+                num_beams=1,
+            )
+        return tokenizer.batch_decode(generated, skip_special_tokens=True)
+    finally:
+        tokenizer.src_lang = prev_src
+
+
+@app.post("/translate", response_model=TranslateResponse)
+async def translate(req: TranslateRequest) -> TranslateResponse:
+    started = time.monotonic()
+    out = _translate([req.text], req.src_lang, req.tgt_lang)
+    elapsed_ms = int((time.monotonic() - started) * 1000)
+    logger.info(
+        "translate src=%s tgt=%s chars=%d elapsed_ms=%d",
+        req.src_lang,
+        req.tgt_lang,
+        len(req.text),
+        elapsed_ms,
+    )
+    return TranslateResponse(
+        translation=out[0],
+        src_lang=req.src_lang,
+        tgt_lang=req.tgt_lang,
+        elapsed_ms=elapsed_ms,
+    )
+
+
+@app.post("/translate/batch", response_model=BatchTranslateResponse)
+async def translate_batch(req: BatchTranslateRequest) -> BatchTranslateResponse:
+    started = time.monotonic()
+    out = _translate(req.texts, req.src_lang, req.tgt_lang)
+    elapsed_ms = int((time.monotonic() - started) * 1000)
+    logger.info(
+        "batch src=%s tgt=%s n=%d elapsed_ms=%d",
+        req.src_lang,
+        req.tgt_lang,
+        len(req.texts),
+        elapsed_ms,
+    )
+    return BatchTranslateResponse(
+        translations=out,
+        src_lang=req.src_lang,
+        tgt_lang=req.tgt_lang,
+        elapsed_ms=elapsed_ms,
+    )


### PR DESCRIPTION
## Summary

Before this PR, \`generate_bank_audio(bank_id, language='mos')\` built a script from \`question.question_text\` (French) and sent it to MMS-TTS's Moore voice — producing **French phonemes read with a Moore accent**. Same for \`dyu\` and \`bam\`. Audio was generated but not intelligible as Moore/Dyula/Bambara.

This PR adds **NLLB-200-distilled-600M as shared multi-tenant infrastructure** and translates question content from the bank's source language to the target audio language *before* MMS-TTS synthesis. One 2.4 GB container serves every tenant — same shared-infra pattern as MMS-TTS.

Closes #1694. Companion PR for tenant provisioning wiring: [Benidrissa/sira-reseller-console#110](https://github.com/Benidrissa/sira-reseller-console/pull/110) (MMS-TTS); an equivalent \`NLLB_URL\` plumbing PR will follow.

## Architecture

~~~
QBank question (fr)
  └─> translate_qbank_task / generate_qbank_audio_task (Celery)
      └─> QBankTranslationService — cached in qbank_question_translations
          └─> NLLBClient — fr -> {mos,dyu,bam}
              └─> shared-nllb sidecar (FastAPI + transformers)
      └─> build_audio_script(question, lang, translation=...)
          └─> MMSTTSClient — synthesize with translated text
~~~

Cache key is \`(question_id, language)\` with a \`source_hash\` (sha256 over question_text + options + explanation) so republishing an unchanged bank is free. \`update_question\` invalidates both the audio and translation caches on text change.

## Files

**New shared service** \`infrastructure/nllb/\`:
- \`Dockerfile\` — Python 3.11-slim, HF cache at \`/models\`, 8000/health
- \`requirements.txt\` — transformers, torch, sentencepiece, fastapi
- \`server.py\` — FastAPI with \`/translate\` and \`/translate/batch\`; lifespan loads model once; per-language load failures don't crash the whole lifespan

**Backend integration**:
- \`backend/app/integrations/nllb.py\` — async \`NLLBClient\`, ISO↔flores-200 mapping (\`fr\` → \`fra_Latn\`, etc.), concurrency semaphore, empty-input guards
- \`backend/app/infrastructure/config/settings.py:93-102\` — \`nllb_url\`, \`nllb_timeout_seconds\`
- \`backend/migrations/versions/071_add_qbank_question_translations.py\` — new cache table
- \`backend/app/domain/models/question_bank.py\` — \`QBankQuestionTranslation\` model + \`translations\` relationship on \`QBankQuestion\`
- \`backend/app/domain/services/qbank_translation_service.py\` — cache reads/writes, batch translate, content-hash invalidation
- \`backend/app/domain/services/qbank_audio_service.py\` — translate before TTS for \`mos/dyu/bam\`; \`build_audio_script\` accepts optional translation
- \`backend/app/domain/services/qbank_service.py:258-270\` — \`update_question\` also drops translation cache when source text changes
- \`backend/app/tasks/qbank_processing.py\` — new \`translate_qbank_task\` Celery task
- \`backend/app/api/v1/qbank.py:645-670\` — new \`POST /banks/{bank_id}/translate?language=...\` endpoint

**Compose + tests**:
- \`docker-compose.yml\` — new \`nllb\` service + \`nllb_models\` volume + \`NLLB_URL\` env on backend
- \`backend/tests/test_nllb_client.py\` — 7 tests: flores mapping, empty-text guard, empty-gap batch reconstruction, 503 → \`NLLBError\`
- \`backend/tests/test_qbank_audio_service.py\` — 2 new tests: translation substitutes question_text/options while keeping local-language prefix; \`None\` translation falls back to source

## Degradation behaviour

When NLLB is unreachable:
- \`QBankTranslationService.ensure_question_translation\` logs and returns \`None\`
- \`build_audio_script\` receives \`translation=None\` and uses source \`question_text\`
- MMS-TTS still synthesizes — result is the pre-existing (broken) behaviour, not a 500 cascade

## Test plan

- [x] 17 unit tests pass locally (\`pytest tests/test_qbank_audio_service.py tests/test_nllb_client.py\`)
- [ ] Run migration 071 against dev DB
- [ ] Build NLLB image locally: \`docker compose build nllb && docker compose up -d nllb\` (allow ~2 min for model download)
- [ ] Provision a bank of 3 driving-school questions in French
- [ ] \`POST /api/v1/qbank/banks/{id}/translate?language=mos\` → confirm rows appear in \`qbank_question_translations\` with translator=\`nllb-200-distilled-600M\`
- [ ] \`POST /api/v1/qbank/banks/{id}/audio/generate?language=mos\` → confirm the MMS-TTS script uses translated text (inspect log \`qbank audio script\` field) and the audio file is saved
- [ ] Send the audio to a native Moore speaker — confirm it's intelligible Moore, not French-phonemes-in-a-Moore-voice
- [ ] Edit one question's text via PATCH → confirm both audio and translation caches are dropped, next audio-gen regenerates both
- [ ] Chaos: \`docker stop santepublique-nllb\` → trigger audio-gen → confirm source-language fallback fires, no 500

## Out of scope for v1 (follow-ups)

- Tenant provisioning plumbing (analog of #109 for NLLB_URL) — file after this lands
- RAG PDF ingest translation — explicitly deferred per issue
- Tutor RAG context pre-translation
- Other QBank types (exam_prep, psychotechnic, general_culture)
- Admin UI to review/edit machine translation before audio gen
- Lesson / flashcard / case-study translation

## Risks

- **mos/dyu/bam translation quality** — NLLB quality for these low-resource languages is materially lower than fr↔en. The v1 flow translates silently; admin review UI is a follow-up. Surface a \"machine-translated, review recommended\" banner before publishing assessment content.
- **Noisy-neighbour** — single shared pool; bulk translate can slow interactive callers. Same concern as MMS-TTS, accepted for now.
- **First boot** — \`start_period: 300s\` accommodates the one-time 600M-parameter model download to \`nllb_models\`. Subsequent starts are fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)