### PR TITLE
feat(qbank): QBank RBAC — org editor + platform role checks (#1783)

### DIFF
--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -198,6 +198,55 @@ def _attempt_response(a):
     )
 
 
+async def _require_org_editor(
+    org_id,
+    current_user: AuthenticatedUser,
+    db,
+) -> None:
+    """Raise 403 unless the caller can edit banks that belong to ``org_id``.
+
+    Allowed:
+    - Platform admin or sub_admin (always).
+    - Platform expert who is any org member.
+    - Org owner or admin (any platform role).
+    Blocks:
+    - Non-members, viewers with a plain "user" platform role.
+    - Any non-admin creating/editing a bank with no org (public bank).
+    """
+    from app.domain.services.organization_service import OrganizationService
+
+    if current_user.role in ("admin", "sub_admin"):
+        return
+    if org_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only platform admins can manage public question banks.",
+        )
+    member = await OrganizationService().get_member_or_none(
+        db,
+        org_id if isinstance(org_id, uuid.UUID) else uuid.UUID(str(org_id)),
+        uuid.UUID(current_user.id),
+    )
+    if member is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not a member of this organisation.",
+        )
+    if current_user.role == "expert":
+        return
+    member_role = member.role.value if hasattr(member.role, "value") else member.role
+    if member_role not in ("owner", "admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Org owner or admin rights required to manage this question bank.",
+        )
+
+
+async def _require_bank_editor(bank, current_user: AuthenticatedUser, db) -> None:
+    """Convenience wrapper around ``_require_org_editor`` for an existing bank."""
+    await _require_org_editor(bank.organization_id, current_user, db)
+
+
 # ---------------------------------------------------------------------------
 # Question Bank CRUD
 # ---------------------------------------------------------------------------
@@ -218,6 +267,8 @@ async def create_bank(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Only platform admins can create public question banks.",
         )
+    if body.visibility != "public":
+        await _require_org_editor(body.organization_id, current_user, db)
     bank = await _svc.create_bank(
         db,
         organization_id=body.organization_id,
@@ -239,6 +290,17 @@ async def list_banks(
     current_user: AuthenticatedUser = Depends(get_current_user),
     db=Depends(get_db_session),
 ):
+    if current_user.role not in ("admin", "sub_admin"):
+        from app.domain.services.organization_service import OrganizationService
+
+        member = await OrganizationService().get_member_or_none(
+            db, org_id, uuid.UUID(current_user.id)
+        )
+        if member is None:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You are not a member of this organisation.",
+            )
     items = await _svc.list_org_banks(db, org_id)
     return [
         _bank_response(item["bank"], item["question_count"], item["test_count"]) for item in items
@@ -307,6 +369,15 @@ async def get_bank(
     db=Depends(get_db_session),
 ):
     bank = await _svc.get_bank(db, bank_id)
+    bank_status = bank.status.value if hasattr(bank.status, "value") else bank.status
+    if bank_status == "draft":
+        try:
+            await _require_bank_editor(bank, current_user, db)
+        except HTTPException:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Question bank not found.",
+            )
     return _bank_response(bank)
 
 
@@ -317,7 +388,14 @@ async def update_bank(
     current_user: AuthenticatedUser = Depends(get_current_user),
     db=Depends(get_db_session),
 ):
+    existing = await _svc.get_bank(db, bank_id)
+    await _require_bank_editor(existing, current_user, db)
     updates = body.model_dump(exclude_unset=True)
+    if updates.get("visibility") == "public" and current_user.role not in ("admin", "sub_admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only platform admins can make a question bank public.",
+        )
     bank = await _svc.update_bank(db, bank_id, uuid.UUID(current_user.id), **updates)
     return _bank_response(bank)
 
@@ -328,6 +406,8 @@ async def delete_bank(
     current_user: AuthenticatedUser = Depends(get_current_user),
     db=Depends(get_db_session),
 ):
