### PR TITLE
feat: assign synthetic phone@sira.app email to phone-only users

### DIFF
--- a/backend/app/domain/services/email_service.py
+++ b/backend/app/domain/services/email_service.py
@@ -16,6 +16,10 @@ class EmailService:
         self.from_email = settings.from_email or "noreply@santepublique-aof.org"
         self.frontend_url = settings.frontend_url or "https://app.santepublique-aof.org"
 
+    @staticmethod
+    def _is_synthetic(email: str) -> bool:
+        return email.endswith("@sira.app")
+
     async def send_magic_link(self, email: str, magic_token: str, language: str = "fr") -> bool:
         """Send a magic link for account recovery.
 
@@ -27,6 +31,8 @@ class EmailService:
         Returns:
             True if email was sent successfully, False otherwise
         """
+        if self._is_synthetic(email):
+            return False
         try:
             magic_url = f"{self.frontend_url}/auth/magic-link?token={magic_token}"
 
@@ -119,6 +125,8 @@ class EmailService:
         Returns:
             True if email was sent successfully, False otherwise
         """
+        if self._is_synthetic(email):
+            return False
         try:
             dashboard_url = f"{self.frontend_url}/dashboard"
 
@@ -236,6 +244,8 @@ class EmailService:
         Returns:
             True if email was sent successfully, False otherwise
         """
+        if self._is_synthetic(email):
+            return False
         try:
             if language == "en":
                 if purpose == "registration":

--- a/backend/app/domain/services/local_auth_service.py
+++ b/backend/app/domain/services/local_auth_service.py
@@ -844,13 +844,13 @@ class LocalAuthService:
         """
         try:
             is_email = "@" in identifier
-            email: str | None = identifier if is_email else None
             phone: str | None = identifier if not is_email else None
+            email: str | None = identifier if is_email else f"{phone}@sira.app"
 
             existing_user = await self.db.scalar(
                 select(User).where(
                     or_(
-                        User.email == email if email else False,
+                        User.email == email,
                         User.phone_number == phone if phone else False,
                     )
                 )

--- a/backend/migrations/versions/073_backfill_synthetic_email_phone_users.py
+++ b/backend/migrations/versions/073_backfill_synthetic_email_phone_users.py
@@ -1,0 +1,42 @@
+"""Backfill synthetic email for phone-only users.
+
+Revision ID: 073
+Revises: 072
+Create Date: 2026-04-20
+
+Phone-only users (email IS NULL, phone_number IS NOT NULL) have no email,
+which prevents them from being added to organizations via the add-member
+endpoint that looks users up by email.  Assigning a deterministic synthetic
+address <phone>@sira.app gives every user a stable, unique email without
+requiring them to own a real inbox.  The EmailService._is_synthetic() guard
+ensures no mail is ever dispatched to these addresses.
+"""
+
+from alembic import op
+
+revision = "073"
+down_revision = "072"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE users
+        SET email = phone_number || '@sira.app'
+        WHERE email IS NULL
+          AND phone_number IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE users
+        SET email = NULL
+        WHERE email LIKE '%@sira.app'
+          AND phone_number IS NOT NULL
+        """
+    )


### PR DESCRIPTION
## Summary

- Phone-only users (registered with phone number only) had `email = NULL`, blocking them from being added to organizations via the add-member flow which looks up users by email
- At registration, `register_user_with_password` now assigns `<phone>@sira.app` as a deterministic synthetic email instead of `None`
- Migration 073 backfills all existing phone-only users (`70220689` → `70220689@sira.app`)
- `EmailService` gains `_is_synthetic()` guard — `send_magic_link`, `send_welcome_email`, and `send_otp_email` return `False` early for `@sira.app` addresses so no real mail is ever attempted

## Test plan

- [ ] Register a new user with phone number only → verify `email = <phone>@sira.app` in DB
- [ ] Run migration 073 on staging → verify existing phone-only users get synthetic email
- [ ] Add user `70220689@sira.app` to an org via admin panel → should succeed
- [ ] Confirm no welcome email is dispatched for phone-only registration
- [ ] Confirm magic-link recovery still works for real-email users

Fixes #1780

🤖 Generated with [Claude Code](https://claude.com/claude-code)