### PR TITLE
feat(qbank): manual audio recording/upload per question per language (#1747)

### DIFF
--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -704,6 +704,14 @@ def _audio_response(
             language=language,
             status="pending",
         )
+    # Bust the HTTP cache whenever the clip is replaced (TTS regen, manual
+    # upload, delete+re-record). ``updated_at`` flips on every UPDATE; for
+    # legacy rows inserted before #1747 it simply equals ``created_at``.
+    version = getattr(row, "updated_at", None) or row.created_at
+    source = getattr(row, "source", None)
+    source_value = (
+        source.value if hasattr(source, "value") else (source or "tts")
+    )
     return AudioStatusResponse(
         question_id=str(question_id),
         language=language,
@@ -713,9 +721,10 @@ def _audio_response(
             question_id,
             language,
             row.storage_key,
-            version=row.created_at,
+            version=version,
         ),
         duration_seconds=row.duration_seconds,
+        source=source_value,
     )
 
 
@@ -780,7 +789,11 @@ async def backfill_bank_translations(
     """
     from sqlalchemy import select
 
-    from app.domain.models.question_bank import QBankQuestion, QBankQuestionAudio
+    from app.domain.models.question_bank import (
+        QBankAudioSource,
+        QBankQuestion,
+        QBankQuestionAudio,
+    )
     from app.domain.services.organization_service import OrganizationService
     from app.tasks.qbank_processing import translate_and_synthesize_question_task
 
@@ -799,16 +812,37 @@ async def backfill_bank_translations(
         .all()
     )
     if question_ids:
+        # Wipe only TTS rows — manual recordings from editors are
+        # preserved so a backfill never silently drops an intentional
+        # human take (#1747).
         await db.execute(
             QBankQuestionAudio.__table__.delete().where(
                 QBankQuestionAudio.question_id.in_(question_ids),
                 QBankQuestionAudio.language == language,
+                QBankQuestionAudio.source != QBankAudioSource.manual,
             )
         )
         await db.commit()
 
+    manual_qids = (
+        (
+            await db.execute(
+                select(QBankQuestionAudio.question_id).where(
+                    QBankQuestionAudio.question_id.in_(question_ids),
+                    QBankQuestionAudio.language == language,
+                    QBankQuestionAudio.source == QBankAudioSource.manual,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    manual_qid_set = set(manual_qids)
+
     task_ids: list[str] = []
     for qid in question_ids:
+        if qid in manual_qid_set:
+            continue
         task = translate_and_synthesize_question_task.delay(str(qid), language)
         task_ids.append(task.id)
 
@@ -951,6 +985,31 @@ async def debug_nllb_probe(
     return result
 
 
+# MIME types accepted for manual audio uploads. Browser MediaRecorder
+# emits webm/opus on Chrome + mp4 on Safari; file-picker uploads may be
+# mp3, wav, m4a, or ogg. Anything outside this set is rejected with 415
+# so operators don't accidentally store text files or videos (#1747).
+_MANUAL_AUDIO_MIME_ALLOWLIST: frozenset[str] = frozenset({
+    "audio/webm",
+    "audio/ogg",
+    "audio/opus",
+    "audio/mpeg",
+    "audio/mp3",
+    "audio/mp4",
+    "audio/x-m4a",
+    "audio/m4a",
+    "audio/aac",
+    "audio/wav",
+    "audio/wave",
+    "audio/x-wav",
+})
+
+# 5 MB cap: a 30-60s voice recording at mid-quality VBR is typically
+# <1 MB; 5 MB leaves plenty of headroom for long questions or wav
+# uploads, while still bounding memory per-request (#1747).
+_MANUAL_AUDIO_MAX_BYTES = 5 * 1024 * 1024
+
+
 @router.post(
     "/questions/{question_id}/audio",
     response_model=AudioStatusResponse,
@@ -963,17 +1022,81 @@ async def upload_question_audio(
     current_user: AuthenticatedUser = Depends(get_current_user),
     db=Depends(get_db_session),
 ):
-    """Manual fallback: org admin uploads a pre-recorded audio file."""
-    from fastapi import HTTPException
+    """Store a manual recording/upload, replacing TTS for this (Q, lang) (#1747).
 
-    if not file.content_type or not file.content_type.startswith("audio/"):
+    Guards: org-role required (same as other qbank write endpoints),
+    MIME allowlist, 5 MB size cap. The row is marked ``source='manual'``
+    so subsequent TTS batch runs skip it — the editor's recording is
+    the source of truth until they explicitly delete it.
+    """
+    from app.domain.services.organization_service import OrganizationService
+
+    q = await db.get(QBankQuestion, question_id)
+    if q is None:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Expected an audio file.",
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Question not found.",
+        )
+    bank = await _svc.get_bank(db, q.question_bank_id)
+    await OrganizationService().require_org_role(
+        db, bank.organization_id, uuid.UUID(current_user.id)
+    )
+
+    content_type = (file.content_type or "").split(";")[0].strip().lower()
+    if content_type not in _MANUAL_AUDIO_MIME_ALLOWLIST:
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail=(
+                "Unsupported audio MIME. Allowed: "
+                + ", ".join(sorted(_MANUAL_AUDIO_MIME_ALLOWLIST))
+            ),
         )
     data = await file.read()
-    row = await _audio.store_uploaded_audio(db, question_id, language, data, file.content_type)
+    if len(data) == 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Empty audio file.",
+        )
+    if len(data) > _MANUAL_AUDIO_MAX_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"Audio file exceeds {_MANUAL_AUDIO_MAX_BYTES // (1024 * 1024)} MB limit.",
+        )
+    row = await _audio.store_uploaded_audio(
+        db, question_id, language, data, content_type
+    )
     return _audio_response(row, question_id, language, request)
+
+
+@router.delete(
+    "/questions/{question_id}/audio",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_question_audio(
+    question_id: uuid.UUID,
+    language: str = Query(..., pattern=r"^(fr|mos|dyu|bam|ful)$"),
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+):
+    """Remove one (question, language) audio row + its MinIO blob (#1747).
+
+    Used by the admin form's "Revert to TTS" button: deleting the manual
+    clip clears the slot so the next batch or per-question TTS call can
+    repopulate it. Same org-role guard as upload.
+    """
+    from app.domain.services.organization_service import OrganizationService
+
+    q = await db.get(QBankQuestion, question_id)
+    if q is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Question not found.",
+        )
+    bank = await _svc.get_bank(db, q.question_bank_id)
+    await OrganizationService().require_org_role(
+        db, bank.organization_id, uuid.UUID(current_user.id)
+    )
+    await _audio.delete_question_audio(db, question_id, language)
 
 
 @router.get(
@@ -1027,9 +1150,12 @@ async def get_question_audio_data(
 
     storage = S3StorageService()
     data = await storage.download_bytes(row.storage_key)
+    # Manual uploads may be webm/mp3/m4a/wav, not just Opus/OGG. Fall
+    # back to ``audio/ogg`` for pre-#1747 rows with no content_type.
+    media_type = getattr(row, "content_type", None) or "audio/ogg"
     return StreamingResponse(
         iter([data]),
-        media_type="audio/ogg",
+        media_type=media_type,
         headers={"Cache-Control": "public, max-age=86400, immutable"},
     )
 

--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -709,9 +709,7 @@ def _audio_response(
     # legacy rows inserted before #1747 it simply equals ``created_at``.
     version = getattr(row, "updated_at", None) or row.created_at
     source = getattr(row, "source", None)
-    source_value = (
-        source.value if hasattr(source, "value") else (source or "tts")
-    )
+    source_value = source.value if hasattr(source, "value") else (source or "tts")
     return AudioStatusResponse(
         question_id=str(question_id),
         language=language,
@@ -989,20 +987,22 @@ async def debug_nllb_probe(
 # emits webm/opus on Chrome + mp4 on Safari; file-picker uploads may be
 # mp3, wav, m4a, or ogg. Anything outside this set is rejected with 415
 # so operators don't accidentally store text files or videos (#1747).
-_MANUAL_AUDIO_MIME_ALLOWLIST: frozenset[str] = frozenset({
-    "audio/webm",
-    "audio/ogg",
-    "audio/opus",
-    "audio/mpeg",
-    "audio/mp3",
-    "audio/mp4",
-    "audio/x-m4a",
-    "audio/m4a",
-    "audio/aac",
-    "audio/wav",
-    "audio/wave",
-    "audio/x-wav",
-})
+_MANUAL_AUDIO_MIME_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "audio/webm",
+        "audio/ogg",
+        "audio/opus",
+        "audio/mpeg",
+        "audio/mp3",
+        "audio/mp4",
+        "audio/x-m4a",
+        "audio/m4a",
+        "audio/aac",
+        "audio/wav",
+        "audio/wave",
+        "audio/x-wav",
+    }
+)
 
 # 5 MB cap: a 30-60s voice recording at mid-quality VBR is typically
 # <1 MB; 5 MB leaves plenty of headroom for long questions or wav
@@ -1062,9 +1062,7 @@ async def upload_question_audio(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
             detail=f"Audio file exceeds {_MANUAL_AUDIO_MAX_BYTES // (1024 * 1024)} MB limit.",
         )
-    row = await _audio.store_uploaded_audio(
-        db, question_id, language, data, content_type
-    )
+    row = await _audio.store_uploaded_audio(db, question_id, language, data, content_type)
     return _audio_response(row, question_id, language, request)
 
 

--- a/backend/app/api/v1/schemas/qbank.py
+++ b/backend/app/api/v1/schemas/qbank.py
@@ -320,6 +320,11 @@ class AudioStatusResponse(BaseModel):
     # (guardrail: backend/tests/test_no_minio_leaks_in_schemas.py).
     audio_url: str | None = None
     duration_seconds: int | None = None
+    # ``tts`` for OpenAI/MMS-generated clips, ``manual`` for clips the
+    # editor recorded or uploaded via the question-bank form (#1747).
+    # Defaults to ``tts`` so existing clients continue to render the
+    # TTS-only UI until they're updated.
+    source: str = "tts"
 
 
 class AudioGenerateResponse(BaseModel):

--- a/backend/app/domain/models/question_bank.py
+++ b/backend/app/domain/models/question_bank.py
@@ -59,6 +59,18 @@ class QBankAudioStatus(enum.StrEnum):
     failed = "failed"
 
 
+class QBankAudioSource(enum.StrEnum):
+    """Distinguishes TTS-generated clips from human recordings/uploads.
+
+    Manual rows (``manual``) are skipped by batch TTS regeneration so an
+    editor's recording is never silently overwritten by a re-publish or
+    backfill (#1747). Default for every existing row is ``tts``.
+    """
+
+    tts = "tts"
+    manual = "manual"
+
+
 class QuestionBank(Base):
     __tablename__ = "question_banks"
 
@@ -144,7 +156,22 @@ class QBankQuestionAudio(Base):
         server_default="pending",
         default=QBankAudioStatus.pending,
     )
+    source: Mapped[QBankAudioSource] = mapped_column(
+        Enum(QBankAudioSource, name="qbankaudiosource"),
+        server_default="tts",
+        default=QBankAudioSource.tts,
+    )
+    # Actual MIME stored in MinIO — TTS clips are always ``audio/ogg``
+    # (Opus) but manual uploads can be webm, mp3, m4a, wav, or ogg; the
+    # playback endpoint needs the real value to hand the browser a
+    # Content-Type it can decode (#1747).
+    content_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
 
     question: Mapped[QBankQuestion] = relationship(back_populates="audio_files")
 

--- a/backend/app/domain/services/qbank_audio_service.py
+++ b/backend/app/domain/services/qbank_audio_service.py
@@ -22,6 +22,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.domain.models.question_bank import (
+    QBankAudioSource,
     QBankAudioStatus,
     QBankQuestion,
     QBankQuestionAudio,
@@ -237,7 +238,14 @@ class QBankAudioService:
         language: str,
         **updates: object,
     ) -> QBankQuestionAudio:
-        """Create or update the (question, language) audio row."""
+        """Create or update the (question, language) audio row.
+
+        Callers in the TTS generation path pass ``_skip_manual=True`` so
+        we return the existing manual row unchanged instead of flipping
+        it back to ``tts``/``generating`` — protects human recordings
+        from being overwritten on the next pregeneration pass (#1747).
+        """
+        skip_manual = bool(updates.pop("_skip_manual", False))
         existing = await db.execute(
             select(QBankQuestionAudio).where(
                 QBankQuestionAudio.question_id == question_id,
@@ -245,6 +253,8 @@ class QBankAudioService:
             )
         )
         row = existing.scalar_one_or_none()
+        if row is not None and skip_manual and row.source == QBankAudioSource.manual:
+            return row
         if row is None:
             row = QBankQuestionAudio(question_id=question_id, language=language)
             db.add(row)
@@ -365,7 +375,20 @@ class QBankAudioService:
         if question is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Question not found.")
 
-        await self._upsert_audio_row(db, question_id, language, status=QBankAudioStatus.generating)
+        # Short-circuit if the editor already uploaded a manual clip for
+        # this (question, language) — the existing recording takes
+        # precedence over anything TTS would produce (#1747).
+        existing = await self.get_audio_status(db, question_id, language)
+        if existing is not None and existing.source == QBankAudioSource.manual:
+            return existing
+
+        await self._upsert_audio_row(
+            db,
+            question_id,
+            language,
+            status=QBankAudioStatus.generating,
+            _skip_manual=True,
+        )
 
         # Translate FR → target before TTS for all non-source languages.
         # Translation fetch is idempotent; on NLLB failure we mark audio
@@ -389,7 +412,11 @@ class QBankAudioService:
                     error=str(exc),
                 )
                 return await self._upsert_audio_row(
-                    db, question_id, language, status=QBankAudioStatus.failed
+                    db,
+                    question_id,
+                    language,
+                    status=QBankAudioStatus.failed,
+                    _skip_manual=True,
                 )
 
         try:
@@ -408,6 +435,7 @@ class QBankAudioService:
                 question_id,
                 language,
                 status=QBankAudioStatus.failed,
+                _skip_manual=True,
             )
         except Exception as exc:
             logger.exception(
@@ -417,7 +445,11 @@ class QBankAudioService:
                 error=str(exc),
             )
             return await self._upsert_audio_row(
-                db, question_id, language, status=QBankAudioStatus.failed
+                db,
+                question_id,
+                language,
+                status=QBankAudioStatus.failed,
+                _skip_manual=True,
             )
 
         return await self._upsert_audio_row(
@@ -428,6 +460,9 @@ class QBankAudioService:
             storage_url=url,
             duration_seconds=estimate_duration_seconds(len(audio_bytes)),
             status=QBankAudioStatus.ready,
+            source=QBankAudioSource.tts,
+            content_type=OPUS_CONTENT_TYPE,
+            _skip_manual=True,
         )
 
     async def batch_generate(
@@ -462,23 +497,33 @@ class QBankAudioService:
         )
 
         ready_question_ids: set[uuid.UUID] = set()
-        if skip_ready and questions:
+        manual_question_ids: set[uuid.UUID] = set()
+        if questions:
             existing = await db.execute(
                 select(QBankQuestionAudio).where(
                     QBankQuestionAudio.question_id.in_([q.id for q in questions]),
                     QBankQuestionAudio.language == language,
-                    QBankQuestionAudio.status == QBankAudioStatus.ready,
                 )
             )
-            ready_question_ids = {row.question_id for row in existing.scalars()}
+            for row in existing.scalars():
+                if row.source == QBankAudioSource.manual:
+                    # Editor-provided clip — never touched by TTS batch (#1747).
+                    manual_question_ids.add(row.question_id)
+                elif skip_ready and row.status == QBankAudioStatus.ready:
+                    ready_question_ids.add(row.question_id)
 
         ready = 0
         failed = 0
         skipped = 0
+        manual = 0
         for q in questions:
+            if q.id in manual_question_ids:
+                manual += 1
+                ready += 1  # Manual clips are always considered ready.
+                continue
             if q.id in ready_question_ids:
                 skipped += 1
-                ready += 1  # Already-ready clips still count as ready.
+                ready += 1  # Already-ready TTS clips still count as ready.
                 continue
             row = await self.generate_question_audio(db, q.id, language)
             if row.status == QBankAudioStatus.ready:
@@ -491,6 +536,7 @@ class QBankAudioService:
             "language": language,
             "total": len(questions),
             "skipped": skipped,
+            "manual": manual,
             "ready": ready,
             "failed": failed,
         }
@@ -500,14 +546,51 @@ class QBankAudioService:
         db: AsyncSession,
         question_id: uuid.UUID,
     ) -> None:
-        """Drop every cached audio row for a question.
+        """Drop every cached TTS audio row for a question.
 
         Called when a question's text or options change — the stored
         clip no longer matches the script and must be regenerated.
+        Manual recordings are preserved: the editor chose that take
+        deliberately and we'd rather play outdated audio than silently
+        discard a human recording (#1747). The editor can delete the
+        manual row explicitly via the admin UI if needed.
         """
         await db.execute(
             QBankQuestionAudio.__table__.delete().where(
                 QBankQuestionAudio.question_id == question_id,
+                QBankQuestionAudio.source != QBankAudioSource.manual,
+            )
+        )
+        await db.commit()
+
+    async def delete_question_audio(
+        self,
+        db: AsyncSession,
+        question_id: uuid.UUID,
+        language: str,
+    ) -> None:
+        """Remove a single (question, language) audio row and its MinIO object.
+
+        Lets an editor clear a manual recording so the TTS pipeline can
+        refill the slot on the next generate/backfill (#1747).
+        """
+        row = await self.get_audio_status(db, question_id, language)
+        if row is None:
+            return
+        if row.storage_key:
+            try:
+                await self._storage.delete_object(row.storage_key)
+            except Exception as exc:
+                logger.warning(
+                    "failed to delete audio object from storage",
+                    question_id=str(question_id),
+                    language=language,
+                    key=row.storage_key,
+                    error=str(exc),
+                )
+        await db.execute(
+            QBankQuestionAudio.__table__.delete().where(
+                QBankQuestionAudio.id == row.id,
             )
         )
         await db.commit()
@@ -520,7 +603,13 @@ class QBankAudioService:
         audio_bytes: bytes,
         content_type: str,
     ) -> QBankQuestionAudio:
-        """Handle the manual-upload fallback from the admin UI."""
+        """Store a human-recorded or file-uploaded clip (#1747).
+
+        Marks the row ``source='manual'`` so subsequent TTS batch runs
+        skip it. The original MIME is persisted so the playback endpoint
+        can return the right Content-Type — editors may upload webm,
+        mp3, m4a or wav in addition to OGG/Opus.
+        """
         question = await db.get(QBankQuestion, question_id)
         if question is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Question not found.")
@@ -534,6 +623,8 @@ class QBankAudioService:
             storage_url=url,
             duration_seconds=estimate_duration_seconds(len(audio_bytes)),
             status=QBankAudioStatus.ready,
+            source=QBankAudioSource.manual,
+            content_type=content_type,
         )
 
     async def get_audio_status(

--- a/backend/migrations/versions/072_add_qbank_question_audio_source.py
+++ b/backend/migrations/versions/072_add_qbank_question_audio_source.py
@@ -1,0 +1,80 @@
+"""Add source, content_type, updated_at to qbank_question_audio.
+
+Revision ID: 072
+Revises: 071
+Create Date: 2026-04-20
+
+Introduces ``source`` (enum: tts / manual) so admins, sub-admins and
+experts can override generated TTS with a human recording or uploaded
+clip on a per-question, per-language basis (#1747). Every pre-existing
+row is backfilled to ``tts`` since all clips on the platform today
+came from OpenAI TTS or MMS-VITS. Batch TTS regeneration and
+translation backfills skip rows where ``source = 'manual'`` so a
+recording is never silently overwritten.
+
+Adds ``content_type`` because manual uploads can be webm/mp3/m4a/wav
+in addition to TTS's Opus/OGG; the playback endpoint needs the real
+MIME to hand the browser a decodable Content-Type header.
+
+Also adds ``updated_at`` because the frontend audio manager needs a
+cache-buster that changes when a clip is replaced — ``created_at``
+stays frozen on the initial insert.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "072"
+down_revision = "071"
+branch_labels = None
+depends_on = None
+
+SOURCE_ENUM_NAME = "qbankaudiosource"
+
+
+def upgrade() -> None:
+    # Postgres enum types are created lazily with create_type=False on
+    # the column below; we create the type up front here so the default
+    # expression can reference it.
+    source_enum = sa.Enum("tts", "manual", name=SOURCE_ENUM_NAME)
+    source_enum.create(op.get_bind(), checkfirst=True)
+
+    source_col_type = sa.Enum(
+        "tts",
+        "manual",
+        name=SOURCE_ENUM_NAME,
+        create_type=False,
+    )
+    op.add_column(
+        "qbank_question_audio",
+        sa.Column(
+            "source",
+            source_col_type,
+            server_default="tts",
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "qbank_question_audio",
+        sa.Column(
+            "content_type",
+            sa.String(100),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "qbank_question_audio",
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("qbank_question_audio", "updated_at")
+    op.drop_column("qbank_question_audio", "content_type")
+    op.drop_column("qbank_question_audio", "source")
+    sa.Enum(name=SOURCE_ENUM_NAME).drop(op.get_bind(), checkfirst=True)

--- a/backend/tests/test_qbank_audio_service.py
+++ b/backend/tests/test_qbank_audio_service.py
@@ -332,12 +332,16 @@ async def test_invalidate_question_preserves_manual_clip(db_session):
     await svc.invalidate_question(db_session, question.id)
 
     remaining = (
-        await db_session.execute(
-            select(QBankQuestionAudio).where(
-                QBankQuestionAudio.question_id == question.id,
+        (
+            await db_session.execute(
+                select(QBankQuestionAudio).where(
+                    QBankQuestionAudio.question_id == question.id,
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(remaining) == 1
     assert remaining[0].language == "mos"
     assert remaining[0].source == QBankAudioSource.manual
@@ -370,11 +374,15 @@ async def test_delete_question_audio_removes_row_and_storage(db_session):
 
     fake_storage.delete_object.assert_awaited_once()
     remaining = (
-        await db_session.execute(
-            select(QBankQuestionAudio).where(
-                QBankQuestionAudio.question_id == question.id,
-                QBankQuestionAudio.language == "fr",
+        (
+            await db_session.execute(
+                select(QBankQuestionAudio).where(
+                    QBankQuestionAudio.question_id == question.id,
+                    QBankQuestionAudio.language == "fr",
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert remaining == []

--- a/backend/tests/test_qbank_audio_service.py
+++ b/backend/tests/test_qbank_audio_service.py
@@ -14,6 +14,10 @@ from unittest.mock import AsyncMock
 import pytest
 from fastapi import HTTPException
 
+from app.domain.models.question_bank import (
+    QBankAudioSource,
+    QBankAudioStatus,
+)
 from app.domain.services.qbank_audio_service import (
     SUPPORTED_LANGUAGES,
     QBankAudioService,
@@ -153,3 +157,224 @@ def test_supported_languages_is_non_empty_tuple():
     assert isinstance(SUPPORTED_LANGUAGES, tuple)
     assert "fr" in SUPPORTED_LANGUAGES
     assert all(isinstance(lang, str) for lang in SUPPORTED_LANGUAGES)
+
+
+# ---------------------------------------------------------------------------
+# Manual audio override (#1747)
+# ---------------------------------------------------------------------------
+
+
+async def _seed_bank_and_question(db_session):
+    """Create a minimal bank + one question + a creator user."""
+    import uuid as _uuid
+
+    from app.domain.models.organization import Organization
+    from app.domain.models.question_bank import (
+        QBankQuestion,
+        QuestionBank,
+        QuestionBankType,
+    )
+    from app.domain.models.user import User, UserRole
+
+    slug_suffix = _uuid.uuid4().hex[:8]
+    org = Organization(
+        id=_uuid.uuid4(),
+        name="Test Org",
+        slug=f"test-org-{slug_suffix}",
+    )
+    db_session.add(org)
+    user = User(
+        id=_uuid.uuid4(),
+        email=f"{slug_suffix}@example.com",
+        name="Test Editor",
+        role=UserRole.admin,
+    )
+    db_session.add(user)
+    await db_session.flush()
+
+    bank = QuestionBank(
+        id=_uuid.uuid4(),
+        organization_id=org.id,
+        title="Test Bank",
+        bank_type=QuestionBankType.driving,
+        created_by=user.id,
+    )
+    db_session.add(bank)
+    await db_session.flush()
+
+    question = QBankQuestion(
+        id=_uuid.uuid4(),
+        question_bank_id=bank.id,
+        order_index=1,
+        question_text="Test question?",
+        options=["A", "B"],
+        correct_answer_indices=[0],
+    )
+    db_session.add(question)
+    await db_session.commit()
+    return bank, question
+
+
+@pytest.mark.asyncio
+async def test_store_uploaded_audio_sets_source_manual(db_session):
+    """Uploads land with ``source=manual`` and the MIME the editor sent."""
+    fake_storage = types.SimpleNamespace(
+        upload_bytes=AsyncMock(return_value="http://minio:9000/k"),
+        delete_object=AsyncMock(),
+    )
+    svc = QBankAudioService()
+    svc._storage = fake_storage
+
+    _, question = await _seed_bank_and_question(db_session)
+    row = await svc.store_uploaded_audio(
+        db_session,
+        question.id,
+        "fr",
+        b"fake-webm-bytes",
+        "audio/webm",
+    )
+    assert row.source == QBankAudioSource.manual
+    assert row.status == QBankAudioStatus.ready
+    assert row.content_type == "audio/webm"
+    fake_storage.upload_bytes.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_generate_question_audio_skips_manual_row(db_session):
+    """TTS path short-circuits when a manual clip already exists (#1747)."""
+    fake_storage = types.SimpleNamespace(
+        upload_bytes=AsyncMock(return_value="http://minio:9000/k"),
+        delete_object=AsyncMock(),
+    )
+    svc = QBankAudioService()
+    svc._storage = fake_storage
+    svc._synthesize_segments = AsyncMock(
+        side_effect=AssertionError("TTS must not run when source=manual"),
+    )
+
+    _, question = await _seed_bank_and_question(db_session)
+    manual_row = await svc.store_uploaded_audio(
+        db_session,
+        question.id,
+        "fr",
+        b"manual-bytes",
+        "audio/webm",
+    )
+
+    returned = await svc.generate_question_audio(db_session, question.id, "fr")
+    assert returned.id == manual_row.id
+    assert returned.source == QBankAudioSource.manual
+    assert returned.content_type == "audio/webm"
+
+
+@pytest.mark.asyncio
+async def test_batch_generate_counts_manual_rows_without_synthesizing(db_session):
+    """Manual clips are counted as ready and never hit the TTS backend."""
+    fake_storage = types.SimpleNamespace(
+        upload_bytes=AsyncMock(return_value="http://minio:9000/k"),
+        delete_object=AsyncMock(),
+    )
+    svc = QBankAudioService()
+    svc._storage = fake_storage
+    svc._synthesize_segments = AsyncMock(
+        side_effect=AssertionError("batch must not synth manual rows"),
+    )
+
+    bank, question = await _seed_bank_and_question(db_session)
+    await svc.store_uploaded_audio(
+        db_session,
+        question.id,
+        "fr",
+        b"manual",
+        "audio/webm",
+    )
+
+    result = await svc.batch_generate(db_session, bank.id, "fr")
+    assert result["total"] == 1
+    assert result["manual"] == 1
+    assert result["ready"] == 1
+    assert result["failed"] == 0
+
+
+@pytest.mark.asyncio
+async def test_invalidate_question_preserves_manual_clip(db_session):
+    """Question-text edits drop TTS rows but keep manual recordings (#1747)."""
+    from sqlalchemy import select
+
+    from app.domain.models.question_bank import QBankQuestionAudio
+
+    fake_storage = types.SimpleNamespace(
+        upload_bytes=AsyncMock(return_value="http://minio:9000/k"),
+        delete_object=AsyncMock(),
+    )
+    svc = QBankAudioService()
+    svc._storage = fake_storage
+
+    _, question = await _seed_bank_and_question(db_session)
+    await svc._upsert_audio_row(
+        db_session,
+        question.id,
+        "fr",
+        status=QBankAudioStatus.ready,
+        source=QBankAudioSource.tts,
+        storage_key="tts-key",
+        storage_url="http://minio:9000/tts",
+        content_type="audio/ogg",
+    )
+    await svc.store_uploaded_audio(
+        db_session,
+        question.id,
+        "mos",
+        b"manual",
+        "audio/webm",
+    )
+
+    await svc.invalidate_question(db_session, question.id)
+
+    remaining = (
+        await db_session.execute(
+            select(QBankQuestionAudio).where(
+                QBankQuestionAudio.question_id == question.id,
+            )
+        )
+    ).scalars().all()
+    assert len(remaining) == 1
+    assert remaining[0].language == "mos"
+    assert remaining[0].source == QBankAudioSource.manual
+
+
+@pytest.mark.asyncio
+async def test_delete_question_audio_removes_row_and_storage(db_session):
+    """``delete_question_audio`` nukes the row + best-effort MinIO delete."""
+    from sqlalchemy import select
+
+    from app.domain.models.question_bank import QBankQuestionAudio
+
+    fake_storage = types.SimpleNamespace(
+        upload_bytes=AsyncMock(return_value="http://minio:9000/k"),
+        delete_object=AsyncMock(),
+    )
+    svc = QBankAudioService()
+    svc._storage = fake_storage
+
+    _, question = await _seed_bank_and_question(db_session)
+    await svc.store_uploaded_audio(
+        db_session,
+        question.id,
+        "fr",
+        b"bytes",
+        "audio/webm",
+    )
+
+    await svc.delete_question_audio(db_session, question.id, "fr")
+
+    fake_storage.delete_object.assert_awaited_once()
+    remaining = (
+        await db_session.execute(
+            select(QBankQuestionAudio).where(
+                QBankQuestionAudio.question_id == question.id,
+                QBankQuestionAudio.language == "fr",
+            )
+        )
+    ).scalars().all()
+    assert remaining == []

--- a/frontend/components/qbank/qbank-audio-manager.tsx
+++ b/frontend/components/qbank/qbank-audio-manager.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Loader2, Mic, Square, Trash2, Upload } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  deleteQBankQuestionAudio,
+  getQBankQuestionAudio,
+  uploadQBankQuestionAudio,
+  type QBankAudioLanguage,
+  type QBankQuestionAudioStatus,
+} from "@/lib/api";
+
+const LANGUAGES: QBankAudioLanguage[] = ["fr", "mos", "dyu", "bam", "ful"];
+
+// Matches backend cap in backend/app/api/v1/qbank.py (#1747).
+const MAX_UPLOAD_BYTES = 5 * 1024 * 1024;
+
+const ACCEPTED_MIME = [
+  "audio/webm",
+  "audio/ogg",
+  "audio/opus",
+  "audio/mpeg",
+  "audio/mp3",
+  "audio/mp4",
+  "audio/x-m4a",
+  "audio/m4a",
+  "audio/aac",
+  "audio/wav",
+  "audio/wave",
+  "audio/x-wav",
+];
+
+interface Props {
+  questionId: string;
+}
+
+/**
+ * Admin-side audio manager for one question: lets the editor record
+ * (via MediaRecorder) or upload a pre-made audio file per language,
+ * replacing the TTS clip. Manual recordings are never overwritten by
+ * batch TTS regeneration — see QBankAudioService.batch_generate (#1747).
+ *
+ * Falls back gracefully when MediaRecorder isn't available (older
+ * Safari, insecure origin) — only the Upload button is shown.
+ */
+export function QBankAudioManager({ questionId }: Props) {
+  const t = useTranslations("qbank");
+  const tLang = useTranslations("qbank.audioLanguages");
+  const [language, setLanguage] = useState<QBankAudioLanguage>("fr");
+  const [status, setStatus] = useState<QBankQuestionAudioStatus | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [recording, setRecording] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [canRecord, setCanRecord] = useState(false);
+  const [recordingSeconds, setRecordingSeconds] = useState(0);
+
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<BlobPart[]>([]);
+  const streamRef = useRef<MediaStream | null>(null);
+  const tickRef = useRef<number | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    // getUserMedia requires HTTPS (except on localhost) and MediaRecorder
+    // is unavailable on iOS Safari < 14.5 — detect once on mount.
+    if (typeof window === "undefined") return;
+    const mediaDevices = window.navigator.mediaDevices;
+    const hasGetUser =
+      !!mediaDevices && typeof mediaDevices.getUserMedia === "function";
+    const hasRecorder = typeof window.MediaRecorder !== "undefined";
+    setCanRecord(hasGetUser && hasRecorder);
+  }, []);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const s = await getQBankQuestionAudio(questionId, language);
+      setStatus(s);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Fetch failed");
+    } finally {
+      setLoading(false);
+    }
+  }, [questionId, language]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  function stopRecordingTicker() {
+    if (tickRef.current !== null) {
+      window.clearInterval(tickRef.current);
+      tickRef.current = null;
+    }
+  }
+
+  function releaseStream() {
+    streamRef.current?.getTracks().forEach((track) => track.stop());
+    streamRef.current = null;
+  }
+
+  async function startRecording() {
+    setError(null);
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+      const mime =
+        MediaRecorder.isTypeSupported("audio/webm;codecs=opus")
+          ? "audio/webm;codecs=opus"
+          : MediaRecorder.isTypeSupported("audio/webm")
+            ? "audio/webm"
+            : MediaRecorder.isTypeSupported("audio/mp4")
+              ? "audio/mp4"
+              : "";
+      const recorder = mime
+        ? new MediaRecorder(stream, { mimeType: mime })
+        : new MediaRecorder(stream);
+      chunksRef.current = [];
+      recorder.ondataavailable = (event) => {
+        if (event.data.size > 0) chunksRef.current.push(event.data);
+      };
+      recorder.onstop = async () => {
+        stopRecordingTicker();
+        releaseStream();
+        const blobType = recorder.mimeType || "audio/webm";
+        const blob = new Blob(chunksRef.current, { type: blobType });
+        chunksRef.current = [];
+        setRecording(false);
+        if (blob.size === 0) {
+          setError(t("audioRecordEmpty"));
+          return;
+        }
+        if (blob.size > MAX_UPLOAD_BYTES) {
+          setError(t("audioTooLarge"));
+          return;
+        }
+        await persistBlob(blob, `recording-${language}.webm`);
+      };
+      recorder.start();
+      recorderRef.current = recorder;
+      setRecording(true);
+      setRecordingSeconds(0);
+      tickRef.current = window.setInterval(() => {
+        setRecordingSeconds((s) => s + 1);
+      }, 1000);
+    } catch (err) {
+      releaseStream();
+      setError(
+        err instanceof Error && err.name === "NotAllowedError"
+          ? t("audioMicDenied")
+          : t("audioRecordFailed"),
+      );
+      setRecording(false);
+    }
+  }
+
+  function stopRecording() {
+    const recorder = recorderRef.current;
+    if (recorder && recorder.state !== "inactive") {
+      recorder.stop();
+    }
+  }
+
+  async function persistBlob(blob: Blob, filename: string) {
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await uploadQBankQuestionAudio(
+        questionId,
+        language,
+        blob,
+        filename,
+      );
+      setStatus(next);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Upload failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function onFilePicked(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    event.target.value = ""; // allow re-picking the same file next time
+    if (!file) return;
+    if (file.size > MAX_UPLOAD_BYTES) {
+      setError(t("audioTooLarge"));
+      return;
+    }
+    const declared = (file.type || "").toLowerCase();
+    if (declared && !ACCEPTED_MIME.includes(declared)) {
+      setError(t("audioUnsupportedType"));
+      return;
+    }
+    await persistBlob(file, file.name);
+  }
+
+  async function handleDelete() {
+    if (!confirm(t("audioDeleteConfirm"))) return;
+    setLoading(true);
+    setError(null);
+    try {
+      await deleteQBankQuestionAudio(questionId, language);
+      setStatus(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Delete failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const audioUrl = status?.audio_url ?? null;
+  const source = status?.source ?? "tts";
+
+  return (
+    <div className="space-y-3 rounded-md border bg-gray-50 p-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-sm font-medium">{t("audioSectionLabel")}</span>
+        <div className="flex flex-wrap gap-1">
+          {LANGUAGES.map((lang) => (
+            <button
+              key={lang}
+              type="button"
+              onClick={() => setLanguage(lang)}
+              className={
+                "rounded-md border px-2 py-1 text-xs font-medium transition " +
+                (language === lang
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-gray-300 bg-white text-gray-700 hover:border-gray-400")
+              }
+            >
+              {tLang(lang)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        {audioUrl ? (
+          <audio
+            key={audioUrl}
+            controls
+            preload="none"
+            src={audioUrl}
+            className="h-9 max-w-full"
+          >
+            <track kind="captions" />
+          </audio>
+        ) : (
+          <span className="text-xs text-gray-600">
+            {status?.status === "generating"
+              ? t("audioGenerating")
+              : t("audioNoClip")}
+          </span>
+        )}
+        {audioUrl && (
+          <span
+            className={
+              "rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase " +
+              (source === "manual"
+                ? "border-emerald-500 bg-emerald-50 text-emerald-700"
+                : "border-gray-300 bg-white text-gray-600")
+            }
+          >
+            {source === "manual" ? t("audioSourceManual") : t("audioSourceTts")}
+          </span>
+        )}
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {canRecord &&
+          (recording ? (
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              onClick={stopRecording}
+              disabled={loading}
+            >
+              <Square className="mr-2 h-4 w-4" />
+              {t("audioStopRecording")} ({recordingSeconds}s)
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={startRecording}
+              disabled={loading}
+            >
+              <Mic className="mr-2 h-4 w-4" />
+              {t("audioRecord")}
+            </Button>
+          ))}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={loading || recording}
+        >
+          <Upload className="mr-2 h-4 w-4" />
+          {t("audioUpload")}
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="audio/*"
+          className="hidden"
+          onChange={onFilePicked}
+        />
+        {audioUrl && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={handleDelete}
+            disabled={loading || recording}
+          >
+            <Trash2 className="mr-2 h-4 w-4" />
+            {t("audioDelete")}
+          </Button>
+        )}
+        {loading && <Loader2 className="h-4 w-4 animate-spin text-gray-500" />}
+      </div>
+
+      {!canRecord && (
+        <p className="text-xs text-gray-500">{t("audioRecordUnsupported")}</p>
+      )}
+      {error && <p className="text-sm text-red-700">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/components/qbank/qbank-question-editor.tsx
+++ b/frontend/components/qbank/qbank-question-editor.tsx
@@ -13,6 +13,7 @@ import {
   type QBankDifficulty,
   type QBankQuestionFull,
 } from "@/lib/api";
+import { QBankAudioManager } from "./qbank-audio-manager";
 
 interface Props {
   question: QBankQuestionFull;
@@ -185,6 +186,8 @@ export function QBankQuestionEditor({ question, onSaved, onDeleted }: Props) {
           className="w-full rounded-md border px-3 py-2 text-sm"
         />
       </div>
+
+      <QBankAudioManager questionId={question.id} />
 
       {error && <p className="text-sm text-red-700">{error}</p>}
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1783,12 +1783,20 @@ export type QBankAudioLanguage = "fr" | "mos" | "dyu" | "bam" | "ful";
 
 export type QBankAudioReadiness = "pending" | "generating" | "ready" | "failed";
 
+export type QBankAudioSource = "tts" | "manual";
+
 export interface QBankQuestionAudioStatus {
   question_id: string;
   language: QBankAudioLanguage;
   status: QBankAudioReadiness;
   audio_url: string | null;
   duration_seconds: number | null;
+  /**
+   * ``manual`` when the editor uploaded/recorded the clip; ``tts`` for
+   * everything auto-generated. Defaults to ``tts`` for backend responses
+   * that predate #1747.
+   */
+  source?: QBankAudioSource;
 }
 
 export async function getQBankQuestionAudio(
@@ -1797,6 +1805,63 @@ export async function getQBankQuestionAudio(
 ): Promise<QBankQuestionAudioStatus> {
   return apiFetch<QBankQuestionAudioStatus>(
     `/api/v1/qbank/questions/${questionId}/audio?lang=${language}`,
+  );
+}
+
+/**
+ * Upload a manual audio clip (recorded or chosen from disk) to replace
+ * the TTS output for one (question, language) pair (#1747). Bypasses
+ * ``apiFetch`` because that helper always sets ``Content-Type:
+ * application/json``, which would clobber the multipart boundary the
+ * browser needs to set.
+ */
+export async function uploadQBankQuestionAudio(
+  questionId: string,
+  language: QBankAudioLanguage,
+  file: Blob,
+  filename?: string,
+): Promise<QBankQuestionAudioStatus> {
+  const form = new FormData();
+  form.append("file", file, filename ?? `audio-${language}`);
+  const headers: Record<string, string> = {};
+  if (typeof window !== "undefined") {
+    try {
+      const { authClient } = await import("./auth");
+      const token = await authClient.getValidToken();
+      headers["Authorization"] = `Bearer ${token}`;
+    } catch {
+      // unauthenticated — backend will 401
+    }
+  }
+  const res = await fetch(
+    `${API_BASE}/api/v1/qbank/questions/${questionId}/audio?language=${language}`,
+    { method: "POST", headers, body: form },
+  );
+  if (!res.ok) {
+    let message = `API error: ${res.status}`;
+    try {
+      const body = await res.json();
+      if (typeof body?.detail === "string") message = body.detail;
+      else if (body?.detail?.message) message = body.detail.message;
+    } catch {
+      /* ignore */
+    }
+    throw new ApiError(message, res.status);
+  }
+  return res.json();
+}
+
+/**
+ * Remove the (question, language) audio row — used to clear a manual
+ * clip so the next TTS batch can repopulate the slot (#1747).
+ */
+export async function deleteQBankQuestionAudio(
+  questionId: string,
+  language: QBankAudioLanguage,
+): Promise<void> {
+  await apiFetch<void>(
+    `/api/v1/qbank/questions/${questionId}/audio?language=${language}`,
+    { method: "DELETE" },
   );
 }
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2104,6 +2104,22 @@
       "dyu": "Dioula",
       "bam": "Bambara",
       "ful": "Fulfulde"
-    }
+    },
+    "audioSectionLabel": "Audio (per language)",
+    "audioNoClip": "No clip for this language — TTS will be generated or record one now.",
+    "audioGenerating": "Generating…",
+    "audioRecord": "Record",
+    "audioStopRecording": "Stop",
+    "audioUpload": "Upload file",
+    "audioDelete": "Delete",
+    "audioDeleteConfirm": "Delete this audio? TTS will regenerate on the next batch.",
+    "audioRecordEmpty": "Empty recording.",
+    "audioRecordFailed": "Could not record.",
+    "audioMicDenied": "Microphone denied. Grant access in your browser.",
+    "audioRecordUnsupported": "Recording isn't available in this browser — use file upload.",
+    "audioUnsupportedType": "Unsupported file type.",
+    "audioTooLarge": "File too large (max 5 MB).",
+    "audioSourceManual": "Manual",
+    "audioSourceTts": "TTS"
   }
-}\n
+}

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -2104,6 +2104,22 @@
       "dyu": "Dioula",
       "bam": "Bambara",
       "ful": "Fulfulde"
-    }
+    },
+    "audioSectionLabel": "Audio (par langue)",
+    "audioNoClip": "Aucun clip pour cette langue — TTS sera généré ou enregistrez‑en un.",
+    "audioGenerating": "Génération en cours…",
+    "audioRecord": "Enregistrer",
+    "audioStopRecording": "Arrêter",
+    "audioUpload": "Importer un fichier",
+    "audioDelete": "Supprimer",
+    "audioDeleteConfirm": "Supprimer cet audio ? Le TTS sera régénéré au prochain traitement.",
+    "audioRecordEmpty": "Enregistrement vide.",
+    "audioRecordFailed": "Enregistrement impossible.",
+    "audioMicDenied": "Microphone refusé. Autorisez l’accès dans le navigateur.",
+    "audioRecordUnsupported": "L’enregistrement n’est pas disponible dans ce navigateur ; utilisez l’import de fichier.",
+    "audioUnsupportedType": "Type de fichier non pris en charge.",
+    "audioTooLarge": "Fichier trop volumineux (maximum 5 Mo).",
+    "audioSourceManual": "Manuel",
+    "audioSourceTts": "TTS"
   }
-}\n
+}


### PR DESCRIPTION
Fixes #1747.

## Summary

- Editors (org owner/admin, incl. sub-admins + experts) can now **record or upload** a voice clip per language per question to replace the auto-generated TTS.
- Recordings survive re-publish, translation backfill, and batch TTS regeneration. The editor can delete a manual clip to fall back to TTS.
- Backend: new ``source`` column on ``qbank_question_audio`` (enum ``tts``/``manual``), new ``content_type`` column so non-OGG uploads play back with the right MIME, new ``updated_at`` for HTTP cache-busting.
- Frontend: new ``QBankAudioManager`` component embedded in the question editor — language tabs, live playback with TTS/Manual badge, Record (MediaRecorder), Upload, Delete; falls back to upload-only when MediaRecorder isn't available.

## Changes

**Backend**
- Migration ``072`` adds ``source`` / ``content_type`` / ``updated_at`` to ``qbank_question_audio`` with ``source`` defaulting to ``tts`` for legacy rows.
- ``QBankAudioService``: ``_upsert_audio_row`` accepts ``_skip_manual``, ``generate_question_audio`` short-circuits on manual rows, ``batch_generate`` counts manual rows without calling TTS, ``invalidate_question`` preserves manual rows, new ``delete_question_audio``.
- Endpoints: ``POST /qbank/questions/{id}/audio`` now requires org role, enforces a MIME allowlist and a 5 MB cap, and persists ``source='manual'``; new ``DELETE /qbank/questions/{id}/audio``; translation-backfill preserves manual rows and doesn't enqueue Celery tasks for them; playback returns the stored content-type.
- Tests: five new pytest-asyncio cases over a real test DB covering the skip-manual / delete invariants.

**Frontend**
- ``QBankAudioManager`` with language tabs (fr/mos/dyu/bam/ful), inline playback + TTS/Manual badge, Record / Upload / Delete controls, mic-permission + size/MIME fallbacks.
- ``uploadQBankQuestionAudio`` (multipart, bypasses the JSON-only ``apiFetch``) and ``deleteQBankQuestionAudio`` in ``lib/api.ts``.
- Ten new i18n keys in FR/EN under ``qbank.*``.

## Test plan
- [ ] Apply migration ``072`` on staging, confirm the new columns exist and default to ``tts``.
- [ ] Open the admin question editor, switch to a bank, pick a question.
- [ ] Record FR audio via mic → save → confirm inline playback is the recording and badge shows "Manuel".
- [ ] Upload an MP3 on Mooré → confirm playback is the uploaded clip.
- [ ] Trigger ``POST /qbank/banks/{id}/audio/generate?language=fr`` — manual FR row is untouched, other TTS rows regenerate.
- [ ] Trigger ``POST /qbank/banks/{id}/translations/backfill?language=mos`` — manual Mooré row survives.
- [ ] Delete the manual Mooré clip → confirm TTS regenerates on next generate call.
- [ ] Upload a ``.txt`` → rejected 415 with helpful error.
- [ ] Revoke mic permission → UI shows fallback text, Upload still works.
- [ ] ``uv run pytest backend/tests/test_qbank_audio_service.py`` passes in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)