### PR TITLE
fix(qbank): migration 071 use correct table name question_banks

### DIFF
--- a/backend/migrations/versions/071_qbank_time_per_question_default_60.py
+++ b/backend/migrations/versions/071_qbank_time_per_question_default_60.py
@@ -1,4 +1,4 @@
-"""Raise qbank_question_banks.time_per_question_sec server_default 25 → 60.
+"""Raise question_banks.time_per_question_sec server_default 25 → 60.
 
 Revision ID: 071
 Revises: 070
@@ -29,19 +29,18 @@ depends_on = None
 
 def upgrade() -> None:
     op.alter_column(
-        "qbank_question_banks",
+        "question_banks",
         "time_per_question_sec",
         server_default=sa.text("60"),
     )
     op.execute(
-        "UPDATE qbank_question_banks SET time_per_question_sec = 60 "
-        "WHERE time_per_question_sec = 25"
+        "UPDATE question_banks SET time_per_question_sec = 60 WHERE time_per_question_sec = 25"
     )
 
 
 def downgrade() -> None:
     op.alter_column(
-        "qbank_question_banks",
+        "question_banks",
         "time_per_question_sec",
         server_default=sa.text("25"),
     )


### PR DESCRIPTION
## Summary
Migration 071 (from #1715) targeted \`qbank_question_banks\`; actual table is \`question_banks\`. 4-occurrence rename.

Deploy run [24626263762](https://github.com/Benidrissa/etutor-digital-ph/actions/runs/24626263762) failed with \`UndefinedTableError\`; transaction rolled back cleanly so no state damage. Staging is running pre-#1715 code (deploy never swapped containers).

## Flow note
First \`fix → dev → main\` roundtrip after hard-resetting \`dev\` to \`main\`. Dev had been 17 commits behind main (qbank hotfix chain #1704–#1712) and 15 ahead with mostly duplicate squashes, making the original sync PR #1713 unmergeable. Now both branches share \`21a6aff\` as their base.

Fixes #1714

## Test plan
- [ ] Merge → dev→main roundtrip PR → main push → staging deploy
- [ ] \`alembic upgrade head\` succeeds (migration 071 applies)
- [ ] Staging test-taker shows 60s timer
- [ ] Autoplay + rate persistence from #1715 now live

🤖 Generated with [Claude Code](https://claude.com/claude-code)