### PR TITLE
fix(qbank): hide bank-detail editor UI from viewers — answer-key leak (#1789)

### DIFF
--- a/frontend/app/[locale]/org/[orgSlug]/qbank/[bankId]/client.tsx
+++ b/frontend/app/[locale]/org/[orgSlug]/qbank/[bankId]/client.tsx
@@ -154,6 +154,7 @@ export function QBankDetailClient({ bankId }: Props) {
         </section>
       )}
 
+      {isEditor && (
       <section className="space-y-3">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <h2 className="text-lg font-medium">{t("questionsHeader")}</h2>
@@ -222,10 +223,13 @@ export function QBankDetailClient({ bankId }: Props) {
           </div>
         )}
       </section>
+      )}
 
-      <section className="rounded-lg border bg-white p-4">
-        <QBankTestConfigList bankId={bankId} canEdit={isEditor} />
-      </section>
+      {isEditor && (
+        <section className="rounded-lg border bg-white p-4">
+          <QBankTestConfigList bankId={bankId} canEdit={isEditor} />
+        </section>
+      )}
     </div>
   );
 }

--- a/frontend/app/[locale]/org/[orgSlug]/qbank/[bankId]/client.tsx
+++ b/frontend/app/[locale]/org/[orgSlug]/qbank/[bankId]/client.tsx
@@ -7,6 +7,7 @@ import { ArrowLeft, Loader2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useOrg } from "@/components/org/org-context";
+import { OrgQBankForbidden } from "@/components/org/org-forbidden";
 import { useCurrentUser } from "@/lib/hooks/use-current-user";
 import { canEditBank, type OrgRole } from "@/lib/permissions";
 import { QBankPdfUpload } from "@/components/qbank/qbank-pdf-upload";
@@ -86,6 +87,7 @@ export function QBankDetailClient({ bankId }: Props) {
   }
   if (error) return <p className="text-sm text-red-700">{error}</p>;
   if (!bank || !org) return null;
