### PR TITLE
fix(nav): icon-only mobile bottom nav — remove text labels

### DIFF
--- a/frontend/components/layout/bottom-nav.tsx
+++ b/frontend/components/layout/bottom-nav.tsx
@@ -189,17 +189,9 @@ export function BottomNav() {
                 aria-current={isActive ? "page" : undefined}
               >
                 <Icon
-                  className={cn("h-5 w-5 mb-1", isActive && "text-primary")}
+                  className={cn("h-5 w-5", isActive && "text-primary")}
                   aria-hidden="true"
                 />
-                <span
-                  className={cn(
-                    "text-xs",
-                    isActive && "text-primary font-medium",
-                  )}
-                >
-                  {item.label}
-                </span>
               </Link>
             );
           })}
@@ -218,19 +210,11 @@ export function BottomNav() {
           >
             <MoreHorizontal
               className={cn(
-                "h-5 w-5 mb-1",
+                "h-5 w-5",
                 (moreOpen || isMoreActive) && "text-primary",
               )}
               aria-hidden="true"
             />
-            <span
-              className={cn(
-                "text-xs",
-                (moreOpen || isMoreActive) && "text-primary font-medium",
-              )}
-            >
-              {t("more")}
-            </span>
           </button>
         </div>
       </nav>


### PR DESCRIPTION
## Summary
- Removes text labels from all mobile bottom nav items (Dashboard, Courses, Flashcards, AI Tutor, More)
- Icons only — reduces nav bar height and clutter on small screens
- Accessibility maintained via existing `aria-label` on each `<Link>` and `<button>`
- Also removes `mb-1` margin from icons (spacing that existed for text)

## Test plan
- [ ] Mobile bottom nav shows icons only (no text)
- [ ] Active icon highlights correctly
- [ ] All nav items still tappable (44px min touch target preserved)
- [ ] "More" button still opens the overflow menu

Fixes #1770

🤖 Generated with [Claude Code](https://claude.ai/claude-code)