+    bank = await _svc.get_bank(db, bank_id)
+    await _require_bank_editor(bank, current_user, db)
     await _svc.delete_bank(db, bank_id, uuid.UUID(current_user.id))
 
 
@@ -365,6 +445,11 @@ async def update_question(
     current_user: AuthenticatedUser = Depends(get_current_user),
     db=Depends(get_db_session),
 ):
+    existing_q = await db.get(QBankQuestion, question_id)
+    if existing_q is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Question not found.")
+    bank = await _svc.get_bank(db, existing_q.question_bank_id)
+    await _require_bank_editor(bank, current_user, db)
     updates = body.model_dump(exclude_unset=True)
     q = await _svc.update_question(db, question_id, uuid.UUID(current_user.id), **updates)
     return _question_response(q, request)
@@ -379,6 +464,11 @@ async def delete_question(
     current_user: AuthenticatedUser = Depends(get_current_user),
     db=Depends(get_db_session),
 ):
+    existing_q = await db.get(QBankQuestion, question_id)
+    if existing_q is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Question not found.")
+    bank = await _svc.get_bank(db, existing_q.question_bank_id)
+    await _require_bank_editor(bank, current_user, db)
     await _svc.delete_question(db, question_id, uuid.UUID(current_user.id))
 
 
@@ -397,6 +487,8 @@ async def create_test(
     current_user: AuthenticatedUser = Depends(get_current_user),
     db=Depends(get_db_session),
 ):
+    bank = await _svc.get_bank(db, body.question_bank_id)
+    await _require_bank_editor(bank, current_user, db)
     test = await _svc.create_test(
         db,
         question_bank_id=body.question_bank_id,
@@ -430,6 +522,13 @@ async def update_test(
     current_user: AuthenticatedUser = Depends(get_current_user),
     db=Depends(get_db_session),
 ):
+    from app.domain.models.question_bank import QBankTest
+
+    test_obj = await db.get(QBankTest, test_id)
+    if test_obj is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Test not found.")
+    bank = await _svc.get_bank(db, test_obj.question_bank_id)
+    await _require_bank_editor(bank, current_user, db)
     updates = body.model_dump(exclude_unset=True)
     test = await _svc.update_test(db, test_id, uuid.UUID(current_user.id), **updates)
     return _test_response(test)
@@ -441,6 +540,13 @@ async def delete_test(
     current_user: AuthenticatedUser = Depends(get_current_user),
     db=Depends(get_db_session),
 ):
+    from app.domain.models.question_bank import QBankTest
+
+    test_obj = await db.get(QBankTest, test_id)
+    if test_obj is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Test not found.")
+    bank = await _svc.get_bank(db, test_obj.question_bank_id)
+    await _require_bank_editor(bank, current_user, db)
     await _svc.delete_test(db, test_id, uuid.UUID(current_user.id))
 
 
@@ -598,16 +704,10 @@ async def upload_pdf(
     db=Depends(get_db_session),
 ):
     """Upload a PDF to extract image-based MCQ questions from slides."""
-    from app.domain.services.organization_service import OrganizationService
     from app.tasks.qbank_processing import process_qbank_pdf
 
     bank = await _svc.get_bank(db, bank_id)
-    org_svc = OrganizationService()
-    await org_svc.require_org_role(
-        db,
-        bank.organization_id,
-        uuid.UUID(current_user.id),
-    )
+    await _require_bank_editor(bank, current_user, db)
 
     if not file.filename or not file.filename.lower().endswith(".pdf"):
         from fastapi import HTTPException
@@ -669,6 +769,8 @@ async def get_bank_analytics(
     db=Depends(get_db_session),
 ):
     """Org admin dashboard: aggregate metrics across all attempts in a bank."""
+    bank = await _svc.get_bank(db, bank_id)
+    await _require_bank_editor(bank, current_user, db)
     return await _analytics.get_bank_analytics(db, bank_id, uuid.UUID(current_user.id))
 
 
@@ -679,6 +781,8 @@ async def get_bank_students(
     db=Depends(get_db_session),
 ):
     """Org admin: per-student roll-up (attempt count, avg score, pass count)."""
+    bank = await _svc.get_bank(db, bank_id)
+    await _require_bank_editor(bank, current_user, db)
     students = await _analytics.get_bank_students(db, bank_id, uuid.UUID(current_user.id))
     return BankStudentsResponse(bank_id=str(bank_id), students=students)
 
@@ -693,7 +797,16 @@ async def get_student_progress(
     current_user: AuthenticatedUser = Depends(get_current_user),
     db=Depends(get_db_session),
 ):
-    """Individual student progress. Students may only view their own record."""
+    """Individual student progress. Editors see any student; others only own."""
+    bank = await _svc.get_bank(db, bank_id)
+    try:
+        await _require_bank_editor(bank, current_user, db)
+    except HTTPException:
+        if str(user_id) != current_user.id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You may only view your own progress.",
+            )
     return await _analytics.get_student_progress(db, bank_id, user_id, uuid.UUID(current_user.id))
 
 
