### PR TITLE
fix(qbank): normalize MMS TTS script to match tokenizer vocab (#1719)

### DIFF
--- a/backend/app/domain/services/qbank_audio_service.py
+++ b/backend/app/domain/services/qbank_audio_service.py
@@ -12,6 +12,7 @@ them. File size target is ~50 KB per 30s clip (Opus @ 24 kbps).
 
 from __future__ import annotations
 
+import re
 import uuid
 from typing import Literal
 
@@ -45,6 +46,31 @@ OPUS_CONTENT_TYPE = "audio/ogg"
 OPUS_BYTES_PER_SECOND = 6 * 1024  # matches LessonAudioService._estimate_duration
 
 
+_MMS_PUNCT_RE = re.compile(r"[^\w\s'\-]+", flags=re.UNICODE)
+_MMS_SPACES_RE = re.compile(r"\s+")
+
+
+def _normalize_for_mms(text: str) -> str:
+    """Strip characters the Meta MMS VITS tokenizer can't encode (#1719).
+
+    facebook/mms-tts-{mos,dyu,bam,ful} have 32-token character vocabs:
+    lowercase letters, a few language-specific diacritics (ɛ, ɔ, ɲ, ŋ,
+    ɓ, ɗ, ʋ, ã, ẽ, ĩ, õ, ũ…), plus ``'``, ``-``, space. Anything else —
+    including ``? . , : ; !`` and uppercase — becomes an ``<unk>`` token
+    that the model renders as noise or silence. VITS learns prosody from
+    the ``add_blank`` pad tokens the tokenizer interleaves between
+    characters, so stripping punctuation doesn't hurt intelligibility.
+
+    This normalization replaces every non-word, non-hyphen, non-apostrophe
+    character with a single space and collapses repeats. Uppercase is
+    handled by the tokenizer itself (``normalize_text`` lowercases), but
+    we do it here too for clarity in logs.
+    """
+    lowered = (text or "").lower()
+    squashed = _MMS_PUNCT_RE.sub(" ", lowered)
+    return _MMS_SPACES_RE.sub(" ", squashed).strip()
+
+
 def build_audio_script(
     question: QBankQuestion,
     language: str,
@@ -60,6 +86,10 @@ def build_audio_script(
     the raw ``question.question_text`` falls through, which is correct
     for ``fr`` (source) but produces gibberish if fed into an MMS model
     for mos/dyu/bam/ful.
+
+    For MMS target languages the final script is passed through
+    ``_normalize_for_mms`` so the per-language character vocab sees only
+    tokens it can encode (#1719).
     """
     prefixes = {
         "fr": "Option",
@@ -81,7 +111,11 @@ def build_audio_script(
     for idx, opt in enumerate(options):
         letter = chr(ord("A") + idx)
         parts.append(f"{prefix} {letter}: {opt}")
-    return ". ".join(p for p in parts if p).strip() + "."
+    script = ". ".join(p for p in parts if p).strip() + "."
+
+    if language != "fr":
+        script = _normalize_for_mms(script)
+    return script
 
 
 def estimate_duration_seconds(audio_bytes: int) -> int:

--- a/backend/tests/test_qbank_audio_service.py
+++ b/backend/tests/test_qbank_audio_service.py
@@ -39,16 +39,44 @@ def test_build_audio_script_french_prefix():
 
 
 def test_build_audio_script_mms_languages_use_native_prefix():
+    # MMS VITS vocab is lowercase-only, no punctuation. build_audio_script
+    # normalizes so the prefix ends up lowercase and the A/B label too.
     q = _FakeQuestion("Question", ["A", "B"])
     for lang, prefix in [
-        ("mos", "Tʋʋmde"),
-        ("dyu", "Sugandili"),
-        ("bam", "Sugandili"),
-        ("ful", "Suɓaande"),
+        ("mos", "tʋʋmde"),
+        ("dyu", "sugandili"),
+        ("bam", "sugandili"),
+        ("ful", "suɓaande"),
     ]:
         script = build_audio_script(q, lang)
-        assert f"{prefix} A" in script
-        assert f"{prefix} B" in script
+        assert f"{prefix} a" in script
+        assert f"{prefix} b" in script
+        # No punctuation the MMS tokenizer cannot encode.
+        assert "?" not in script
+        assert "." not in script
+        assert ":" not in script
+        assert "," not in script
+        # No uppercase letters either.
+        assert script == script.lower()
+
+
+def test_build_audio_script_mms_strips_punctuation_from_translation():
+    """Real-world case: stored dyu translation has `?` and `'` etc."""
+    from types import SimpleNamespace
+
+    q = _FakeQuestion("QUE T'INDIQUE CE PANNEAU ?", ["Oui.", "Non."])
+    tr = SimpleNamespace(
+        question_text="I ka kan k'a kɛ cogo di o koo ɲɔgɔn na?",
+        options=["O ye mun lo yira i la?", "A b'a fɔ i ye."],
+    )
+    script = build_audio_script(q, "dyu", translation=tr)
+    # Apostrophe survives (in MMS vocab); question mark stripped to space.
+    assert "k'a" in script
+    assert "ɲɔgɔn" in script
+    assert "?" not in script
+    assert script == script.lower()
+    # Collapsed spaces — no double spaces.
+    assert "  " not in script
 
 
 def test_build_audio_script_handles_empty_options():


### PR DESCRIPTION
## Summary
The Meta MMS VITS models for **mos/dyu/bam/ful** have 32-token character vocabs: lowercase letters + language-specific diacritics (ɛ, ɔ, ɲ, ŋ, ɓ, ɗ, ʋ, ã, etc.) + apostrophe, hyphen, space. Every other character — including \`? . , : ; !\` and uppercase — becomes \`<unk>\` at tokenization time, which the model renders as brief silence or noise.

**Result on staging:** a Dioula native speaker hears the audio as \"French with Dioula phonology\" because the \`<unk>\` noises at sentence boundaries sound like French prosody glitches layered over otherwise-correct Dioula phonemes.

## Evidence
- \`facebook/mms-tts-dyu/vocab.json\` = 32 tokens, no punctuation except \`' - _\`
- \`tokenizer_config.json\`: \`normalize=true\`, \`phonemize=false\`, \`is_uroman=false\`, \`unk_token=\"<unk>\"\`
- \`VitsTokenizer._convert_token_to_id\` returns \`unk_token_id\` for anything outside \`encoder\`

For the stored dyu translation \`\"I ka kan k'a kɛ cogo di o koo ɲɔgɔn na?\"\` + options with prefixes, the MMS input contained **7 \`<unk>\` positions** (\`?\` × 2, \`.\` × 3, \`:\` × 2).

## Fix
\`_normalize_for_mms(text)\` lowercases, replaces every non-word + non-\`'\` + non-\`-\` character with a single space, and collapses repeats. Applied to the final script for non-FR languages after prefixes are added. French path (OpenAI TTS) is unchanged.

**Before:**
\`\`\`
I ka kan k'a kɛ cogo di o koo ɲɔgɔn na?. Sugandili A: I be filɛli kɛ fan bɛɛ la...
\`\`\`

**After:**
\`\`\`
i ka kan k'a kɛ cogo di o koo ɲɔgɔn na sugandili a i be filɛli kɛ fan bɛɛ la...
\`\`\`

VITS learns prosody from the \`add_blank\` pad token the tokenizer interleaves between characters — punctuation-less training is the MMS norm, so stripping doesn't hurt intelligibility.

## Test plan
- [x] Unit tests in \`test_qbank_audio_service.py\` updated + pass
- [ ] dev → main sync → staging deploys
- [ ] POST \`/qbank/banks/43fb7500…/translations/backfill?language=dyu\` regenerates audio
- [ ] Native Dioula speaker listens — should hear actual Dioula, not French-phonology noise

Fixes #1719

🤖 Generated with [Claude Code](https://claude.com/claude-code)