### PR TITLE
chore: sync dev → main (#1727 audio fixes + any dev-side infra)

### DIFF
--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -75,6 +75,7 @@ def _audio_url_for(
     question_id,
     language: str,
     storage_key: str | None,
+    version: object | None = None,
 ) -> str | None:
     """Build a browser-reachable proxy URL for a question's audio clip.
 
@@ -83,6 +84,13 @@ def _audio_url_for(
     stores ``http://minio:9000/...`` which the browser can't reach —
     same pattern as ``_image_url_for``. Returns ``None`` when the audio
     row has no bytes yet (pending/failed states).
+
+    ``version`` is appended as ``?v=<unix-ts>`` so the URL changes when
+    the underlying audio row gets regenerated (typical during a
+    translation backfill). Without it, browsers serve the cached opus
+    bytes forever — even after an operator wipes + re-synthesizes the
+    audio — because the stable URL hits HTTP cache (#1719 follow-up).
+    Accepts a datetime, int, or ``None`` (returns the unbusted URL).
     """
     if not storage_key:
         return None
@@ -90,7 +98,15 @@ def _audio_url_for(
     host = request.headers.get("x-forwarded-host") or request.headers.get("host")
     if not host:
         return None
-    return f"{proto}://{host}/api/v1/qbank/questions/{question_id}/audio/{language}/data"
+    base = f"{proto}://{host}/api/v1/qbank/questions/{question_id}/audio/{language}/data"
+    if version is None:
+        return base
+    # Accept datetime (preferred — use unix timestamp for compactness) or raw int/str.
+    try:
+        v = int(version.timestamp()) if hasattr(version, "timestamp") else int(version)
+    except (TypeError, ValueError):
+        v = str(version)
+    return f"{base}?v={v}"
 
 
 def _bank_response(bank, question_count: int = 0, test_count: int = 0):
@@ -431,7 +447,13 @@ async def start_test(
             )
         )
         for row in audio_rows.scalars():
-            url = _audio_url_for(request, row.question_id, row.language, row.storage_key)
+            url = _audio_url_for(
+                request,
+                row.question_id,
+                row.language,
+                row.storage_key,
+                version=row.created_at,
+            )
             if url is None:
                 continue
             audio_map.setdefault(str(row.question_id), {})[row.language] = url
@@ -651,7 +673,13 @@ def _audio_response(
         question_id=str(question_id),
         language=language,
         status=row.status.value if hasattr(row.status, "value") else row.status,
-        audio_url=_audio_url_for(request, question_id, language, row.storage_key),
+        audio_url=_audio_url_for(
+            request,
+            question_id,
+            language,
+            row.storage_key,
+            version=row.created_at,
+        ),
         duration_seconds=row.duration_seconds,
     )
 

--- a/backend/app/domain/services/qbank_audio_service.py
+++ b/backend/app/domain/services/qbank_audio_service.py
@@ -49,6 +49,33 @@ OPUS_BYTES_PER_SECOND = 6 * 1024  # matches LessonAudioService._estimate_duratio
 _MMS_PUNCT_RE = re.compile(r"[^\w\s'\-]+", flags=re.UNICODE)
 _MMS_SPACES_RE = re.compile(r"\s+")
 
+# Ordinal words for MMS option labels. Saying "a", "b", "c", "d" via MMS
+# produces either silence (single letters are not a pronounceable token
+# sequence) or a sound too subtle to distinguish options apart. Users
+# reported "no difference among options" on #1719. Replace letters with
+# native-language ordinal words MMS can pronounce clearly. French path
+# is untouched — OpenAI TTS handles "Option A/B/C" natively.
+# Sources: standard orthography from the MMS training corpora (vocab.json).
+# Fallback to number word if we somehow see a 5+ option question.
+_MMS_OPTION_ORDINALS: dict[str, tuple[str, ...]] = {
+    # Mooré (mos): numbers / ordinals
+    "mos": ("pipi", "yiibu", "tãabo", "naase", "nu"),
+    # Dioula (dyu): cardinal numbers used for ordering
+    "dyu": ("kelen", "fila", "saba", "naani", "duuru"),
+    # Bambara (bam): same root as Dioula
+    "bam": ("kelen", "fila", "saba", "naani", "duuru"),
+    # Fulfulde (ful)
+    "ful": ("goo", "ɗiɗi", "tati", "nayi", "jowi"),
+}
+# Silence between sentence segments when we splice per-sentence synth
+# (#1719 follow-up). 300 ms reads as a natural pause without being
+# perceived as a dropout.
+_SEGMENT_SILENCE_MS = 300
+# Split the script into sentences on the original punctuation BEFORE we
+# strip it for the MMS tokenizer. These are the natural boundaries where
+# we want the spliced silence to land.
+_SENTENCE_SPLIT_RE = re.compile(r"[.!?;]+\s*|\n+")
+
 
 def _normalize_for_mms(text: str) -> str:
     """Strip characters the Meta MMS VITS tokenizer can't encode (#1719).
@@ -71,6 +98,23 @@ def _normalize_for_mms(text: str) -> str:
     return _MMS_SPACES_RE.sub(" ", squashed).strip()
 
 
+def _option_label(language: str, idx: int) -> str:
+    """Return the spoken label for option at ``idx`` (0-based).
+
+    French uses the Latin letter (OpenAI TTS handles "A"/"B"/"C" fine).
+    MMS languages use a native ordinal word — saying "a"/"b" after MMS's
+    lowercase-normalize produces sub-audible output and users cannot
+    tell options apart (#1719). Falls back to the last ordinal if a
+    question has more options than we have ordinals cached.
+    """
+    if language == "fr":
+        return chr(ord("A") + idx)
+    ordinals = _MMS_OPTION_ORDINALS.get(language, ())
+    if not ordinals:
+        return str(idx + 1)
+    return ordinals[idx] if idx < len(ordinals) else ordinals[-1]
+
+
 def build_audio_script(
     question: QBankQuestion,
     language: str,
@@ -79,7 +123,8 @@ def build_audio_script(
     """Return the text that should be spoken for a question.
 
     Prepends the option label in the speaker's language so the TTS reads
-    "Option A: ..." in French and the native prefix in MMS languages.
+    "Option A: ..." in French and the native prefix + ordinal in MMS
+    languages ("sugandili kelen" for dyu option 1, etc.).
 
     When ``translation`` is provided (#1690), its translated question_text
     and options are used instead of the source-language ones. Without it
@@ -109,13 +154,65 @@ def build_audio_script(
 
     parts = [q_text]
     for idx, opt in enumerate(options):
-        letter = chr(ord("A") + idx)
-        parts.append(f"{prefix} {letter}: {opt}")
+        label = _option_label(language, idx)
+        parts.append(f"{prefix} {label}: {opt}")
     script = ". ".join(p for p in parts if p).strip() + "."
 
     if language != "fr":
         script = _normalize_for_mms(script)
     return script
+
+
+def build_audio_segments(
+    question: QBankQuestion,
+    language: str,
+    translation: QBankQuestionTranslation | None = None,
+) -> list[str]:
+    """Return a list of sentence-sized chunks for per-segment MMS synth.
+
+    MMS VITS models produce clearer prosody on short inputs and we want
+    an audible pause between the question and each option so the listener
+    can parse the structure (#1719). Each returned chunk is already
+    normalized for the MMS tokenizer.
+
+    French uses a single-blob path (OpenAI TTS is fine with long text);
+    for ``fr`` this returns a one-element list.
+    """
+    prefixes = {
+        "fr": "Option",
+        "mos": "Tʋʋmde",
+        "dyu": "Sugandili",
+        "bam": "Sugandili",
+        "ful": "Suɓaande",
+    }
+    prefix = prefixes.get(language, "Option")
+
+    if translation is not None:
+        q_text = (translation.question_text or "").strip()
+        options = list(translation.options or [])
+    else:
+        q_text = (question.question_text or "").strip()
+        options = list(question.options or [])
+
+    raw_segments: list[str] = []
+    # The question may itself contain multiple sentences (e.g. when the
+    # source French has line breaks collapsed into ". "); split on
+    # sentence-terminators before we strip them.
+    for sub in _SENTENCE_SPLIT_RE.split(q_text):
+        if sub.strip():
+            raw_segments.append(sub.strip())
+    for idx, opt in enumerate(options):
+        if not opt or not opt.strip():
+            continue
+        label = _option_label(language, idx)
+        raw_segments.append(f"{prefix} {label}: {opt.strip()}")
+
+    if language == "fr":
+        return [". ".join(raw_segments).strip() + "."] if raw_segments else []
+    # For MMS langs, normalize each segment individually. Empty results
+    # (e.g. a stray punctuation-only chunk) are dropped.
+    normalized = [_normalize_for_mms(s) for s in raw_segments]
+    return [s for s in normalized if s]
 
 
 def estimate_duration_seconds(audio_bytes: int) -> int:
@@ -182,6 +279,51 @@ class QBankAudioService:
             detail=f"Unsupported audio language: {language}",
         )
 
+    async def _synthesize_segments(self, segments: list[str], language: str) -> bytes:
+        """Synthesize each segment individually and splice with silence.
+
+        MMS VITS produces flatter prosody on long inputs, so we break the
+        question + options into one clip per sentence and concatenate
+        with 300ms silence between. This also restores the
+        "end of thought" cue that punctuation would have carried if MMS
+        tokenizers could encode it (#1719).
+
+        French takes the single-blob path — OpenAI TTS is fine with long
+        text and silence-splicing its output wouldn't pay off.
+        """
+        if not segments:
+            raise MMSTTSError("no segments to synthesize")
+        if language == "fr" or len(segments) == 1:
+            return await self._synthesize_bytes(segments[0], language)
+
+        # Per-segment MMS calls. Backend MMS client already has a
+        # Semaphore(2); we just call sequentially within one task to
+        # keep the sidecar from being overwhelmed.
+        clips: list[bytes] = []
+        for seg in segments:
+            clips.append(await self._mms.synthesize(seg, language))
+
+        # Splice via pydub — the MMS sidecar already uses pydub to
+        # encode WAV → Opus so the dep is available in this container.
+        import io
+
+        from pydub import AudioSegment
+
+        audio_parts = [AudioSegment.from_file(io.BytesIO(b), format="ogg") for b in clips]
+        silence = AudioSegment.silent(duration=_SEGMENT_SILENCE_MS)
+        combined = audio_parts[0]
+        for part in audio_parts[1:]:
+            combined = combined + silence + part
+        buf = io.BytesIO()
+        combined.export(
+            buf,
+            format="ogg",
+            codec="libopus",
+            bitrate="24k",
+            parameters=["-application", "voip"],
+        )
+        return buf.getvalue()
+
     async def generate_question_audio(
         self,
         db: AsyncSession,
@@ -228,8 +370,10 @@ class QBankAudioService:
                 )
 
         try:
-            script = build_audio_script(question, language, translation=translation)
-            audio_bytes = await self._synthesize_bytes(script, language)
+            segments = build_audio_segments(question, language, translation=translation)
+            if not segments:
+                raise ValueError("empty audio script")
+            audio_bytes = await self._synthesize_segments(segments, language)
             key = self._storage_key(question.question_bank_id, question_id, language)
             url = await self._storage.upload_bytes(
                 key=key, data=audio_bytes, content_type=OPUS_CONTENT_TYPE

--- a/backend/app/domain/services/qbank_audio_service.py
+++ b/backend/app/domain/services/qbank_audio_service.py
@@ -12,6 +12,7 @@ them. File size target is ~50 KB per 30s clip (Opus @ 24 kbps).
 
 from __future__ import annotations
 
+import re
 import uuid
 from typing import Literal
 
@@ -45,6 +46,31 @@ OPUS_CONTENT_TYPE = "audio/ogg"
 OPUS_BYTES_PER_SECOND = 6 * 1024  # matches LessonAudioService._estimate_duration
 
 
+_MMS_PUNCT_RE = re.compile(r"[^\w\s'\-]+", flags=re.UNICODE)
+_MMS_SPACES_RE = re.compile(r"\s+")
+
+
+def _normalize_for_mms(text: str) -> str:
+    """Strip characters the Meta MMS VITS tokenizer can't encode (#1719).
+
+    facebook/mms-tts-{mos,dyu,bam,ful} have 32-token character vocabs:
+    lowercase letters, a few language-specific diacritics (ɛ, ɔ, ɲ, ŋ,
+    ɓ, ɗ, ʋ, ã, ẽ, ĩ, õ, ũ…), plus ``'``, ``-``, space. Anything else —
+    including ``? . , : ; !`` and uppercase — becomes an ``<unk>`` token
+    that the model renders as noise or silence. VITS learns prosody from
+    the ``add_blank`` pad tokens the tokenizer interleaves between
+    characters, so stripping punctuation doesn't hurt intelligibility.
+
+    This normalization replaces every non-word, non-hyphen, non-apostrophe
+    character with a single space and collapses repeats. Uppercase is
+    handled by the tokenizer itself (``normalize_text`` lowercases), but
+    we do it here too for clarity in logs.
+    """
+    lowered = (text or "").lower()
+    squashed = _MMS_PUNCT_RE.sub(" ", lowered)
+    return _MMS_SPACES_RE.sub(" ", squashed).strip()
+
+
 def build_audio_script(
     question: QBankQuestion,
     language: str,
@@ -60,6 +86,10 @@ def build_audio_script(
     the raw ``question.question_text`` falls through, which is correct
     for ``fr`` (source) but produces gibberish if fed into an MMS model
     for mos/dyu/bam/ful.
+
+    For MMS target languages the final script is passed through
+    ``_normalize_for_mms`` so the per-language character vocab sees only
+    tokens it can encode (#1719).
     """
     prefixes = {
         "fr": "Option",
@@ -81,7 +111,11 @@ def build_audio_script(
     for idx, opt in enumerate(options):
         letter = chr(ord("A") + idx)
         parts.append(f"{prefix} {letter}: {opt}")
-    return ". ".join(p for p in parts if p).strip() + "."
+    script = ". ".join(p for p in parts if p).strip() + "."
+
+    if language != "fr":
+        script = _normalize_for_mms(script)
+    return script
 
 
 def estimate_duration_seconds(audio_bytes: int) -> int:

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -94,13 +94,22 @@ class Settings(BaseSettings):
     mms_tts_url: str = "http://mms-tts:5050"
     mms_tts_timeout_seconds: float = 60.0
 
-    # Meta NLLB-200 translation sidecar — translates French qbank text
-    # into mos/dyu/bam/ful before MMS TTS synthesizes (#1690). CPU
-    # inference of distilled-600M is slow; timeout must cover worst-
-    # case 96-token greedy decode under load.
+    # NLLB translation sidecar — pruned + CT2 int8 artifact (#1709) replacing
+    # the original transformers + distilled-600M setup (#1690, #1705). Port
+    # 5060 is the sidecar's inbound. Timeout kept at 180s to cover the
+    # worst-case CPU decode under load, even though CT2 int8 is much faster
+    # than the old transformers greedy path. nllb_model tracks which
+    # upstream model generation the artifact derives from, for telemetry.
     nllb_url: str = "http://nllb:5060"
     nllb_timeout_seconds: float = 180.0
     nllb_model: str = "distilled-600M"
+    # Artifact pin — docker-compose passes these to the sidecar Dockerfile
+    # at build time so the CT2 int8 tarball is baked into the image.
+    # Production overrides the tag via env when cutting a new release.
+    # Artifact is produced by the Benidrissa/sira-nllb-distill pipeline and
+    # published as ct2_int8.tar.gz on a GitHub release.
+    nllb_artifact_release_repo: str = "Benidrissa/sira-nllb-distill"
+    nllb_artifact_release_tag: str = "v1.0.0"
 
     # MinIO / S3-compatible object storage
     minio_endpoint: str = "http://localhost:9000"

--- a/backend/migrations/versions/071_qbank_time_per_question_default_60.py
+++ b/backend/migrations/versions/071_qbank_time_per_question_default_60.py
@@ -1,4 +1,4 @@
-"""Raise qbank_question_banks.time_per_question_sec server_default 25 → 60.
+"""Raise question_banks.time_per_question_sec server_default 25 → 60.
 
 Revision ID: 071
 Revises: 070
@@ -29,19 +29,18 @@ depends_on = None
 
 def upgrade() -> None:
     op.alter_column(
-        "qbank_question_banks",
+        "question_banks",
         "time_per_question_sec",
         server_default=sa.text("60"),
     )
     op.execute(
-        "UPDATE qbank_question_banks SET time_per_question_sec = 60 "
-        "WHERE time_per_question_sec = 25"
+        "UPDATE question_banks SET time_per_question_sec = 60 WHERE time_per_question_sec = 25"
     )
 
 
 def downgrade() -> None:
     op.alter_column(
-        "qbank_question_banks",
+        "question_banks",
         "time_per_question_sec",
         server_default=sa.text("25"),
     )

--- a/backend/tests/test_qbank_audio_service.py
+++ b/backend/tests/test_qbank_audio_service.py
@@ -18,6 +18,7 @@ from app.domain.services.qbank_audio_service import (
     SUPPORTED_LANGUAGES,
     QBankAudioService,
     build_audio_script,
+    build_audio_segments,
     estimate_duration_seconds,
 )
 
@@ -38,24 +39,25 @@ def test_build_audio_script_french_prefix():
     assert script.endswith(".")
 
 
-def test_build_audio_script_mms_languages_use_native_prefix():
-    # MMS VITS vocab is lowercase-only, no punctuation. build_audio_script
-    # normalizes so the prefix ends up lowercase and the A/B label too.
+def test_build_audio_script_mms_languages_use_ordinal_word_labels():
+    # MMS VITS vocab is lowercase-only, no punctuation, and can't
+    # distinguish single-letter labels "a" / "b" when pronounced. We use
+    # native ordinal words instead so the listener hears a clear
+    # difference between options (#1719).
     q = _FakeQuestion("Question", ["A", "B"])
-    for lang, prefix in [
-        ("mos", "tʋʋmde"),
-        ("dyu", "sugandili"),
-        ("bam", "sugandili"),
-        ("ful", "suɓaande"),
-    ]:
+    expectations = [
+        ("mos", "tʋʋmde", "pipi", "yiibu"),
+        ("dyu", "sugandili", "kelen", "fila"),
+        ("bam", "sugandili", "kelen", "fila"),
+        ("ful", "suɓaande", "goo", "ɗiɗi"),
+    ]
+    for lang, prefix, ord1, ord2 in expectations:
         script = build_audio_script(q, lang)
-        assert f"{prefix} a" in script
-        assert f"{prefix} b" in script
+        assert f"{prefix} {ord1}" in script
+        assert f"{prefix} {ord2}" in script
         # No punctuation the MMS tokenizer cannot encode.
-        assert "?" not in script
-        assert "." not in script
-        assert ":" not in script
-        assert "," not in script
+        for bad in ("?", ".", ":", ",", ";", "!"):
+            assert bad not in script
         # No uppercase letters either.
         assert script == script.lower()
 
@@ -77,6 +79,38 @@ def test_build_audio_script_mms_strips_punctuation_from_translation():
     assert script == script.lower()
     # Collapsed spaces — no double spaces.
     assert "  " not in script
+    # Ordinal labels used instead of letters.
+    assert "sugandili kelen" in script
+    assert "sugandili fila" in script
+
+
+def test_build_audio_segments_dyu_splits_question_and_options():
+    """Each sentence becomes its own segment so we can splice silence."""
+    from types import SimpleNamespace
+
+    q = _FakeQuestion("QUE T'INDIQUE CE PANNEAU ?", ["Oui.", "Non."])
+    tr = SimpleNamespace(
+        question_text="I ka kan k'a kɛ cogo di o koo ɲɔgɔn na?",
+        options=["O ye mun lo yira i la?", "A b'a fɔ i ye."],
+    )
+    segments = build_audio_segments(q, "dyu", translation=tr)
+    # Question + 2 options → 3 segments.
+    assert len(segments) == 3
+    assert all(s == s.lower() for s in segments)
+    assert segments[0].startswith("i ka kan k'a kɛ")
+    assert segments[1].startswith("sugandili kelen")
+    assert segments[2].startswith("sugandili fila")
+    for s in segments:
+        for bad in ("?", ".", ":", ","):
+            assert bad not in s
+
+
+def test_build_audio_segments_fr_returns_single_blob():
+    q = _FakeQuestion("Question française", ["Oui", "Non"])
+    segments = build_audio_segments(q, "fr")
+    assert len(segments) == 1
+    assert "Option A: Oui" in segments[0]
+    assert "Option B: Non" in segments[0]
 
 
 def test_build_audio_script_handles_empty_options():

--- a/backend/tests/test_qbank_audio_service.py
+++ b/backend/tests/test_qbank_audio_service.py
@@ -39,16 +39,44 @@ def test_build_audio_script_french_prefix():
 
 
 def test_build_audio_script_mms_languages_use_native_prefix():
+    # MMS VITS vocab is lowercase-only, no punctuation. build_audio_script
+    # normalizes so the prefix ends up lowercase and the A/B label too.
     q = _FakeQuestion("Question", ["A", "B"])
     for lang, prefix in [
-        ("mos", "Tʋʋmde"),
-        ("dyu", "Sugandili"),
-        ("bam", "Sugandili"),
-        ("ful", "Suɓaande"),
+        ("mos", "tʋʋmde"),
+        ("dyu", "sugandili"),
+        ("bam", "sugandili"),
+        ("ful", "suɓaande"),
     ]:
         script = build_audio_script(q, lang)
-        assert f"{prefix} A" in script
-        assert f"{prefix} B" in script
+        assert f"{prefix} a" in script
+        assert f"{prefix} b" in script
+        # No punctuation the MMS tokenizer cannot encode.
+        assert "?" not in script
+        assert "." not in script
+        assert ":" not in script
+        assert "," not in script
+        # No uppercase letters either.
+        assert script == script.lower()
+
+
+def test_build_audio_script_mms_strips_punctuation_from_translation():
+    """Real-world case: stored dyu translation has `?` and `'` etc."""
+    from types import SimpleNamespace
+
+    q = _FakeQuestion("QUE T'INDIQUE CE PANNEAU ?", ["Oui.", "Non."])
+    tr = SimpleNamespace(
+        question_text="I ka kan k'a kɛ cogo di o koo ɲɔgɔn na?",
+        options=["O ye mun lo yira i la?", "A b'a fɔ i ye."],
+    )
+    script = build_audio_script(q, "dyu", translation=tr)
+    # Apostrophe survives (in MMS vocab); question mark stripped to space.
+    assert "k'a" in script
+    assert "ɲɔgɔn" in script
+    assert "?" not in script
+    assert script == script.lower()
+    # Collapsed spaces — no double spaces.
+    assert "  " not in script
 
 
 def test_build_audio_script_handles_empty_options():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,33 +49,33 @@ services:
         limits:
           memory: 4G
 
+  # Shared multi-tenant translation service. Translates French qbank text
+  # into mos/dyu/bam/ful before MMS TTS synthesizes audio (#1690, rewritten
+  # on CT2 int8 pruned artifact in #1709). The artifact is a vocab-pruned
+  # NLLB-200-distilled-600M restricted to fra/mos/dyu/bam/fuv — ~600 MB RAM
+  # vs the original ~2.4 GB, and 3–6s/translation on CPU vs the old ~30s.
   nllb:
-    # NLLB-200 translation sidecar. Translates French qbank text into
-    # mos/dyu/bam/ful before MMS TTS synthesizes audio (#1690). Loads
-    # facebook/nllb-200-distilled-600M once at startup (~2.4 GB in RAM).
     build:
       context: ./infrastructure/nllb
       dockerfile: Dockerfile
+      args:
+        NLLB_ARTIFACT_RELEASE_REPO: ${NLLB_ARTIFACT_RELEASE_REPO:-Benidrissa/sira-nllb-distill}
+        NLLB_ARTIFACT_RELEASE_TAG: ${NLLB_ARTIFACT_RELEASE_TAG:-v1.0.0}
     container_name: santepublique-nllb
     ports:
       - "5060:5060"
-    volumes:
-      - nllb_models:/models
+    # No nllb_models volume anymore: the artifact is baked into the image at
+    # build time (see Dockerfile), so there's nothing stateful to persist.
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:5060/health"]
       interval: 30s
       timeout: 5s
-      start_period: 240s
+      start_period: 60s  # CT2 loads from disk in seconds, not minutes
       retries: 3
     deploy:
       resources:
         limits:
-          # distilled-600M ~2.4 GB FP32 weights + transformers runtime +
-          # activations during generate() easily exceeds 4 GB on first
-          # forward pass, triggering container OOM + restart loop that
-          # makes /health time out (#1696 follow-up). 8 GB covers load
-          # + peak generate comfortably.
-          memory: 8G
+          memory: 2G
 
   backend:
     build:
@@ -111,4 +111,4 @@ volumes:
   redisdata:
   uploads_data:
   mms_models:
-  nllb_models:
+  # nllb_models removed in #1709 — CT2 int8 artifact is baked into the image

--- a/infrastructure/nllb/Dockerfile
+++ b/infrastructure/nllb/Dockerfile
@@ -1,9 +1,14 @@
 FROM python:3.11-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    HF_HOME=/models \
-    TRANSFORMERS_CACHE=/models
+    PYTHONUNBUFFERED=1
+
+# Build args pin which pruned + CT2 int8 artifact this image ships. The
+# artifact is produced by the Benidrissa/sira-nllb-distill pipeline and
+# attached to a GitHub release as ct2_int8.tar.gz. Production overrides
+# the tag via docker-compose build.args when cutting a new release.
+ARG NLLB_ARTIFACT_RELEASE_REPO=Benidrissa/sira-nllb-distill
+ARG NLLB_ARTIFACT_RELEASE_TAG=v1.0.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
@@ -14,11 +19,72 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Pull the pinned artifact from a GitHub release and bake it into the image
+# so the container starts without any network fetch. The release repo is
+# private, which requires the two-step GitHub API pattern:
+#   1. GET  /repos/{repo}/releases/tags/{tag}    → find asset by name
+#   2. GET  /repos/{repo}/releases/assets/{id}   → with Accept: application/octet-stream
+# The browser-style /releases/download/{tag}/{name} URL returns 404 for
+# private repos regardless of how the token is passed.
+#
+# Build needs a GitHub token passed as a build secret:
+#   docker build --secret id=gh_token,env=GH_TOKEN .
+# In CI this is typically ${{ secrets.GITHUB_TOKEN }} (read-only, scoped to
+# the repo) or a PAT with `repo` scope for cross-repo reads.
+RUN --mount=type=secret,id=gh_token,required=true \
+    GH_TOKEN=$(cat /run/secrets/gh_token) \
+    NLLB_REPO="${NLLB_ARTIFACT_RELEASE_REPO}" \
+    NLLB_TAG="${NLLB_ARTIFACT_RELEASE_TAG}" \
+    python <<'PY'
+import json, os, shutil, tarfile, time, urllib.request
+token = os.environ["GH_TOKEN"]
+repo = os.environ["NLLB_REPO"]
+tag = os.environ["NLLB_TAG"]
+# Step 1: resolve asset id from tag + filename.
+req = urllib.request.Request(
+    f"https://api.github.com/repos/{repo}/releases/tags/{tag}",
+    headers={"Authorization": f"Bearer {token}", "Accept": "application/vnd.github+json"},
+)
+release = json.loads(urllib.request.urlopen(req).read())
+asset = next(a for a in release["assets"] if a["name"] == "ct2_int8.tar.gz")
+# Step 2: download the asset binary with retries — release-assets CDN can
+# drop long streaming connections mid-transfer; a plain retry is usually enough.
+last_err = None
+for attempt in range(1, 6):
+    try:
+        req = urllib.request.Request(
+            asset["url"],
+            headers={"Authorization": f"Bearer {token}", "Accept": "application/octet-stream"},
+        )
+        with urllib.request.urlopen(req) as src, open("/tmp/nllb-ct2.tar.gz", "wb") as dst:
+            shutil.copyfileobj(src, dst)
+        if os.path.getsize("/tmp/nllb-ct2.tar.gz") == asset["size"]:
+            break
+        raise OSError(f"incomplete download on attempt {attempt}")
+    except Exception as err:
+        last_err = err
+        print(f"attempt {attempt}/5 failed: {err}; retrying after {2**attempt}s")
+        time.sleep(2 ** attempt)
+else:
+    raise RuntimeError(f"failed to download {asset['name']} after 5 attempts: {last_err}")
+# Extract and move into /models/nllb-ct2/.
+with tarfile.open("/tmp/nllb-ct2.tar.gz") as tf:
+    tf.extractall("/tmp", filter="data")
+os.makedirs("/models/nllb-ct2", exist_ok=True)
+for name in os.listdir("/tmp/ct2_int8"):
+    shutil.move(f"/tmp/ct2_int8/{name}", f"/models/nllb-ct2/{name}")
+os.rmdir("/tmp/ct2_int8")
+os.remove("/tmp/nllb-ct2.tar.gz")
+print(f"installed artifact from {repo}@{tag} ({asset['size']} bytes)")
+PY
+
 COPY server.py .
 
 EXPOSE 5060
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=180s --retries=3 \
+# CT2 int8 artifact loads from disk in seconds, not minutes — drop start_period
+# from 180s (old transformers+HF download path) to 60s.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
     CMD curl -fsS http://localhost:5060/health || exit 1
 
 CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "5060", "--workers", "1"]

--- a/infrastructure/nllb/requirements.txt
+++ b/infrastructure/nllb/requirements.txt
@@ -1,5 +1,4 @@
 fastapi==0.115.6
 uvicorn[standard]==0.32.1
-transformers==4.47.1
-torch==2.5.1
+ctranslate2>=4.5.0
 sentencepiece==0.2.0

--- a/infrastructure/nllb/server.py
+++ b/infrastructure/nllb/server.py
@@ -1,15 +1,24 @@
-"""Meta NLLB-200 translation HTTP server.
+"""NLLB translation HTTP server — CTranslate2 int8, vocab-pruned artifact.
 
 Translates short driving-school qbank texts from French to four low-resource
 West African languages: Mooré (mos_Latn), Dioula (dyu_Latn), Bambara
-(bam_Latn), and Fulfulde — Western Niger variant (fuh_Latn). Pairs with the
-MMS TTS sidecar: translate here first, synthesize audio there. MMS is
-monolingual TTS and will pronounce French syllables with the target
-phonology if fed raw French; this service fixes that (#1690).
+(bam_Latn), and Fulfulde — Nigerian variant (fuv_Latn). Pairs with the
+MMS TTS sidecar: translate here first, synthesize audio there.
 
-Model: ``facebook/nllb-200-distilled-600M`` (~2.4 GB RAM). Preloads the
-model once on startup and keeps it hot. Batch translate up to ~10 short
-texts in one forward pass.
+Replaces the earlier transformers + torch implementation with a CTranslate2
+int8 pipeline (#1709). The artifact is a vocab-pruned fork of
+``facebook/nllb-200-distilled-600M`` restricted to {fra, mos, dyu, bam, fuv}
+and produced by the Benidrissa/sira-nllb-distill pipeline; see
+``infrastructure/nllb/Dockerfile`` for how it's baked into the image.
+
+HTTP contract is preserved bit-for-bit from the transformers era so
+``backend/app/integrations/nllb_translate.py`` doesn't change:
+    POST /translate  {texts, src, tgt}  ->  {translations, elapsed_ms}
+    GET  /health                         ->  {status, model_loaded, ...}
+
+Decoding knobs (beam, no_repeat_ngram, repetition_penalty, max_decoding_length)
+match what landed on dev to fix mos/dyu/bam/ful repetition loops (#1706 +
+#1712). CT2's Translator.translate_batch() accepts all of them natively.
 """
 
 from __future__ import annotations
@@ -19,29 +28,41 @@ import logging
 import os
 import time
 from contextlib import asynccontextmanager
+from pathlib import Path
 
-import torch
+import ctranslate2
+import sentencepiece as spm
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
-from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+
+MODEL_DIR = Path(os.getenv("NLLB_MODEL_DIR", "/models/nllb-ct2"))
+SP_MODEL_PATH = MODEL_DIR / "sentencepiece.bpe.model"
 
 MAX_INPUT_CHARS = 2000
 MAX_TEXTS_PER_BATCH = 32
 # Short qbank content rarely needs more than ~80 output tokens. A high cap
-# only slows greedy decoding by running past EOS on CPU.
+# only slows decoding by running past EOS on CPU.
 MAX_NEW_TOKENS = 96
 
-# Serialize generate() calls — PyTorch model forward passes aren't
-# thread-safe in single-worker uvicorn, and without a queue cap a
-# spike of concurrent /translate requests pins the CPU and makes
-# /health time out alongside them.
-_GENERATE_SEMAPHORE = asyncio.Semaphore(1)
+# Decoding parameters — greedy (beam=1) with no_repeat_ngram + repetition
+# penalty to prevent degenerate loops on mos/dyu/bam/ful. beam=4 was too
+# slow on the old transformers path (#1712), but may be worth revisiting
+# on CT2 int8; leave greedy for now to match dev's shipping settings.
+BEAM_SIZE = int(os.getenv("NLLB_BEAM_SIZE", "1"))
+NO_REPEAT_NGRAM_SIZE = 3
+REPETITION_PENALTY = 1.2
 
-# NLLB source/target codes for the qbank pipeline. The sidecar itself is
-# source-agnostic (NLLB-200 handles 200+ languages); the backend picks
-# the right source code per bank and sends it here. These constants are
-# only used for the ``/health`` payload and input validation reporting.
+COMPUTE_TYPE = os.getenv("NLLB_COMPUTE_TYPE", "int8")
+INTER_THREADS = int(os.getenv("NLLB_INTER_THREADS", "1"))
+INTRA_THREADS = int(os.getenv("NLLB_INTRA_THREADS", "0"))  # 0 = auto
+
+# Serialize translate_batch() calls — CT2 is thread-safe but concurrent
+# Python callers under a single-worker uvicorn still pin the CPU. Keeping
+# the same semaphore pattern as the transformers version (#1705) prevents
+# a spike of concurrent /translate requests from making /health time out.
+_TRANSLATE_SEMAPHORE = asyncio.Semaphore(1)
+
 DEFAULT_SOURCE = "fra_Latn"
 SUPPORTED_TARGETS = ("mos_Latn", "dyu_Latn", "bam_Latn", "fuv_Latn")
 
@@ -50,44 +71,48 @@ logger = logging.getLogger("nllb")
 
 
 class _Bundle:
-    __slots__ = ("model", "tokenizer")
+    __slots__ = ("translator", "sp")
 
-    def __init__(self, model, tokenizer):
-        self.model = model
-        self.tokenizer = tokenizer
+    def __init__(self, translator: ctranslate2.Translator, sp: spm.SentencePieceProcessor):
+        self.translator = translator
+        self.sp = sp
 
 
 _BUNDLE: _Bundle | None = None
 
 
-def _load_model() -> _Bundle:
-    model_id = os.getenv("NLLB_MODEL_ID", "facebook/nllb-200-distilled-600M")
-    logger.info("loading %s", model_id)
-    tokenizer = AutoTokenizer.from_pretrained(model_id)
-    model = AutoModelForSeq2SeqLM.from_pretrained(model_id)
-    model.eval()
-    return _Bundle(model=model, tokenizer=tokenizer)
+def _load() -> _Bundle:
+    logger.info("loading CT2 model from %s (compute_type=%s)", MODEL_DIR, COMPUTE_TYPE)
+    translator = ctranslate2.Translator(
+        str(MODEL_DIR),
+        device="cpu",
+        compute_type=COMPUTE_TYPE,
+        inter_threads=INTER_THREADS,
+        intra_threads=INTRA_THREADS,
+    )
+    sp = spm.SentencePieceProcessor()
+    sp.load(str(SP_MODEL_PATH))
+    logger.info("loaded CT2 model + SentencePiece (vocab=%d)", sp.get_piece_size())
+    return _Bundle(translator=translator, sp=sp)
 
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
     global _BUNDLE
-    # Per-language loading isn't a concept for NLLB — one model handles
-    # all 200+ target codes. If the model itself fails to download we
-    # log and keep the server alive so /health reflects the outage
-    # without taking the container into a crash loop (same resilience
-    # pattern as the MMS sidecar after #1681).
+    # Don't crash lifespan on load failure — /health will return 503
+    # until the container is restarted. Same resilience pattern as the
+    # MMS sidecar (#1681).
     try:
-        _BUNDLE = _load_model()
+        _BUNDLE = _load()
         logger.info("nllb model loaded")
     except Exception as exc:
-        logger.exception("failed to load nllb model: %s", exc)
+        logger.exception("failed to load nllb ct2 model: %s", exc)
         _BUNDLE = None
     yield
     _BUNDLE = None
 
 
-app = FastAPI(title="NLLB Translation Sidecar", version="1.0.0", lifespan=lifespan)
+app = FastAPI(title="NLLB Translation Sidecar (CT2 int8)", version="2.0.0", lifespan=lifespan)
 
 
 class TranslateRequest(BaseModel):
@@ -108,11 +133,25 @@ async def health() -> JSONResponse:
         {
             "status": "ok" if loaded else "degraded",
             "model_loaded": loaded,
+            "model_dir": str(MODEL_DIR),
+            "compute_type": COMPUTE_TYPE,
             "supported_targets": list(SUPPORTED_TARGETS),
             "default_source": DEFAULT_SOURCE,
         },
         status_code=200 if loaded else 503,
     )
+
+
+def _encode(sp: spm.SentencePieceProcessor, text: str, src: str) -> list[str]:
+    # NLLB source-side format: [src_lang, *sp_pieces, </s>]
+    return [src, *sp.encode_as_pieces(text), "</s>"]
+
+
+def _decode(sp: spm.SentencePieceProcessor, tokens: list[str], tgt: str) -> str:
+    # Strip the forced target-language prefix CT2 echoes back.
+    if tokens and tokens[0] == tgt:
+        tokens = tokens[1:]
+    return sp.decode(tokens)
 
 
 @app.post("/translate", response_model=TranslateResponse)
@@ -127,48 +166,26 @@ async def translate(req: TranslateRequest) -> TranslateResponse:
                 detail=f"input text exceeds {MAX_INPUT_CHARS} characters",
             )
 
-    tokenizer = _BUNDLE.tokenizer
-    model = _BUNDLE.model
-    tokenizer.src_lang = req.src
+    sp = _BUNDLE.sp
+    translator = _BUNDLE.translator
 
-    # NLLB forced_bos_token_id selects the target language at generation
-    # time. ``convert_tokens_to_ids`` is the supported way to retrieve it
-    # across transformers versions.
-    tgt_id = tokenizer.convert_tokens_to_ids(req.tgt)
-    if tgt_id is None or tgt_id == tokenizer.unk_token_id:
+    # Validate tgt is a pruned language code the tokenizer knows.
+    if sp.piece_to_id(req.tgt) == sp.unk_id():
         raise HTTPException(status_code=400, detail=f"unknown target lang: {req.tgt}")
 
-    async with _GENERATE_SEMAPHORE:
+    async with _TRANSLATE_SEMAPHORE:
         started = time.monotonic()
-        inputs = tokenizer(
-            req.texts,
-            return_tensors="pt",
-            padding=True,
-            truncation=True,
-            max_length=MAX_INPUT_CHARS,
+        batch = [_encode(sp, t, req.src) for t in req.texts]
+        target_prefix = [[req.tgt]] * len(batch)
+        results = translator.translate_batch(
+            batch,
+            target_prefix=target_prefix,
+            max_decoding_length=MAX_NEW_TOKENS,
+            beam_size=BEAM_SIZE,
+            no_repeat_ngram_size=NO_REPEAT_NGRAM_SIZE,
+            repetition_penalty=REPETITION_PENALTY,
         )
-
-        # ``inference_mode`` disables autograd tracking, reducing memory
-        # and modest speedup vs ``no_grad`` on CPU.
-        #
-        # Decoding knobs for low-resource languages: greedy decoding on
-        # distilled-600M produces degenerate repetition loops for
-        # mos/dyu/bam/ful ("A mi mi mi..."). no_repeat_ngram_size +
-        # repetition_penalty alone prevent those loops; beam search
-        # adds marginal quality but 4x decode cost. On CPU this makes
-        # the serial Semaphore(1) throughput unusable for bank
-        # backfills, so drop to greedy (#1711).
-        with torch.inference_mode():
-            generated = model.generate(
-                **inputs,
-                forced_bos_token_id=tgt_id,
-                max_new_tokens=MAX_NEW_TOKENS,
-                num_beams=1,
-                no_repeat_ngram_size=3,
-                repetition_penalty=1.2,
-                early_stopping=True,
-            )
-        translations = tokenizer.batch_decode(generated, skip_special_tokens=True)
+        translations = [_decode(sp, r.hypotheses[0], req.tgt) for r in results]
         elapsed_ms = int((time.monotonic() - started) * 1000)
 
     logger.info(

--- a/infrastructure/nllb/server.py
+++ b/infrastructure/nllb/server.py
@@ -169,9 +169,15 @@ async def translate(req: TranslateRequest) -> TranslateResponse:
     sp = _BUNDLE.sp
     translator = _BUNDLE.translator
 
-    # Validate tgt is a pruned language code the tokenizer knows.
-    if sp.piece_to_id(req.tgt) == sp.unk_id():
-        raise HTTPException(status_code=400, detail=f"unknown target lang: {req.tgt}")
+    # Validate tgt against the pruned artifact's kept languages. Language
+    # codes live in the CT2-extended vocabulary, not the raw SentencePiece
+    # model, so probing the SP vocab always returns unk_id — whitelist-check
+    # instead. (#1709 hotfix: the SP probe rejected every valid target.)
+    if req.tgt not in SUPPORTED_TARGETS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unsupported target lang {req.tgt}; expected one of {list(SUPPORTED_TARGETS)}",
+        )
 
     async with _TRANSLATE_SEMAPHORE:
         started = time.monotonic()


### PR DESCRIPTION
## Summary
Sync dev→main for PR #1727 (qbank audio: cache-bust \`?v=\`, ordinal option labels, per-sentence MMS splice).

Plus any dev-only infra changes that accumulated since the last sync (likely \`infrastructure/nllb/server.py\` CT2 migration).

## Test plan
- [ ] Admin-squash merge once CI green
- [ ] Staging deploy succeeds
- [ ] Serial regen: \`DELETE FROM qbank_question_audio WHERE language != 'fr'\` then in-process loop
- [ ] Native Dioula speaker: confirms option boundaries are audible and \`kelen\` / \`fila\` are recognizable

Fixes #1719 (when verified end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)