### PR TITLE
fix(frontend): skip i18n middleware for /api/ routes (#1760)

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -67,6 +67,11 @@ export default function middleware(request: NextRequest) {
     }
   }
 
+  // API routes are proxied by next.config.ts rewrites — skip i18n middleware.
+  if (pathname.startsWith("/api/")) {
+    return NextResponse.next();
+  }
+
   return intlMiddleware(request);
 }
 


### PR DESCRIPTION
## Summary

- After #1742, browser API calls use relative `/api/v1/...` URLs proxied by Next.js rewrites
- The `next-intl` middleware was treating those as locale-less pages and redirecting to `/fr/api/v1/...`, which redirected back — infinite 307 loop, login broken on staging
- Fix: one guard in `middleware.ts` — `pathname.startsWith("/api/")` → `NextResponse.next()` before calling `intlMiddleware`

## Test plan

- [ ] Log in on staging → succeeds, backend logs show `POST /api/v1/auth/login-password 200`
- [ ] Navigate to qbank editor → audio manager loads

Fixes #1760

🤖 Generated with [Claude Code](https://claude.com/claude-code)