### PR TITLE
fix(qbank): migration 071 use correct table name question_banks

### DIFF
--- a/backend/migrations/versions/071_qbank_time_per_question_default_60.py
+++ b/backend/migrations/versions/071_qbank_time_per_question_default_60.py
@@ -1,4 +1,4 @@
-"""Raise qbank_question_banks.time_per_question_sec server_default 25 → 60.
+"""Raise question_banks.time_per_question_sec server_default 25 → 60.
 
 Revision ID: 071
 Revises: 070
@@ -29,19 +29,18 @@ depends_on = None
 
 def upgrade() -> None:
     op.alter_column(
-        "qbank_question_banks",
+        "question_banks",
         "time_per_question_sec",
         server_default=sa.text("60"),
     )
     op.execute(
-        "UPDATE qbank_question_banks SET time_per_question_sec = 60 "
-        "WHERE time_per_question_sec = 25"
+        "UPDATE question_banks SET time_per_question_sec = 60 WHERE time_per_question_sec = 25"
     )
 
 
 def downgrade() -> None:
     op.alter_column(
-        "qbank_question_banks",
+        "question_banks",
         "time_per_question_sec",
         server_default=sa.text("25"),
     )


### PR DESCRIPTION
## Summary
Migration 071 from PR #1715 targeted \`qbank_question_banks\` but the actual table is \`question_banks\` (migration 067). Deploy run [24626263762](https://github.com/Benidrissa/etutor-digital-ph/actions/runs/24626263762) failed with \`UndefinedTableError\`. Transaction rolled back cleanly — no state damage.

Fix is a rename-only, 4 occurrences.

Fixes #1714 deploy.

## Test plan
- [ ] Merge → staging deploys → \`alembic upgrade head\` now passes
- [ ] \`SELECT time_per_question_sec FROM question_banks WHERE id='43fb7500-74b2-4c0f-bb1d-fbd3a8b85e19'\` returns 60
- [ ] Test-taker shows 60s timer

🤖 Generated with [Claude Code](https://claude.com/claude-code)