### PR TITLE
hotfix(qbank): NLLB sidecar rejecting every request (#1709 follow-up)

### DIFF
--- a/infrastructure/nllb/server.py
+++ b/infrastructure/nllb/server.py
@@ -169,9 +169,15 @@ async def translate(req: TranslateRequest) -> TranslateResponse:
     sp = _BUNDLE.sp
     translator = _BUNDLE.translator
 
-    # Validate tgt is a pruned language code the tokenizer knows.
-    if sp.piece_to_id(req.tgt) == sp.unk_id():
-        raise HTTPException(status_code=400, detail=f"unknown target lang: {req.tgt}")
+    # Validate tgt against the pruned artifact's kept languages. Language
+    # codes live in the CT2-extended vocabulary, not the raw SentencePiece
+    # model, so probing the SP vocab always returns unk_id — whitelist-check
+    # instead. (#1709 hotfix: the SP probe rejected every valid target.)
+    if req.tgt not in SUPPORTED_TARGETS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unsupported target lang {req.tgt}; expected one of {list(SUPPORTED_TARGETS)}",
+        )
 
     async with _TRANSLATE_SEMAPHORE:
         started = time.monotonic()


### PR DESCRIPTION
Production bug I shipped in #1710. The CT2 sidecar's language-code validation uses the wrong probe and returns HTTP 400 on every request.

## Bug

\`\`\`python
if sp.piece_to_id(req.tgt) == sp.unk_id():
    raise HTTPException(status_code=400, detail=f"unknown target lang: {req.tgt}")
\`\`\`

NLLB language codes (\`fra_Latn\`, \`mos_Latn\`, \`dyu_Latn\`, \`bam_Latn\`, \`fuv_Latn\`) live in **CTranslate2's extended vocabulary**, not the raw SentencePiece model. \`sp.piece_to_id\` returns \`unk_id\` for ALL of them — so every translation request returned 400 \`"unknown target lang: mos_Latn"\`.

## Fix

Whitelist-check against \`SUPPORTED_TARGETS\` (the same tuple already defined for \`/health\`). Return the acceptable list in the error detail.

## How it got through

I smoke-tested locally with the correct whitelist check, but the fix was only in the working tree — the \`git commit --amend\` that stripped the backend-service files snapshot predates that Edit, so the fix never reached the commit. Found during post-merge inspection of deployed artifact on main.

## Verification

Smoke test run from earlier (replayed after committing this hotfix):
- fr→mos: 200 OK, "Y sã n wa na n maan bũmb ning..." (no repetition)
- fr→fuv 4-batch: 200 OK, proper Fulfulde, 173ms total
- xxx_Latn: 400 Bad Request with \`"unsupported target lang xxx_Latn; expected one of ['mos_Latn', 'dyu_Latn', 'bam_Latn', 'fuv_Latn']"\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)