### PR TITLE
fix(deploy): make frontend image env-agnostic — runtime API URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -232,21 +232,10 @@ jobs:
           cache-from: type=registry,ref=${{ matrix.image }}:buildcache
           cache-to: type=registry,ref=${{ matrix.image }}:buildcache,mode=max
           build-args: |
-            NEXT_PUBLIC_API_URL=https://api.elearning.portfolio2.kimbetien.com
             NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
             SENTRY_ORG=${{ secrets.SENTRY_ORG }}
             SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
-
-      - name: Build and push tenant frontend (no baked API URL)
-        if: matrix.service == 'frontend'
-        uses: docker/build-push-action@v6
-        with:
-          context: ${{ matrix.context }}
-          push: true
-          tags: ${{ matrix.image }}:tenant
-          cache-from: type=registry,ref=${{ matrix.image }}:buildcache
-          cache-to: type=registry,ref=${{ matrix.image }}:buildcache,mode=max
 
   deploy:
     name: Deploy to Server

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,7 +13,6 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN mkdir -p public
 
-ARG NEXT_PUBLIC_API_URL
 ARG NEXT_PUBLIC_SENTRY_DSN
 ARG SENTRY_ORG
 ARG SENTRY_PROJECT

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -3,17 +3,15 @@ import { DEFAULT_BRANDING } from "./branding";
 
 /**
  * API_BASE resolves to:
- * - Server-side (SSR): BACKEND_URL for direct container-to-container calls,
- *   falls back to NEXT_PUBLIC_API_URL, then localhost.
- * - Client-side (browser): NEXT_PUBLIC_API_URL for direct calls to the
- *   backend via Traefik, falls back to empty string (relative URLs).
+ * - Server-side (SSR): BACKEND_URL for direct container-to-container calls.
+ * - Client-side (browser): empty string — calls go to the same Next.js origin
+ *   and next.config.ts rewrites `/api/*` to BACKEND_URL. Keeps one image
+ *   portable across envs (#1742).
  */
 export const API_BASE =
   typeof window === "undefined"
-    ? process.env.BACKEND_URL ||
-      process.env.NEXT_PUBLIC_API_URL ||
-      "http://localhost:8000"
-    : process.env.NEXT_PUBLIC_API_URL || "";
+    ? process.env.BACKEND_URL || "http://localhost:8000"
+    : "";
 
 export class ApiError extends Error {
   constructor(

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -72,6 +72,13 @@ const nextConfig: NextConfig = {
     ],
   },
 
+  async rewrites() {
+    const backend = process.env.BACKEND_URL || "http://backend:8000";
+    return [
+      { source: "/api/:path*", destination: `${backend}/api/:path*` },
+    ];
+  },
+
   async headers() {
     return [
       {


### PR DESCRIPTION
## Summary
- Client-side `API_BASE` becomes `""`; browser calls go to same origin, Next.js rewrites `/api/*` to `BACKEND_URL` (container network in prod, localhost in dev).
- Drops `NEXT_PUBLIC_API_URL` build-arg from `frontend/Dockerfile` + `deploy.yml` — was baking the staging domain into every image, including prod.
- Drops the `:tenant` variant step — single image now covers both standalone and tenant deployments; confirmed no consumers reference `:tenant` (provisioning uses `:latest`).

Fixes #1742

## Test plan
- [ ] `npm run build` + `npm start` locally with `BACKEND_URL=http://localhost:8000`; exercise login, dashboard, one qbank test; confirm network tab shows XHRs to `/api/v1/...` (relative).
- [ ] Staging auto-deploy succeeds; app still reachable at `etutor.elearning.portfolio2.kimbetien.com`; dashboard + qbank flows still call the staging backend via same origin.
- [ ] Tenant provisioning unaffected — `docker compose pull` on a provisioned tenant pulls the same image and works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)