### PR TITLE
feat(qbank): parallelize translate+TTS per question (#1708)

### DIFF
--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -708,23 +708,18 @@ async def backfill_bank_translations(
 ):
     """Backfill NLLB translations for an existing bank, then re-generate audio.
 
-    Before dispatching the translate→audio chain, delete every
-    ``QBankQuestionAudio`` row for ``(bank_id, language)``. Otherwise
-    ``batch_generate``'s ``skip_ready`` gate keeps stale pre-NLLB audio
-    (French text synthesized with target-language phonology = the
-    original gibberish from #1670/#1693) in place forever (#1696).
-    With the audio rows gone, the audio task re-synthesizes using the
-    fresh translation.
+    Delete every stale ``QBankQuestionAudio`` row for
+    ``(bank_id, language)`` up front, then fan out one
+    ``translate_and_synthesize_question_task`` per question (#1708).
+    Per-question tasks let MMS synthesis for question K run in parallel
+    with NLLB translating question K+1 instead of waiting for the whole
+    bank to finish translating.
     """
-    from celery import chain as celery_chain
     from sqlalchemy import select
 
     from app.domain.models.question_bank import QBankQuestion, QBankQuestionAudio
     from app.domain.services.organization_service import OrganizationService
-    from app.tasks.qbank_processing import (
-        generate_qbank_audio_task,
-        translate_qbank_bank_task,
-    )
+    from app.tasks.qbank_processing import translate_and_synthesize_question_task
 
     bank = await _svc.get_bank(db, bank_id)
     await OrganizationService().require_org_role(
@@ -749,11 +744,19 @@ async def backfill_bank_translations(
         )
         await db.commit()
 
-    task = celery_chain(
-        translate_qbank_bank_task.si(str(bank_id), language),
-        generate_qbank_audio_task.si(str(bank_id), language),
-    ).apply_async()
-    return AudioGenerateResponse(task_id=task.id, bank_id=str(bank_id), language=language)
+    task_ids: list[str] = []
+    for qid in question_ids:
+        task = translate_and_synthesize_question_task.delay(str(qid), language)
+        task_ids.append(task.id)
+
+    # Return the first task id for compatibility with the existing
+    # AudioGenerateResponse shape; callers that want full tracking can
+    # poll per-question audio status instead.
+    return AudioGenerateResponse(
+        task_id=task_ids[0] if task_ids else "",
+        bank_id=str(bank_id),
+        language=language,
+    )
 
 
 @router.get(

--- a/backend/app/domain/services/qbank_service.py
+++ b/backend/app/domain/services/qbank_service.py
@@ -25,37 +25,43 @@ logger = structlog.get_logger(__name__)
 _org_svc = OrganizationService()
 
 
-def _enqueue_pregenerate_audio(bank_id: uuid.UUID) -> None:
-    """Fire a Celery task per supported language to pregenerate audio.
+async def _enqueue_pregenerate_audio(db: AsyncSession, bank_id: uuid.UUID) -> None:
+    """Fan-out Celery tasks to translate + synthesize audio (#1708).
 
-    For non-source languages (mos/dyu/bam/ful), chain
-    ``translate_qbank_bank_task`` → ``generate_qbank_audio_task`` so MMS
-    TTS receives native-language text rather than French (#1690). French
-    still runs audio-only since it's the source.
+    Per-question fan-out: for each non-FR target language, enqueue one
+    ``translate_and_synthesize_question_task`` per question. NLLB still
+    serializes (single sidecar worker), but MMS synthesis for question
+    K can now run in parallel with NLLB translating question K+1, and
+    different languages can progress concurrently rather than waiting
+    for a bank-level chain. French skips translation and uses the
+    existing bank-level audio task.
 
-    Kept as a module-level helper so it can be called from ``update_bank``
-    (publish transition) and ``update_question`` (text change) without
-    creating a service cycle. Imports are local so this module stays
-    safe to import in contexts where Celery isn't wired up (e.g. tests
-    that patch the task).
+    Imports are local so this module stays safe to import in contexts
+    where Celery isn't wired up (tests that patch the task).
     """
-    from celery import chain as celery_chain
-
     from app.domain.services.qbank_audio_service import SUPPORTED_LANGUAGES
     from app.domain.services.qbank_translation_service import TARGET_LANGUAGES
     from app.tasks.qbank_processing import (
         generate_qbank_audio_task,
-        translate_qbank_bank_task,
+        translate_and_synthesize_question_task,
     )
 
     bank_id_str = str(bank_id)
+    question_ids = (
+        (
+            await db.execute(
+                select(QBankQuestion.id).where(QBankQuestion.question_bank_id == bank_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
     for language in SUPPORTED_LANGUAGES:
         try:
             if language in TARGET_LANGUAGES:
-                celery_chain(
-                    translate_qbank_bank_task.si(bank_id_str, language),
-                    generate_qbank_audio_task.si(bank_id_str, language),
-                ).apply_async()
+                for qid in question_ids:
+                    translate_and_synthesize_question_task.delay(str(qid), language)
             else:
                 generate_qbank_audio_task.delay(bank_id_str, language)
         except Exception as exc:
@@ -234,7 +240,7 @@ class QBankService:
         # language so learners never wait on the timer for TTS (#1674).
         new_status = bank.status.value if hasattr(bank.status, "value") else bank.status
         if previous_status != "published" and new_status == "published":
-            _enqueue_pregenerate_audio(bank_id)
+            await _enqueue_pregenerate_audio(db, bank_id)
 
         return bank
 
@@ -339,7 +345,7 @@ class QBankService:
             # will trigger fresh NLLB calls for dropped rows (#1690).
             await QBankAudioService().invalidate_question(db, question_id)
             await QBankTranslationService().invalidate_question(db, question_id)
-            _enqueue_pregenerate_audio(question.question_bank_id)
+            await _enqueue_pregenerate_audio(db, question.question_bank_id)
 
         return question
 

--- a/backend/app/tasks/qbank_processing.py
+++ b/backend/app/tasks/qbank_processing.py
@@ -78,6 +78,7 @@ async def _process_pdf_async(task, bank_id: str, pdf_filename: str) -> dict:
     errors = []
     created = 0
 
+    created_question_ids: list[str] = []
     with Session(engine) as session:
         # Get current max order_index for this bank
         from sqlalchemy import func, select
@@ -115,6 +116,8 @@ async def _process_pdf_async(task, bank_id: str, pdf_filename: str) -> dict:
                     category=q.category,
                 )
                 session.add(question)
+                session.flush()  # populate question.id before commit
+                created_question_ids.append(str(question.id))
                 created += 1
 
             except Exception as e:
@@ -135,24 +138,21 @@ async def _process_pdf_async(task, bank_id: str, pdf_filename: str) -> dict:
         errors_count=len(errors),
     )
 
-    # Fire audio pregeneration for every supported language so the first
-    # learner to take a test doesn't wait on the MMS sidecar (#1674).
-    # For non-source languages, chain translate→audio so MMS receives
-    # native-language text rather than French (#1690). Skipped when no
-    # questions were added — nothing to translate or synthesize.
+    # Fire audio pregeneration for every supported language (#1674).
+    # Per-question fan-out (#1708): each non-FR (question, language)
+    # pair becomes its own task, so MMS synthesis for question K can
+    # start as soon as NLLB translation for K is done — no more waiting
+    # for the whole bank to finish translating. French has no
+    # translation step, so it uses the single bank-level task.
     if created:
-        from celery import chain as celery_chain
-
         from app.domain.services.qbank_audio_service import SUPPORTED_LANGUAGES
         from app.domain.services.qbank_translation_service import TARGET_LANGUAGES
 
         for language in SUPPORTED_LANGUAGES:
             try:
                 if language in TARGET_LANGUAGES:
-                    celery_chain(
-                        translate_qbank_bank_task.si(bank_id, language),
-                        generate_qbank_audio_task.si(bank_id, language),
-                    ).apply_async()
+                    for qid in created_question_ids:
+                        translate_and_synthesize_question_task.delay(qid, language)
                 else:
                     generate_qbank_audio_task.delay(bank_id, language)
             except Exception as exc:
@@ -255,3 +255,64 @@ async def _translate_bank_async(bank_id: str, language: str) -> dict:
         result=result,
     )
     return result
+
+
+@celery_app.task(
+    base=QBankTask,
+    bind=True,
+    name="qbank.translate_and_synthesize_question",
+    max_retries=2,
+    default_retry_delay=60,
+    soft_time_limit=600,
+    time_limit=660,
+    rate_limit="20/m",
+)
+def translate_and_synthesize_question_task(self, question_id: str, language: str) -> dict:
+    """Translate one (question, language) pair then synthesize its audio (#1708).
+
+    Per-question fan-out replaces the old bank-level translate→audio
+    chain: as soon as NLLB finishes a single question's translation,
+    the paired MMS synthesis starts for that question, in parallel with
+    NLLB translating the next question. On a multi-worker Celery pool
+    this serializes only on the sidecar side (NLLB semaphore=1, MMS
+    semaphore=2) instead of on the whole 11-question batch.
+    """
+    return asyncio.run(_translate_and_synthesize_question_async(question_id, language))
+
+
+async def _translate_and_synthesize_question_async(question_id: str, language: str) -> dict:
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.domain.services.qbank_audio_service import QBankAudioService
+    from app.domain.services.qbank_translation_service import (
+        QBankTranslationService,
+    )
+    from app.infrastructure.config.settings import settings
+
+    qid = uuid.UUID(question_id)
+    engine = create_async_engine(settings.database_url, echo=False)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    try:
+        async with session_factory() as session:
+            await QBankTranslationService().ensure_translation(session, qid, language)
+        async with session_factory() as session:
+            audio_row = await QBankAudioService().generate_question_audio(session, qid, language)
+    finally:
+        await engine.dispose()
+
+    logger.info(
+        "qbank translate+synth complete",
+        question_id=question_id,
+        language=language,
+        audio_status=audio_row.status.value
+        if hasattr(audio_row.status, "value")
+        else str(audio_row.status),
+    )
+    return {
+        "question_id": question_id,
+        "language": language,
+        "audio_status": audio_row.status.value
+        if hasattr(audio_row.status, "value")
+        else str(audio_row.status),
+    }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -157,7 +157,11 @@ services:
   celery-worker:
     image: ghcr.io/benidrissa/etutor-digital-ph/backend:latest
     container_name: etutor-celery-worker
-    command: uv run celery -A app.tasks.celery_app worker --loglevel=info
+    # --concurrency=4 lets per-question qbank tasks (#1708) fan out:
+    # translate(Qk) for language X can run on one worker while
+    # generate_audio(Qj) for language Y runs on another, bounded by
+    # sidecar semaphores (NLLB=1, MMS=2).
+    command: uv run celery -A app.tasks.celery_app worker --loglevel=info --concurrency=4
     environment:
       DATABASE_URL: postgresql+asyncpg://postgres:${POSTGRES_PASSWORD}@postgres:5432/santepublique_aof
       REDIS_URL: redis://redis:6379/0


### PR DESCRIPTION
Replaces bank-level translate→audio chain with per-question fan-out. MMS synthesis for question K runs in parallel with NLLB translating Q(K+1).

+ celery-worker --concurrency=4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)