### PR TITLE
fix(qbank): NLLB 4G→8G + invalidate stale audio on backfill (#1696)

### DIFF
--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -672,10 +672,18 @@ async def backfill_bank_translations(
 ):
     """Backfill NLLB translations for an existing bank, then re-generate audio.
 
-    Idempotent: questions already translated are skipped (#1690).
+    Before dispatching the translate→audio chain, delete every
+    ``QBankQuestionAudio`` row for ``(bank_id, language)``. Otherwise
+    ``batch_generate``'s ``skip_ready`` gate keeps stale pre-NLLB audio
+    (French text synthesized with target-language phonology = the
+    original gibberish from #1670/#1693) in place forever (#1696).
+    With the audio rows gone, the audio task re-synthesizes using the
+    fresh translation.
     """
     from celery import chain as celery_chain
+    from sqlalchemy import select
 
+    from app.domain.models.question_bank import QBankQuestion, QBankQuestionAudio
     from app.domain.services.organization_service import OrganizationService
     from app.tasks.qbank_processing import (
         generate_qbank_audio_task,
@@ -686,6 +694,25 @@ async def backfill_bank_translations(
     await OrganizationService().require_org_role(
         db, bank.organization_id, uuid.UUID(current_user.id)
     )
+
+    question_ids = (
+        (
+            await db.execute(
+                select(QBankQuestion.id).where(QBankQuestion.question_bank_id == bank_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if question_ids:
+        await db.execute(
+            QBankQuestionAudio.__table__.delete().where(
+                QBankQuestionAudio.question_id.in_(question_ids),
+                QBankQuestionAudio.language == language,
+            )
+        )
+        await db.commit()
+
     task = celery_chain(
         translate_qbank_bank_task.si(str(bank_id), language),
         generate_qbank_audio_task.si(str(bank_id), language),

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -68,7 +68,12 @@ services:
     deploy:
       resources:
         limits:
-          memory: 4G
+          # distilled-600M ~2.4 GB FP32 weights + transformers runtime +
+          # activations during generate() easily exceeds 4 GB on first
+          # forward pass, triggering container OOM + restart loop that
+          # makes /health time out (#1696 follow-up). 8 GB covers load
+          # + peak generate comfortably.
+          memory: 8G
 
   backend:
     image: ghcr.io/benidrissa/etutor-digital-ph/backend:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,12 @@ services:
     deploy:
       resources:
         limits:
-          memory: 4G
+          # distilled-600M ~2.4 GB FP32 weights + transformers runtime +
+          # activations during generate() easily exceeds 4 GB on first
+          # forward pass, triggering container OOM + restart loop that
+          # makes /health time out (#1696 follow-up). 8 GB covers load
+          # + peak generate comfortably.
+          memory: 8G
 
   backend:
     build:


### PR DESCRIPTION
Bumps NLLB sidecar memory (was OOM-looping, making /health time out) + /backfill now wipes stale audio rows so regen actually runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)