### PR TITLE
fix(qbank): unoptimized on QBankImageQuestion to skip Next image optimizer 400 (#1787)

### DIFF
--- a/frontend/components/qbank/qbank-image-question.tsx
+++ b/frontend/components/qbank/qbank-image-question.tsx
@@ -78,6 +78,7 @@ export function QBankImageQuestion({
             className="object-contain"
             onLoad={onImageLoad}
             priority
+            unoptimized
           />
         </div>
       )}


### PR DESCRIPTION
## Summary

Adds the \`unoptimized\` prop to the \`<Image>\` in \`QBankImageQuestion\`, matching the \`unoptimized\` already set on \`QBankQuestionEditor\`'s image.

## Problem

The Next.js image optimizer returns HTTP 400 for the QBank question image proxy URLs:

\`\`\`
GET /_next/image?url=https%3A%2F%2F<host>%2Fapi%2Fv1%2Fqbank%2Fquestions%2F{id}%2Fimage&w=750&q=75 → 400
\`\`\`

This blanks out every image-based MCQ on:
- The test player (\`/fr/qbank/tests/[testId]\`) while taking the test
- The results/review page (\`/fr/qbank/tests/[testId]/results\`)

The raw backend proxy (\`/api/v1/qbank/questions/{id}/image\`) already returns \`image/webp\` fine — the optimizer itself is rejecting the upstream.

## Fix

Opt out of optimization for QBank question images. The backend serves pre-sized webp, so the optimizer wasn't adding value. This is the same approach already used for the editor-side image — now consistent across read + edit.

## Test plan

- [ ] Start a test on a driving bank (image-based MCQs) → every question image renders, no grey placeholders.
- [ ] Submit, land on results page → every image renders in the review.
- [ ] DevTools network tab: confirm requests go to \`/api/v1/qbank/questions/{id}/image\` directly (no \`/_next/image\` hits for those URLs).

Fixes #1787

🤖 Generated with [Claude Code](https://claude.com/claude-code)