### PR TITLE
fix(frontend): exclude /api/ from middleware matcher — defense-in-depth

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -76,5 +76,5 @@ export default function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/", "/(fr|en)/:path*", "/((?!_next|favicon.ico|manifest.webmanifest|icon-|sw.js|offline\\.html|.well-known|.*\\.(?:png|jpg|jpeg|gif|webp|ico|pdf)).*)"],
+  matcher: ["/", "/(fr|en)/:path*", "/((?!_next|favicon.ico|manifest.webmanifest|icon-|sw.js|offline\\.html|.well-known|api/|.*\\.(?:png|jpg|jpeg|gif|webp|ico|pdf)).*)"],
 };


### PR DESCRIPTION
Adds `api/` to the matcher exclusion list so `/api/*` requests skip the middleware function entirely, rather than relying on the early-return guard added in #1761. Defense-in-depth follow-up to the #1742 regression fix.

Fixes #1760 (follow-up hardening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)