@@ -754,7 +867,6 @@ async def generate_bank_audio(
     """
     from celery import chain as celery_chain
 
-    from app.domain.services.organization_service import OrganizationService
     from app.domain.services.qbank_translation_service import TARGET_LANGUAGES
     from app.tasks.qbank_processing import (
         generate_qbank_audio_task,
@@ -762,9 +874,7 @@ async def generate_bank_audio(
     )
 
     bank = await _svc.get_bank(db, bank_id)
-    await OrganizationService().require_org_role(
-        db, bank.organization_id, uuid.UUID(current_user.id)
-    )
+    await _require_bank_editor(bank, current_user, db)
     if language in TARGET_LANGUAGES:
         task = celery_chain(
             translate_qbank_bank_task.si(str(bank_id), language),
@@ -802,13 +912,10 @@ async def backfill_bank_translations(
         QBankQuestion,
         QBankQuestionAudio,
     )
-    from app.domain.services.organization_service import OrganizationService
     from app.tasks.qbank_processing import translate_and_synthesize_question_task
 
     bank = await _svc.get_bank(db, bank_id)
-    await OrganizationService().require_org_role(
-        db, bank.organization_id, uuid.UUID(current_user.id)
-    )
+    await _require_bank_editor(bank, current_user, db)
 
     question_ids = (
         (
@@ -1039,8 +1146,6 @@ async def upload_question_audio(
     so subsequent TTS batch runs skip it — the editor's recording is
     the source of truth until they explicitly delete it.
     """
-    from app.domain.services.organization_service import OrganizationService
-
     q = await db.get(QBankQuestion, question_id)
     if q is None:
         raise HTTPException(
@@ -1048,9 +1153,7 @@ async def upload_question_audio(
             detail="Question not found.",
         )
     bank = await _svc.get_bank(db, q.question_bank_id)
-    await OrganizationService().require_org_role(
-        db, bank.organization_id, uuid.UUID(current_user.id)
-    )
+    await _require_bank_editor(bank, current_user, db)
 
     content_type = (file.content_type or "").split(";")[0].strip().lower()
     if content_type not in _MANUAL_AUDIO_MIME_ALLOWLIST:
@@ -1092,8 +1195,6 @@ async def delete_question_audio(
     clip clears the slot so the next batch or per-question TTS call can
     repopulate it. Same org-role guard as upload.
     """
-    from app.domain.services.organization_service import OrganizationService
-
     q = await db.get(QBankQuestion, question_id)
     if q is None:
         raise HTTPException(
@@ -1101,9 +1202,7 @@ async def delete_question_audio(
             detail="Question not found.",
         )
     bank = await _svc.get_bank(db, q.question_bank_id)
-    await OrganizationService().require_org_role(
-        db, bank.organization_id, uuid.UUID(current_user.id)
-    )
+    await _require_bank_editor(bank, current_user, db)
     await _audio.delete_question_audio(db, question_id, language)
 
 

--- a/backend/app/domain/services/organization_service.py
+++ b/backend/app/domain/services/organization_service.py
@@ -403,3 +403,18 @@ class OrganizationService:
                 detail=f"Requires role: {', '.join(r.value for r in allowed_roles)}.",
             )
         return member
+
+    async def get_member_or_none(
+        self,
+        db: AsyncSession,
+        org_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> OrganizationMember | None:
+        """Non-raising variant of require_org_role — returns None if not a member."""
+        result = await db.execute(
+            select(OrganizationMember).where(
+                OrganizationMember.organization_id == org_id,
+                OrganizationMember.user_id == user_id,
+            )
+        )
+        return result.scalar_one_or_none()

--- a/backend/app/domain/services/qbank_service.py
+++ b/backend/app/domain/services/qbank_service.py
@@ -11,18 +11,14 @@ from fastapi import HTTPException, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.domain.models.organization import OrgMemberRole
 from app.domain.models.question_bank import (
     QBankQuestion,
     QBankTest,
     QBankTestAttempt,
     QuestionBank,
 )
-from app.domain.services.organization_service import OrganizationService
 
 logger = structlog.get_logger(__name__)
-
-_org_svc = OrganizationService()
 
 
 async def _enqueue_pregenerate_audio(db: AsyncSession, bank_id: uuid.UUID) -> None:
@@ -92,14 +88,6 @@ class QBankService:
         passing_score: float = 80.0,
         visibility: str = "org_restricted",
     ) -> QuestionBank:
-        if visibility == "org_restricted":
-            await _org_svc.require_org_role(
-                db,
-                organization_id,
-                created_by,
-                OrgMemberRole.owner,
-                OrgMemberRole.admin,
-            )
         bank = QuestionBank(
             organization_id=organization_id,
             visibility=visibility,
@@ -298,13 +286,6 @@ class QBankService:
         **fields,
     ) -> QuestionBank:
         bank = await self.get_bank(db, bank_id)
-        await _org_svc.require_org_role(
-            db,
-            bank.organization_id,
-            actor_id,
-            OrgMemberRole.owner,
-            OrgMemberRole.admin,
-        )
         allowed = {
             "title",
             "description",
@@ -312,6 +293,7 @@ class QBankService:
             "time_per_question_sec",
             "passing_score",
             "status",
+            "visibility",
         }
         previous_status = bank.status.value if hasattr(bank.status, "value") else bank.status
         for key, value in fields.items():
@@ -335,13 +317,6 @@ class QBankService:
         actor_id: uuid.UUID,
     ) -> None:
         bank = await self.get_bank(db, bank_id)
-        await _org_svc.require_org_role(
-            db,
-            bank.organization_id,
-            actor_id,
-            OrgMemberRole.owner,
-            OrgMemberRole.admin,
-        )
         await db.delete(bank)
         await db.commit()
 
@@ -388,14 +363,7 @@ class QBankService:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="Question not found.",
             )
-        bank = await self.get_bank(db, question.question_bank_id)
-        await _org_svc.require_org_role(
-            db,
-            bank.organization_id,
-            actor_id,
-            OrgMemberRole.owner,
-            OrgMemberRole.admin,
-        )
+        await self.get_bank(db, question.question_bank_id)
         allowed = {
             "question_text",
             "options",
@@ -445,14 +413,7 @@ class QBankService:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="Question not found.",
             )
-        bank = await self.get_bank(db, question.question_bank_id)
-        await _org_svc.require_org_role(
-            db,
-            bank.organization_id,
-            actor_id,
-            OrgMemberRole.owner,
-            OrgMemberRole.admin,
-        )
+        await self.get_bank(db, question.question_bank_id)
         await db.delete(question)
         await db.commit()
 
@@ -475,14 +436,7 @@ class QBankService:
         filter_categories: list[str] | None = None,
         filter_failed_only: bool = False,
     ) -> QBankTest:
-        bank = await self.get_bank(db, question_bank_id)
-        await _org_svc.require_org_role(
-            db,
-            bank.organization_id,
-            created_by,
-            OrgMemberRole.owner,
-            OrgMemberRole.admin,
-        )
+        await self.get_bank(db, question_bank_id)
         test = QBankTest(
             question_bank_id=question_bank_id,
             title=title,
@@ -525,14 +479,7 @@ class QBankService:
         **fields,
     ) -> QBankTest:
         test = await self.get_test(db, test_id)
-        bank = await self.get_bank(db, test.question_bank_id)
-        await _org_svc.require_org_role(
-            db,
-            bank.organization_id,
-            actor_id,
-            OrgMemberRole.owner,
-            OrgMemberRole.admin,
-        )
+        await self.get_bank(db, test.question_bank_id)
         allowed = {
             "title",
             "mode",
@@ -557,14 +504,7 @@ class QBankService:
         actor_id: uuid.UUID,
     ) -> None:
         test = await self.get_test(db, test_id)
-        bank = await self.get_bank(db, test.question_bank_id)
-        await _org_svc.require_org_role(
-            db,
-            bank.organization_id,
-            actor_id,
-            OrgMemberRole.owner,
-            OrgMemberRole.admin,
-        )
+        await self.get_bank(db, test.question_bank_id)
         await db.delete(test)
         await db.commit()
 

--- a/frontend/app/[locale]/org/[orgSlug]/qbank/[bankId]/client.tsx
+++ b/frontend/app/[locale]/org/[orgSlug]/qbank/[bankId]/client.tsx
@@ -7,6 +7,8 @@ import { ArrowLeft, Loader2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useOrg } from "@/components/org/org-context";
+import { useCurrentUser } from "@/lib/hooks/use-current-user";
+import { canEditBank, type OrgRole } from "@/lib/permissions";
 import { QBankPdfUpload } from "@/components/qbank/qbank-pdf-upload";
 import { QBankQuestionEditor } from "@/components/qbank/qbank-question-editor";
 import { QBankTestConfigList } from "@/components/qbank/qbank-test-config";
@@ -33,7 +35,9 @@ const STATUS_KEY: Record<"draft" | "published" | "archived", string> = {
 export function QBankDetailClient({ bankId }: Props) {
   const locale = useLocale();
   const t = useTranslations("qbank");
-  const { org } = useOrg();
+  const { org, role } = useOrg();
+  const currentUser = useCurrentUser();
+  const isEditor = canEditBank(role as OrgRole, currentUser?.role);
   const [bank, setBank] = useState<QBankBank | null>(null);
   const [questions, setQuestions] = useState<QBankQuestionFull[]>([]);
   const [total, setTotal] = useState(0);
@@ -130,21 +134,25 @@ export function QBankDetailClient({ bankId }: Props) {
             {t("questionCount", { count: total })} · {t("timePerQSuffix", { seconds: bank.time_per_question_sec })} · {bank.passing_score}% · {bank.language.toUpperCase()}
           </p>
         </div>
-        <Button onClick={togglePublished} disabled={publishing} variant="outline">
-          {publishing && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-          {bank.status === "published" ? t("unpublish") : t("publish")}
-        </Button>
+        {isEditor && (
+          <Button onClick={togglePublished} disabled={publishing} variant="outline">
+            {publishing && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {bank.status === "published" ? t("unpublish") : t("publish")}
+          </Button>
+        )}
       </header>
 
-      <section className="space-y-3 rounded-lg border bg-white p-4">
-        <h2 className="text-lg font-medium">{t("addMoreQuestions")}</h2>
-        <QBankPdfUpload
-          bankId={bankId}
-          onProcessed={(res) => {
-            if (res.status === "success") void loadQuestions(1);
-          }}
-        />
-      </section>
+      {isEditor && (
+        <section className="space-y-3 rounded-lg border bg-white p-4">
+          <h2 className="text-lg font-medium">{t("addMoreQuestions")}</h2>
+          <QBankPdfUpload
+            bankId={bankId}
+            onProcessed={(res) => {
+              if (res.status === "success") void loadQuestions(1);
+            }}
+          />
+        </section>
+      )}
 
       <section className="space-y-3">
         <div className="flex flex-wrap items-center justify-between gap-2">
@@ -176,6 +184,7 @@ export function QBankDetailClient({ bankId }: Props) {
               <li key={q.id}>
                 <QBankQuestionEditor
                   question={q}
+                  canEdit={isEditor}
                   onSaved={(updated) =>
                     setQuestions((prev) => prev.map((p) => (p.id === updated.id ? updated : p)))
                   }
@@ -215,7 +224,7 @@ export function QBankDetailClient({ bankId }: Props) {
       </section>
 
       <section className="rounded-lg border bg-white p-4">
-        <QBankTestConfigList bankId={bankId} />
+        <QBankTestConfigList bankId={bankId} canEdit={isEditor} />
       </section>
     </div>
   );

--- a/frontend/app/[locale]/org/[orgSlug]/qbank/client.tsx
+++ b/frontend/app/[locale]/org/[orgSlug]/qbank/client.tsx
@@ -6,6 +6,8 @@ import { useLocale, useTranslations } from "next-intl";
 import { ClipboardList, Loader2, Plus } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { useOrg } from "@/components/org/org-context";
+import { useCurrentUser } from "@/lib/hooks/use-current-user";
+import { canEditBank, type OrgRole } from "@/lib/permissions";
 import { listQBankBanks, type QBankBank, type QBankStatus, type QBankType } from "@/lib/api";
 
 const TYPE_KEY: Record<QBankType, string> = {
@@ -30,7 +32,9 @@ const STATUS_STYLES: Record<QBankStatus, string> = {
 export function QBankListClient() {
   const locale = useLocale();
   const t = useTranslations("qbank");
-  const { org, loading: orgLoading } = useOrg();
+  const { org, role, loading: orgLoading } = useOrg();
+  const currentUser = useCurrentUser();
+  const isEditor = canEditBank(role as OrgRole, currentUser?.role);
   const [banks, setBanks] = useState<QBankBank[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -78,12 +82,14 @@ export function QBankListClient() {
           </h1>
           <p className="text-sm text-muted-foreground">{t("banksSubtitle")}</p>
         </div>
-        <Link
-          href={`${base}/create`}
-          className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-2.5 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/80"
-        >
-          <Plus className="h-4 w-4" /> {t("newBank")}
-        </Link>
+        {isEditor && (
+          <Link
+            href={`${base}/create`}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-2.5 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/80"
+          >
+            <Plus className="h-4 w-4" /> {t("newBank")}
+          </Link>
+        )}
       </header>
 
       <div className="flex flex-wrap gap-2">

--- a/frontend/app/[locale]/org/[orgSlug]/qbank/create/client.tsx
+++ b/frontend/app/[locale]/org/[orgSlug]/qbank/create/client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
@@ -9,6 +9,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useOrg } from "@/components/org/org-context";
+import { useCurrentUser } from "@/lib/hooks/use-current-user";
+import { canEditBank, type OrgRole } from "@/lib/permissions";
 import { QBankPdfUpload } from "@/components/qbank/qbank-pdf-upload";
 import { createQBankBank, type QBankBank, type QBankType } from "@/lib/api";
 
@@ -23,7 +25,9 @@ export function QBankCreateClient() {
   const locale = useLocale();
   const t = useTranslations("qbank");
   const router = useRouter();
-  const { org } = useOrg();
+  const { org, role, loading: orgLoading } = useOrg();
+  const currentUser = useCurrentUser();
+  const isEditor = canEditBank(role as OrgRole, currentUser?.role);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [bank, setBank] = useState<QBankBank | null>(null);
@@ -35,8 +39,16 @@ export function QBankCreateClient() {
   const [timePerQuestion, setTimePerQuestion] = useState(25);
   const [passingScore, setPassingScore] = useState(80);
 
-  if (!org) return null;
-  const base = `/${locale}/org/${org.slug}/qbank`;
+  const base = org ? `/${locale}/org/${org.slug}/qbank` : null;
+
+  useEffect(() => {
+    if (!orgLoading && base && !isEditor) {
+      router.replace(base);
+    }
+  }, [orgLoading, isEditor, base, router]);
+
+  if (!org || !base) return null;
+  if (!isEditor) return null;
 
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();

--- a/frontend/components/qbank/qbank-audio-manager.tsx
+++ b/frontend/components/qbank/qbank-audio-manager.tsx
@@ -34,6 +34,7 @@ const ACCEPTED_MIME = [
 
 interface Props {
   questionId: string;
+  canEdit?: boolean;
 }
 
 /**
@@ -45,7 +46,7 @@ interface Props {
  * Falls back gracefully when MediaRecorder isn't available (older
  * Safari, insecure origin) — only the Upload button is shown.
  */
-export function QBankAudioManager({ questionId }: Props) {
+export function QBankAudioManager({ questionId, canEdit = true }: Props) {
   const t = useTranslations("qbank");
   const tLang = useTranslations("qbank.audioLanguages");
   const [language, setLanguage] = useState<QBankAudioLanguage>("fr");
@@ -214,6 +215,8 @@ export function QBankAudioManager({ questionId }: Props) {
 
   const audioUrl = status?.audio_url ?? null;
   const source = status?.source ?? "tts";
+
+  if (!canEdit) return null;
 
   return (
     <div className="space-y-3 rounded-md border bg-gray-50 p-3">

--- a/frontend/components/qbank/qbank-question-editor.tsx
+++ b/frontend/components/qbank/qbank-question-editor.tsx
@@ -17,13 +17,14 @@ import { QBankAudioManager } from "./qbank-audio-manager";
 
 interface Props {
   question: QBankQuestionFull;
+  canEdit?: boolean;
   onSaved: (updated: QBankQuestionFull) => void;
   onDeleted: (id: string) => void;
 }
 
 const DIFFICULTIES: QBankDifficulty[] = ["easy", "medium", "hard"];
 
-export function QBankQuestionEditor({ question, onSaved, onDeleted }: Props) {
+export function QBankQuestionEditor({ question, canEdit = true, onSaved, onDeleted }: Props) {
   const t = useTranslations("qbank");
   const [text, setText] = useState(question.question_text);
   const [options, setOptions] = useState([...question.options]);
@@ -187,25 +188,27 @@ export function QBankQuestionEditor({ question, onSaved, onDeleted }: Props) {
         />
       </div>
 
-      <QBankAudioManager questionId={question.id} />
+      <QBankAudioManager questionId={question.id} canEdit={canEdit} />
 
       {error && <p className="text-sm text-red-700">{error}</p>}
 
-      <div className="flex justify-between">
-        <Button
-          type="button"
-          variant="outline"
-          onClick={handleDelete}
-          disabled={deleting || saving}
-        >
-          {deleting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Trash2 className="mr-2 h-4 w-4" />}
-          {t("delete")}
-        </Button>
-        <Button type="button" onClick={handleSave} disabled={!dirty || saving}>
-          {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-          {t("saveChanges")}
-        </Button>
-      </div>
+      {canEdit && (
+        <div className="flex justify-between">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleDelete}
+            disabled={deleting || saving}
+          >
+            {deleting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Trash2 className="mr-2 h-4 w-4" />}
+            {t("delete")}
+          </Button>
+          <Button type="button" onClick={handleSave} disabled={!dirty || saving}>
+            {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {t("saveChanges")}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/components/qbank/qbank-test-config.tsx
+++ b/frontend/components/qbank/qbank-test-config.tsx
@@ -15,6 +15,7 @@ import {
 
 interface Props {
   bankId: string;
+  canEdit?: boolean;
 }
 
 const MODES: { value: QBankTestMode; key: string }[] = [
@@ -23,7 +24,7 @@ const MODES: { value: QBankTestMode; key: string }[] = [
   { value: "review", key: "modeReview" },
 ];
 
-export function QBankTestConfigList({ bankId }: Props) {
+export function QBankTestConfigList({ bankId, canEdit = true }: Props) {
   const t = useTranslations("qbank");
   const [tests, setTests] = useState<QBankTestConfig[]>([]);
   const [loading, setLoading] = useState(true);
@@ -95,7 +96,7 @@ export function QBankTestConfigList({ bankId }: Props) {
         </ul>
       )}
 
-      <form onSubmit={handleCreate} className="space-y-3 rounded-md border bg-gray-50 p-4">
+      {canEdit && <form onSubmit={handleCreate} className="space-y-3 rounded-md border bg-gray-50 p-4">
         <h3 className="text-sm font-medium">{t("newTest")}</h3>
 
         <div className="space-y-2">
@@ -181,7 +182,7 @@ export function QBankTestConfigList({ bankId }: Props) {
             {t("createTest")}
           </Button>
         </div>
-      </form>
+      </form>}
     </div>
   );
 }

--- a/frontend/lib/permissions.ts
+++ b/frontend/lib/permissions.ts
@@ -1,0 +1,19 @@
+export type OrgRole = "owner" | "admin" | "viewer" | null;
+
+/**
+ * Returns true when the user may create or edit question banks in an org.
+ *
+ * Allowed:
+ * - Platform admin or sub_admin (always, regardless of org role).
+ * - Platform expert who is any org member.
+ * - Org owner or admin (any platform role).
+ */
+export function canEditBank(
+  orgRole: OrgRole,
+  platformRole: string | undefined,
+): boolean {
+  if (platformRole === "admin" || platformRole === "sub_admin") return true;
+  if (!orgRole) return false;
+  if (platformRole === "expert") return true;
+  return orgRole === "owner" || orgRole === "admin";
+}


### PR DESCRIPTION
## Summary

- **Backend**: adds `_require_bank_editor()` / `_require_org_editor()` API-layer helpers that gate all write and analytics endpoints; removes the `require_org_role(owner, admin)` calls scattered across 8 service methods (which blocked `sub_admin` and `expert` entirely). Allows: platform `admin`/`sub_admin` always, `expert` org members, and org `owner`/`admin` for everyone else.
- **Backend fixes**: `update_bank` now accepts `visibility` changes (was silently dropped); draft banks return 404 to non-editors on `GET /banks/{id}`; `GET /banks` requires org membership; `get_student_progress` restricts learners to their own record.
- **Frontend**: new `lib/permissions.ts` with `canEditBank(orgRole, platformRole)` utility; "New Bank" button, Publish button, PDF upload section, question save/delete actions, and test-creation form are hidden when `canEditBank` returns false; non-editors are redirected away from the create page.
- **Follow-up fix (#1786)**: `QBankAudioManager` now also honors `canEdit` — caught during staging browser test where viewers still saw Record/Upload/Delete audio buttons.

## Test plan

- [ ] Platform `admin` can create/edit/delete banks, questions, tests, analytics
- [ ] Platform `sub_admin` can do all of the above (previously blocked)
- [ ] `expert` org member can edit (previously blocked)
- [ ] Org `owner`/`admin` (plain `user` platform role) can edit their org's banks
- [ ] Org `viewer` gets 403 on all write endpoints
- [ ] Regular `user` with no org membership gets 403
- [ ] Draft bank returns 404 to non-editors, visible to editors
- [ ] Learner can only view their own progress record
- [ ] Frontend: editor UI hidden for viewers (including audio manager); `/qbank/create` redirects non-editors

Fixes #1783
Fixes #1786

## Staging verification (before #1785 deploy)
End-to-end browser test with learner account (`70220689`, platform `user`, org `viewer`):
- ✅ Login, QBank discovery, bank detail, tests list, start test, submit, review all work.
- ✅ Backend still protected pre-deploy by service-layer `require_org_role` (old error message).
- ⚠️ Image optimizer 400 on review page — separate issue filed as #1787.

Re-verify after staging deploy: Publish button hidden, audio manager gone, `/qbank/create` redirects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)