### PR TITLE
fix(frontend): exclude /api/ from middleware matcher — defense-in-depth

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -76,5 +76,5 @@ export default function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/", "/(fr|en)/:path*", "/((?!_next|favicon.ico|manifest.webmanifest|icon-|sw.js|offline\\.html|.well-known|.*\\.(?:png|jpg|jpeg|gif|webp|ico|pdf)).*)"],
+  matcher: ["/", "/(fr|en)/:path*", "/((?!_next|favicon.ico|manifest.webmanifest|icon-|sw.js|offline\\.html|.well-known|api/|.*\\.(?:png|jpg|jpeg|gif|webp|ico|pdf)).*)"],
 };


### PR DESCRIPTION
## Summary

- Excludes `api/` from the Next.js middleware matcher so `/api/*` requests never enter the middleware function at all and proceed directly to the `next.config.ts` rewrite rule
- Companion hardening to #1761 (the emergency early-return fix): if code is ever added before the `pathname.startsWith("/api/")` guard, the regression cannot silently re-surface
- The existing early-return at line 71 and `PUBLIC_PATTERNS` entry stay as belt-and-suspenders

## Root cause recap

`3b2e6ce` made `API_BASE = ""` on client-side and added the `/api/:path*` rewrite. The i18n middleware was still matching those routes, causing 307 redirects. Browsers strip `Authorization: Bearer` on redirects → authenticated endpoints (dashboard stats, revisions) returned 401 while public endpoints (curricula) continued to work. Fixed by #1761; this PR hardens the matcher so the middleware is bypassed entirely for API routes.

## Test plan

- [ ] Deploy to staging and verify dashboard stats + upcoming revisions load
- [ ] Browser DevTools → Network: no 307 redirects for `/api/*` requests
- [ ] Public course catalog loads without login
- [ ] Run E2E suite

Fixes #1760

🤖 Generated with [Claude Code](https://claude.com/claude-code)