### PR TITLE
Merge dev → main: qbank NLLB CT2 pruned artifact + tactical fixes

### DIFF
--- a/backend/app/domain/services/qbank_audio_service.py
+++ b/backend/app/domain/services/qbank_audio_service.py
@@ -12,6 +12,7 @@ them. File size target is ~50 KB per 30s clip (Opus @ 24 kbps).
 
 from __future__ import annotations
 
+import re
 import uuid
 from typing import Literal
 
@@ -45,6 +46,31 @@ OPUS_CONTENT_TYPE = "audio/ogg"
 OPUS_BYTES_PER_SECOND = 6 * 1024  # matches LessonAudioService._estimate_duration
 
 
+_MMS_PUNCT_RE = re.compile(r"[^\w\s'\-]+", flags=re.UNICODE)
+_MMS_SPACES_RE = re.compile(r"\s+")
+
+
+def _normalize_for_mms(text: str) -> str:
+    """Strip characters the Meta MMS VITS tokenizer can't encode (#1719).
+
+    facebook/mms-tts-{mos,dyu,bam,ful} have 32-token character vocabs:
+    lowercase letters, a few language-specific diacritics (ɛ, ɔ, ɲ, ŋ,
+    ɓ, ɗ, ʋ, ã, ẽ, ĩ, õ, ũ…), plus ``'``, ``-``, space. Anything else —
+    including ``? . , : ; !`` and uppercase — becomes an ``<unk>`` token
+    that the model renders as noise or silence. VITS learns prosody from
+    the ``add_blank`` pad tokens the tokenizer interleaves between
+    characters, so stripping punctuation doesn't hurt intelligibility.
+
+    This normalization replaces every non-word, non-hyphen, non-apostrophe
+    character with a single space and collapses repeats. Uppercase is
+    handled by the tokenizer itself (``normalize_text`` lowercases), but
+    we do it here too for clarity in logs.
+    """
+    lowered = (text or "").lower()
+    squashed = _MMS_PUNCT_RE.sub(" ", lowered)
+    return _MMS_SPACES_RE.sub(" ", squashed).strip()
+
+
 def build_audio_script(
     question: QBankQuestion,
     language: str,
@@ -60,6 +86,10 @@ def build_audio_script(
     the raw ``question.question_text`` falls through, which is correct
     for ``fr`` (source) but produces gibberish if fed into an MMS model
     for mos/dyu/bam/ful.
+
+    For MMS target languages the final script is passed through
+    ``_normalize_for_mms`` so the per-language character vocab sees only
+    tokens it can encode (#1719).
     """
     prefixes = {
         "fr": "Option",
@@ -81,7 +111,11 @@ def build_audio_script(
     for idx, opt in enumerate(options):
         letter = chr(ord("A") + idx)
         parts.append(f"{prefix} {letter}: {opt}")
-    return ". ".join(p for p in parts if p).strip() + "."
+    script = ". ".join(p for p in parts if p).strip() + "."
+
+    if language != "fr":
+        script = _normalize_for_mms(script)
+    return script
 
 
 def estimate_duration_seconds(audio_bytes: int) -> int:

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -94,13 +94,22 @@ class Settings(BaseSettings):
     mms_tts_url: str = "http://mms-tts:5050"
     mms_tts_timeout_seconds: float = 60.0
 
-    # Meta NLLB-200 translation sidecar — translates French qbank text
-    # into mos/dyu/bam/ful before MMS TTS synthesizes (#1690). CPU
-    # inference of distilled-600M is slow; timeout must cover worst-
-    # case 96-token greedy decode under load.
+    # NLLB translation sidecar — pruned + CT2 int8 artifact (#1709) replacing
+    # the original transformers + distilled-600M setup (#1690, #1705). Port
+    # 5060 is the sidecar's inbound. Timeout kept at 180s to cover the
+    # worst-case CPU decode under load, even though CT2 int8 is much faster
+    # than the old transformers greedy path. nllb_model tracks which
+    # upstream model generation the artifact derives from, for telemetry.
     nllb_url: str = "http://nllb:5060"
     nllb_timeout_seconds: float = 180.0
     nllb_model: str = "distilled-600M"
+    # Artifact pin — docker-compose passes these to the sidecar Dockerfile
+    # at build time so the CT2 int8 tarball is baked into the image.
+    # Production overrides the tag via env when cutting a new release.
+    # Artifact is produced by the Benidrissa/sira-nllb-distill pipeline and
+    # published as ct2_int8.tar.gz on a GitHub release.
+    nllb_artifact_release_repo: str = "Benidrissa/sira-nllb-distill"
+    nllb_artifact_release_tag: str = "v1.0.0"
 
     # MinIO / S3-compatible object storage
     minio_endpoint: str = "http://localhost:9000"

--- a/backend/migrations/versions/071_qbank_time_per_question_default_60.py
+++ b/backend/migrations/versions/071_qbank_time_per_question_default_60.py
@@ -1,4 +1,4 @@
-"""Raise qbank_question_banks.time_per_question_sec server_default 25 → 60.
+"""Raise question_banks.time_per_question_sec server_default 25 → 60.
 
 Revision ID: 071
 Revises: 070
@@ -29,19 +29,18 @@ depends_on = None
 
 def upgrade() -> None:
     op.alter_column(
-        "qbank_question_banks",
+        "question_banks",
         "time_per_question_sec",
         server_default=sa.text("60"),
     )
     op.execute(
-        "UPDATE qbank_question_banks SET time_per_question_sec = 60 "
-        "WHERE time_per_question_sec = 25"
+        "UPDATE question_banks SET time_per_question_sec = 60 WHERE time_per_question_sec = 25"
     )
 
 
 def downgrade() -> None:
     op.alter_column(
-        "qbank_question_banks",
+        "question_banks",
         "time_per_question_sec",
         server_default=sa.text("25"),
     )

--- a/backend/tests/test_qbank_audio_service.py
+++ b/backend/tests/test_qbank_audio_service.py
@@ -39,16 +39,44 @@ def test_build_audio_script_french_prefix():
 
 
 def test_build_audio_script_mms_languages_use_native_prefix():
+    # MMS VITS vocab is lowercase-only, no punctuation. build_audio_script
+    # normalizes so the prefix ends up lowercase and the A/B label too.
     q = _FakeQuestion("Question", ["A", "B"])
     for lang, prefix in [
-        ("mos", "Tʋʋmde"),
-        ("dyu", "Sugandili"),
-        ("bam", "Sugandili"),
-        ("ful", "Suɓaande"),
+        ("mos", "tʋʋmde"),
+        ("dyu", "sugandili"),
+        ("bam", "sugandili"),
+        ("ful", "suɓaande"),
     ]:
         script = build_audio_script(q, lang)
-        assert f"{prefix} A" in script
-        assert f"{prefix} B" in script
+        assert f"{prefix} a" in script
+        assert f"{prefix} b" in script
+        # No punctuation the MMS tokenizer cannot encode.
+        assert "?" not in script
+        assert "." not in script
+        assert ":" not in script
+        assert "," not in script
+        # No uppercase letters either.
+        assert script == script.lower()
+
+
+def test_build_audio_script_mms_strips_punctuation_from_translation():
+    """Real-world case: stored dyu translation has `?` and `'` etc."""
+    from types import SimpleNamespace
+
+    q = _FakeQuestion("QUE T'INDIQUE CE PANNEAU ?", ["Oui.", "Non."])
+    tr = SimpleNamespace(
+        question_text="I ka kan k'a kɛ cogo di o koo ɲɔgɔn na?",
+        options=["O ye mun lo yira i la?", "A b'a fɔ i ye."],
+    )
+    script = build_audio_script(q, "dyu", translation=tr)
+    # Apostrophe survives (in MMS vocab); question mark stripped to space.
+    assert "k'a" in script
+    assert "ɲɔgɔn" in script
+    assert "?" not in script
+    assert script == script.lower()
+    # Collapsed spaces — no double spaces.
+    assert "  " not in script
 
 
 def test_build_audio_script_handles_empty_options():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,33 +49,33 @@ services:
         limits:
           memory: 4G
 
+  # Shared multi-tenant translation service. Translates French qbank text
+  # into mos/dyu/bam/ful before MMS TTS synthesizes audio (#1690, rewritten
+  # on CT2 int8 pruned artifact in #1709). The artifact is a vocab-pruned
+  # NLLB-200-distilled-600M restricted to fra/mos/dyu/bam/fuv — ~600 MB RAM
+  # vs the original ~2.4 GB, and 3–6s/translation on CPU vs the old ~30s.
   nllb:
-    # NLLB-200 translation sidecar. Translates French qbank text into
-    # mos/dyu/bam/ful before MMS TTS synthesizes audio (#1690). Loads
-    # facebook/nllb-200-distilled-600M once at startup (~2.4 GB in RAM).
     build:
       context: ./infrastructure/nllb
       dockerfile: Dockerfile
+      args:
+        NLLB_ARTIFACT_RELEASE_REPO: ${NLLB_ARTIFACT_RELEASE_REPO:-Benidrissa/sira-nllb-distill}
+        NLLB_ARTIFACT_RELEASE_TAG: ${NLLB_ARTIFACT_RELEASE_TAG:-v1.0.0}
     container_name: santepublique-nllb
     ports:
       - "5060:5060"
-    volumes:
-      - nllb_models:/models
+    # No nllb_models volume anymore: the artifact is baked into the image at
+    # build time (see Dockerfile), so there's nothing stateful to persist.
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:5060/health"]
       interval: 30s
       timeout: 5s
-      start_period: 240s
+      start_period: 60s  # CT2 loads from disk in seconds, not minutes
       retries: 3
     deploy:
       resources:
         limits:
-          # distilled-600M ~2.4 GB FP32 weights + transformers runtime +
-          # activations during generate() easily exceeds 4 GB on first
-          # forward pass, triggering container OOM + restart loop that
-          # makes /health time out (#1696 follow-up). 8 GB covers load
-          # + peak generate comfortably.
-          memory: 8G
+          memory: 2G
 
   backend:
     build:
@@ -111,4 +111,4 @@ volumes:
   redisdata:
   uploads_data:
   mms_models:
-  nllb_models:
+  # nllb_models removed in #1709 — CT2 int8 artifact is baked into the image

--- a/infrastructure/nllb/Dockerfile
+++ b/infrastructure/nllb/Dockerfile
@@ -1,9 +1,14 @@
 FROM python:3.11-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    HF_HOME=/models \
-    TRANSFORMERS_CACHE=/models
+    PYTHONUNBUFFERED=1
+
+# Build args pin which pruned + CT2 int8 artifact this image ships. The
+# artifact is produced by the Benidrissa/sira-nllb-distill pipeline and
+# attached to a GitHub release as ct2_int8.tar.gz. Production overrides
+# the tag via docker-compose build.args when cutting a new release.
+ARG NLLB_ARTIFACT_RELEASE_REPO=Benidrissa/sira-nllb-distill
+ARG NLLB_ARTIFACT_RELEASE_TAG=v1.0.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
@@ -14,11 +19,72 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Pull the pinned artifact from a GitHub release and bake it into the image
+# so the container starts without any network fetch. The release repo is
+# private, which requires the two-step GitHub API pattern:
+#   1. GET  /repos/{repo}/releases/tags/{tag}    → find asset by name
+#   2. GET  /repos/{repo}/releases/assets/{id}   → with Accept: application/octet-stream
+# The browser-style /releases/download/{tag}/{name} URL returns 404 for
+# private repos regardless of how the token is passed.
+#
+# Build needs a GitHub token passed as a build secret:
+#   docker build --secret id=gh_token,env=GH_TOKEN .
+# In CI this is typically ${{ secrets.GITHUB_TOKEN }} (read-only, scoped to
+# the repo) or a PAT with `repo` scope for cross-repo reads.
+RUN --mount=type=secret,id=gh_token,required=true \
+    GH_TOKEN=$(cat /run/secrets/gh_token) \
+    NLLB_REPO="${NLLB_ARTIFACT_RELEASE_REPO}" \
+    NLLB_TAG="${NLLB_ARTIFACT_RELEASE_TAG}" \
+    python <<'PY'
+import json, os, shutil, tarfile, time, urllib.request
+token = os.environ["GH_TOKEN"]
+repo = os.environ["NLLB_REPO"]
+tag = os.environ["NLLB_TAG"]
+# Step 1: resolve asset id from tag + filename.
+req = urllib.request.Request(
+    f"https://api.github.com/repos/{repo}/releases/tags/{tag}",
+    headers={"Authorization": f"Bearer {token}", "Accept": "application/vnd.github+json"},
+)
+release = json.loads(urllib.request.urlopen(req).read())
+asset = next(a for a in release["assets"] if a["name"] == "ct2_int8.tar.gz")
+# Step 2: download the asset binary with retries — release-assets CDN can
+# drop long streaming connections mid-transfer; a plain retry is usually enough.
+last_err = None
+for attempt in range(1, 6):
+    try:
+        req = urllib.request.Request(
+            asset["url"],
+            headers={"Authorization": f"Bearer {token}", "Accept": "application/octet-stream"},
+        )
+        with urllib.request.urlopen(req) as src, open("/tmp/nllb-ct2.tar.gz", "wb") as dst:
+            shutil.copyfileobj(src, dst)
+        if os.path.getsize("/tmp/nllb-ct2.tar.gz") == asset["size"]:
+            break
+        raise OSError(f"incomplete download on attempt {attempt}")
+    except Exception as err:
+        last_err = err
+        print(f"attempt {attempt}/5 failed: {err}; retrying after {2**attempt}s")
+        time.sleep(2 ** attempt)
+else:
+    raise RuntimeError(f"failed to download {asset['name']} after 5 attempts: {last_err}")
+# Extract and move into /models/nllb-ct2/.
+with tarfile.open("/tmp/nllb-ct2.tar.gz") as tf:
+    tf.extractall("/tmp", filter="data")
+os.makedirs("/models/nllb-ct2", exist_ok=True)
+for name in os.listdir("/tmp/ct2_int8"):
+    shutil.move(f"/tmp/ct2_int8/{name}", f"/models/nllb-ct2/{name}")
+os.rmdir("/tmp/ct2_int8")
+os.remove("/tmp/nllb-ct2.tar.gz")
+print(f"installed artifact from {repo}@{tag} ({asset['size']} bytes)")
+PY
+
 COPY server.py .
 
 EXPOSE 5060
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=180s --retries=3 \
+# CT2 int8 artifact loads from disk in seconds, not minutes — drop start_period
+# from 180s (old transformers+HF download path) to 60s.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
     CMD curl -fsS http://localhost:5060/health || exit 1
 
 CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "5060", "--workers", "1"]

--- a/infrastructure/nllb/requirements.txt
+++ b/infrastructure/nllb/requirements.txt
@@ -1,5 +1,4 @@
 fastapi==0.115.6
 uvicorn[standard]==0.32.1
-transformers==4.47.1
-torch==2.5.1
+ctranslate2>=4.5.0
 sentencepiece==0.2.0

--- a/infrastructure/nllb/server.py
+++ b/infrastructure/nllb/server.py
@@ -1,15 +1,24 @@
-"""Meta NLLB-200 translation HTTP server.
+"""NLLB translation HTTP server — CTranslate2 int8, vocab-pruned artifact.
 
 Translates short driving-school qbank texts from French to four low-resource
 West African languages: Mooré (mos_Latn), Dioula (dyu_Latn), Bambara
-(bam_Latn), and Fulfulde — Western Niger variant (fuh_Latn). Pairs with the
-MMS TTS sidecar: translate here first, synthesize audio there. MMS is
-monolingual TTS and will pronounce French syllables with the target
-phonology if fed raw French; this service fixes that (#1690).
+(bam_Latn), and Fulfulde — Nigerian variant (fuv_Latn). Pairs with the
+MMS TTS sidecar: translate here first, synthesize audio there.
 
-Model: ``facebook/nllb-200-distilled-600M`` (~2.4 GB RAM). Preloads the
-model once on startup and keeps it hot. Batch translate up to ~10 short
-texts in one forward pass.
+Replaces the earlier transformers + torch implementation with a CTranslate2
+int8 pipeline (#1709). The artifact is a vocab-pruned fork of
+``facebook/nllb-200-distilled-600M`` restricted to {fra, mos, dyu, bam, fuv}
+and produced by the Benidrissa/sira-nllb-distill pipeline; see
+``infrastructure/nllb/Dockerfile`` for how it's baked into the image.
+
+HTTP contract is preserved bit-for-bit from the transformers era so
+``backend/app/integrations/nllb_translate.py`` doesn't change:
+    POST /translate  {texts, src, tgt}  ->  {translations, elapsed_ms}
+    GET  /health                         ->  {status, model_loaded, ...}
+
+Decoding knobs (beam, no_repeat_ngram, repetition_penalty, max_decoding_length)
+match what landed on dev to fix mos/dyu/bam/ful repetition loops (#1706 +
+#1712). CT2's Translator.translate_batch() accepts all of them natively.
 """
 
 from __future__ import annotations
@@ -19,29 +28,41 @@ import logging
 import os
 import time
 from contextlib import asynccontextmanager
+from pathlib import Path
 
-import torch
+import ctranslate2
+import sentencepiece as spm
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
-from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+
+MODEL_DIR = Path(os.getenv("NLLB_MODEL_DIR", "/models/nllb-ct2"))
+SP_MODEL_PATH = MODEL_DIR / "sentencepiece.bpe.model"
 
 MAX_INPUT_CHARS = 2000
 MAX_TEXTS_PER_BATCH = 32
 # Short qbank content rarely needs more than ~80 output tokens. A high cap
-# only slows greedy decoding by running past EOS on CPU.
+# only slows decoding by running past EOS on CPU.
 MAX_NEW_TOKENS = 96
 
-# Serialize generate() calls — PyTorch model forward passes aren't
-# thread-safe in single-worker uvicorn, and without a queue cap a
-# spike of concurrent /translate requests pins the CPU and makes
-# /health time out alongside them.
-_GENERATE_SEMAPHORE = asyncio.Semaphore(1)
+# Decoding parameters — greedy (beam=1) with no_repeat_ngram + repetition
+# penalty to prevent degenerate loops on mos/dyu/bam/ful. beam=4 was too
+# slow on the old transformers path (#1712), but may be worth revisiting
+# on CT2 int8; leave greedy for now to match dev's shipping settings.
+BEAM_SIZE = int(os.getenv("NLLB_BEAM_SIZE", "1"))
+NO_REPEAT_NGRAM_SIZE = 3
+REPETITION_PENALTY = 1.2
 
-# NLLB source/target codes for the qbank pipeline. The sidecar itself is
-# source-agnostic (NLLB-200 handles 200+ languages); the backend picks
-# the right source code per bank and sends it here. These constants are
-# only used for the ``/health`` payload and input validation reporting.
+COMPUTE_TYPE = os.getenv("NLLB_COMPUTE_TYPE", "int8")
+INTER_THREADS = int(os.getenv("NLLB_INTER_THREADS", "1"))
+INTRA_THREADS = int(os.getenv("NLLB_INTRA_THREADS", "0"))  # 0 = auto
+
+# Serialize translate_batch() calls — CT2 is thread-safe but concurrent
+# Python callers under a single-worker uvicorn still pin the CPU. Keeping
+# the same semaphore pattern as the transformers version (#1705) prevents
+# a spike of concurrent /translate requests from making /health time out.
+_TRANSLATE_SEMAPHORE = asyncio.Semaphore(1)
+
 DEFAULT_SOURCE = "fra_Latn"
 SUPPORTED_TARGETS = ("mos_Latn", "dyu_Latn", "bam_Latn", "fuv_Latn")
 
@@ -50,44 +71,48 @@ logger = logging.getLogger("nllb")
 
 
 class _Bundle:
-    __slots__ = ("model", "tokenizer")
+    __slots__ = ("translator", "sp")
 
-    def __init__(self, model, tokenizer):
-        self.model = model
-        self.tokenizer = tokenizer
+    def __init__(self, translator: ctranslate2.Translator, sp: spm.SentencePieceProcessor):
+        self.translator = translator
+        self.sp = sp
 
 
 _BUNDLE: _Bundle | None = None
 
 
-def _load_model() -> _Bundle:
-    model_id = os.getenv("NLLB_MODEL_ID", "facebook/nllb-200-distilled-600M")
-    logger.info("loading %s", model_id)
-    tokenizer = AutoTokenizer.from_pretrained(model_id)
-    model = AutoModelForSeq2SeqLM.from_pretrained(model_id)
-    model.eval()
-    return _Bundle(model=model, tokenizer=tokenizer)
+def _load() -> _Bundle:
+    logger.info("loading CT2 model from %s (compute_type=%s)", MODEL_DIR, COMPUTE_TYPE)
+    translator = ctranslate2.Translator(
+        str(MODEL_DIR),
+        device="cpu",
+        compute_type=COMPUTE_TYPE,
+        inter_threads=INTER_THREADS,
+        intra_threads=INTRA_THREADS,
+    )
+    sp = spm.SentencePieceProcessor()
+    sp.load(str(SP_MODEL_PATH))
+    logger.info("loaded CT2 model + SentencePiece (vocab=%d)", sp.get_piece_size())
+    return _Bundle(translator=translator, sp=sp)
 
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
     global _BUNDLE
-    # Per-language loading isn't a concept for NLLB — one model handles
-    # all 200+ target codes. If the model itself fails to download we
-    # log and keep the server alive so /health reflects the outage
-    # without taking the container into a crash loop (same resilience
-    # pattern as the MMS sidecar after #1681).
+    # Don't crash lifespan on load failure — /health will return 503
+    # until the container is restarted. Same resilience pattern as the
+    # MMS sidecar (#1681).
     try:
-        _BUNDLE = _load_model()
+        _BUNDLE = _load()
         logger.info("nllb model loaded")
     except Exception as exc:
-        logger.exception("failed to load nllb model: %s", exc)
+        logger.exception("failed to load nllb ct2 model: %s", exc)
         _BUNDLE = None
     yield
     _BUNDLE = None
 
 
-app = FastAPI(title="NLLB Translation Sidecar", version="1.0.0", lifespan=lifespan)
+app = FastAPI(title="NLLB Translation Sidecar (CT2 int8)", version="2.0.0", lifespan=lifespan)
 
 
 class TranslateRequest(BaseModel):
@@ -108,11 +133,25 @@ async def health() -> JSONResponse:
         {
             "status": "ok" if loaded else "degraded",
             "model_loaded": loaded,
+            "model_dir": str(MODEL_DIR),
+            "compute_type": COMPUTE_TYPE,
             "supported_targets": list(SUPPORTED_TARGETS),
             "default_source": DEFAULT_SOURCE,
         },
         status_code=200 if loaded else 503,
     )
+
+
+def _encode(sp: spm.SentencePieceProcessor, text: str, src: str) -> list[str]:
+    # NLLB source-side format: [src_lang, *sp_pieces, </s>]
+    return [src, *sp.encode_as_pieces(text), "</s>"]
+
+
+def _decode(sp: spm.SentencePieceProcessor, tokens: list[str], tgt: str) -> str:
+    # Strip the forced target-language prefix CT2 echoes back.
+    if tokens and tokens[0] == tgt:
+        tokens = tokens[1:]
+    return sp.decode(tokens)
 
 
 @app.post("/translate", response_model=TranslateResponse)
@@ -127,48 +166,26 @@ async def translate(req: TranslateRequest) -> TranslateResponse:
                 detail=f"input text exceeds {MAX_INPUT_CHARS} characters",
             )
 
-    tokenizer = _BUNDLE.tokenizer
-    model = _BUNDLE.model
-    tokenizer.src_lang = req.src
+    sp = _BUNDLE.sp
+    translator = _BUNDLE.translator
 
-    # NLLB forced_bos_token_id selects the target language at generation
-    # time. ``convert_tokens_to_ids`` is the supported way to retrieve it
-    # across transformers versions.
-    tgt_id = tokenizer.convert_tokens_to_ids(req.tgt)
-    if tgt_id is None or tgt_id == tokenizer.unk_token_id:
+    # Validate tgt is a pruned language code the tokenizer knows.
+    if sp.piece_to_id(req.tgt) == sp.unk_id():
         raise HTTPException(status_code=400, detail=f"unknown target lang: {req.tgt}")
 
-    async with _GENERATE_SEMAPHORE:
+    async with _TRANSLATE_SEMAPHORE:
         started = time.monotonic()
-        inputs = tokenizer(
-            req.texts,
-            return_tensors="pt",
-            padding=True,
-            truncation=True,
-            max_length=MAX_INPUT_CHARS,
+        batch = [_encode(sp, t, req.src) for t in req.texts]
+        target_prefix = [[req.tgt]] * len(batch)
+        results = translator.translate_batch(
+            batch,
+            target_prefix=target_prefix,
+            max_decoding_length=MAX_NEW_TOKENS,
+            beam_size=BEAM_SIZE,
+            no_repeat_ngram_size=NO_REPEAT_NGRAM_SIZE,
+            repetition_penalty=REPETITION_PENALTY,
         )
-
-        # ``inference_mode`` disables autograd tracking, reducing memory
-        # and modest speedup vs ``no_grad`` on CPU.
-        #
-        # Decoding knobs for low-resource languages: greedy decoding on
-        # distilled-600M produces degenerate repetition loops for
-        # mos/dyu/bam/ful ("A mi mi mi..."). no_repeat_ngram_size +
-        # repetition_penalty alone prevent those loops; beam search
-        # adds marginal quality but 4x decode cost. On CPU this makes
-        # the serial Semaphore(1) throughput unusable for bank
-        # backfills, so drop to greedy (#1711).
-        with torch.inference_mode():
-            generated = model.generate(
-                **inputs,
-                forced_bos_token_id=tgt_id,
-                max_new_tokens=MAX_NEW_TOKENS,
-                num_beams=1,
-                no_repeat_ngram_size=3,
-                repetition_penalty=1.2,
-                early_stopping=True,
-            )
-        translations = tokenizer.batch_decode(generated, skip_special_tokens=True)
+        translations = [_decode(sp, r.hypotheses[0], req.tgt) for r in results]
         elapsed_ms = int((time.monotonic() - started) * 1000)
 
     logger.info(


### PR DESCRIPTION
Promoting dev to main as requested.

## Highlights

- **#1710 feat(qbank): consume pruned + CT2 int8 NLLB artifact** — sidecar swap to CTranslate2 int8, loading the vocab-pruned artifact from the [sira-nllb-distill v1.0.0 release](https://github.com/Benidrissa/sira-nllb-distill/releases/tag/v1.0.0). Memory 8G → 2G, latency ~30s → single-digit seconds per translation.

- **#1717 fix(qbank): migration 071** table name fix.
- **#1715 fix(qbank): test-taker UX** — audio autoplay + rate persistence + 60s timer default.
- **#1712 fix(qbank): NLLB beam → greedy** to unblock staging backfill (obsolete once sidecar flips to CT2 but harmless).
- **#1708 feat(qbank): parallelize translate+TTS per question** (bank-level → per-question fan-out).
- **#1707 feat(qbank): cross-org discovery** page + nav menu entry.
- **#1706 fix(qbank): NLLB beam search + no_repeat_ngram** to fix mos/dyu/bam/ful repetition (ported to CT2 server as of #1710).
- Other tactical NLLB diagnostics + fixes (#1704, #1703, #1702, #1700, #1698).

🤖 Generated with [Claude Code](https://claude.com/claude-code)