+  if (!isEditor) return <OrgQBankForbidden />;
 
   const base = `/${locale}/org/${org.slug}/qbank`;
   const categories = Array.from(
@@ -134,27 +136,22 @@ export function QBankDetailClient({ bankId }: Props) {
             {t("questionCount", { count: total })} · {t("timePerQSuffix", { seconds: bank.time_per_question_sec })} · {bank.passing_score}% · {bank.language.toUpperCase()}
           </p>
         </div>
-        {isEditor && (
-          <Button onClick={togglePublished} disabled={publishing} variant="outline">
-            {publishing && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            {bank.status === "published" ? t("unpublish") : t("publish")}
-          </Button>
-        )}
+        <Button onClick={togglePublished} disabled={publishing} variant="outline">
+          {publishing && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          {bank.status === "published" ? t("unpublish") : t("publish")}
+        </Button>
       </header>
 
-      {isEditor && (
-        <section className="space-y-3 rounded-lg border bg-white p-4">
-          <h2 className="text-lg font-medium">{t("addMoreQuestions")}</h2>
-          <QBankPdfUpload
-            bankId={bankId}
-            onProcessed={(res) => {
-              if (res.status === "success") void loadQuestions(1);
-            }}
-          />
-        </section>
-      )}
+      <section className="space-y-3 rounded-lg border bg-white p-4">
+        <h2 className="text-lg font-medium">{t("addMoreQuestions")}</h2>
+        <QBankPdfUpload
+          bankId={bankId}
+          onProcessed={(res) => {
+            if (res.status === "success") void loadQuestions(1);
+          }}
+        />
+      </section>
 
-      {isEditor && (
       <section className="space-y-3">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <h2 className="text-lg font-medium">{t("questionsHeader")}</h2>
@@ -223,13 +220,10 @@ export function QBankDetailClient({ bankId }: Props) {
           </div>
         )}
       </section>
-      )}
 
-      {isEditor && (
-        <section className="rounded-lg border bg-white p-4">
-          <QBankTestConfigList bankId={bankId} canEdit={isEditor} />
-        </section>
-      )}
+      <section className="rounded-lg border bg-white p-4">
+        <QBankTestConfigList bankId={bankId} canEdit={isEditor} />
+      </section>
     </div>
   );
 }

--- a/frontend/app/[locale]/org/[orgSlug]/qbank/client.tsx
+++ b/frontend/app/[locale]/org/[orgSlug]/qbank/client.tsx
@@ -6,6 +6,7 @@ import { useLocale, useTranslations } from "next-intl";
 import { ClipboardList, Loader2, Plus } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { useOrg } from "@/components/org/org-context";
+import { OrgQBankForbidden } from "@/components/org/org-forbidden";
 import { useCurrentUser } from "@/lib/hooks/use-current-user";
 import { canEditBank, type OrgRole } from "@/lib/permissions";
 import { listQBankBanks, type QBankBank, type QBankStatus, type QBankType } from "@/lib/api";
@@ -68,6 +69,10 @@ export function QBankListClient() {
 
   if (!org) {
     return <p className="text-muted-foreground">Organization not found.</p>;
+  }
+
+  if (!isEditor) {
+    return <OrgQBankForbidden />;
   }
 
   const filtered = typeFilter === "all" ? banks : banks.filter((b) => b.bank_type === typeFilter);

--- a/frontend/app/[locale]/org/[orgSlug]/qbank/create/client.tsx
+++ b/frontend/app/[locale]/org/[orgSlug]/qbank/create/client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useOrg } from "@/components/org/org-context";
+import { OrgQBankForbidden } from "@/components/org/org-forbidden";
 import { useCurrentUser } from "@/lib/hooks/use-current-user";
 import { canEditBank, type OrgRole } from "@/lib/permissions";
 import { QBankPdfUpload } from "@/components/qbank/qbank-pdf-upload";
@@ -39,16 +40,17 @@ export function QBankCreateClient() {
   const [timePerQuestion, setTimePerQuestion] = useState(25);
   const [passingScore, setPassingScore] = useState(80);
 
-  const base = org ? `/${locale}/org/${org.slug}/qbank` : null;
+  if (orgLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+      </div>
+    );
+  }
+  if (!org) return null;
+  if (!isEditor) return <OrgQBankForbidden />;
 
-  useEffect(() => {
-    if (!orgLoading && base && !isEditor) {
-      router.replace(base);
-    }
-  }, [orgLoading, isEditor, base, router]);
-
-  if (!org || !base) return null;
-  if (!isEditor) return null;
+  const base = `/${locale}/org/${org.slug}/qbank`;
 
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();

--- a/frontend/components/org/org-forbidden.tsx
+++ b/frontend/components/org/org-forbidden.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import Link from "next/link";
+import { useLocale } from "next-intl";
+import { ShieldOff } from "lucide-react";
+
+const MESSAGES = {
+  fr: {
+    heading: "403 — Accès refusé",
+    body: "Vous n'avez pas les droits nécessaires pour gérer les banques de questions de cette organisation.",
+    ctaLearner: "Retour aux tests disponibles",
+  },
+  en: {
+    heading: "403 — Forbidden",
+    body: "You don't have permission to manage this organization's question banks.",
+    ctaLearner: "Back to available tests",
+  },
+} as const;
+
+export function OrgQBankForbidden() {
+  const locale = useLocale();
+  const m = locale === "en" ? MESSAGES.en : MESSAGES.fr;
+  return (
+    <div className="mx-auto flex max-w-xl flex-col items-center gap-4 rounded-lg border bg-white p-10 text-center">
+      <ShieldOff className="h-10 w-10 text-red-500" aria-hidden />
+      <h1 className="text-xl font-semibold">{m.heading}</h1>
+      <p className="text-sm text-muted-foreground">{m.body}</p>
+      <Link
+        href={`/${locale}/qbank`}
+        className="inline-flex items-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-gray-50"
+      >
+        {m.ctaLearner}
+      </Link>
+    </div>
+  );
+}

--- a/frontend/components/org/org-nav.tsx
+++ b/frontend/components/org/org-nav.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
 import { useOrg } from "./org-context";
+import { useCurrentUser } from "@/lib/hooks/use-current-user";
+import { canEditBank, type OrgRole } from "@/lib/permissions";
 import {
   LayoutDashboard,
   BookOpen,
@@ -19,7 +21,9 @@ export function OrgNav() {
   const t = useTranslations("Organization");
   const locale = useLocale();
   const pathname = usePathname();
-  const { org } = useOrg();
+  const { org, role } = useOrg();
+  const currentUser = useCurrentUser();
+  const isEditor = canEditBank(role as OrgRole, currentUser?.role);
 
   if (!org) return null;
 
@@ -28,7 +32,9 @@ export function OrgNav() {
     { href: base, label: t("dashboard"), icon: LayoutDashboard },
     { href: `${base}/courses`, label: "Courses", icon: GraduationCap },
     { href: `${base}/curricula`, label: t("curricula"), icon: Library },
-    { href: `${base}/qbank`, label: "Question Banks", icon: ClipboardList },
+    ...(isEditor
+      ? [{ href: `${base}/qbank`, label: "Question Banks", icon: ClipboardList }]
+      : []),
     { href: `${base}/codes`, label: t("codes"), icon: QrCode },
     { href: `${base}/reports`, label: t("reports"), icon: BarChart3 },
     { href: `${base}/members`, label: t("members"), icon: Users },

--- a/frontend/components/qbank/qbank-question-editor.tsx
+++ b/frontend/components/qbank/qbank-question-editor.tsx
@@ -97,6 +97,8 @@ export function QBankQuestionEditor({ question, canEdit = true, onSaved, onDelet
     }
   }
 
+  if (!canEdit) return null;
+
   return (
     <div className="space-y-4 rounded-lg border bg-white p-4">
       {question.image_url && (


### PR DESCRIPTION
## Summary

Lock down the org-scoped QBank admin UI from non-editors — addresses both the answer-key leak and the nav/URL exposure reported during post-#1785 staging review.

**Two layers of protection:**
1. **Primary**: the `Question Banks` tab is removed from the org top-nav for non-editors (`OrgNav`), and every page under `/fr/org/[slug]/qbank*` early-returns a shared 403 component (`OrgQBankForbidden`) when `canEditBank` is false. No admin UI mounts at all.
2. **Defense-in-depth**: `QBankQuestionEditor` returns `null` when `canEdit=false`, so any future caller that forgets the page guard cannot accidentally render the correct-answer checkboxes or editable option inputs.

## Problem

PR #1785 hid `Save` / `Delete` buttons but still rendered the full editor form — including checkboxes whose `checked` state was driven by `correct_answer_indices`. A learner on `/fr/org/[slug]/qbank/[id]` could read the answer key for every question before taking the test, defeating any exam on that bank. It also left the `Question Banks` top-nav tab visible to viewers and let them reach the admin list/create pages via direct URL.

Reproduced on staging as `70220689` (platform `user`, org `viewer`): all 20 question textareas were editable and every correct option checkbox was visibly ticked.

## What's in this PR

- `frontend/components/org/org-nav.tsx` — conditionally drops the `Question Banks` tab when `canEditBank` is false.
- `frontend/components/org/org-forbidden.tsx` (new) — shared FR/EN 403 page with a CTA back to `/fr/qbank`.
- `frontend/app/[locale]/org/[orgSlug]/qbank/client.tsx` — returns `<OrgQBankForbidden />` for non-editors.
- `frontend/app/[locale]/org/[orgSlug]/qbank/[bankId]/client.tsx` — returns `<OrgQBankForbidden />` for non-editors; drops the now-redundant `{isEditor && ...}` section wrappers since the page never renders admin UI for viewers.
- `frontend/app/[locale]/org/[orgSlug]/qbank/create/client.tsx` — replaces the silent `useEffect` redirect with the same 403 render.
- `frontend/components/qbank/qbank-question-editor.tsx` — `if (!canEdit) return null` for defense-in-depth.

## Test plan

As `70220689` on staging (platform `user`, org `viewer` in zepintel):

- [ ] `/fr/org/zepintel` — the `Question Banks` tab is **absent** from the top nav.
- [ ] Paste `/fr/org/zepintel/qbank` — 403 page renders with "Retour aux tests disponibles" CTA to `/fr/qbank`.
- [ ] Paste `/fr/org/zepintel/qbank/32f95a24-…` — 403 page, no question text or checkboxes in the DOM.
- [ ] Paste `/fr/org/zepintel/qbank/create` — 403 page, no form.
- [ ] Test-taking flow at `/fr/qbank/tests/[testId]` still works; `correct_answer_indices` stays `null` in exam mode (#1632 unchanged).

Positive control as an editor (org owner/admin or platform admin):

- [ ] All three routes render the admin UI normally; `Question Banks` tab visible.

Fixes #1789

🤖 Generated with [Claude Code](https://claude.com/claude-code)