### PR TITLE
fix(nav): hide Question Banks sidebar entry from learners (#1789 follow-up)

### DIFF
--- a/frontend/components/layout/bottom-nav.tsx
+++ b/frontend/components/layout/bottom-nav.tsx
@@ -23,6 +23,21 @@ import {
   type CurriculumContextValue,
 } from "@/lib/curriculum-context";
 
+function getUserRole(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const token = localStorage.getItem("access_token");
+    if (!token) return null;
+    const base64Url = token.split(".")[1];
+    if (!base64Url) return null;
+    const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+    const payload = JSON.parse(atob(base64)) as Record<string, unknown>;
+    return typeof payload?.role === "string" ? payload.role : null;
+  } catch {
+    return null;
+  }
+}
+
 export function BottomNav() {
   const t = useTranslations("Navigation");
   const pathname = usePathname();
@@ -30,10 +45,14 @@ export function BottomNav() {
   const [moreOpen, setMoreOpen] = useState(false);
   const [curriculumCtx, setCurriculumCtx] =
     useState<CurriculumContextValue | null>(null);
+  const [userRole, setUserRole] = useState<string | null>(null);
   const moreRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    startTransition(() => setCurriculumCtx(getCurriculumContext()));
+    startTransition(() => {
+      setCurriculumCtx(getCurriculumContext());
+      setUserRole(getUserRole());
+    });
   }, [pathname]);
 
   useEffect(() => {
@@ -99,12 +118,18 @@ export function BottomNav() {
       icon: ListChecks,
       description: t("qbankTestsDescription"),
     },
-    {
-      href: `/${locale}/qbank`,
-      label: t("qbank"),
-      icon: Brain,
-      description: t("qbankDescription"),
-    },
+    ...(userRole === "admin" ||
+    userRole === "sub_admin" ||
+    userRole === "expert"
+      ? [
+          {
+            href: `/${locale}/qbank`,
+            label: t("qbank"),
+            icon: Brain,
+            description: t("qbankDescription"),
+          },
+        ]
+      : []),
     {
       href: `/${locale}/profile`,
       label: t("profile"),

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -124,12 +124,18 @@ export function Sidebar() {
       icon: ListChecks,
       description: t("qbankTestsDescription"),
     },
-    {
-      href: `/${locale}/qbank`,
-      label: t("qbank"),
-      icon: Brain,
-      description: t("qbankDescription"),
-    },
+    ...(userRole === "admin" ||
+    userRole === "sub_admin" ||
+    userRole === "expert"
+      ? [
+          {
+            href: `/${locale}/qbank`,
+            label: t("qbank"),
+            icon: Brain,
+            description: t("qbankDescription"),
+          },
+        ]
+      : []),
     {
       href: `/${locale}/certificates`,
       label: t("certificates"),


### PR DESCRIPTION
## Summary

Follow-up to PR #1790. After hiding the org admin's \`Question Banks\` tab, the global left sidebar (\`Sidebar\`) and mobile More menu (\`BottomNav\`) still exposed \`Question Banks\` → \`/fr/qbank\` to every user. That page lists accessible banks, but each bank card links to the org admin detail page — which now 403s for non-editors. So the entry was a dead end for anyone who isn't a platform admin/sub_admin/expert.

Gate the sidebar + bottom-nav qbank entries to \`admin\` / \`sub_admin\` / \`expert\` (same pattern as the existing \"Organizations\" and \"Admin\" sidebar items at \`sidebar.tsx:157\` and \`:167\`).

Bottom-nav previously had no role detection, so this PR also adds the same \`getUserRole()\` helper used in \`Sidebar\`.

## What's not affected

- **Practice tests** entry (\`/fr/qbank/tests\`) stays visible for everyone — that's the intended learner test-discovery path.
- Org admins with platform \`user\` role still reach their org's qbank admin via the org top-nav (which already gates correctly per #1790).

## Test plan

- [ ] As \`70220689\` on staging (platform \`user\`, viewer in zepintel): the left sidebar shows \`Practice tests\` but **not** \`Question Banks\`. Mobile More menu likewise.
- [ ] As an admin/sub_admin/expert: both entries are visible (no regression).

Refs #1789

🤖 Generated with [Claude Code](https://claude.com/claude-code)