### PR TITLE
fix(qbank): NLLB server semaphore + shorter decode + 180s timeouts

### DIFF
--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -815,18 +815,25 @@ async def debug_nllb_probe(
     except Exception as exc:
         result["mms_dns_error"] = f"{type(exc).__name__}: {exc}"
 
-    # NLLB health + translate probe
+    # NLLB health + translate probe. The translate side needs a long
+    # timeout — CPU greedy decode on distilled-600M can push past 60s
+    # when several requests are backed up behind the sidecar's single
+    # generate worker.
+    import time as _time
+
     try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(timeout=180.0) as client:
             health = await client.get(f"{base_url}/health")
             result["nllb_health_status"] = health.status_code
             result["nllb_health_body"] = health.text[:300]
+            t_start = _time.monotonic()
             translate = await client.post(
                 f"{base_url}/translate",
                 json={"texts": [text], "src": src_code, "tgt": tgt_code},
             )
             result["nllb_translate_status"] = translate.status_code
             result["nllb_translate_body"] = translate.text[:500]
+            result["nllb_translate_elapsed_ms"] = int((_time.monotonic() - t_start) * 1000)
     except Exception as exc:
         result["nllb_error"] = f"{type(exc).__name__}: {exc!r}"
 

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -95,9 +95,11 @@ class Settings(BaseSettings):
     mms_tts_timeout_seconds: float = 60.0
 
     # Meta NLLB-200 translation sidecar — translates French qbank text
-    # into mos/dyu/bam/ful before MMS TTS synthesizes (#1690).
+    # into mos/dyu/bam/ful before MMS TTS synthesizes (#1690). CPU
+    # inference of distilled-600M is slow; timeout must cover worst-
+    # case 96-token greedy decode under load.
     nllb_url: str = "http://nllb:5060"
-    nllb_timeout_seconds: float = 60.0
+    nllb_timeout_seconds: float = 180.0
     nllb_model: str = "distilled-600M"
 
     # MinIO / S3-compatible object storage

--- a/infrastructure/nllb/server.py
+++ b/infrastructure/nllb/server.py
@@ -14,11 +14,13 @@ texts in one forward pass.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import time
 from contextlib import asynccontextmanager
 
+import torch
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
@@ -26,7 +28,15 @@ from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
 
 MAX_INPUT_CHARS = 2000
 MAX_TEXTS_PER_BATCH = 32
-MAX_NEW_TOKENS = 256
+# Short qbank content rarely needs more than ~80 output tokens. A high cap
+# only slows greedy decoding by running past EOS on CPU.
+MAX_NEW_TOKENS = 96
+
+# Serialize generate() calls — PyTorch model forward passes aren't
+# thread-safe in single-worker uvicorn, and without a queue cap a
+# spike of concurrent /translate requests pins the CPU and makes
+# /health time out alongside them.
+_GENERATE_SEMAPHORE = asyncio.Semaphore(1)
 
 # NLLB source/target codes for the qbank pipeline. The sidecar itself is
 # source-agnostic (NLLB-200 handles 200+ languages); the backend picks
@@ -121,15 +131,6 @@ async def translate(req: TranslateRequest) -> TranslateResponse:
     model = _BUNDLE.model
     tokenizer.src_lang = req.src
 
-    started = time.monotonic()
-    inputs = tokenizer(
-        req.texts,
-        return_tensors="pt",
-        padding=True,
-        truncation=True,
-        max_length=MAX_INPUT_CHARS,
-    )
-
     # NLLB forced_bos_token_id selects the target language at generation
     # time. ``convert_tokens_to_ids`` is the supported way to retrieve it
     # across transformers versions.
@@ -137,14 +138,27 @@ async def translate(req: TranslateRequest) -> TranslateResponse:
     if tgt_id is None or tgt_id == tokenizer.unk_token_id:
         raise HTTPException(status_code=400, detail=f"unknown target lang: {req.tgt}")
 
-    generated = model.generate(
-        **inputs,
-        forced_bos_token_id=tgt_id,
-        max_new_tokens=MAX_NEW_TOKENS,
-        num_beams=1,
-    )
-    translations = tokenizer.batch_decode(generated, skip_special_tokens=True)
-    elapsed_ms = int((time.monotonic() - started) * 1000)
+    async with _GENERATE_SEMAPHORE:
+        started = time.monotonic()
+        inputs = tokenizer(
+            req.texts,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=MAX_INPUT_CHARS,
+        )
+
+        # ``inference_mode`` disables autograd tracking, reducing memory
+        # and modest speedup vs ``no_grad`` on CPU.
+        with torch.inference_mode():
+            generated = model.generate(
+                **inputs,
+                forced_bos_token_id=tgt_id,
+                max_new_tokens=MAX_NEW_TOKENS,
+                num_beams=1,
+            )
+        translations = tokenizer.batch_decode(generated, skip_special_tokens=True)
+        elapsed_ms = int((time.monotonic() - started) * 1000)
 
     logger.info(
         "translate src=%s tgt=%s batch=%d elapsed_ms=%d",


### PR DESCRIPTION
CPU inference of distilled-600M backed up under load when older requests weren't cancelled after client timeout. This PR caps max_new_tokens at 96, serializes generate() with a server-side asyncio semaphore, wraps with torch.inference_mode, and bumps all NLLB client timeouts to 180s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)