### PR TITLE
fix(qbank): mms timeout, nllb volume, learner test discovery, deploy secret, pydub fallback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,6 +164,13 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=ghcr.io/benidrissa/etutor-digital-ph/nllb:buildcache
           cache-to: type=registry,ref=ghcr.io/benidrissa/etutor-digital-ph/nllb:buildcache,mode=max
+          # gh_token: used by the Dockerfile to pull the pinned
+          # sira-nllb-distill release asset (ct2_int8.tar.gz) from the
+          # cross-repo private release via the GitHub API. The default
+          # GITHUB_TOKEN cannot read another user-owned private repo, so
+          # we need a PAT stored as NLLB_ARTIFACT_READ_TOKEN.
+          secrets: |
+            gh_token=${{ secrets.NLLB_ARTIFACT_READ_TOKEN }}
 
   build-and-push:
     name: Build & Push (${{ matrix.service }})

--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -12,6 +12,7 @@ from fastapi.responses import StreamingResponse
 from app.api.deps import get_db_session
 from app.api.deps_local_auth import AuthenticatedUser, get_current_user
 from app.api.v1.schemas.qbank import (
+    AccessibleTestResponse,
     AudioGenerateResponse,
     AudioStatusResponse,
     BankAnalyticsResponse,
@@ -252,6 +253,40 @@ async def list_accessible_banks(
     )
     return [
         _bank_response(item["bank"], item["question_count"], item["test_count"]) for item in items
+    ]
+
+
+@router.get("/tests/accessible", response_model=list[AccessibleTestResponse])
+async def list_accessible_tests(
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    """Flat list of every test the learner can take across accessible banks.
+
+    Powers the top-level "Tests" discovery page (#1732). Learners don't
+    have to drill into a bank to see its tests — this endpoint returns
+    everything they're eligible for in one call, grouped client-side by
+    bank. Published-only (inherited from ``list_accessible_banks``).
+    """
+    items = await _svc.list_accessible_tests(db, uuid.UUID(current_user.id))
+    return [
+        AccessibleTestResponse(
+            id=str(item["test"].id),
+            question_bank_id=str(item["test"].question_bank_id),
+            title=item["test"].title,
+            mode=item["test"].mode.value
+            if hasattr(item["test"].mode, "value")
+            else item["test"].mode,
+            question_count=item["test"].question_count,
+            time_per_question_sec=item["test"].time_per_question_sec,
+            show_feedback=item["test"].show_feedback,
+            created_at=item["test"].created_at.isoformat(),
+            bank_title=item["bank_title"],
+            bank_language=item["bank_language"],
+            bank_org_name=item["bank_org_name"],
+            bank_org_slug=item["bank_org_slug"],
+        )
+        for item in items
     ]
 
 

--- a/backend/app/api/v1/schemas/qbank.py
+++ b/backend/app/api/v1/schemas/qbank.py
@@ -133,6 +133,27 @@ class TestResponse(BaseModel):
     created_at: str
 
 
+class AccessibleTestResponse(BaseModel):
+    """A test returned by ``/tests/accessible`` for the learner-facing
+    "Tests I can take" page (#1732). Wraps ``TestResponse`` plus enough
+    bank/org context so the learner page can group tests by bank
+    without a second round-trip per test.
+    """
+
+    id: str
+    question_bank_id: str
+    title: str
+    mode: str
+    question_count: int | None = None
+    time_per_question_sec: int | None = None
+    show_feedback: bool
+    created_at: str
+    bank_title: str | None = None
+    bank_language: str | None = None
+    bank_org_name: str | None = None
+    bank_org_slug: str | None = None
+
+
 # ---------------------------------------------------------------------------
 # Test Session (taking a test)
 # ---------------------------------------------------------------------------

--- a/backend/app/domain/services/qbank_audio_service.py
+++ b/backend/app/domain/services/qbank_audio_service.py
@@ -290,11 +290,29 @@ class QBankAudioService:
 
         French takes the single-blob path — OpenAI TTS is fine with long
         text and silence-splicing its output wouldn't pay off.
+
+        Splicing uses pydub (+ ffmpeg). If either isn't available in the
+        runtime image (the backend container ships without ffmpeg today),
+        gracefully fall back to a single MMS call on the joined
+        segments — the ordinal labels and punctuation normalization still
+        take effect, just without the explicit inter-segment silence.
         """
         if not segments:
             raise MMSTTSError("no segments to synthesize")
         if language == "fr" or len(segments) == 1:
             return await self._synthesize_bytes(segments[0], language)
+
+        try:
+            import io
+
+            from pydub import AudioSegment
+        except ImportError:
+            logger.info(
+                "pydub unavailable; falling back to single-blob MMS call",
+                language=language,
+                segments=len(segments),
+            )
+            return await self._synthesize_bytes(" ".join(segments), language)
 
         # Per-segment MMS calls. Backend MMS client already has a
         # Semaphore(2); we just call sequentially within one task to
@@ -303,26 +321,31 @@ class QBankAudioService:
         for seg in segments:
             clips.append(await self._mms.synthesize(seg, language))
 
-        # Splice via pydub — the MMS sidecar already uses pydub to
-        # encode WAV → Opus so the dep is available in this container.
-        import io
-
-        from pydub import AudioSegment
-
-        audio_parts = [AudioSegment.from_file(io.BytesIO(b), format="ogg") for b in clips]
-        silence = AudioSegment.silent(duration=_SEGMENT_SILENCE_MS)
-        combined = audio_parts[0]
-        for part in audio_parts[1:]:
-            combined = combined + silence + part
-        buf = io.BytesIO()
-        combined.export(
-            buf,
-            format="ogg",
-            codec="libopus",
-            bitrate="24k",
-            parameters=["-application", "voip"],
-        )
-        return buf.getvalue()
+        try:
+            audio_parts = [AudioSegment.from_file(io.BytesIO(b), format="ogg") for b in clips]
+            silence = AudioSegment.silent(duration=_SEGMENT_SILENCE_MS)
+            combined = audio_parts[0]
+            for part in audio_parts[1:]:
+                combined = combined + silence + part
+            buf = io.BytesIO()
+            combined.export(
+                buf,
+                format="ogg",
+                codec="libopus",
+                bitrate="24k",
+                parameters=["-application", "voip"],
+            )
+            return buf.getvalue()
+        except FileNotFoundError as exc:
+            # pydub is installed but ffmpeg/libopus isn't — same
+            # fallback. Log once so we can track how often this path
+            # runs in prod.
+            logger.warning(
+                "pydub splice failed (likely missing ffmpeg); using joined single call",
+                language=language,
+                error=str(exc),
+            )
+            return await self._synthesize_bytes(" ".join(segments), language)
 
     async def generate_question_audio(
         self,

--- a/backend/app/domain/services/qbank_service.py
+++ b/backend/app/domain/services/qbank_service.py
@@ -183,6 +183,60 @@ class QBankService:
 
         return await self._enrich_banks(db, banks)
 
+    async def list_accessible_tests(
+        self,
+        db: AsyncSession,
+        user_id: uuid.UUID,
+    ) -> list[dict]:
+        """Return tests the user can take, flattened across accessible banks.
+
+        Uses ``list_accessible_banks`` (published-only) to find every bank
+        the user has org-level access to, then loads the tests under each.
+        Returns one dict per test with enough bank context for the
+        learner-facing "Tests I can take" page (#1732) to render without a
+        drill-through.
+        """
+        from sqlalchemy.orm import selectinload
+
+        bank_rows = await self.list_accessible_banks(db, user_id)
+        if not bank_rows:
+            return []
+
+        bank_ids = [row["bank"].id for row in bank_rows]
+        banks_by_id = {row["bank"].id: row["bank"] for row in bank_rows}
+
+        tests = (
+            (
+                await db.execute(
+                    select(QBankTest)
+                    .where(QBankTest.question_bank_id.in_(bank_ids))
+                    .options(
+                        selectinload(QBankTest.question_bank).selectinload(
+                            QuestionBank.organization
+                        )
+                    )
+                    .order_by(QBankTest.created_at.desc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        out: list[dict] = []
+        for test in tests:
+            bank = test.question_bank or banks_by_id.get(test.question_bank_id)
+            org = getattr(bank, "organization", None) if bank else None
+            out.append(
+                {
+                    "test": test,
+                    "bank_title": bank.title if bank else None,
+                    "bank_language": bank.language if bank else None,
+                    "bank_org_name": org.name if org else None,
+                    "bank_org_slug": org.slug if org else None,
+                }
+            )
+        return out
+
     async def _enrich_banks(self, db: AsyncSession, banks: list[QuestionBank]) -> list[dict]:
         """Attach question + test counts to a list of banks."""
         out = []

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -92,7 +92,11 @@ class Settings(BaseSettings):
 
     # Meta MMS TTS sidecar (Moore / Dioula / Bambara) — see #1503.
     mms_tts_url: str = "http://mms-tts:5050"
-    mms_tts_timeout_seconds: float = 60.0
+    # 180s (matches nllb_timeout_seconds) — MMS-TTS synthesis on CPU for
+    # long question text can take 30–60s per call, and when multiple
+    # Celery workers hit the single-worker sidecar concurrently calls
+    # queue up and 60s hits before the request is served (#1732 follow-up).
+    mms_tts_timeout_seconds: float = 180.0
 
     # NLLB translation sidecar — pruned + CT2 int8 artifact (#1709) replacing
     # the original transformers + distilled-600M setup (#1690, #1705). Port

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -49,31 +49,28 @@ services:
           memory: 4G
 
   nllb:
-    # NLLB-200 translation sidecar (#1690). Loads facebook/nllb-200-
-    # distilled-600M (~2.4 GB RAM) and translates French qbank text to
-    # mos/dyu/bam/ful before the MMS sidecar synthesizes audio.
+    # NLLB translation sidecar — pruned + CT2 int8 artifact (#1709) replacing
+    # the original transformers + distilled-600M setup. The CT2 int8 model
+    # (~350 MB) is baked into the image at build time by
+    # infrastructure/nllb/Dockerfile pulling the pinned sira-nllb-distill
+    # release asset. No volume mount — a volume overlay on /models would
+    # hide the baked-in files (#1732 hotfix). ~600 MB RAM at runtime; 2G
+    # limit has headroom for batch translation.
     image: ghcr.io/benidrissa/etutor-digital-ph/nllb:latest
     container_name: etutor-nllb
-    volumes:
-      - nllb_models:/models
     networks:
       - etutor-data
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:5060/health"]
       interval: 30s
       timeout: 5s
-      start_period: 240s
+      start_period: 60s
       retries: 3
     restart: unless-stopped
     deploy:
       resources:
         limits:
-          # distilled-600M ~2.4 GB FP32 weights + transformers runtime +
-          # activations during generate() easily exceeds 4 GB on first
-          # forward pass, triggering container OOM + restart loop that
-          # makes /health time out (#1696 follow-up). 8 GB covers load
-          # + peak generate comfortably.
-          memory: 8G
+          memory: 2G
 
   backend:
     image: ghcr.io/benidrissa/etutor-digital-ph/backend:latest
@@ -216,7 +213,8 @@ volumes:
   uploads:
   minio_data:
   mms_models:
-  nllb_models:
+  # nllb_models removed in #1732 — CT2 int8 artifact is baked into the image
+  # at build time; a volume here would hide the baked-in /models/nllb-ct2/.
 
 networks:
   etutor-data:

--- a/frontend/app/[locale]/(app)/qbank/tests/client.tsx
+++ b/frontend/app/[locale]/(app)/qbank/tests/client.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import {
+  Building2,
+  ClipboardList,
+  ListChecks,
+  Loader2,
+  PlayCircle,
+  Timer,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { listAccessibleTests, type AccessibleQBankTest } from "@/lib/api";
+
+const MODE_PILL: Record<string, string> = {
+  exam: "bg-red-100 text-red-700",
+  training: "bg-green-100 text-green-700",
+  review: "bg-blue-100 text-blue-700",
+};
+
+export function QBankTestsDiscoveryClient() {
+  const locale = useLocale();
+  const t = useTranslations("qbank");
+  const [tests, setTests] = useState<AccessibleQBankTest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    listAccessibleTests()
+      .then((rows) => {
+        if (cancelled) return;
+        setTests(rows);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Load failed");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Group by bank so the learner sees which bank each test belongs to.
+  const groupedByBank = useMemo(() => {
+    const groups: Record<
+      string,
+      {
+        bankId: string;
+        bankTitle: string | null;
+        bankOrgName: string | null;
+        tests: AccessibleQBankTest[];
+      }
+    > = {};
+    for (const test of tests) {
+      const key = test.question_bank_id;
+      if (!groups[key]) {
+        groups[key] = {
+          bankId: test.question_bank_id,
+          bankTitle: test.bank_title ?? null,
+          bankOrgName: test.bank_org_name ?? null,
+          tests: [],
+        };
+      }
+      groups[key].tests.push(test);
+    }
+    return Object.values(groups);
+  }, [tests]);
+
+  return (
+    <div className="mx-auto w-full max-w-5xl px-4 py-6 sm:py-8">
+      <header className="mb-6 flex flex-col gap-2 sm:mb-8">
+        <div className="flex items-center gap-2">
+          <ListChecks className="h-6 w-6 text-primary" aria-hidden />
+          <h1 className="text-2xl font-bold sm:text-3xl">
+            {t("testsDiscoveryTitle")}
+          </h1>
+        </div>
+        <p className="text-sm text-muted-foreground sm:text-base">
+          {t("testsDiscoveryIntro")}
+        </p>
+      </header>
+
+      {loading && (
+        <div className="flex min-h-[40vh] items-center justify-center">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {!loading && error && (
+        <p className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+          {error}
+        </p>
+      )}
+
+      {!loading && !error && tests.length === 0 && (
+        <p className="rounded-lg border border-dashed border-muted-foreground/30 p-8 text-center text-sm text-muted-foreground">
+          {t("testsDiscoveryEmpty")}
+        </p>
+      )}
+
+      {!loading && !error && groupedByBank.length > 0 && (
+        <div className="space-y-6">
+          {groupedByBank.map((group) => (
+            <section key={group.bankId} className="space-y-2">
+              <div className="flex flex-wrap items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                <ClipboardList className="h-4 w-4" aria-hidden />
+                <span className="text-foreground">
+                  {group.bankTitle ?? "—"}
+                </span>
+                {group.bankOrgName && (
+                  <span className="flex items-center gap-1">
+                    <Building2 className="h-3.5 w-3.5" aria-hidden />
+                    {group.bankOrgName}
+                  </span>
+                )}
+              </div>
+              <ul className="grid gap-3 sm:grid-cols-2">
+                {group.tests.map((test) => (
+                  <li key={test.id}>
+                    <Link
+                      href={`/${locale}/qbank/tests/${test.id}`}
+                      className="flex h-full flex-col gap-2 rounded-lg border bg-card p-4 transition-colors hover:border-primary/50 hover:bg-muted/50"
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <h2 className="text-base font-semibold leading-snug">
+                          {test.title}
+                        </h2>
+                        <Badge
+                          className={`${MODE_PILL[test.mode] ?? "bg-muted text-muted-foreground"} shrink-0`}
+                          variant="secondary"
+                        >
+                          {t(`mode.${test.mode}`)}
+                        </Badge>
+                      </div>
+                      <div className="mt-auto flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                        {typeof test.question_count === "number" && (
+                          <span className="flex items-center gap-1">
+                            <ClipboardList
+                              className="h-3.5 w-3.5"
+                              aria-hidden
+                            />
+                            {t("questionCount", { count: test.question_count })}
+                          </span>
+                        )}
+                        {typeof test.time_per_question_sec === "number" && (
+                          <span className="flex items-center gap-1">
+                            <Timer className="h-3.5 w-3.5" aria-hidden />
+                            {test.time_per_question_sec}s / {t("perQuestion")}
+                          </span>
+                        )}
+                        <span className="ml-auto flex items-center gap-1 text-primary">
+                          <PlayCircle className="h-4 w-4" aria-hidden />
+                          {t("startTest")}
+                        </span>
+                      </div>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/[locale]/(app)/qbank/tests/page.tsx
+++ b/frontend/app/[locale]/(app)/qbank/tests/page.tsx
@@ -1,0 +1,5 @@
+import { QBankTestsDiscoveryClient } from "./client";
+
+export default function QBankTestsDiscoveryPage() {
+  return <QBankTestsDiscoveryClient />;
+}

--- a/frontend/components/layout/bottom-nav.tsx
+++ b/frontend/components/layout/bottom-nav.tsx
@@ -9,6 +9,7 @@ import {
   CreditCard,
   Bot,
   Brain,
+  ListChecks,
   MoreHorizontal,
   BookOpen,
   User,
@@ -16,14 +17,19 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { startTransition, useState, useEffect, useRef } from "react";
-import { getCurriculumContext, onCurriculumContextChange, type CurriculumContextValue } from "@/lib/curriculum-context";
+import {
+  getCurriculumContext,
+  onCurriculumContextChange,
+  type CurriculumContextValue,
+} from "@/lib/curriculum-context";
 
 export function BottomNav() {
   const t = useTranslations("Navigation");
   const pathname = usePathname();
   const locale = useLocale();
   const [moreOpen, setMoreOpen] = useState(false);
-  const [curriculumCtx, setCurriculumCtx] = useState<CurriculumContextValue | null>(null);
+  const [curriculumCtx, setCurriculumCtx] =
+    useState<CurriculumContextValue | null>(null);
   const moreRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -88,6 +94,12 @@ export function BottomNav() {
       description: t("modulesDescription"),
     },
     {
+      href: `/${locale}/qbank/tests`,
+      label: t("qbankTests"),
+      icon: ListChecks,
+      description: t("qbankTestsDescription"),
+    },
+    {
       href: `/${locale}/qbank`,
       label: t("qbank"),
       icon: Brain,
@@ -137,7 +149,7 @@ export function BottomNav() {
                     "flex min-h-[56px] flex-col items-center justify-center gap-1 rounded-md px-2 py-3 text-xs transition-colors",
                     isActive
                       ? "bg-primary/10 text-primary"
-                      : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                      : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
                   )}
                   aria-label={item.description}
                   aria-current={isActive ? "page" : undefined}
@@ -171,22 +183,19 @@ export function BottomNav() {
                   "flex min-h-11 min-w-11 flex-1 flex-col items-center justify-center py-2 text-xs transition-colors",
                   isActive
                     ? "text-primary"
-                    : "text-muted-foreground hover:text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
                 )}
                 aria-label={item.description}
                 aria-current={isActive ? "page" : undefined}
               >
                 <Icon
-                  className={cn(
-                    "h-5 w-5 mb-1",
-                    isActive && "text-primary"
-                  )}
+                  className={cn("h-5 w-5 mb-1", isActive && "text-primary")}
                   aria-hidden="true"
                 />
                 <span
                   className={cn(
                     "text-xs",
-                    isActive && "text-primary font-medium"
+                    isActive && "text-primary font-medium",
                   )}
                 >
                   {item.label}
@@ -198,9 +207,9 @@ export function BottomNav() {
           <button
             className={cn(
               "flex min-h-11 min-w-11 flex-1 flex-col items-center justify-center py-2 text-xs transition-colors",
-              (moreOpen || isMoreActive)
+              moreOpen || isMoreActive
                 ? "text-primary"
-                : "text-muted-foreground hover:text-foreground"
+                : "text-muted-foreground hover:text-foreground",
             )}
             onClick={() => setMoreOpen((prev) => !prev)}
             aria-label={t("moreMenuLabel")}
@@ -210,14 +219,14 @@ export function BottomNav() {
             <MoreHorizontal
               className={cn(
                 "h-5 w-5 mb-1",
-                (moreOpen || isMoreActive) && "text-primary"
+                (moreOpen || isMoreActive) && "text-primary",
               )}
               aria-hidden="true"
             />
             <span
               className={cn(
                 "text-xs",
-                (moreOpen || isMoreActive) && "text-primary font-medium"
+                (moreOpen || isMoreActive) && "text-primary font-medium",
               )}
             >
               {t("more")}

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -11,6 +11,7 @@ import {
   CreditCard,
   Bot,
   Brain,
+  ListChecks,
   User,
   ChevronLeft,
   ChevronRight,
@@ -26,7 +27,11 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { authClient } from "@/lib/auth";
 import { useQueryClient } from "@tanstack/react-query";
-import { getCurriculumContext, onCurriculumContextChange, type CurriculumContextValue } from "@/lib/curriculum-context";
+import {
+  getCurriculumContext,
+  onCurriculumContextChange,
+  type CurriculumContextValue,
+} from "@/lib/curriculum-context";
 
 function getUserRole(): string | null {
   if (typeof window === "undefined") return null;
@@ -53,7 +58,8 @@ export function Sidebar() {
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const [userRole, setUserRole] = useState<string | null>(null);
-  const [curriculumCtx, setCurriculumCtx] = useState<CurriculumContextValue | null>(null);
+  const [curriculumCtx, setCurriculumCtx] =
+    useState<CurriculumContextValue | null>(null);
 
   useEffect(() => {
     startTransition(() => {
@@ -88,7 +94,7 @@ export function Sidebar() {
         : `/${locale}/dashboard`,
       label: t("dashboard"),
       icon: Home,
-      description: t("dashboardDescription")
+      description: t("dashboardDescription"),
     },
     {
       href: curriculumCtx
@@ -98,49 +104,55 @@ export function Sidebar() {
         : `/${locale}/courses`,
       label: t("courses"),
       icon: GraduationCap,
-      description: t("coursesDescription")
+      description: t("coursesDescription"),
     },
     {
       href: `/${locale}/modules`,
       label: t("modules"),
       icon: BookOpen,
-      description: t("modulesDescription")
+      description: t("modulesDescription"),
     },
     {
       href: `/${locale}/flashcards`,
       label: t("flashcards"),
       icon: CreditCard,
-      description: t("flashcardsDescription")
+      description: t("flashcardsDescription"),
+    },
+    {
+      href: `/${locale}/qbank/tests`,
+      label: t("qbankTests"),
+      icon: ListChecks,
+      description: t("qbankTestsDescription"),
     },
     {
       href: `/${locale}/qbank`,
       label: t("qbank"),
       icon: Brain,
-      description: t("qbankDescription")
+      description: t("qbankDescription"),
     },
     {
       href: `/${locale}/certificates`,
       label: t("certificates"),
       icon: Award,
-      description: t("certificatesDescription")
+      description: t("certificatesDescription"),
     },
     {
       href: `/${locale}/tutor`,
       label: t("tutor"),
       icon: Bot,
-      description: t("tutorDescription")
+      description: t("tutorDescription"),
     },
     {
       href: `/${locale}/profile`,
       label: t("profile"),
       icon: User,
-      description: t("profileDescription")
+      description: t("profileDescription"),
     },
     {
       href: `/${locale}/subscribe`,
       label: t("subscribe"),
       icon: Wallet,
-      description: t("subscribeDescription")
+      description: t("subscribeDescription"),
     },
     ...(userRole === "admin" || userRole === "sub_admin"
       ? [
@@ -152,7 +164,9 @@ export function Sidebar() {
           },
         ]
       : []),
-    ...(userRole === "admin" || userRole === "sub_admin" || userRole === "expert"
+    ...(userRole === "admin" ||
+    userRole === "sub_admin" ||
+    userRole === "expert"
       ? [
           {
             href: `/${locale}/admin/users`,
@@ -165,18 +179,20 @@ export function Sidebar() {
   ];
 
   return (
-    <aside 
+    <aside
       className={cn(
         "hidden shrink-0 border-r bg-card md:flex md:flex-col transition-all duration-300",
-        isCollapsed ? "w-16" : "w-60"
+        isCollapsed ? "w-16" : "w-60",
       )}
       role="navigation"
       aria-label={t("desktopNavigation")}
     >
-      <div className={cn(
-        "flex h-14 items-center border-b",
-        isCollapsed ? "px-2 justify-center" : "px-4 justify-between"
-      )}>
+      <div
+        className={cn(
+          "flex h-14 items-center border-b",
+          isCollapsed ? "px-2 justify-center" : "px-4 justify-between",
+        )}
+      >
         {!isCollapsed && (
           <span className="text-sm font-semibold truncate">
             {tCommon("appName")}
@@ -196,12 +212,12 @@ export function Sidebar() {
           )}
         </Button>
       </div>
-      
+
       <nav className="flex flex-col gap-1 p-2 flex-1">
         {navItems.map((item) => {
           const Icon = item.icon;
           const isActive = pathname.includes(item.href);
-          
+
           return (
             <Link
               key={item.href}
@@ -211,24 +227,19 @@ export function Sidebar() {
                 isActive
                   ? "bg-accent text-accent-foreground"
                   : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
-                isCollapsed && "justify-center px-2"
+                isCollapsed && "justify-center px-2",
               )}
               title={isCollapsed ? item.description : undefined}
               aria-label={item.description}
               aria-current={isActive ? "page" : undefined}
             >
-              <Icon 
-                className="h-4 w-4 shrink-0" 
-                aria-hidden="true"
-              />
-              {!isCollapsed && (
-                <span className="truncate">{item.label}</span>
-              )}
+              <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+              {!isCollapsed && <span className="truncate">{item.label}</span>}
             </Link>
           );
         })}
       </nav>
-      
+
       <div className="border-t p-2">
         {!isCollapsed ? (
           <div className="space-y-1 p-2">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -10,13 +10,19 @@ import { DEFAULT_BRANDING } from "./branding";
  */
 export const API_BASE =
   typeof window === "undefined"
-    ? process.env.BACKEND_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"
+    ? process.env.BACKEND_URL ||
+      process.env.NEXT_PUBLIC_API_URL ||
+      "http://localhost:8000"
     : process.env.NEXT_PUBLIC_API_URL || "";
 
 export class ApiError extends Error {
-  constructor(message: string, public status: number, public code?: string) {
+  constructor(
+    message: string,
+    public status: number,
+    public code?: string,
+  ) {
     super(message);
-    this.name = 'ApiError';
+    this.name = "ApiError";
   }
 }
 
@@ -90,20 +96,24 @@ export async function getCourses(filters?: {
   curriculum?: string;
 }): Promise<CourseResponse[]> {
   const params = new URLSearchParams();
-  if (filters?.course_domain) params.set("course_domain", filters.course_domain);
+  if (filters?.course_domain)
+    params.set("course_domain", filters.course_domain);
   if (filters?.course_level) params.set("course_level", filters.course_level);
-  if (filters?.audience_type) params.set("audience_type", filters.audience_type);
+  if (filters?.audience_type)
+    params.set("audience_type", filters.audience_type);
   if (filters?.search) params.set("search", filters.search);
   if (filters?.curriculum) params.set("curriculum", filters.curriculum);
   const qs = params.toString();
   return apiFetch<CourseResponse[]>(`/api/v1/courses${qs ? `?${qs}` : ""}`);
 }
 
-export async function enrollInCourse(courseId: string): Promise<EnrollmentResponse> {
+export async function enrollInCourse(
+  courseId: string,
+): Promise<EnrollmentResponse> {
   const { authClient } = await import("./auth");
   return authClient.authenticatedFetch<EnrollmentResponse>(
     `/api/v1/courses/${courseId}/enroll`,
-    { method: "POST" }
+    { method: "POST" },
   );
 }
 
@@ -111,7 +121,7 @@ export async function enrollInCourse(courseId: string): Promise<EnrollmentRespon
 export async function getAdminTaxonomy(): Promise<TaxonomyAdminResponse> {
   const { authClient } = await import("./auth");
   return authClient.authenticatedFetch<TaxonomyAdminResponse>(
-    "/api/v1/admin/taxonomy"
+    "/api/v1/admin/taxonomy",
   );
 }
 
@@ -125,40 +135,44 @@ export async function createTaxonomyCategory(data: {
   const { authClient } = await import("./auth");
   return authClient.authenticatedFetch<TaxonomyCategoryAdmin>(
     "/api/v1/admin/taxonomy",
-    { method: "POST", body: JSON.stringify(data) }
+    { method: "POST", body: JSON.stringify(data) },
   );
 }
 
 export async function updateTaxonomyCategory(
   id: string,
-  data: Partial<{ label_fr: string; label_en: string; sort_order: number; is_active: boolean }>
+  data: Partial<{
+    label_fr: string;
+    label_en: string;
+    sort_order: number;
+    is_active: boolean;
+  }>,
 ): Promise<TaxonomyCategoryAdmin> {
   const { authClient } = await import("./auth");
   return authClient.authenticatedFetch<TaxonomyCategoryAdmin>(
     `/api/v1/admin/taxonomy/${id}`,
-    { method: "PATCH", body: JSON.stringify(data) }
+    { method: "PATCH", body: JSON.stringify(data) },
   );
 }
 
 export async function deleteTaxonomyCategory(id: string): Promise<void> {
   const { authClient } = await import("./auth");
-  await authClient.authenticatedFetch(
-    `/api/v1/admin/taxonomy/${id}`,
-    { method: "DELETE" }
-  );
+  await authClient.authenticatedFetch(`/api/v1/admin/taxonomy/${id}`, {
+    method: "DELETE",
+  });
 }
 
 export async function getMyEnrollments(opts?: {
-  orderBy?: 'last_accessed';
+  orderBy?: "last_accessed";
   limit?: number;
 }): Promise<CourseWithEnrollment[]> {
   const { authClient } = await import("./auth");
   const params = new URLSearchParams();
-  if (opts?.orderBy) params.set('order_by', opts.orderBy);
-  if (opts?.limit) params.set('limit', String(opts.limit));
+  if (opts?.orderBy) params.set("order_by", opts.orderBy);
+  if (opts?.limit) params.set("limit", String(opts.limit));
   const qs = params.toString();
   return authClient.authenticatedFetch<CourseWithEnrollment[]>(
-    `/api/v1/courses/my-enrollments${qs ? `?${qs}` : ''}`
+    `/api/v1/courses/my-enrollments${qs ? `?${qs}` : ""}`,
   );
 }
 
@@ -189,7 +203,7 @@ export interface UnitProgressDetail {
   description_en?: string;
   estimated_minutes: number;
   order_index: number;
-  unit_type?: 'lesson' | 'quiz' | 'case-study';
+  unit_type?: "lesson" | "quiz" | "case-study";
   status: "pending" | "in_progress" | "completed";
 }
 
@@ -219,14 +233,18 @@ export interface LessonAccessRequest {
 }
 
 // Progress API Functions
-export async function getModuleProgress(moduleId: string): Promise<ModuleProgressResponse> {
+export async function getModuleProgress(
+  moduleId: string,
+): Promise<ModuleProgressResponse> {
   const { authClient } = await import("./auth");
   return authClient.authenticatedFetch<ModuleProgressResponse>(
-    `/api/v1/progress/modules/${moduleId}`
+    `/api/v1/progress/modules/${moduleId}`,
   );
 }
 
-export async function getAllModuleProgress(courseId?: string): Promise<ModuleProgressResponse[]> {
+export async function getAllModuleProgress(
+  courseId?: string,
+): Promise<ModuleProgressResponse[]> {
   const { authClient } = await import("./auth");
   const url = courseId
     ? `/api/v1/progress/modules?course_id=${encodeURIComponent(courseId)}`
@@ -235,11 +253,11 @@ export async function getAllModuleProgress(courseId?: string): Promise<ModulePro
 }
 
 export async function getModuleDetailWithProgress(
-  moduleId: string
+  moduleId: string,
 ): Promise<ModuleDetailWithProgressResponse> {
   const { authClient } = await import("./auth");
   return authClient.authenticatedFetch<ModuleDetailWithProgressResponse>(
-    `/api/v1/progress/modules/${moduleId}/detail`
+    `/api/v1/progress/modules/${moduleId}/detail`,
   );
 }
 
@@ -252,7 +270,7 @@ export interface PublicUnitDetail {
   description_en?: string;
   estimated_minutes: number;
   order_index: number;
-  unit_type?: 'lesson' | 'quiz' | 'case-study';
+  unit_type?: "lesson" | "quiz" | "case-study";
 }
 
 export interface ModuleUnitsResponse {
@@ -270,23 +288,30 @@ export interface ModuleUnitsResponse {
   units: PublicUnitDetail[];
 }
 
-export async function getModuleUnits(moduleId: string): Promise<ModuleUnitsResponse> {
-  return apiFetch<ModuleUnitsResponse>(`/api/v1/content/modules/${moduleId}/units`);
+export async function getModuleUnits(
+  moduleId: string,
+): Promise<ModuleUnitsResponse> {
+  return apiFetch<ModuleUnitsResponse>(
+    `/api/v1/content/modules/${moduleId}/units`,
+  );
 }
 
 export async function trackLessonAccess(
-  request: LessonAccessRequest
+  request: LessonAccessRequest,
 ): Promise<ModuleProgressResponse> {
   const { authClient } = await import("./auth");
-  return authClient.authenticatedFetch<ModuleProgressResponse>("/api/v1/progress/lesson-access", {
-    method: "POST",
-    body: JSON.stringify(request),
-  });
+  return authClient.authenticatedFetch<ModuleProgressResponse>(
+    "/api/v1/progress/lesson-access",
+    {
+      method: "POST",
+      body: JSON.stringify(request),
+    },
+  );
 }
 
 export async function apiFetch<T>(
   path: string,
-  options?: RequestInit
+  options?: RequestInit,
 ): Promise<T> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
@@ -313,7 +338,7 @@ export async function apiFetch<T>(
     try {
       const body = await res.json();
       if (body?.detail?.message) message = body.detail.message;
-      else if (typeof body?.detail === 'string') message = body.detail;
+      else if (typeof body?.detail === "string") message = body.detail;
       if (body?.detail?.code) code = body.detail.code;
     } catch {
       // ignore parse errors — keep the status-code message
@@ -328,7 +353,7 @@ export async function apiFetch<T>(
 export const fetchApi = apiFetch;
 
 // Lesson Image API Types
-export type LessonImageStatus = 'pending' | 'generating' | 'ready' | 'failed';
+export type LessonImageStatus = "pending" | "generating" | "ready" | "failed";
 
 export interface LessonImageResponse {
   lesson_id: string;
@@ -355,11 +380,15 @@ interface _ApiLessonImagesListResponse {
   total: number;
 }
 
-export async function getLessonImageStatus(lessonId: string): Promise<LessonImageResponse> {
-  const data = await apiFetch<_ApiLessonImagesListResponse>(`/api/v1/images/lesson/${lessonId}`);
+export async function getLessonImageStatus(
+  lessonId: string,
+): Promise<LessonImageResponse> {
+  const data = await apiFetch<_ApiLessonImagesListResponse>(
+    `/api/v1/images/lesson/${lessonId}`,
+  );
   const first = data.images[0];
   if (!first) {
-    return { lesson_id: lessonId, status: 'pending' };
+    return { lesson_id: lessonId, status: "pending" };
   }
   return {
     lesson_id: first.lesson_id,
@@ -372,7 +401,7 @@ export async function getLessonImageStatus(lessonId: string): Promise<LessonImag
 }
 
 // Lesson Audio API Types
-export type LessonAudioStatus = 'pending' | 'generating' | 'ready' | 'failed';
+export type LessonAudioStatus = "pending" | "generating" | "ready" | "failed";
 
 export interface LessonAudioResponse {
   lesson_id: string;
@@ -396,11 +425,15 @@ interface _ApiLessonAudioListResponse {
   total: number;
 }
 
-export async function getLessonAudioStatus(lessonId: string): Promise<LessonAudioResponse> {
-  const data = await apiFetch<_ApiLessonAudioListResponse>(`/api/v1/audio/lesson/${lessonId}`);
+export async function getLessonAudioStatus(
+  lessonId: string,
+): Promise<LessonAudioResponse> {
+  const data = await apiFetch<_ApiLessonAudioListResponse>(
+    `/api/v1/audio/lesson/${lessonId}`,
+  );
   const first = data.audio[0];
   if (!first) {
-    return { lesson_id: lessonId, status: 'pending' };
+    return { lesson_id: lessonId, status: "pending" };
   }
   return {
     lesson_id: first.lesson_id,
@@ -421,19 +454,23 @@ export interface DashboardStats {
 }
 
 export async function getDashboardStats(): Promise<DashboardStats> {
-  const { authClient } = await import('./auth');
-  
+  const { authClient } = await import("./auth");
+
   // Get user's timezone offset for accurate streak calculations
   const timezoneOffset = -new Date().getTimezoneOffset() / 60; // Convert to hours
-  const offsetString = timezoneOffset >= 0 ? 
-    `+${timezoneOffset.toString().padStart(2, '0')}:00` : 
-    `${timezoneOffset.toString().padStart(3, '0')}:00`;
+  const offsetString =
+    timezoneOffset >= 0
+      ? `+${timezoneOffset.toString().padStart(2, "0")}:00`
+      : `${timezoneOffset.toString().padStart(3, "0")}:00`;
 
-  return authClient.authenticatedFetch<DashboardStats>("/api/v1/dashboard/stats", {
-    headers: {
-      "X-Timezone-Offset": offsetString,
+  return authClient.authenticatedFetch<DashboardStats>(
+    "/api/v1/dashboard/stats",
+    {
+      headers: {
+        "X-Timezone-Offset": offsetString,
+      },
     },
-  });
+  );
 }
 
 export interface UpcomingReviewSession {
@@ -451,8 +488,10 @@ export interface UpcomingReviewsResponse {
 }
 
 export async function getUpcomingReviews(): Promise<UpcomingReviewsResponse> {
-  const { authClient } = await import('./auth');
-  return authClient.authenticatedFetch<UpcomingReviewsResponse>("/api/v1/flashcards/upcoming");
+  const { authClient } = await import("./auth");
+  return authClient.authenticatedFetch<UpcomingReviewsResponse>(
+    "/api/v1/flashcards/upcoming",
+  );
 }
 
 export interface FlashcardSetResponse {
@@ -469,10 +508,10 @@ export async function generateModuleFlashcards(params: {
   language: string;
   level?: number;
 }): Promise<FlashcardSetResponse> {
-  const { authClient } = await import('./auth');
+  const { authClient } = await import("./auth");
   const level = params.level ?? 1;
   return authClient.authenticatedFetch<FlashcardSetResponse>(
-    `/api/v1/flashcards/modules/${params.moduleId}?language=${params.language}&level=${level}`
+    `/api/v1/flashcards/modules/${params.moduleId}?language=${params.language}&level=${level}`,
   );
 }
 
@@ -571,7 +610,7 @@ export async function getQuiz(quizId: string): Promise<Quiz> {
 }
 
 export async function submitQuizAttempt(
-  request: QuizAttemptRequest
+  request: QuizAttemptRequest,
 ): Promise<QuizAttemptResponse> {
   return apiFetch<QuizAttemptResponse>("/api/v1/quiz/attempt", {
     method: "POST",
@@ -614,10 +653,10 @@ export interface UnitQuizValidationStatus {
 
 export async function checkUnitQuizPassed(
   moduleId: string,
-  unitId: string
+  unitId: string,
 ): Promise<UnitQuizValidationStatus> {
   return apiFetch<UnitQuizValidationStatus>(
-    `/api/v1/quiz/attempts/status?module_id=${encodeURIComponent(moduleId)}&unit_id=${encodeURIComponent(unitId)}`
+    `/api/v1/quiz/attempts/status?module_id=${encodeURIComponent(moduleId)}&unit_id=${encodeURIComponent(unitId)}`,
   );
 }
 
@@ -641,20 +680,23 @@ export async function generateSummativeAssessment(params: {
 }
 
 export async function canAttemptSummativeAssessment(
-  moduleId: string
+  moduleId: string,
 ): Promise<SummativeAssessmentAttemptCheck> {
   return apiFetch<SummativeAssessmentAttemptCheck>(
-    `/api/v1/quiz/summative/${moduleId}/can-attempt`
+    `/api/v1/quiz/summative/${moduleId}/can-attempt`,
   );
 }
 
 export async function submitSummativeAssessmentAttempt(
-  request: QuizAttemptRequest
+  request: QuizAttemptRequest,
 ): Promise<SummativeAssessmentResponse> {
-  return apiFetch<SummativeAssessmentResponse>("/api/v1/quiz/summative/attempt", {
-    method: "POST",
-    body: JSON.stringify(request),
-  });
+  return apiFetch<SummativeAssessmentResponse>(
+    "/api/v1/quiz/summative/attempt",
+    {
+      method: "POST",
+      body: JSON.stringify(request),
+    },
+  );
 }
 
 // ── Source Image (PDF extraction) API ─────────────────────────
@@ -675,7 +717,7 @@ export interface LessonResponse {
   id: string;
   module_id: string;
   unit_id: string;
-  language: 'fr' | 'en';
+  language: "fr" | "en";
   level: number;
   country_context: string;
   content: {
@@ -692,8 +734,8 @@ export interface LessonResponse {
 
 // ── Module Media API ──────────────────────────────────────────
 
-export type MediaType = 'audio' | 'video';
-export type MediaStatus = 'pending' | 'generating' | 'ready' | 'failed';
+export type MediaType = "audio" | "video";
+export type MediaStatus = "pending" | "generating" | "ready" | "failed";
 
 export interface ModuleMediaResponse {
   id: string;
@@ -712,23 +754,36 @@ export interface GenerateModuleMediaRequest {
   language: string;
 }
 
-export async function getModuleMedia(moduleId: string): Promise<ModuleMediaResponse[]> {
+export async function getModuleMedia(
+  moduleId: string,
+): Promise<ModuleMediaResponse[]> {
   return apiFetch<ModuleMediaResponse[]>(`/api/v1/modules/${moduleId}/media`);
 }
 
 export async function generateModuleMedia(
   moduleId: string,
   mediaType: MediaType,
-  language: string
+  language: string,
 ): Promise<ModuleMediaResponse> {
-  return apiFetch<ModuleMediaResponse>(`/api/v1/modules/${moduleId}/media/generate`, {
-    method: 'POST',
-    body: JSON.stringify({ media_type: mediaType, language } satisfies GenerateModuleMediaRequest),
-  });
+  return apiFetch<ModuleMediaResponse>(
+    `/api/v1/modules/${moduleId}/media/generate`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        media_type: mediaType,
+        language,
+      } satisfies GenerateModuleMediaRequest),
+    },
+  );
 }
 
-export async function deleteModuleMedia(moduleId: string, mediaId: string): Promise<void> {
-  await apiFetch<void>(`/api/v1/modules/${moduleId}/media/${mediaId}`, { method: 'DELETE' });
+export async function deleteModuleMedia(
+  moduleId: string,
+  mediaId: string,
+): Promise<void> {
+  await apiFetch<void>(`/api/v1/modules/${moduleId}/media/${mediaId}`, {
+    method: "DELETE",
+  });
 }
 
 // ── Platform Settings ─────────────────────────────────────────
@@ -757,9 +812,10 @@ export interface PublicConfig {
 }
 
 export async function getPublicConfig(): Promise<PublicConfig> {
-  const res = await apiFetch<{ settings: Record<string, unknown>; branding?: Branding }>(
-    "/api/v1/settings/public",
-  );
+  const res = await apiFetch<{
+    settings: Record<string, unknown>;
+    branding?: Branding;
+  }>("/api/v1/settings/public");
   return { settings: res.settings, branding: res.branding ?? DEFAULT_BRANDING };
 }
 
@@ -772,7 +828,10 @@ export async function getAdminSettings(): Promise<SettingsByCategory[]> {
   return apiFetch<SettingsByCategory[]>("/api/v1/admin/settings");
 }
 
-export async function updateSetting(key: string, value: unknown): Promise<PlatformSetting> {
+export async function updateSetting(
+  key: string,
+  value: unknown,
+): Promise<PlatformSetting> {
   return apiFetch<PlatformSetting>("/api/v1/admin/settings/update", {
     method: "POST",
     body: JSON.stringify({ key, value }),
@@ -787,9 +846,11 @@ export async function resetSetting(key: string): Promise<PlatformSetting> {
 }
 
 export async function resetSettingCategory(
-  category: string
+  category: string,
 ): Promise<{ category: string; reset_count: number }> {
-  return apiFetch(`/api/v1/admin/settings/reset-category/${category}`, { method: "POST" });
+  return apiFetch(`/api/v1/admin/settings/reset-category/${category}`, {
+    method: "POST",
+  });
 }
 
 // ── Curricula API ─────────────────────────────────────────────
@@ -822,7 +883,15 @@ export interface CurriculumAdminResponse {
   visibility: "public" | "private";
   created_by?: string;
   course_count: number;
-  courses?: Array<{ id: string; slug: string; title_fr: string; title_en: string; status: string; module_count: number; estimated_hours: number }>;
+  courses?: Array<{
+    id: string;
+    slug: string;
+    title_fr: string;
+    title_en: string;
+    status: string;
+    module_count: number;
+    estimated_hours: number;
+  }>;
   created_at: string;
   published_at?: string;
 }
@@ -843,22 +912,34 @@ export async function getCurricula(): Promise<CurriculumPublicResponse[]> {
   return apiFetch<CurriculumPublicResponse[]>("/api/v1/curricula");
 }
 
-export async function getCurriculumBySlug(slug: string): Promise<CurriculumPublicDetailResponse> {
+export async function getCurriculumBySlug(
+  slug: string,
+): Promise<CurriculumPublicDetailResponse> {
   return apiFetch<CurriculumPublicDetailResponse>(`/api/v1/curricula/${slug}`);
 }
 
-export async function getCoursesByCurriculum(curriculumSlug: string): Promise<CourseResponse[]> {
-  return apiFetch<CourseResponse[]>(`/api/v1/courses?curriculum=${encodeURIComponent(curriculumSlug)}`);
+export async function getCoursesByCurriculum(
+  curriculumSlug: string,
+): Promise<CourseResponse[]> {
+  return apiFetch<CourseResponse[]>(
+    `/api/v1/courses?curriculum=${encodeURIComponent(curriculumSlug)}`,
+  );
 }
 
 export async function getAdminCurricula(): Promise<CurriculumAdminResponse[]> {
   const { authClient } = await import("./auth");
-  return authClient.authenticatedFetch<CurriculumAdminResponse[]>("/api/v1/admin/curricula");
+  return authClient.authenticatedFetch<CurriculumAdminResponse[]>(
+    "/api/v1/admin/curricula",
+  );
 }
 
-export async function getAdminCurriculum(id: string): Promise<CurriculumAdminDetailResponse> {
+export async function getAdminCurriculum(
+  id: string,
+): Promise<CurriculumAdminDetailResponse> {
   const { authClient } = await import("./auth");
-  return authClient.authenticatedFetch<CurriculumAdminDetailResponse>(`/api/v1/admin/curricula/${id}`);
+  return authClient.authenticatedFetch<CurriculumAdminDetailResponse>(
+    `/api/v1/admin/curricula/${id}`,
+  );
 }
 
 export async function createAdminCurriculum(data: {
@@ -869,10 +950,13 @@ export async function createAdminCurriculum(data: {
   cover_image_url?: string;
 }): Promise<CurriculumAdminDetailResponse> {
   const { authClient } = await import("./auth");
-  return authClient.authenticatedFetch<CurriculumAdminDetailResponse>("/api/v1/admin/curricula", {
-    method: "POST",
-    body: JSON.stringify(data),
-  });
+  return authClient.authenticatedFetch<CurriculumAdminDetailResponse>(
+    "/api/v1/admin/curricula",
+    {
+      method: "POST",
+      body: JSON.stringify(data),
+    },
+  );
 }
 
 export async function updateAdminCurriculum(
@@ -883,53 +967,68 @@ export async function updateAdminCurriculum(
     description_fr: string;
     description_en: string;
     cover_image_url: string;
-  }>
+  }>,
 ): Promise<CurriculumAdminDetailResponse> {
   const { authClient } = await import("./auth");
-  return authClient.authenticatedFetch<CurriculumAdminDetailResponse>(`/api/v1/admin/curricula/${id}`, {
-    method: "PATCH",
-    body: JSON.stringify(data),
-  });
+  return authClient.authenticatedFetch<CurriculumAdminDetailResponse>(
+    `/api/v1/admin/curricula/${id}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    },
+  );
 }
 
-export async function publishAdminCurriculum(id: string): Promise<CurriculumAdminDetailResponse> {
+export async function publishAdminCurriculum(
+  id: string,
+): Promise<CurriculumAdminDetailResponse> {
   const { authClient } = await import("./auth");
-  return authClient.authenticatedFetch<CurriculumAdminDetailResponse>(`/api/v1/admin/curricula/${id}/publish`, {
-    method: "POST",
-  });
+  return authClient.authenticatedFetch<CurriculumAdminDetailResponse>(
+    `/api/v1/admin/curricula/${id}/publish`,
+    {
+      method: "POST",
+    },
+  );
 }
 
-export async function archiveAdminCurriculum(id: string): Promise<CurriculumAdminDetailResponse> {
+export async function archiveAdminCurriculum(
+  id: string,
+): Promise<CurriculumAdminDetailResponse> {
   const { authClient } = await import("./auth");
-  return authClient.authenticatedFetch<CurriculumAdminDetailResponse>(`/api/v1/admin/curricula/${id}/archive`, {
-    method: "POST",
-  });
+  return authClient.authenticatedFetch<CurriculumAdminDetailResponse>(
+    `/api/v1/admin/curricula/${id}/archive`,
+    {
+      method: "POST",
+    },
+  );
 }
 
 export async function deleteAdminCurriculum(id: string): Promise<void> {
   const { authClient } = await import("./auth");
-  await authClient.authenticatedFetch(`/api/v1/admin/curricula/${id}`, { method: "DELETE" });
+  await authClient.authenticatedFetch(`/api/v1/admin/curricula/${id}`, {
+    method: "DELETE",
+  });
 }
 
 export async function assignCurriculumCourses(
   curriculumId: string,
-  courseIds: string[]
+  courseIds: string[],
 ): Promise<CurriculumAdminDetailResponse> {
   const { authClient } = await import("./auth");
   return authClient.authenticatedFetch<CurriculumAdminDetailResponse>(
     `/api/v1/admin/curricula/${curriculumId}/courses`,
-    { method: "PUT", body: JSON.stringify({ course_ids: courseIds }) }
+    { method: "PUT", body: JSON.stringify({ course_ids: courseIds }) },
   );
 }
 
 export async function setCurriculumVisibility(
   curriculumId: string,
-  visibility: "public" | "private"
+  visibility: "public" | "private",
 ): Promise<CurriculumAdminDetailResponse> {
   const { authClient } = await import("./auth");
   return authClient.authenticatedFetch<CurriculumAdminDetailResponse>(
     `/api/v1/admin/curricula/${curriculumId}/visibility`,
-    { method: "POST", body: JSON.stringify({ visibility }) }
+    { method: "POST", body: JSON.stringify({ visibility }) },
   );
 }
 
@@ -943,32 +1042,34 @@ export interface CurriculumAccessEntry {
   granted_at: string;
 }
 
-export async function getCurriculumAccess(curriculumId: string): Promise<CurriculumAccessEntry[]> {
+export async function getCurriculumAccess(
+  curriculumId: string,
+): Promise<CurriculumAccessEntry[]> {
   const { authClient } = await import("./auth");
   return authClient.authenticatedFetch<CurriculumAccessEntry[]>(
-    `/api/v1/admin/curricula/${curriculumId}/access`
+    `/api/v1/admin/curricula/${curriculumId}/access`,
   );
 }
 
 export async function grantCurriculumAccess(
   curriculumId: string,
-  data: { user_id?: string; group_id?: string }
+  data: { user_id?: string; group_id?: string },
 ): Promise<CurriculumAccessEntry> {
   const { authClient } = await import("./auth");
   return authClient.authenticatedFetch<CurriculumAccessEntry>(
     `/api/v1/admin/curricula/${curriculumId}/access`,
-    { method: "POST", body: JSON.stringify(data) }
+    { method: "POST", body: JSON.stringify(data) },
   );
 }
 
 export async function revokeCurriculumAccess(
   curriculumId: string,
-  accessId: string
+  accessId: string,
 ): Promise<void> {
   const { authClient } = await import("./auth");
   await authClient.authenticatedFetch(
     `/api/v1/admin/curricula/${curriculumId}/access/${accessId}`,
-    { method: "DELETE" }
+    { method: "DELETE" },
   );
 }
 
@@ -999,7 +1100,9 @@ interface GroupDetailResponse extends UserGroupResponse {
 
 export async function getAdminGroups(): Promise<UserGroupResponse[]> {
   const { authClient } = await import("./auth");
-  return authClient.authenticatedFetch<UserGroupResponse[]>("/api/v1/admin/groups");
+  return authClient.authenticatedFetch<UserGroupResponse[]>(
+    "/api/v1/admin/groups",
+  );
 }
 
 export async function createAdminGroup(data: {
@@ -1007,52 +1110,76 @@ export async function createAdminGroup(data: {
   description?: string;
 }): Promise<UserGroupResponse> {
   const { authClient } = await import("./auth");
-  return authClient.authenticatedFetch<UserGroupResponse>("/api/v1/admin/groups", {
-    method: "POST",
-    body: JSON.stringify(data),
-  });
+  return authClient.authenticatedFetch<UserGroupResponse>(
+    "/api/v1/admin/groups",
+    {
+      method: "POST",
+      body: JSON.stringify(data),
+    },
+  );
 }
 
 export async function updateAdminGroup(
   id: string,
-  data: { name?: string; description?: string }
+  data: { name?: string; description?: string },
 ): Promise<UserGroupResponse> {
   const { authClient } = await import("./auth");
-  return authClient.authenticatedFetch<UserGroupResponse>(`/api/v1/admin/groups/${id}`, {
-    method: "PATCH",
-    body: JSON.stringify(data),
-  });
+  return authClient.authenticatedFetch<UserGroupResponse>(
+    `/api/v1/admin/groups/${id}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    },
+  );
 }
 
 export async function deleteAdminGroup(id: string): Promise<void> {
   const { authClient } = await import("./auth");
-  await authClient.authenticatedFetch(`/api/v1/admin/groups/${id}`, { method: "DELETE" });
+  await authClient.authenticatedFetch(`/api/v1/admin/groups/${id}`, {
+    method: "DELETE",
+  });
 }
 
-export async function getAdminGroupMembers(groupId: string): Promise<UserGroupMember[]> {
+export async function getAdminGroupMembers(
+  groupId: string,
+): Promise<UserGroupMember[]> {
   const { authClient } = await import("./auth");
-  const detail = await authClient.authenticatedFetch<GroupDetailResponse>(`/api/v1/admin/groups/${groupId}`);
+  const detail = await authClient.authenticatedFetch<GroupDetailResponse>(
+    `/api/v1/admin/groups/${groupId}`,
+  );
   return detail.members.map((m) => ({
     user_id: m.user_id,
-    email: m.user_email ?? '',
+    email: m.user_email ?? "",
     name: m.user_name,
     joined_at: m.added_at,
   }));
 }
 
-export async function addGroupMember(groupId: string, userId: string): Promise<void> {
+export async function addGroupMember(
+  groupId: string,
+  userId: string,
+): Promise<void> {
   const { authClient } = await import("./auth");
-  await authClient.authenticatedFetch(`/api/v1/admin/groups/${groupId}/members`, {
-    method: "POST",
-    body: JSON.stringify({ user_id: userId }),
-  });
+  await authClient.authenticatedFetch(
+    `/api/v1/admin/groups/${groupId}/members`,
+    {
+      method: "POST",
+      body: JSON.stringify({ user_id: userId }),
+    },
+  );
 }
 
-export async function removeGroupMember(groupId: string, userId: string): Promise<void> {
+export async function removeGroupMember(
+  groupId: string,
+  userId: string,
+): Promise<void> {
   const { authClient } = await import("./auth");
-  await authClient.authenticatedFetch(`/api/v1/admin/groups/${groupId}/members/${userId}`, {
-    method: "DELETE",
-  });
+  await authClient.authenticatedFetch(
+    `/api/v1/admin/groups/${groupId}/members/${userId}`,
+    {
+      method: "DELETE",
+    },
+  );
 }
 
 // ── Expert Activation Codes API ───────────────────────────────
@@ -1079,7 +1206,7 @@ export interface CodeRedemptionResponse {
 export async function generateActivationCodes(
   courseId: string,
   count: number,
-  maxUses?: number
+  maxUses?: number,
 ): Promise<ActivationCodeResponse[]> {
   const { authClient } = await import("./auth");
   return authClient.authenticatedFetch<ActivationCodeResponse[]>(
@@ -1087,28 +1214,33 @@ export async function generateActivationCodes(
     {
       method: "POST",
       body: JSON.stringify({ count, max_uses: maxUses ?? null }),
-    }
+    },
   );
 }
 
-export async function getActivationCodes(courseId: string): Promise<ActivationCodeResponse[]> {
+export async function getActivationCodes(
+  courseId: string,
+): Promise<ActivationCodeResponse[]> {
   const { authClient } = await import("./auth");
   return authClient.authenticatedFetch<ActivationCodeResponse[]>(
-    `/api/v1/expert/courses/${courseId}/codes`
+    `/api/v1/expert/courses/${courseId}/codes`,
   );
 }
 
 export async function getCodeRedemptions(
   courseId: string,
-  codeId: string
+  codeId: string,
 ): Promise<CodeRedemptionResponse[]> {
   const { authClient } = await import("./auth");
   return authClient.authenticatedFetch<CodeRedemptionResponse[]>(
-    `/api/v1/expert/courses/${courseId}/codes/${codeId}/redemptions`
+    `/api/v1/expert/courses/${courseId}/codes/${codeId}/redemptions`,
   );
 }
 
-export async function getCodeQR(courseId: string, codeId: string): Promise<Blob> {
+export async function getCodeQR(
+  courseId: string,
+  codeId: string,
+): Promise<Blob> {
   const { authClient } = await import("./auth");
   const token = await authClient.getValidToken();
   const res = await fetch(
@@ -1117,7 +1249,7 @@ export async function getCodeQR(courseId: string, codeId: string): Promise<Blob>
       headers: {
         Authorization: `Bearer ${token}`,
       },
-    }
+    },
   );
   if (!res.ok) throw new ApiError(`API error: ${res.status}`, res.status);
   return res.blob();
@@ -1126,7 +1258,7 @@ export async function getCodeQR(courseId: string, codeId: string): Promise<Blob>
 export async function manualActivate(
   courseId: string,
   codeId: string,
-  learnerEmail: string
+  learnerEmail: string,
 ): Promise<{ message: string }> {
   const { authClient } = await import("./auth");
   return authClient.authenticatedFetch<{ message: string }>(
@@ -1134,7 +1266,7 @@ export async function manualActivate(
     {
       method: "POST",
       body: JSON.stringify({ learner_email: learnerEmail }),
-    }
+    },
   );
 }
 
@@ -1181,17 +1313,21 @@ export interface ActivationRedeemResponse {
   enrolled?: boolean;
 }
 
-export async function previewActivationCode(code: string): Promise<ActivationPreviewResponse> {
-  return apiFetch<ActivationPreviewResponse>(`/api/v1/activate/${encodeURIComponent(code)}/preview`);
+export async function previewActivationCode(
+  code: string,
+): Promise<ActivationPreviewResponse> {
+  return apiFetch<ActivationPreviewResponse>(
+    `/api/v1/activate/${encodeURIComponent(code)}/preview`,
+  );
 }
 
 export async function redeemActivationCode(
   code: string,
-  method: "code" | "qr"
+  method: "code" | "qr",
 ): Promise<ActivationRedeemResponse> {
   return apiFetch<ActivationRedeemResponse>(
     `/api/v1/activate/${encodeURIComponent(code)}/redeem`,
-    { method: "POST", body: JSON.stringify({ method }) }
+    { method: "POST", body: JSON.stringify({ method }) },
   );
 }
 
@@ -1289,64 +1425,87 @@ export async function fetchOrgMembers(orgId: string): Promise<OrgMember[]> {
   return apiFetch<OrgMember[]>(`/api/v1/organizations/${orgId}/members`);
 }
 
-export async function addOrgMember(orgId: string, email: string, role: string): Promise<OrgMember> {
+export async function addOrgMember(
+  orgId: string,
+  email: string,
+  role: string,
+): Promise<OrgMember> {
   return apiFetch<OrgMember>(`/api/v1/organizations/${orgId}/members`, {
     method: "POST",
     body: JSON.stringify({ email, role }),
   });
 }
 
-export async function removeOrgMember(orgId: string, userId: string): Promise<void> {
+export async function removeOrgMember(
+  orgId: string,
+  userId: string,
+): Promise<void> {
   return apiFetch<void>(`/api/v1/organizations/${orgId}/members/${userId}`, {
     method: "DELETE",
   });
 }
 
 // Organization Credits
-export async function fetchOrgCredits(orgId: string): Promise<{ balance: number }> {
-  return apiFetch<{ balance: number }>(`/api/v1/organizations/${orgId}/credits`);
+export async function fetchOrgCredits(
+  orgId: string,
+): Promise<{ balance: number }> {
+  return apiFetch<{ balance: number }>(
+    `/api/v1/organizations/${orgId}/credits`,
+  );
 }
 
 // Organization Curricula
-export async function fetchOrgCurricula(orgId: string): Promise<OrgCurriculumResponse[]> {
-  return apiFetch<OrgCurriculumResponse[]>(`/api/v1/organizations/${orgId}/curricula`);
+export async function fetchOrgCurricula(
+  orgId: string,
+): Promise<OrgCurriculumResponse[]> {
+  return apiFetch<OrgCurriculumResponse[]>(
+    `/api/v1/organizations/${orgId}/curricula`,
+  );
 }
 
-export async function createOrgCurriculum(orgId: string, data: {
-  title_fr: string;
-  title_en: string;
-  slug: string;
-  description_fr?: string;
-  description_en?: string;
-}): Promise<OrgCurriculumResponse> {
-  return apiFetch<OrgCurriculumResponse>(`/api/v1/organizations/${orgId}/curricula`, {
-    method: "POST",
-    body: JSON.stringify(data),
-  });
+export async function createOrgCurriculum(
+  orgId: string,
+  data: {
+    title_fr: string;
+    title_en: string;
+    slug: string;
+    description_fr?: string;
+    description_en?: string;
+  },
+): Promise<OrgCurriculumResponse> {
+  return apiFetch<OrgCurriculumResponse>(
+    `/api/v1/organizations/${orgId}/curricula`,
+    {
+      method: "POST",
+      body: JSON.stringify(data),
+    },
+  );
 }
 
-export async function fetchOrgCourses(orgId: string): Promise<{
-  id: string;
-  slug: string;
-  title_fr: string;
-  title_en: string;
-  status: string;
-  creation_mode: string;
-  creation_step: string;
-  created_at: string;
-  cover_image_url?: string;
-}[]> {
+export async function fetchOrgCourses(orgId: string): Promise<
+  {
+    id: string;
+    slug: string;
+    title_fr: string;
+    title_en: string;
+    status: string;
+    creation_mode: string;
+    creation_step: string;
+    created_at: string;
+    cover_image_url?: string;
+  }[]
+> {
   return apiFetch(`/api/v1/organizations/${orgId}/courses`);
 }
 
 export async function setOrgCurriculumCourses(
   orgId: string,
   curriculumId: string,
-  courseIds: string[]
+  courseIds: string[],
 ): Promise<OrgCurriculumResponse> {
   return apiFetch<OrgCurriculumResponse>(
     `/api/v1/organizations/${orgId}/curricula/${curriculumId}/courses`,
-    { method: "PUT", body: JSON.stringify({ course_ids: courseIds }) }
+    { method: "PUT", body: JSON.stringify({ course_ids: courseIds }) },
   );
 }
 
@@ -1355,22 +1514,31 @@ export async function fetchOrgCodes(orgId: string): Promise<OrgCodeResponse[]> {
   return apiFetch<OrgCodeResponse[]>(`/api/v1/organizations/${orgId}/codes`);
 }
 
-export async function generateOrgCodes(orgId: string, data: {
-  curriculum_id?: string;
-  course_id?: string;
-  count: number;
-  max_uses?: number;
-}): Promise<OrgCodeResponse[]> {
+export async function generateOrgCodes(
+  orgId: string,
+  data: {
+    curriculum_id?: string;
+    course_id?: string;
+    count: number;
+    max_uses?: number;
+  },
+): Promise<OrgCodeResponse[]> {
   return apiFetch<OrgCodeResponse[]>(`/api/v1/organizations/${orgId}/codes`, {
     method: "POST",
     body: JSON.stringify(data),
   });
 }
 
-export async function revokeOrgCode(orgId: string, codeId: string): Promise<void> {
-  return apiFetch<void>(`/api/v1/organizations/${orgId}/codes/${codeId}/revoke`, {
-    method: "POST",
-  });
+export async function revokeOrgCode(
+  orgId: string,
+  codeId: string,
+): Promise<void> {
+  return apiFetch<void>(
+    `/api/v1/organizations/${orgId}/codes/${codeId}/revoke`,
+    {
+      method: "POST",
+    },
+  );
 }
 
 // Organization Reports
@@ -1378,29 +1546,36 @@ export async function fetchOrgSummary(orgId: string): Promise<OrgSummary> {
   return apiFetch<OrgSummary>(`/api/v1/organizations/${orgId}/reports/summary`);
 }
 
-export async function fetchOrgLearners(orgId: string, params?: {
-  curriculum_id?: string;
-  course_id?: string;
-  limit?: number;
-  offset?: number;
-}): Promise<LearnerProgress[]> {
+export async function fetchOrgLearners(
+  orgId: string,
+  params?: {
+    curriculum_id?: string;
+    course_id?: string;
+    limit?: number;
+    offset?: number;
+  },
+): Promise<LearnerProgress[]> {
   const searchParams = new URLSearchParams();
-  if (params?.curriculum_id) searchParams.set("curriculum_id", params.curriculum_id);
+  if (params?.curriculum_id)
+    searchParams.set("curriculum_id", params.curriculum_id);
   if (params?.course_id) searchParams.set("course_id", params.course_id);
   if (params?.limit) searchParams.set("limit", String(params.limit));
   if (params?.offset) searchParams.set("offset", String(params.offset));
   const qs = searchParams.toString();
   return apiFetch<LearnerProgress[]>(
-    `/api/v1/organizations/${orgId}/reports/learners${qs ? `?${qs}` : ""}`
+    `/api/v1/organizations/${orgId}/reports/learners${qs ? `?${qs}` : ""}`,
   );
 }
 
 export async function exportOrgCsv(orgId: string): Promise<string> {
-  const res = await fetch(`${API_BASE}/api/v1/organizations/${orgId}/reports/export`, {
-    headers: {
-      Authorization: `Bearer ${localStorage.getItem("access_token")}`,
+  const res = await fetch(
+    `${API_BASE}/api/v1/organizations/${orgId}/reports/export`,
+    {
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem("access_token")}`,
+      },
     },
-  });
+  );
   return res.text();
 }
 
@@ -1448,25 +1623,34 @@ export interface CertificateVerifyResponse {
 
 // ── Certificate API Functions ─────────────────────────────────────
 
-export async function getCertificateTemplate(courseId: string): Promise<CertificateTemplateResponse> {
-  return apiFetch<CertificateTemplateResponse>(`/api/v1/expert/courses/${courseId}/certificate-template`);
+export async function getCertificateTemplate(
+  courseId: string,
+): Promise<CertificateTemplateResponse> {
+  return apiFetch<CertificateTemplateResponse>(
+    `/api/v1/expert/courses/${courseId}/certificate-template`,
+  );
 }
 
 export async function upsertCertificateTemplate(
   courseId: string,
-  data: Partial<CertificateTemplateResponse>
+  data: Partial<CertificateTemplateResponse>,
 ): Promise<CertificateTemplateResponse> {
-  return apiFetch<CertificateTemplateResponse>(`/api/v1/expert/courses/${courseId}/certificate-template`, {
-    method: "POST",
-    body: JSON.stringify(data),
-  });
+  return apiFetch<CertificateTemplateResponse>(
+    `/api/v1/expert/courses/${courseId}/certificate-template`,
+    {
+      method: "POST",
+      body: JSON.stringify(data),
+    },
+  );
 }
 
 export async function getMyCertificates(): Promise<CertificateListItem[]> {
   return apiFetch<CertificateListItem[]>("/api/v1/certificates");
 }
 
-export async function downloadCertificatePdf(certificateId: string): Promise<Blob> {
+export async function downloadCertificatePdf(
+  certificateId: string,
+): Promise<Blob> {
   const headers: Record<string, string> = {};
   if (typeof window !== "undefined") {
     try {
@@ -1477,12 +1661,17 @@ export async function downloadCertificatePdf(certificateId: string): Promise<Blo
       // proceed without auth
     }
   }
-  const res = await fetch(`${API_BASE}/api/v1/certificates/${certificateId}/download`, { headers });
+  const res = await fetch(
+    `${API_BASE}/api/v1/certificates/${certificateId}/download`,
+    { headers },
+  );
   if (!res.ok) throw new ApiError("Download failed", res.status);
   return res.blob();
 }
 
-export async function verifyCertificate(code: string): Promise<CertificateVerifyResponse> {
+export async function verifyCertificate(
+  code: string,
+): Promise<CertificateVerifyResponse> {
   return apiFetch<CertificateVerifyResponse>(`/api/v1/verify/${code}`);
 }
 
@@ -1552,39 +1741,49 @@ export interface QBankReviewResponse {
   questions: QBankReviewQuestion[];
 }
 
-export async function startQBankTest(testId: string): Promise<QBankTestStartResponse> {
-  return apiFetch<QBankTestStartResponse>(`/api/v1/qbank/tests/${testId}/start`);
+export async function startQBankTest(
+  testId: string,
+): Promise<QBankTestStartResponse> {
+  return apiFetch<QBankTestStartResponse>(
+    `/api/v1/qbank/tests/${testId}/start`,
+  );
 }
 
 export async function submitQBankTest(
   testId: string,
-  answers: Record<string, { selected: number[]; time_sec: number }>
+  answers: Record<string, { selected: number[]; time_sec: number }>,
 ): Promise<QBankTestAttemptResponse> {
-  return apiFetch<QBankTestAttemptResponse>(`/api/v1/qbank/tests/${testId}/submit`, {
-    method: "POST",
-    body: JSON.stringify({ answers }),
-  });
+  return apiFetch<QBankTestAttemptResponse>(
+    `/api/v1/qbank/tests/${testId}/submit`,
+    {
+      method: "POST",
+      body: JSON.stringify({ answers }),
+    },
+  );
 }
 
-export async function getQBankTestHistory(testId: string): Promise<QBankTestAttemptResponse[]> {
-  return apiFetch<QBankTestAttemptResponse[]>(`/api/v1/qbank/tests/${testId}/history`);
+export async function getQBankTestHistory(
+  testId: string,
+): Promise<QBankTestAttemptResponse[]> {
+  return apiFetch<QBankTestAttemptResponse[]>(
+    `/api/v1/qbank/tests/${testId}/history`,
+  );
 }
 
 export async function getQBankTestReview(
-  testId: string, attemptId: string
+  testId: string,
+  attemptId: string,
 ): Promise<QBankReviewResponse> {
-  return apiFetch<QBankReviewResponse>(`/api/v1/qbank/tests/${testId}/review/${attemptId}`);
+  return apiFetch<QBankReviewResponse>(
+    `/api/v1/qbank/tests/${testId}/review/${attemptId}`,
+  );
 }
 
 // Question audio — backend streams OGG/Opus from MinIO via a proxy (#1658).
 // The status poll returns `audio_url` only when `status === "ready"`.
 export type QBankAudioLanguage = "fr" | "mos" | "dyu" | "bam" | "ful";
 
-export type QBankAudioReadiness =
-  | "pending"
-  | "generating"
-  | "ready"
-  | "failed";
+export type QBankAudioReadiness = "pending" | "generating" | "ready" | "failed";
 
 export interface QBankQuestionAudioStatus {
   question_id: string;
@@ -1607,7 +1806,11 @@ export async function getQBankQuestionAudio(
 // QBank management (org admin) — #1504
 // ---------------------------------------------------------------------------
 
-export type QBankType = "driving" | "exam_prep" | "psychotechnic" | "general_culture";
+export type QBankType =
+  | "driving"
+  | "exam_prep"
+  | "psychotechnic"
+  | "general_culture";
 export type QBankStatus = "draft" | "published" | "archived";
 export type QBankDifficulty = "easy" | "medium" | "hard";
 export type QBankTestMode = "exam" | "training" | "review";
@@ -1730,7 +1933,32 @@ export async function listAccessibleQBanks(options?: {
   return apiFetch<QBankBank[]>(`/api/v1/qbank/banks/accessible${qs}`);
 }
 
-export async function createQBankBank(body: QBankBankCreate): Promise<QBankBank> {
+/** A test the learner can take, with enough bank context to render without
+ * drilling into the bank. Powers the /qbank/tests discovery page (#1732). */
+export interface AccessibleQBankTest {
+  id: string;
+  question_bank_id: string;
+  title: string;
+  mode: "exam" | "training" | "review" | string;
+  question_count: number | null;
+  time_per_question_sec: number | null;
+  show_feedback: boolean;
+  created_at: string;
+  bank_title: string | null;
+  bank_language: string | null;
+  bank_org_name: string | null;
+  bank_org_slug: string | null;
+}
+
+/** Flat list of every test the learner can take across accessible banks
+ * (#1732). Cross-org, published-only, grouped client-side by bank. */
+export async function listAccessibleTests(): Promise<AccessibleQBankTest[]> {
+  return apiFetch<AccessibleQBankTest[]>(`/api/v1/qbank/tests/accessible`);
+}
+
+export async function createQBankBank(
+  body: QBankBankCreate,
+): Promise<QBankBank> {
   return apiFetch<QBankBank>(`/api/v1/qbank/banks`, {
     method: "POST",
     body: JSON.stringify(body),
@@ -1743,7 +1971,7 @@ export async function getQBankBank(bankId: string): Promise<QBankBank> {
 
 export async function updateQBankBank(
   bankId: string,
-  body: QBankBankUpdate
+  body: QBankBankUpdate,
 ): Promise<QBankBank> {
   return apiFetch<QBankBank>(`/api/v1/qbank/banks/${bankId}`, {
     method: "PATCH",
@@ -1758,16 +1986,16 @@ export async function deleteQBankBank(bankId: string): Promise<void> {
 export async function listQBankQuestions(
   bankId: string,
   page = 1,
-  perPage = 50
+  perPage = 50,
 ): Promise<QBankQuestionList> {
   return apiFetch<QBankQuestionList>(
-    `/api/v1/qbank/banks/${bankId}/questions?page=${page}&per_page=${perPage}`
+    `/api/v1/qbank/banks/${bankId}/questions?page=${page}&per_page=${perPage}`,
   );
 }
 
 export async function updateQBankQuestion(
   questionId: string,
-  body: QBankQuestionUpdate
+  body: QBankQuestionUpdate,
 ): Promise<QBankQuestionFull> {
   return apiFetch<QBankQuestionFull>(`/api/v1/qbank/questions/${questionId}`, {
     method: "PATCH",
@@ -1781,11 +2009,15 @@ export async function deleteQBankQuestion(questionId: string): Promise<void> {
   });
 }
 
-export async function listQBankTests(bankId: string): Promise<QBankTestConfig[]> {
+export async function listQBankTests(
+  bankId: string,
+): Promise<QBankTestConfig[]> {
   return apiFetch<QBankTestConfig[]>(`/api/v1/qbank/tests?bank_id=${bankId}`);
 }
 
-export async function createQBankTest(body: QBankTestCreate): Promise<QBankTestConfig> {
+export async function createQBankTest(
+  body: QBankTestCreate,
+): Promise<QBankTestConfig> {
   return apiFetch<QBankTestConfig>(`/api/v1/qbank/tests`, {
     method: "POST",
     body: JSON.stringify(body),
@@ -1794,8 +2026,13 @@ export async function createQBankTest(body: QBankTestCreate): Promise<QBankTestC
 
 export async function uploadQBankPdf(
   bankId: string,
-  file: File
-): Promise<{ task_id: string; bank_id: string; filename: string; status: string }> {
+  file: File,
+): Promise<{
+  task_id: string;
+  bank_id: string;
+  filename: string;
+  status: string;
+}> {
   const formData = new FormData();
   formData.append("file", file);
   const headers: Record<string, string> = {};
@@ -1808,18 +2045,23 @@ export async function uploadQBankPdf(
       // no auth header if no token
     }
   }
-  const res = await fetch(`${API_BASE}/api/v1/qbank/banks/${bankId}/upload-pdf`, {
-    method: "POST",
-    headers,
-    body: formData,
-  });
+  const res = await fetch(
+    `${API_BASE}/api/v1/qbank/banks/${bankId}/upload-pdf`,
+    {
+      method: "POST",
+      headers,
+      body: formData,
+    },
+  );
   if (!res.ok) {
     let message = `API error: ${res.status}`;
     try {
       const body = await res.json();
       if (typeof body?.detail === "string") message = body.detail;
       else if (body?.detail?.message) message = body.detail.message;
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
     throw new ApiError(message, res.status);
   }
   return res.json();
@@ -1827,9 +2069,9 @@ export async function uploadQBankPdf(
 
 export async function getQBankProcessingStatus(
   bankId: string,
-  taskId: string
+  taskId: string,
 ): Promise<QBankProcessingStatus> {
   return apiFetch<QBankProcessingStatus>(
-    `/api/v1/qbank/banks/${bankId}/processing-status?task_id=${taskId}`
+    `/api/v1/qbank/banks/${bankId}/processing-status?task_id=${taskId}`,
   );
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -50,7 +50,9 @@
     "certificates": "Certificates",
     "certificatesDescription": "View your earned certificates",
     "qbank": "Question Banks",
-    "qbankDescription": "Practice question banks from your organizations"
+    "qbankDescription": "Practice question banks from your organizations",
+    "qbankTests": "Practice tests",
+    "qbankTestsDescription": "Jump straight into an available test"
   },
   "Auth": {
     "login": "Sign in",
@@ -2017,6 +2019,15 @@
     "discoveryIntro": "Published question banks from every organization you belong to.",
     "discoveryEmpty": "No published question banks are available yet. Join an organization or ask your admin to publish one.",
     "discoveryOrgLink": "Open organization",
+    "testsDiscoveryTitle": "Practice tests",
+    "testsDiscoveryIntro": "Jump straight into any available test without drilling through banks.",
+    "testsDiscoveryEmpty": "No tests are available yet. Ask your admin to publish a bank.",
+    "startTest": "Start",
+    "mode": {
+      "exam": "Exam",
+      "training": "Training",
+      "review": "Review"
+    },
     "filterAllTypes": "All types",
     "perQuestion": "question",
     "typeDriving": "Driving school",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -50,7 +50,9 @@
     "certificates": "Certificats",
     "certificatesDescription": "Consultez vos certificats obtenus",
     "qbank": "Banques de questions",
-    "qbankDescription": "Entraînez-vous sur les banques de questions de vos organisations"
+    "qbankDescription": "Entraînez-vous sur les banques de questions de vos organisations",
+    "qbankTests": "Tests de révision",
+    "qbankTestsDescription": "Lancez directement un test depuis la liste disponible"
   },
   "Auth": {
     "login": "Se connecter",
@@ -2017,6 +2019,15 @@
     "discoveryIntro": "Banques de questions publiées de toutes vos organisations.",
     "discoveryEmpty": "Aucune banque de questions publiée pour l'instant. Rejoignez une organisation ou demandez à votre admin d'en publier une.",
     "discoveryOrgLink": "Ouvrir l'organisation",
+    "testsDiscoveryTitle": "Tests de révision",
+    "testsDiscoveryIntro": "Lancez n'importe quel test disponible dans vos banques, sans avoir à fouiller.",
+    "testsDiscoveryEmpty": "Aucun test disponible pour l'instant. Demandez à votre admin de publier une banque.",
+    "startTest": "Démarrer",
+    "mode": {
+      "exam": "Examen",
+      "training": "Entraînement",
+      "review": "Révision"
+    },
     "filterAllTypes": "Tous les types",
     "perQuestion": "question",
     "typeDriving": "Auto-école",


### PR DESCRIPTION
## Summary
Rolls up the pending qbank fix-branch commits ahead of main. Opened to unblock the voice-input PR (#1750) stacked on this branch.

## Commits
- 0b51fcc — fix(qbank): bump mms_tts_timeout_seconds 60→180 (#1732 follow-up)
- 25d45b0 — fix(qbank): remove nllb_models volume from prod compose (#1732 hotfix) (#1738)
- d46d223 — feat(qbank): learner-facing tests discovery page + nav entry (#1732) (#1736)
- 9b0b75e — fix(qbank): wire gh_token build secret in deploy.yml so build-nllb works (#1732) (#1733)
- 2d86e0a — fix(qbank): pydub fallback so MMS segment splice doesn't crash (#1719 hotfix)

These were authored by @Benidrissa directly and are being rolled to main via this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)