### PR TITLE
feat(qbank): cross-org discovery page + nav menu entry (#1692)

### DIFF
--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -94,9 +94,24 @@ def _audio_url_for(
 
 
 def _bank_response(bank, question_count: int = 0, test_count: int = 0):
+    # Org name/slug are populated only when the relationship is already
+    # loaded on the bank (e.g. the cross-org accessible-banks list).
+    # For single-bank endpoints where the relationship isn't eager-
+    # loaded, accessing it would trigger a detached-instance error, so
+    # fall back to None silently.
+    org_name = None
+    org_slug = None
+    try:
+        if getattr(bank, "organization", None) is not None:
+            org_name = bank.organization.name
+            org_slug = bank.organization.slug
+    except Exception:
+        pass
     return QuestionBankResponse(
         id=str(bank.id),
         organization_id=str(bank.organization_id),
+        organization_name=org_name,
+        organization_slug=org_slug,
         title=bank.title,
         description=bank.description,
         bank_type=bank.bank_type.value if hasattr(bank.bank_type, "value") else bank.bank_type,
@@ -198,6 +213,27 @@ async def list_banks(
     db=Depends(get_db_session),
 ):
     items = await _svc.list_org_banks(db, org_id)
+    return [
+        _bank_response(item["bank"], item["question_count"], item["test_count"]) for item in items
+    ]
+
+
+@router.get("/banks/accessible", response_model=list[QuestionBankResponse])
+async def list_accessible_banks(
+    include_drafts: bool = Query(False, description="Include draft banks (owner/admin view)."),
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    """Every question bank the user can reach across all their orgs (#1692).
+
+    Used by the top-level ``/fr/qbank`` discovery page so learners don't
+    have to drill Organizations → org → Question Banks for every bank
+    they might want to practice. Defaults to published banks only;
+    admins can set ``include_drafts=true`` for admin UIs.
+    """
+    items = await _svc.list_accessible_banks(
+        db, uuid.UUID(current_user.id), include_drafts=include_drafts
+    )
     return [
         _bank_response(item["bank"], item["question_count"], item["test_count"]) for item in items
     ]

--- a/backend/app/api/v1/schemas/qbank.py
+++ b/backend/app/api/v1/schemas/qbank.py
@@ -33,6 +33,12 @@ class QuestionBankUpdate(BaseModel):
 class QuestionBankResponse(BaseModel):
     id: str
     organization_id: str
+    # ``organization_name`` + ``organization_slug`` are populated by
+    # ``_bank_response`` when the org relationship is preloaded. The
+    # cross-org discovery page (#1692) relies on these so the
+    # frontend doesn't need to fetch every org separately.
+    organization_name: str | None = None
+    organization_slug: str | None = None
     title: str
     description: str | None = None
     bank_type: str

--- a/backend/app/domain/services/qbank_service.py
+++ b/backend/app/domain/services/qbank_service.py
@@ -123,6 +123,62 @@ class QBankService:
             .order_by(QuestionBank.created_at.desc())
         )
         banks = result.scalars().all()
+        return await self._enrich_banks(db, banks)
+
+    async def list_accessible_banks(
+        self,
+        db: AsyncSession,
+        user_id: uuid.UUID,
+        *,
+        include_drafts: bool = False,
+    ) -> list[dict]:
+        """Return banks across every org the user is a member of (#1692).
+
+        By default limits to ``status=published`` so learners don't see
+        banks admins are still editing. Admins can flip ``include_drafts``
+        when building an admin dashboard.
+        """
+        from sqlalchemy.orm import selectinload
+
+        from app.domain.models.organization import OrganizationMember
+        from app.domain.models.question_bank import QuestionBankStatus
+
+        user_orgs = (
+            (
+                await db.execute(
+                    select(OrganizationMember.organization_id).where(
+                        OrganizationMember.user_id == user_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        if not user_orgs:
+            return []
+
+        filters = [QuestionBank.organization_id.in_(user_orgs)]
+        if not include_drafts:
+            filters.append(QuestionBank.status == QuestionBankStatus.published)
+
+        banks = (
+            (
+                await db.execute(
+                    select(QuestionBank)
+                    .where(*filters)
+                    .options(selectinload(QuestionBank.organization))
+                    .order_by(QuestionBank.created_at.desc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        return await self._enrich_banks(db, banks)
+
+    async def _enrich_banks(self, db: AsyncSession, banks: list[QuestionBank]) -> list[dict]:
+        """Attach question + test counts to a list of banks."""
         out = []
         for bank in banks:
             q_count = await db.scalar(

--- a/frontend/app/[locale]/(app)/qbank/client.tsx
+++ b/frontend/app/[locale]/(app)/qbank/client.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import { Brain, Building2, ClipboardList, Loader2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import {
+  listAccessibleQBanks,
+  type QBankBank,
+  type QBankType,
+} from "@/lib/api";
+
+const TYPE_KEY: Record<QBankType, string> = {
+  driving: "typeDriving",
+  exam_prep: "typeExamPrep",
+  psychotechnic: "typePsychotechnic",
+  general_culture: "typeGeneralCulture",
+};
+
+const PILL_COLORS: Record<QBankType, string> = {
+  driving: "bg-blue-100 text-blue-700",
+  exam_prep: "bg-indigo-100 text-indigo-700",
+  psychotechnic: "bg-purple-100 text-purple-700",
+  general_culture: "bg-amber-100 text-amber-700",
+};
+
+export function QBankDiscoveryClient() {
+  const locale = useLocale();
+  const t = useTranslations("qbank");
+  const tNav = useTranslations("Navigation");
+  const [banks, setBanks] = useState<QBankBank[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [typeFilter, setTypeFilter] = useState<QBankType | "all">("all");
+
+  useEffect(() => {
+    let cancelled = false;
+    listAccessibleQBanks()
+      .then((rows) => {
+        if (cancelled) return;
+        setBanks(rows);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Load failed");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const filtered = useMemo(() => {
+    if (typeFilter === "all") return banks;
+    return banks.filter((b) => b.bank_type === typeFilter);
+  }, [banks, typeFilter]);
+
+  // Group by organization so learners see which org owns each bank.
+  const groupedByOrg = useMemo(() => {
+    const groups: Record<
+      string,
+      { orgId: string; orgName: string; orgSlug: string | null; banks: QBankBank[] }
+    > = {};
+    for (const bank of filtered) {
+      const key = bank.organization_id;
+      if (!groups[key]) {
+        groups[key] = {
+          orgId: bank.organization_id,
+          orgName: bank.organization_name ?? "—",
+          orgSlug: bank.organization_slug ?? null,
+          banks: [],
+        };
+      }
+      groups[key].banks.push(bank);
+    }
+    return Object.values(groups);
+  }, [filtered]);
+
+  return (
+    <div className="mx-auto w-full max-w-5xl px-4 py-6 sm:py-8">
+      <header className="mb-6 flex flex-col gap-2 sm:mb-8">
+        <div className="flex items-center gap-2">
+          <Brain className="h-6 w-6 text-primary" aria-hidden />
+          <h1 className="text-2xl font-bold sm:text-3xl">{tNav("qbank")}</h1>
+        </div>
+        <p className="text-sm text-muted-foreground sm:text-base">
+          {t("discoveryIntro")}
+        </p>
+      </header>
+
+      <div className="mb-4 flex flex-wrap gap-2 sm:mb-6">
+        <FilterChip
+          active={typeFilter === "all"}
+          onClick={() => setTypeFilter("all")}
+          label={t("filterAllTypes")}
+        />
+        {(Object.keys(TYPE_KEY) as QBankType[]).map((type) => (
+          <FilterChip
+            key={type}
+            active={typeFilter === type}
+            onClick={() => setTypeFilter(type)}
+            label={t(TYPE_KEY[type])}
+          />
+        ))}
+      </div>
+
+      {loading && (
+        <div className="flex min-h-[40vh] items-center justify-center">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {!loading && error && (
+        <p className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+          {error}
+        </p>
+      )}
+
+      {!loading && !error && filtered.length === 0 && (
+        <p className="rounded-lg border border-dashed border-muted-foreground/30 p-8 text-center text-sm text-muted-foreground">
+          {t("discoveryEmpty")}
+        </p>
+      )}
+
+      {!loading && !error && groupedByOrg.length > 0 && (
+        <div className="space-y-6">
+          {groupedByOrg.map((group) => (
+            <section key={group.orgId} className="space-y-2">
+              <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                <Building2 className="h-4 w-4" aria-hidden />
+                <span>{group.orgName}</span>
+                {group.orgSlug && (
+                  <Link
+                    href={`/${locale}/org/${group.orgSlug}`}
+                    className="text-primary underline-offset-2 hover:underline"
+                  >
+                    {t("discoveryOrgLink")}
+                  </Link>
+                )}
+              </div>
+              <ul className="grid gap-3 sm:grid-cols-2">
+                {group.banks.map((bank) => (
+                  <li key={bank.id}>
+                    <Link
+                      href={
+                        group.orgSlug
+                          ? `/${locale}/org/${group.orgSlug}/qbank/${bank.id}`
+                          : `/${locale}/qbank/banks/${bank.id}`
+                      }
+                      className="flex h-full flex-col gap-2 rounded-lg border bg-card p-4 transition-colors hover:border-primary/50 hover:bg-muted/50"
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <h2 className="text-base font-semibold leading-snug">
+                          {bank.title}
+                        </h2>
+                        <Badge
+                          className={`${PILL_COLORS[bank.bank_type]} shrink-0`}
+                          variant="secondary"
+                        >
+                          {t(TYPE_KEY[bank.bank_type])}
+                        </Badge>
+                      </div>
+                      {bank.description && (
+                        <p className="line-clamp-2 text-xs text-muted-foreground">
+                          {bank.description}
+                        </p>
+                      )}
+                      <div className="mt-auto flex items-center gap-3 text-xs text-muted-foreground">
+                        <span className="flex items-center gap-1">
+                          <ClipboardList className="h-3.5 w-3.5" aria-hidden />
+                          {t("questionCount", { count: bank.question_count })}
+                        </span>
+                        <span>
+                          {t("testCount", { count: bank.test_count })}
+                        </span>
+                        <span>
+                          {bank.time_per_question_sec}s / {t("perQuestion")}
+                        </span>
+                      </div>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FilterChip({
+  active,
+  onClick,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={
+        active
+          ? "rounded-full border border-primary bg-primary px-3 py-1 text-xs font-medium text-primary-foreground sm:text-sm"
+          : "rounded-full border border-border bg-background px-3 py-1 text-xs font-medium hover:border-primary/50 sm:text-sm"
+      }
+    >
+      {label}
+    </button>
+  );
+}

--- a/frontend/app/[locale]/(app)/qbank/page.tsx
+++ b/frontend/app/[locale]/(app)/qbank/page.tsx
@@ -1,0 +1,5 @@
+import { QBankDiscoveryClient } from "./client";
+
+export default function QBankDiscoveryPage() {
+  return <QBankDiscoveryClient />;
+}

--- a/frontend/components/layout/bottom-nav.tsx
+++ b/frontend/components/layout/bottom-nav.tsx
@@ -8,6 +8,7 @@ import {
   GraduationCap,
   CreditCard,
   Bot,
+  Brain,
   MoreHorizontal,
   BookOpen,
   User,
@@ -85,6 +86,12 @@ export function BottomNav() {
       label: t("modules"),
       icon: BookOpen,
       description: t("modulesDescription"),
+    },
+    {
+      href: `/${locale}/qbank`,
+      label: t("qbank"),
+      icon: Brain,
+      description: t("qbankDescription"),
     },
     {
       href: `/${locale}/profile`,

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -10,6 +10,7 @@ import {
   GraduationCap,
   CreditCard,
   Bot,
+  Brain,
   User,
   ChevronLeft,
   ChevronRight,
@@ -110,6 +111,12 @@ export function Sidebar() {
       label: t("flashcards"),
       icon: CreditCard,
       description: t("flashcardsDescription")
+    },
+    {
+      href: `/${locale}/qbank`,
+      label: t("qbank"),
+      icon: Brain,
+      description: t("qbankDescription")
     },
     {
       href: `/${locale}/certificates`,

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1615,6 +1615,9 @@ export type QBankTestMode = "exam" | "training" | "review";
 export interface QBankBank {
   id: string;
   organization_id: string;
+  /** Populated by the cross-org ``/banks/accessible`` endpoint (#1692). */
+  organization_name?: string | null;
+  organization_slug?: string | null;
   title: string;
   description: string | null;
   bank_type: QBankType;
@@ -1717,6 +1720,14 @@ export interface QBankProcessingStatus {
 
 export async function listQBankBanks(orgId: string): Promise<QBankBank[]> {
   return apiFetch<QBankBank[]>(`/api/v1/qbank/banks?org_id=${orgId}`);
+}
+
+/** Every qbank the current user can reach across all their orgs (#1692). */
+export async function listAccessibleQBanks(options?: {
+  includeDrafts?: boolean;
+}): Promise<QBankBank[]> {
+  const qs = options?.includeDrafts ? "?include_drafts=true" : "";
+  return apiFetch<QBankBank[]>(`/api/v1/qbank/banks/accessible${qs}`);
 }
 
 export async function createQBankBank(body: QBankBankCreate): Promise<QBankBank> {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -48,7 +48,9 @@
     "organizations": "Organizations",
     "organizationsDescription": "Manage your organizations",
     "certificates": "Certificates",
-    "certificatesDescription": "View your earned certificates"
+    "certificatesDescription": "View your earned certificates",
+    "qbank": "Question Banks",
+    "qbankDescription": "Practice question banks from your organizations"
   },
   "Auth": {
     "login": "Sign in",
@@ -2012,6 +2014,11 @@
     "newBank": "New bank",
     "allTypes": "All types",
     "noBanks": "No question banks yet. Create one to get started.",
+    "discoveryIntro": "Published question banks from every organization you belong to.",
+    "discoveryEmpty": "No published question banks are available yet. Join an organization or ask your admin to publish one.",
+    "discoveryOrgLink": "Open organization",
+    "filterAllTypes": "All types",
+    "perQuestion": "question",
     "typeDriving": "Driving school",
     "typeExamPrep": "Exam prep",
     "typePsychotechnic": "Psychotechnic",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -48,7 +48,9 @@
     "organizations": "Organisations",
     "organizationsDescription": "Gérer vos organisations",
     "certificates": "Certificats",
-    "certificatesDescription": "Consultez vos certificats obtenus"
+    "certificatesDescription": "Consultez vos certificats obtenus",
+    "qbank": "Banques de questions",
+    "qbankDescription": "Entraînez-vous sur les banques de questions de vos organisations"
   },
   "Auth": {
     "login": "Se connecter",
@@ -2012,6 +2014,11 @@
     "newBank": "Nouvelle banque",
     "allTypes": "Tous les types",
     "noBanks": "Aucune banque de questions pour l'instant. Créez-en une pour commencer.",
+    "discoveryIntro": "Banques de questions publiées de toutes vos organisations.",
+    "discoveryEmpty": "Aucune banque de questions publiée pour l'instant. Rejoignez une organisation ou demandez à votre admin d'en publier une.",
+    "discoveryOrgLink": "Ouvrir l'organisation",
+    "filterAllTypes": "Tous les types",
+    "perQuestion": "question",
     "typeDriving": "Auto-école",
     "typeExamPrep": "Préparation aux examens",
     "typePsychotechnic": "Psychotechnique",


### PR DESCRIPTION
## Summary
- Backend: \`GET /qbank/banks/accessible\` returns banks across all user's orgs (+ \`organization_name\`/\`slug\` on responses).
- Frontend: new \`/fr/qbank\` list page grouped by org with type filters.
- Nav: sidebar entry + mobile bottom-nav \"Plus\" overflow.

Fixes #1692

## Test plan
- [x] Backend ruff + pytest (54 passed)
- [x] Frontend tsc + eslint clean
- [ ] Logged-in learner on staging: sidebar shows \"Question Banks\" / \"Banques de questions\", clicking lands on /fr/qbank with all accessible banks grouped by org
- [ ] Mobile viewport: \"Plus\" → Brain icon → qbank
- [ ] \`include_drafts=true\` returns draft banks when called from admin contexts (manual curl with admin token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)