### PR TITLE
fix(tutor): stack mic above attachment icon for wider textarea

### DIFF
--- a/frontend/components/chat/chat-input.tsx
+++ b/frontend/components/chat/chat-input.tsx
@@ -394,48 +394,50 @@ export function ChatInput({ onSendMessage, disabled = false, placeholder, conver
           capture="environment"
         />
 
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="min-h-[44px] min-w-[44px] shrink-0"
-          aria-label={t('fileUpload.attachAriaLabel')}
-          disabled={disabled}
-          onClick={() => fileInputRef.current?.click()}
-        >
-          <Paperclip className="h-4 w-4" />
-        </Button>
+        <div className="flex flex-col shrink-0">
+          <Button
+            type="button"
+            variant={isRecording ? 'destructive' : 'ghost'}
+            size="icon"
+            className="min-h-[44px] min-w-[44px]"
+            aria-label={
+              isRecording
+                ? t('voice.releaseToSend')
+                : isTranscribing
+                  ? t('voice.transcribing')
+                  : t('voice.holdToTalk')
+            }
+            aria-pressed={isRecording}
+            disabled={disabled || isTranscribing}
+            onPointerDown={(e) => {
+              e.preventDefault();
+              startRecording();
+            }}
+            onPointerUp={() => stopRecording(false)}
+            onPointerLeave={() => {
+              if (isRecording) stopRecording(false);
+            }}
+            onPointerCancel={() => stopRecording(true)}
+          >
+            {isTranscribing ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Mic className={cn('h-4 w-4', isRecording && 'animate-pulse')} />
+            )}
+          </Button>
 
-        <Button
-          type="button"
-          variant={isRecording ? 'destructive' : 'ghost'}
-          size="icon"
-          className="min-h-[44px] min-w-[44px] shrink-0"
-          aria-label={
-            isRecording
-              ? t('voice.releaseToSend')
-              : isTranscribing
-                ? t('voice.transcribing')
-                : t('voice.holdToTalk')
-          }
-          aria-pressed={isRecording}
-          disabled={disabled || isTranscribing}
-          onPointerDown={(e) => {
-            e.preventDefault();
-            startRecording();
-          }}
-          onPointerUp={() => stopRecording(false)}
-          onPointerLeave={() => {
-            if (isRecording) stopRecording(false);
-          }}
-          onPointerCancel={() => stopRecording(true)}
-        >
-          {isTranscribing ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <Mic className={cn('h-4 w-4', isRecording && 'animate-pulse')} />
-          )}
-        </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="min-h-[44px] min-w-[44px]"
+            aria-label={t('fileUpload.attachAriaLabel')}
+            disabled={disabled}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <Paperclip className="h-4 w-4" />
+          </Button>
+        </div>
 
         <div className="flex-1 relative">
           <textarea


### PR DESCRIPTION
## Summary
- Wraps the Mic and Paperclip buttons in a `flex-col` column (44px wide) instead of side-by-side (~88px)
- Mic on top (primary action), Paperclip below
- Textarea gains ~44px of horizontal space

## Test plan
- [ ] Open AI Tutor page — icons are stacked vertically (Mic above Paperclip)
- [ ] Textarea is visibly wider than before
- [ ] Hold Mic button → voice recording works, transcription populates textarea
- [ ] Tap Paperclip → file picker opens
- [ ] Test on 375px viewport (mobile-first)

Fixes #1764

🤖 Generated with [Claude Code](https://claude.ai/claude-code)