### PR TITLE
chore: sync dev → main (migration 071 table-name fix, #1714)

### DIFF
--- a/backend/migrations/versions/071_qbank_time_per_question_default_60.py
+++ b/backend/migrations/versions/071_qbank_time_per_question_default_60.py
@@ -1,4 +1,4 @@
-"""Raise qbank_question_banks.time_per_question_sec server_default 25 → 60.
+"""Raise question_banks.time_per_question_sec server_default 25 → 60.
 
 Revision ID: 071
 Revises: 070
@@ -29,19 +29,18 @@ depends_on = None
 
 def upgrade() -> None:
     op.alter_column(
-        "qbank_question_banks",
+        "question_banks",
         "time_per_question_sec",
         server_default=sa.text("60"),
     )
     op.execute(
-        "UPDATE qbank_question_banks SET time_per_question_sec = 60 "
-        "WHERE time_per_question_sec = 25"
+        "UPDATE question_banks SET time_per_question_sec = 60 WHERE time_per_question_sec = 25"
     )
 
 
 def downgrade() -> None:
     op.alter_column(
-        "qbank_question_banks",
+        "question_banks",
         "time_per_question_sec",
         server_default=sa.text("25"),
     )


### PR DESCRIPTION
## Summary
First \`dev → main\` roundtrip after resyncing dev to main. Only substantive change: the migration 071 table-name hotfix (renamed \`qbank_question_banks\` → \`question_banks\` in 4 places) landed on dev via #1717.

## Why this is one-liner
Before the sync, \`dev\` was 17 commits behind and 15 ahead with mostly duplicate squashes of the same qbank hotfix chain (#1704–#1712, #1715). After hard-resetting dev to main + landing #1717, dev is exactly \`main + 1 commit\`, so this PR is a fast-forward.

Fixes #1714 deploy.

## Test plan
- [ ] Admin-squash merge → main push
- [ ] Staging deploy: \`alembic upgrade head\` applies migration 071 successfully
- [ ] Containers swap; staging serves the new frontend (#1715)
- [ ] Test-taker shows 60s timer and audio autoplay works across questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)