### PR TITLE
chore: sync dev → main (audio cache-bust + ordinal labels + MMS splice, #1727)

### DIFF
--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -75,6 +75,7 @@ def _audio_url_for(
     question_id,
     language: str,
     storage_key: str | None,
+    version: object | None = None,
 ) -> str | None:
     """Build a browser-reachable proxy URL for a question's audio clip.
 
@@ -83,6 +84,13 @@ def _audio_url_for(
     stores ``http://minio:9000/...`` which the browser can't reach —
     same pattern as ``_image_url_for``. Returns ``None`` when the audio
     row has no bytes yet (pending/failed states).
+
+    ``version`` is appended as ``?v=<unix-ts>`` so the URL changes when
+    the underlying audio row gets regenerated (typical during a
+    translation backfill). Without it, browsers serve the cached opus
+    bytes forever — even after an operator wipes + re-synthesizes the
+    audio — because the stable URL hits HTTP cache (#1719 follow-up).
+    Accepts a datetime, int, or ``None`` (returns the unbusted URL).
     """
     if not storage_key:
         return None
@@ -90,7 +98,15 @@ def _audio_url_for(
     host = request.headers.get("x-forwarded-host") or request.headers.get("host")
     if not host:
         return None
-    return f"{proto}://{host}/api/v1/qbank/questions/{question_id}/audio/{language}/data"
+    base = f"{proto}://{host}/api/v1/qbank/questions/{question_id}/audio/{language}/data"
+    if version is None:
+        return base
+    # Accept datetime (preferred — use unix timestamp for compactness) or raw int/str.
+    try:
+        v = int(version.timestamp()) if hasattr(version, "timestamp") else int(version)
+    except (TypeError, ValueError):
+        v = str(version)
+    return f"{base}?v={v}"
 
 
 def _bank_response(bank, question_count: int = 0, test_count: int = 0):
@@ -431,7 +447,13 @@ async def start_test(
             )
         )
         for row in audio_rows.scalars():
-            url = _audio_url_for(request, row.question_id, row.language, row.storage_key)
+            url = _audio_url_for(
+                request,
+                row.question_id,
+                row.language,
+                row.storage_key,
+                version=row.created_at,
+            )
             if url is None:
                 continue
             audio_map.setdefault(str(row.question_id), {})[row.language] = url
@@ -651,7 +673,13 @@ def _audio_response(
         question_id=str(question_id),
         language=language,
         status=row.status.value if hasattr(row.status, "value") else row.status,
-        audio_url=_audio_url_for(request, question_id, language, row.storage_key),
+        audio_url=_audio_url_for(
+            request,
+            question_id,
+            language,
+            row.storage_key,
+            version=row.created_at,
+        ),
         duration_seconds=row.duration_seconds,
     )
 

--- a/backend/app/domain/services/qbank_audio_service.py
+++ b/backend/app/domain/services/qbank_audio_service.py
@@ -49,6 +49,33 @@ OPUS_BYTES_PER_SECOND = 6 * 1024  # matches LessonAudioService._estimate_duratio
 _MMS_PUNCT_RE = re.compile(r"[^\w\s'\-]+", flags=re.UNICODE)
 _MMS_SPACES_RE = re.compile(r"\s+")
 
+# Ordinal words for MMS option labels. Saying "a", "b", "c", "d" via MMS
+# produces either silence (single letters are not a pronounceable token
+# sequence) or a sound too subtle to distinguish options apart. Users
+# reported "no difference among options" on #1719. Replace letters with
+# native-language ordinal words MMS can pronounce clearly. French path
+# is untouched — OpenAI TTS handles "Option A/B/C" natively.
+# Sources: standard orthography from the MMS training corpora (vocab.json).
+# Fallback to number word if we somehow see a 5+ option question.
+_MMS_OPTION_ORDINALS: dict[str, tuple[str, ...]] = {
+    # Mooré (mos): numbers / ordinals
+    "mos": ("pipi", "yiibu", "tãabo", "naase", "nu"),
+    # Dioula (dyu): cardinal numbers used for ordering
+    "dyu": ("kelen", "fila", "saba", "naani", "duuru"),
+    # Bambara (bam): same root as Dioula
+    "bam": ("kelen", "fila", "saba", "naani", "duuru"),
+    # Fulfulde (ful)
+    "ful": ("goo", "ɗiɗi", "tati", "nayi", "jowi"),
+}
+# Silence between sentence segments when we splice per-sentence synth
+# (#1719 follow-up). 300 ms reads as a natural pause without being
+# perceived as a dropout.
+_SEGMENT_SILENCE_MS = 300
+# Split the script into sentences on the original punctuation BEFORE we
+# strip it for the MMS tokenizer. These are the natural boundaries where
+# we want the spliced silence to land.
+_SENTENCE_SPLIT_RE = re.compile(r"[.!?;]+\s*|\n+")
+
 
 def _normalize_for_mms(text: str) -> str:
     """Strip characters the Meta MMS VITS tokenizer can't encode (#1719).
@@ -71,6 +98,23 @@ def _normalize_for_mms(text: str) -> str:
     return _MMS_SPACES_RE.sub(" ", squashed).strip()
 
 
+def _option_label(language: str, idx: int) -> str:
+    """Return the spoken label for option at ``idx`` (0-based).
+
+    French uses the Latin letter (OpenAI TTS handles "A"/"B"/"C" fine).
+    MMS languages use a native ordinal word — saying "a"/"b" after MMS's
+    lowercase-normalize produces sub-audible output and users cannot
+    tell options apart (#1719). Falls back to the last ordinal if a
+    question has more options than we have ordinals cached.
+    """
+    if language == "fr":
+        return chr(ord("A") + idx)
+    ordinals = _MMS_OPTION_ORDINALS.get(language, ())
+    if not ordinals:
+        return str(idx + 1)
+    return ordinals[idx] if idx < len(ordinals) else ordinals[-1]
+
+
 def build_audio_script(
     question: QBankQuestion,
     language: str,
@@ -79,7 +123,8 @@ def build_audio_script(
     """Return the text that should be spoken for a question.
 
     Prepends the option label in the speaker's language so the TTS reads
-    "Option A: ..." in French and the native prefix in MMS languages.
+    "Option A: ..." in French and the native prefix + ordinal in MMS
+    languages ("sugandili kelen" for dyu option 1, etc.).
 
     When ``translation`` is provided (#1690), its translated question_text
     and options are used instead of the source-language ones. Without it
@@ -109,13 +154,65 @@ def build_audio_script(
 
     parts = [q_text]
     for idx, opt in enumerate(options):
-        letter = chr(ord("A") + idx)
-        parts.append(f"{prefix} {letter}: {opt}")
+        label = _option_label(language, idx)
+        parts.append(f"{prefix} {label}: {opt}")
     script = ". ".join(p for p in parts if p).strip() + "."
 
     if language != "fr":
         script = _normalize_for_mms(script)
     return script
+
+
+def build_audio_segments(
+    question: QBankQuestion,
+    language: str,
+    translation: QBankQuestionTranslation | None = None,
+) -> list[str]:
+    """Return a list of sentence-sized chunks for per-segment MMS synth.
+
+    MMS VITS models produce clearer prosody on short inputs and we want
+    an audible pause between the question and each option so the listener
+    can parse the structure (#1719). Each returned chunk is already
+    normalized for the MMS tokenizer.
+
+    French uses a single-blob path (OpenAI TTS is fine with long text);
+    for ``fr`` this returns a one-element list.
+    """
+    prefixes = {
+        "fr": "Option",
+        "mos": "Tʋʋmde",
+        "dyu": "Sugandili",
+        "bam": "Sugandili",
+        "ful": "Suɓaande",
+    }
+    prefix = prefixes.get(language, "Option")
+
+    if translation is not None:
+        q_text = (translation.question_text or "").strip()
+        options = list(translation.options or [])
+    else:
+        q_text = (question.question_text or "").strip()
+        options = list(question.options or [])
+
+    raw_segments: list[str] = []
+    # The question may itself contain multiple sentences (e.g. when the
+    # source French has line breaks collapsed into ". "); split on
+    # sentence-terminators before we strip them.
+    for sub in _SENTENCE_SPLIT_RE.split(q_text):
+        if sub.strip():
+            raw_segments.append(sub.strip())
+    for idx, opt in enumerate(options):
+        if not opt or not opt.strip():
+            continue
+        label = _option_label(language, idx)
+        raw_segments.append(f"{prefix} {label}: {opt.strip()}")
+
+    if language == "fr":
+        return [". ".join(raw_segments).strip() + "."] if raw_segments else []
+    # For MMS langs, normalize each segment individually. Empty results
+    # (e.g. a stray punctuation-only chunk) are dropped.
+    normalized = [_normalize_for_mms(s) for s in raw_segments]
+    return [s for s in normalized if s]
 
 
 def estimate_duration_seconds(audio_bytes: int) -> int:
@@ -182,6 +279,51 @@ class QBankAudioService:
             detail=f"Unsupported audio language: {language}",
         )
 
+    async def _synthesize_segments(self, segments: list[str], language: str) -> bytes:
+        """Synthesize each segment individually and splice with silence.
+
+        MMS VITS produces flatter prosody on long inputs, so we break the
+        question + options into one clip per sentence and concatenate
+        with 300ms silence between. This also restores the
+        "end of thought" cue that punctuation would have carried if MMS
+        tokenizers could encode it (#1719).
+
+        French takes the single-blob path — OpenAI TTS is fine with long
+        text and silence-splicing its output wouldn't pay off.
+        """
+        if not segments:
+            raise MMSTTSError("no segments to synthesize")
+        if language == "fr" or len(segments) == 1:
+            return await self._synthesize_bytes(segments[0], language)
+
+        # Per-segment MMS calls. Backend MMS client already has a
+        # Semaphore(2); we just call sequentially within one task to
+        # keep the sidecar from being overwhelmed.
+        clips: list[bytes] = []
+        for seg in segments:
+            clips.append(await self._mms.synthesize(seg, language))
+
+        # Splice via pydub — the MMS sidecar already uses pydub to
+        # encode WAV → Opus so the dep is available in this container.
+        import io
+
+        from pydub import AudioSegment
+
+        audio_parts = [AudioSegment.from_file(io.BytesIO(b), format="ogg") for b in clips]
+        silence = AudioSegment.silent(duration=_SEGMENT_SILENCE_MS)
+        combined = audio_parts[0]
+        for part in audio_parts[1:]:
+            combined = combined + silence + part
+        buf = io.BytesIO()
+        combined.export(
+            buf,
+            format="ogg",
+            codec="libopus",
+            bitrate="24k",
+            parameters=["-application", "voip"],
+        )
+        return buf.getvalue()
+
     async def generate_question_audio(
         self,
         db: AsyncSession,
@@ -228,8 +370,10 @@ class QBankAudioService:
                 )
 
         try:
-            script = build_audio_script(question, language, translation=translation)
-            audio_bytes = await self._synthesize_bytes(script, language)
+            segments = build_audio_segments(question, language, translation=translation)
+            if not segments:
+                raise ValueError("empty audio script")
+            audio_bytes = await self._synthesize_segments(segments, language)
             key = self._storage_key(question.question_bank_id, question_id, language)
             url = await self._storage.upload_bytes(
                 key=key, data=audio_bytes, content_type=OPUS_CONTENT_TYPE

--- a/backend/tests/test_qbank_audio_service.py
+++ b/backend/tests/test_qbank_audio_service.py
@@ -18,6 +18,7 @@ from app.domain.services.qbank_audio_service import (
     SUPPORTED_LANGUAGES,
     QBankAudioService,
     build_audio_script,
+    build_audio_segments,
     estimate_duration_seconds,
 )
 
@@ -38,24 +39,25 @@ def test_build_audio_script_french_prefix():
     assert script.endswith(".")
 
 
-def test_build_audio_script_mms_languages_use_native_prefix():
-    # MMS VITS vocab is lowercase-only, no punctuation. build_audio_script
-    # normalizes so the prefix ends up lowercase and the A/B label too.
+def test_build_audio_script_mms_languages_use_ordinal_word_labels():
+    # MMS VITS vocab is lowercase-only, no punctuation, and can't
+    # distinguish single-letter labels "a" / "b" when pronounced. We use
+    # native ordinal words instead so the listener hears a clear
+    # difference between options (#1719).
     q = _FakeQuestion("Question", ["A", "B"])
-    for lang, prefix in [
-        ("mos", "tʋʋmde"),
-        ("dyu", "sugandili"),
-        ("bam", "sugandili"),
-        ("ful", "suɓaande"),
-    ]:
+    expectations = [
+        ("mos", "tʋʋmde", "pipi", "yiibu"),
+        ("dyu", "sugandili", "kelen", "fila"),
+        ("bam", "sugandili", "kelen", "fila"),
+        ("ful", "suɓaande", "goo", "ɗiɗi"),
+    ]
+    for lang, prefix, ord1, ord2 in expectations:
         script = build_audio_script(q, lang)
-        assert f"{prefix} a" in script
-        assert f"{prefix} b" in script
+        assert f"{prefix} {ord1}" in script
+        assert f"{prefix} {ord2}" in script
         # No punctuation the MMS tokenizer cannot encode.
-        assert "?" not in script
-        assert "." not in script
-        assert ":" not in script
-        assert "," not in script
+        for bad in ("?", ".", ":", ",", ";", "!"):
+            assert bad not in script
         # No uppercase letters either.
         assert script == script.lower()
 
@@ -77,6 +79,38 @@ def test_build_audio_script_mms_strips_punctuation_from_translation():
     assert script == script.lower()
     # Collapsed spaces — no double spaces.
     assert "  " not in script
+    # Ordinal labels used instead of letters.
+    assert "sugandili kelen" in script
+    assert "sugandili fila" in script
+
+
+def test_build_audio_segments_dyu_splits_question_and_options():
+    """Each sentence becomes its own segment so we can splice silence."""
+    from types import SimpleNamespace
+
+    q = _FakeQuestion("QUE T'INDIQUE CE PANNEAU ?", ["Oui.", "Non."])
+    tr = SimpleNamespace(
+        question_text="I ka kan k'a kɛ cogo di o koo ɲɔgɔn na?",
+        options=["O ye mun lo yira i la?", "A b'a fɔ i ye."],
+    )
+    segments = build_audio_segments(q, "dyu", translation=tr)
+    # Question + 2 options → 3 segments.
+    assert len(segments) == 3
+    assert all(s == s.lower() for s in segments)
+    assert segments[0].startswith("i ka kan k'a kɛ")
+    assert segments[1].startswith("sugandili kelen")
+    assert segments[2].startswith("sugandili fila")
+    for s in segments:
+        for bad in ("?", ".", ":", ","):
+            assert bad not in s
+
+
+def test_build_audio_segments_fr_returns_single_blob():
+    q = _FakeQuestion("Question française", ["Oui", "Non"])
+    segments = build_audio_segments(q, "fr")
+    assert len(segments) == 1
+    assert "Option A: Oui" in segments[0]
+    assert "Option B: Non" in segments[0]
 
 
 def test_build_audio_script_handles_empty_options():


### PR DESCRIPTION
## Summary
Dev was hard-reset to main's \`a8861ba\` and then cherry-picked commit \`5cc73e9\` (PR #1727: qbank audio cache-bust + ordinal option labels + per-sentence MMS splice). So this PR is exactly \`main + 1 commit\` — fast-forward, no conflicts.

Fixes #1719

## Test plan
- [ ] Admin-squash merge once CI green
- [ ] Staging deploy succeeds
- [ ] Serial regen: \`DELETE ... WHERE language != 'fr'\` + in-process loop
- [ ] Native Dioula listener confirms ordinal labels audible, sentence boundaries clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)