### PR TITLE
chore: sync dev → main (MMS punct normalize, #1721)

### DIFF
--- a/backend/app/domain/services/qbank_audio_service.py
+++ b/backend/app/domain/services/qbank_audio_service.py
@@ -12,6 +12,7 @@ them. File size target is ~50 KB per 30s clip (Opus @ 24 kbps).
 
 from __future__ import annotations
 
+import re
 import uuid
 from typing import Literal
 
@@ -45,6 +46,31 @@ OPUS_CONTENT_TYPE = "audio/ogg"
 OPUS_BYTES_PER_SECOND = 6 * 1024  # matches LessonAudioService._estimate_duration
 
 
+_MMS_PUNCT_RE = re.compile(r"[^\w\s'\-]+", flags=re.UNICODE)
+_MMS_SPACES_RE = re.compile(r"\s+")
+
+
+def _normalize_for_mms(text: str) -> str:
+    """Strip characters the Meta MMS VITS tokenizer can't encode (#1719).
+
+    facebook/mms-tts-{mos,dyu,bam,ful} have 32-token character vocabs:
+    lowercase letters, a few language-specific diacritics (ɛ, ɔ, ɲ, ŋ,
+    ɓ, ɗ, ʋ, ã, ẽ, ĩ, õ, ũ…), plus ``'``, ``-``, space. Anything else —
+    including ``? . , : ; !`` and uppercase — becomes an ``<unk>`` token
+    that the model renders as noise or silence. VITS learns prosody from
+    the ``add_blank`` pad tokens the tokenizer interleaves between
+    characters, so stripping punctuation doesn't hurt intelligibility.
+
+    This normalization replaces every non-word, non-hyphen, non-apostrophe
+    character with a single space and collapses repeats. Uppercase is
+    handled by the tokenizer itself (``normalize_text`` lowercases), but
+    we do it here too for clarity in logs.
+    """
+    lowered = (text or "").lower()
+    squashed = _MMS_PUNCT_RE.sub(" ", lowered)
+    return _MMS_SPACES_RE.sub(" ", squashed).strip()
+
+
 def build_audio_script(
     question: QBankQuestion,
     language: str,
@@ -60,6 +86,10 @@ def build_audio_script(
     the raw ``question.question_text`` falls through, which is correct
     for ``fr`` (source) but produces gibberish if fed into an MMS model
     for mos/dyu/bam/ful.
+
+    For MMS target languages the final script is passed through
+    ``_normalize_for_mms`` so the per-language character vocab sees only
+    tokens it can encode (#1719).
     """
     prefixes = {
         "fr": "Option",
@@ -81,7 +111,11 @@ def build_audio_script(
     for idx, opt in enumerate(options):
         letter = chr(ord("A") + idx)
         parts.append(f"{prefix} {letter}: {opt}")
-    return ". ".join(p for p in parts if p).strip() + "."
+    script = ". ".join(p for p in parts if p).strip() + "."
+
+    if language != "fr":
+        script = _normalize_for_mms(script)
+    return script
 
 
 def estimate_duration_seconds(audio_bytes: int) -> int:

--- a/backend/migrations/versions/071_qbank_time_per_question_default_60.py
+++ b/backend/migrations/versions/071_qbank_time_per_question_default_60.py
@@ -1,4 +1,4 @@
-"""Raise qbank_question_banks.time_per_question_sec server_default 25 → 60.
+"""Raise question_banks.time_per_question_sec server_default 25 → 60.
 
 Revision ID: 071
 Revises: 070
@@ -29,19 +29,18 @@ depends_on = None
 
 def upgrade() -> None:
     op.alter_column(
-        "qbank_question_banks",
+        "question_banks",
         "time_per_question_sec",
         server_default=sa.text("60"),
     )
     op.execute(
-        "UPDATE qbank_question_banks SET time_per_question_sec = 60 "
-        "WHERE time_per_question_sec = 25"
+        "UPDATE question_banks SET time_per_question_sec = 60 WHERE time_per_question_sec = 25"
     )
 
 
 def downgrade() -> None:
     op.alter_column(
-        "qbank_question_banks",
+        "question_banks",
         "time_per_question_sec",
         server_default=sa.text("25"),
     )

--- a/backend/tests/test_qbank_audio_service.py
+++ b/backend/tests/test_qbank_audio_service.py
@@ -39,16 +39,44 @@ def test_build_audio_script_french_prefix():
 
 
 def test_build_audio_script_mms_languages_use_native_prefix():
+    # MMS VITS vocab is lowercase-only, no punctuation. build_audio_script
+    # normalizes so the prefix ends up lowercase and the A/B label too.
     q = _FakeQuestion("Question", ["A", "B"])
     for lang, prefix in [
-        ("mos", "Tʋʋmde"),
-        ("dyu", "Sugandili"),
-        ("bam", "Sugandili"),
-        ("ful", "Suɓaande"),
+        ("mos", "tʋʋmde"),
+        ("dyu", "sugandili"),
+        ("bam", "sugandili"),
+        ("ful", "suɓaande"),
     ]:
         script = build_audio_script(q, lang)
-        assert f"{prefix} A" in script
-        assert f"{prefix} B" in script
+        assert f"{prefix} a" in script
+        assert f"{prefix} b" in script
+        # No punctuation the MMS tokenizer cannot encode.
+        assert "?" not in script
+        assert "." not in script
+        assert ":" not in script
+        assert "," not in script
+        # No uppercase letters either.
+        assert script == script.lower()
+
+
+def test_build_audio_script_mms_strips_punctuation_from_translation():
+    """Real-world case: stored dyu translation has `?` and `'` etc."""
+    from types import SimpleNamespace
+
+    q = _FakeQuestion("QUE T'INDIQUE CE PANNEAU ?", ["Oui.", "Non."])
+    tr = SimpleNamespace(
+        question_text="I ka kan k'a kɛ cogo di o koo ɲɔgɔn na?",
+        options=["O ye mun lo yira i la?", "A b'a fɔ i ye."],
+    )
+    script = build_audio_script(q, "dyu", translation=tr)
+    # Apostrophe survives (in MMS vocab); question mark stripped to space.
+    assert "k'a" in script
+    assert "ɲɔgɔn" in script
+    assert "?" not in script
+    assert script == script.lower()
+    # Collapsed spaces — no double spaces.
+    assert "  " not in script
 
 
 def test_build_audio_script_handles_empty_options():


### PR DESCRIPTION
## Summary
One-commit dev→main roundtrip for **PR #1721** — the MMS TTS punct normalization fix.

## Why
Root cause of \"French-sounding\" Dioula audio: MMS VITS tokenizer has a 32-token lowercase-only vocab with no \`? . , : ; !\`. Each unsupported char becomes \`<unk>\` which renders as silence/noise. Fix lowercases + strips punctuation from the MMS script.

Fixes #1719

## Test plan
- [ ] Admin-squash merge once CI green
- [ ] Staging deploy succeeds
- [ ] POST \`/qbank/banks/43fb7500…/translations/backfill?language=dyu\` re-synthesizes audio with normalized text
- [ ] Native Dioula speaker confirms audio sounds correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)