### PR TITLE
fix(deploy): patch Next.js rewrite destination at runtime via entrypoint (#1778)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -33,8 +33,11 @@ RUN addgroup --system --gid 1001 nodejs && \
 COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --chown=nextjs:nodejs docker-entrypoint.sh /app/docker-entrypoint.sh
 
 USER nextjs
+
+RUN chmod +x /app/docker-entrypoint.sh
 
 EXPOSE 3000
 
@@ -42,4 +45,4 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD node -e "fetch('http://localhost:3000/fr/dashboard').then(r => r.status < 500 ? process.exit(0) : process.exit(1)).catch(() => process.exit(1))" || exit 1
 
-CMD ["node", "server.js"]
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+# Patch the baked-in rewrite destination with the runtime BACKEND_URL.
+# Next.js bakes process.env.BACKEND_URL into routes-manifest.json at build
+# time; if BACKEND_URL was not set during the CI build it defaults to
+# http://backend:8000, which collides with same-named services from tenant
+# stacks sharing the Traefik proxy network. Patching here at startup lets
+# docker-compose supply the correct container name (e.g. etutor-backend)
+# without requiring a rebuild. (#1778)
+if [ -n "$BACKEND_URL" ]; then
+  sed -i "s|http://backend:8000|${BACKEND_URL}|g" /app/.next/routes-manifest.json
+fi
+exec node server.js "$@"


### PR DESCRIPTION
## Summary

- Next.js bakes \`BACKEND_URL\` into \`routes-manifest.json\` at build time; when CI builds without \`BACKEND_URL\` it defaults to \`http://backend:8000\`
- On staging, \`backend\` resolves non-deterministically across tenant stacks sharing the Traefik \`proxy\` network → client-side \`/api/*\` rewrites hit wrong backends
- Adds \`frontend/docker-entrypoint.sh\` that sed-patches \`routes-manifest.json\` at container startup using runtime \`\$BACKEND_URL\`
- \`docker-compose.prod.yml\` already supplies \`BACKEND_URL=http://etutor-backend:8000\` (PR #1774)

## Test plan

- [ ] Deploy to staging, then: \`docker exec etutor-frontend grep destination /app/.next/routes-manifest.json\` → should show \`http://etutor-backend:8000\`
- [ ] Browse \`/fr/dashboard\` — stats should load without "Impossible de charger les statistiques"
- [ ] Browse \`/fr/qbank\` — banks list should load without "Not Found"

Fixes #1778

🤖 Generated with [Claude Code](https://claude.com/claude-code)