### PR TITLE
fix(deploy): use container name in BACKEND_URL to avoid DNS collision (#1774)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -125,7 +125,7 @@ services:
     image: ghcr.io/benidrissa/etutor-digital-ph/frontend:latest
     container_name: etutor-frontend
     environment:
-      BACKEND_URL: http://backend:8000
+      BACKEND_URL: http://etutor-backend:8000
       HOSTNAME: "0.0.0.0"
       PORT: "3000"
       NEXT_PUBLIC_SENTRY_DSN: ${NEXT_PUBLIC_SENTRY_DSN}


### PR DESCRIPTION
## Summary

- Changes `BACKEND_URL: http://backend:8000` → `http://etutor-backend:8000` in `docker-compose.prod.yml`
- Service name `backend` is shared by every tenant deployment on the `proxy` network; container name `etutor-backend` is globally unique

## Root cause

The frontend container is attached to both `etutor-data` and the shared `proxy` Traefik network. Tenant backends (provisioned via the reseller console) are also on `proxy` and use the same service name `backend`. Docker DNS resolved `backend` → `tenant-public-02-test-backend` (172.23.0.5) instead of `etutor-backend` (172.23.0.12), silently routing all Next.js proxy requests to the wrong tenant's database.

## Hotfix applied

Already patched on staging via `sed` + `docker compose up -d --no-deps frontend`. This PR persists the fix in the repo so it survives the next deploy.

## Test plan

- [ ] Verify `docker exec etutor-frontend getent hosts backend` → `etutor-backend` IP
- [ ] `/api/v1/curricula` returns full curriculum list (was returning `[]`)
- [ ] Admin curricula panel shows all 7 curricula

Fixes #1774

🤖 Generated with [Claude Code](https://claude.com/claude-code)