### PR TITLE
fix(tutor): refresh enrolled-course list after each message

### DIFF
--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -124,18 +124,23 @@ export function ChatPanel({
   // Fetch enrolled courses for course selector. Skip for anonymous visitors
   // so /courses (public catalog) doesn't fire a 401 into every visitor's
   // console (#1622) — there's nothing to enroll-list for logged-out users.
-  useEffect(() => {
+  const refreshEnrolledCourses = useCallback(async () => {
     if (!authClient.isAuthenticated()) return;
-    getMyEnrollments({ orderBy: 'last_accessed', limit: 3 })
-      .then((courses) => {
-        setEnrolledCourses(courses);
-        // Auto-select first course if none set
-        if (!activeCourseId && courses.length > 0) {
-          setActiveCourseId(courses[0].id);
-        }
-      })
-      .catch(() => {});
-  }, []);  // eslint-disable-line react-hooks/exhaustive-deps
+    try {
+      const courses = await getMyEnrollments({ orderBy: 'last_accessed', limit: 3 });
+      setEnrolledCourses(courses);
+      setActiveCourseId((current) => {
+        if (current && courses.some((c) => c.id === current)) return current;
+        return courses[0]?.id ?? current;
+      });
+    } catch {
+      // silent — matches prior behavior
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshEnrolledCourses();
+  }, [refreshEnrolledCourses]);
 
   useEffect(() => {
     // Same reasoning as the enrollments fetch above — anonymous visitors
@@ -335,6 +340,7 @@ export function ChatPanel({
                 const finishedConvId = chunk.data.conversation_id as string;
                 invalidateConversationCache(finishedConvId);
                 invalidateConversationsCache();
+                void refreshEnrolledCourses();
                 if (typeof chunk.data?.remaining_messages === 'number') {
                   const remaining = chunk.data.remaining_messages as number;
                   setCurrentUsage(maxDailyUsage - remaining);


### PR DESCRIPTION
## Summary

- Tutor chat dropdown shows enrolled courses ordered by `last_accessed`, but the list was only fetched once on mount — `touch_course_interaction()` bumps `last_accessed` on every message, so the ordering went stale immediately.
- Extract the enrollments fetch into a `useCallback` and re-invoke it on the SSE `finished` event alongside `invalidateConversationsCache()`.
- Use a functional `setActiveCourseId` updater so the user's current selection is preserved when it's still in the refreshed top-3.

Fixes #1748

## Test plan

- [ ] As a learner enrolled in 3+ courses, open `/tutor/`, note dropdown order.
- [ ] Send a message on a course that isn't already #1; after `finished`, confirm that course moves to the top of the dropdown.
- [ ] Active selection is preserved across the refresh.
- [ ] Send 3 rapid messages — no console errors, final order matches latest `last_accessed`.
- [ ] Anonymous visitor: no 401 spam (guard still in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)