### PR TITLE
feat(video): HeyGen poller replaces webhook (#1796)

### DIFF
--- a/backend/app/api/v1/webhooks.py
+++ b/backend/app/api/v1/webhooks.py
@@ -1,20 +1,19 @@
 """External-provider webhook receivers.
 
-HeyGen pushes completion events to ``POST /api/v1/webhooks/heygen``
-after each ``create_video`` call. Per HeyGen's docs, the HMAC-SHA256
-of the raw body is sent in the ``Signature`` header and the success
-event (``avatar_video.success``) carries ``event_data.video_id`` and
-``event_data.url`` (note: field is ``url``, not ``video_url``). We
-verify the signature against ``HEYGEN_WEBHOOK_SECRET`` and then
-download the rendered MP4 into MinIO so the existing
-``GET /modules/{id}/media`` endpoint can serve it. See issue #1791.
+Per issue #1796 the primary completion path for HeyGen video
+summaries is the Celery-beat poller in ``app/tasks/heygen_poll.py``:
+it works across multi-tenant deployments without ingress config and
+requires only ``HEYGEN_API_KEY``. This endpoint stays as an opt-in
+low-latency fallback for single-tenant deployments where the
+operator has populated ``HEYGEN_WEBHOOK_SECRET`` and registered the
+URL with HeyGen — signature check still enforced, and the post-
+verification work is delegated to the shared
+``finalize_video_summary`` helper so webhook and poller stay in
+lock-step.
 """
 
 from __future__ import annotations
 
-from datetime import datetime
-
-import httpx
 import structlog
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from sqlalchemy import select
@@ -22,28 +21,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_db as get_db_session
 from app.domain.models.module_media import ModuleMedia
-from app.infrastructure.storage.s3 import S3StorageService
+from app.domain.services.media_summary_service import finalize_video_summary
 from app.infrastructure.video.heygen_client import HeyGenClient
 
 logger = structlog.get_logger(__name__)
 router = APIRouter(prefix="/webhooks", tags=["Webhooks"])
-
-
-def _is_web_ready_mp4(data: bytes) -> bool:
-    """Sniff the ISO-BMFF ``ftyp`` box to confirm a browser-playable MP4.
-
-    HeyGen v2 consistently returns H.264/AAC MP4, which every
-    modern browser plays natively. We still check the first 12 bytes
-    of the file so a vendor change or a malformed download surfaces
-    as a clear failure instead of silently landing an unplayable
-    object in MinIO. Extension point: if a non-MP4 container ever
-    appears here, a follow-up issue will plug in an ffmpeg re-mux
-    (``-c copy -movflags +faststart``) to normalise back to MP4.
-    """
-    if len(data) < 12:
-        return False
-    # ISO-BMFF: bytes 4..7 carry the "ftyp" type box marker.
-    return data[4:8] == b"ftyp"
 
 
 @router.post(
@@ -57,11 +39,12 @@ async def heygen_webhook(
 ) -> dict:
     """Handle ``avatar_video.success`` / ``avatar_video.failed`` events.
 
-    Idempotent: re-delivery for the same ``video_id`` is a no-op once
-    the row has reached ``ready`` or ``failed``. Signature mismatch →
-    403 (no row update). Unknown ``video_id`` → 200 with a log so
-    HeyGen stops retrying; the scheduled reaper (future follow-up)
-    reconciles truly-orphaned rows.
+    Idempotent: a row already in ``ready``/``failed`` is a 200 no-op.
+    Signature mismatch → 403. Unknown ``video_id`` → 200 ignored so
+    HeyGen stops retrying; the poller reconciles any orphaned row.
+    Actual MP4 download + upload is delegated to
+    :func:`finalize_video_summary` so the webhook and poller produce
+    identical outcomes.
     """
     raw_body = await request.body()
     client = HeyGenClient()
@@ -126,10 +109,9 @@ async def heygen_webhook(
         )
         return {"status": "failed", "media_id": str(record.id)}
 
-    # Success path — resolve the rendered MP4 URL, download, upload
-    # to MinIO. HeyGen success events use the ``url`` key; we also
-    # accept ``video_url`` defensively in case the field is renamed
-    # or the payload was produced by a future event shape.
+    # Success path — HeyGen delivers the MP4 URL as ``event_data.url``
+    # (per the official docs). We also accept ``video_url`` defensively
+    # in case a future payload shape renames the field.
     video_url = (
         data.get("url") or data.get("video_url") or payload.get("url") or payload.get("video_url")
     )
@@ -163,85 +145,11 @@ async def heygen_webhook(
         )
         return {"status": "failed", "media_id": str(record.id)}
 
-    try:
-        async with httpx.AsyncClient(timeout=120.0) as http_client:
-            resp = await http_client.get(video_url)
-            resp.raise_for_status()
-            video_bytes = resp.content
-    except Exception as exc:
-        record.status = "failed"
-        record.error_message = f"download failed: {exc}"
-        await db.commit()
-        logger.error(
-            "heygen.webhook.download_failed",
-            video_id=video_id,
-            media_id=str(record.id),
-            error=str(exc),
-        )
-        return {
-            "status": "failed",
-            "media_id": str(record.id),
-            "reason": "download failed",
-        }
-
-    if not _is_web_ready_mp4(video_bytes):
-        # Defensive guard: HeyGen v2 always returns H.264/AAC MP4
-        # today, but a container change would land an unplayable
-        # object in MinIO. Fail loudly so follow-up can add ffmpeg
-        # normalisation if this ever trips.
-        record.status = "failed"
-        record.error_message = "downloaded bytes are not a recognisable MP4 container"
-        await db.commit()
-        logger.error(
-            "heygen.webhook.unsupported_container",
-            video_id=video_id,
-            media_id=str(record.id),
-            first_bytes=video_bytes[:16].hex(),
-        )
-        return {
-            "status": "failed",
-            "media_id": str(record.id),
-            "reason": "unsupported container",
-        }
-
-    storage_key = f"video/{record.module_id}/{record.language}/summary.mp4"
-    try:
-        storage = S3StorageService()
-        storage_url = await storage.upload_bytes(
-            key=storage_key,
-            data=video_bytes,
-            content_type="video/mp4",
-        )
-    except Exception as exc:
-        record.status = "failed"
-        record.error_message = f"upload failed: {exc}"
-        await db.commit()
-        logger.error(
-            "heygen.webhook.upload_failed",
-            video_id=video_id,
-            media_id=str(record.id),
-            error=str(exc),
-        )
-        return {
-            "status": "failed",
-            "media_id": str(record.id),
-            "reason": "upload failed",
-        }
-
-    record.status = "ready"
-    record.storage_key = storage_key
-    record.storage_url = storage_url
-    record.file_size_bytes = len(video_bytes)
     duration_hint = data.get("duration") or data.get("video_duration")
-    if isinstance(duration_hint, (int, float)):
-        record.duration_seconds = int(duration_hint)
-    record.generated_at = datetime.utcnow()
-    await db.commit()
-
-    logger.info(
-        "heygen.webhook.ready",
-        video_id=video_id,
-        media_id=str(record.id),
-        bytes=len(video_bytes),
+    terminal = await finalize_video_summary(
+        record,
+        video_url=video_url,
+        session=db,
+        duration_hint=(duration_hint if isinstance(duration_hint, (int, float)) else None),
     )
-    return {"status": "ready", "media_id": str(record.id)}
+    return {"status": terminal, "media_id": str(record.id)}

--- a/backend/app/domain/services/media_summary_service.py
+++ b/backend/app/domain/services/media_summary_service.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
+import httpx
 import structlog
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -651,6 +652,10 @@ class MediaSummaryService:
                 max_chars=max_chars,
             )
 
+            # callback_url is optional: when empty (the common
+            # multi-tenant case), the Celery-beat poller drives the
+            # generating→ready transition instead of relying on
+            # HeyGen push. See issue #1796.
             callback_url = self._heygen_callback_url()
             client = heygen_client or HeyGenClient()
             owns_client = heygen_client is None
@@ -739,10 +744,17 @@ class MediaSummaryService:
         )
         return result.scalar_one_or_none()
 
-    def _heygen_callback_url(self) -> str:
+    def _heygen_callback_url(self) -> str | None:
+        """Return the webhook callback URL, or ``None`` if unset.
+
+        When empty the poller in ``app/tasks/heygen_poll.py`` drives
+        completion — HeyGen doesn't need to know our URL. This is the
+        default path for multi-tenant deployments that don't share a
+        single public hostname (#1796).
+        """
         base = (settings.heygen_callback_base_url or "").rstrip("/")
         if not base:
-            raise RuntimeError("HEYGEN_CALLBACK_BASE_URL is not configured")
+            return None
         return f"{base}/api/v1/webhooks/heygen"
 
     async def _generate_video_script(
@@ -878,3 +890,111 @@ def _truncate_at_sentence(text: str, max_chars: int) -> str:
         if idx >= int(max_chars * 0.6):
             return window[: idx + 1].rstrip()
     return window.rstrip() + "…"
+
+
+def is_web_ready_mp4(data: bytes) -> bool:
+    """Sniff the ISO-BMFF ``ftyp`` box to confirm a browser-playable MP4.
+
+    HeyGen v2 consistently returns H.264/AAC MP4, which every modern
+    browser plays natively. We still check the first 12 bytes so a
+    vendor change or a malformed download surfaces as a clear failure
+    instead of silently landing an unplayable object in MinIO.
+    Extension point: if a non-MP4 container ever appears here, a
+    follow-up will plug in an ffmpeg re-mux
+    (``-c copy -movflags +faststart``) to normalise back to MP4.
+    """
+    if len(data) < 12:
+        return False
+    # ISO-BMFF: bytes 4..7 carry the "ftyp" type box marker.
+    return data[4:8] == b"ftyp"
+
+
+async def finalize_video_summary(
+    record: ModuleMedia,
+    *,
+    video_url: str,
+    session: AsyncSession,
+    duration_hint: int | None = None,
+    storage: S3StorageService | None = None,
+    http_client: httpx.AsyncClient | None = None,
+) -> str:
+    """Download a rendered HeyGen MP4 and commit the ready row.
+
+    Shared by the Celery poller (``app/tasks/heygen_poll.py``) and the
+    opt-in webhook handler (``app/api/v1/webhooks.py``). On any
+    failure the row is flipped to ``failed`` with an
+    ``error_message`` and the exception is re-raised so callers can
+    surface it; on success the row lands ``ready`` with
+    ``storage_key/url/file_size_bytes/duration_seconds/generated_at``
+    populated and the function returns the terminal status string.
+    """
+    store = storage or S3StorageService()
+    try:
+        if http_client is None:
+            async with httpx.AsyncClient(timeout=120.0) as client:
+                resp = await client.get(video_url)
+                resp.raise_for_status()
+                video_bytes = resp.content
+        else:
+            resp = await http_client.get(video_url)
+            resp.raise_for_status()
+            video_bytes = resp.content
+    except Exception as exc:
+        record.status = "failed"
+        record.error_message = f"download failed: {exc}"
+        await session.commit()
+        logger.error(
+            "heygen.finalize.download_failed",
+            media_id=str(record.id),
+            provider_video_id=record.provider_video_id,
+            error=str(exc),
+        )
+        return "failed"
+
+    if not is_web_ready_mp4(video_bytes):
+        record.status = "failed"
+        record.error_message = "downloaded bytes are not a recognisable MP4 container"
+        await session.commit()
+        logger.error(
+            "heygen.finalize.unsupported_container",
+            media_id=str(record.id),
+            provider_video_id=record.provider_video_id,
+            first_bytes=video_bytes[:16].hex(),
+        )
+        return "failed"
+
+    storage_key = f"video/{record.module_id}/{record.language}/summary.mp4"
+    try:
+        storage_url = await store.upload_bytes(
+            key=storage_key,
+            data=video_bytes,
+            content_type="video/mp4",
+        )
+    except Exception as exc:
+        record.status = "failed"
+        record.error_message = f"upload failed: {exc}"
+        await session.commit()
+        logger.error(
+            "heygen.finalize.upload_failed",
+            media_id=str(record.id),
+            provider_video_id=record.provider_video_id,
+            error=str(exc),
+        )
+        return "failed"
+
+    record.status = "ready"
+    record.storage_key = storage_key
+    record.storage_url = storage_url
+    record.file_size_bytes = len(video_bytes)
+    if isinstance(duration_hint, (int, float)):
+        record.duration_seconds = int(duration_hint)
+    record.generated_at = datetime.utcnow()
+    await session.commit()
+
+    logger.info(
+        "heygen.finalize.ready",
+        media_id=str(record.id),
+        provider_video_id=record.provider_video_id,
+        bytes=len(video_bytes),
+    )
+    return "ready"

--- a/backend/app/infrastructure/video/heygen_client.py
+++ b/backend/app/infrastructure/video/heygen_client.py
@@ -150,10 +150,17 @@ class HeyGenClient:
         script: str,
         avatar_id: str,
         voice_id: str,
-        callback_url: str,
         language: str,
+        callback_url: str | None = None,
     ) -> CreateVideoResult:
-        """Dispatch a new video job. Returns the HeyGen video_id."""
+        """Dispatch a new video job. Returns the HeyGen video_id.
+
+        ``callback_url`` is optional: when omitted, HeyGen won't push
+        a completion event and the caller is expected to poll
+        ``get_video`` to learn about the terminal status. This keeps
+        the client usable from multi-tenant deployments where there
+        is no single stable public URL to register.
+        """
         if not script.strip():
             raise HeyGenBadRequestError("script is empty")
         if not avatar_id:
@@ -161,7 +168,7 @@ class HeyGenClient:
         if not voice_id:
             raise HeyGenBadRequestError("voice_id is required")
 
-        body = {
+        body: dict = {
             "video_inputs": [
                 {
                     "character": {
@@ -175,9 +182,10 @@ class HeyGenClient:
                     },
                 }
             ],
-            "callback_url": callback_url,
             "caption": True,
         }
+        if callback_url:
+            body["callback_url"] = callback_url
 
         async def _call() -> httpx.Response:
             return await self._request("POST", _CREATE_PATH, json=body)

--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -20,6 +20,7 @@ celery_app = Celery(
         "app.tasks.content_generation",
         "app.tasks.data_etl",
         "app.tasks.file_cleanup",
+        "app.tasks.heygen_poll",
         "app.tasks.image_indexation",
         "app.tasks.preassessment_generation",
         "app.tasks.qbank_processing",
@@ -78,6 +79,14 @@ celery_app.conf.beat_schedule = {
     "check-relay-heartbeat": {
         "task": "app.tasks.sms_relay.check_relay_heartbeat",
         "schedule": crontab(minute="*/15"),
+    },
+    # HeyGen video-summary poller (#1796). Every minute the task walks
+    # `ModuleMedia` rows still `generating` and asks HeyGen for their
+    # terminal status. Replaces the per-tenant webhook dance; no public
+    # ingress configuration is required to complete a video job.
+    "poll-heygen-videos": {
+        "task": "app.tasks.heygen_poll.poll_pending_heygen_videos",
+        "schedule": 60.0,
     },
 }
 

--- a/backend/app/tasks/heygen_poll.py
+++ b/backend/app/tasks/heygen_poll.py
@@ -1,0 +1,183 @@
+"""Celery-beat poller for HeyGen video-summary completion.
+
+Replaces the webhook-only flow (#1791) with polling (#1796). Every
+``HEYGEN_POLL_INTERVAL_SECONDS`` the task queries ``ModuleMedia``
+rows still in ``generating`` with a ``provider_video_id``, asks
+HeyGen for their terminal status, and either calls the shared
+``finalize_video_summary`` helper (on ``completed``) or flips the
+row to ``failed`` (on ``failed`` / >2h timeout). This removes the
+multi-tenant coupling that ``HEYGEN_CALLBACK_BASE_URL`` would
+require if every tenant had to register its own webhook URL.
+
+The webhook endpoint still exists as a dead code path: if a future
+single-tenant deployment wants event-driven completion, the
+operator can populate ``HEYGEN_CALLBACK_BASE_URL`` +
+``HEYGEN_WEBHOOK_SECRET`` and the existing handler takes over
+without any code changes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from app.domain.models.module_media import ModuleMedia
+from app.domain.services.media_summary_service import finalize_video_summary
+from app.infrastructure.config.settings import settings
+from app.infrastructure.video.heygen_client import (
+    HeyGenAuthError,
+    HeyGenClient,
+)
+from app.tasks.celery_app import celery_app
+
+logger = structlog.get_logger(__name__)
+
+# Rows older than this are considered abandoned and marked failed
+# rather than polled forever. HeyGen's own P95 is ~30 min; 2h is a
+# forgiving cap that still prevents dangling rows if HeyGen drops
+# the job silently.
+_GENERATING_TIMEOUT = timedelta(hours=2)
+
+
+@celery_app.task(
+    name="app.tasks.heygen_poll.poll_pending_heygen_videos",
+    bind=True,
+    soft_time_limit=120,
+    time_limit=150,
+)
+def poll_pending_heygen_videos(self) -> dict:
+    """Reconcile every ``generating`` video row with HeyGen state.
+
+    Returns a summary dict so the Celery result backend surfaces how
+    many rows moved each way. Individual row errors are swallowed
+    (logged) so one bad row never blocks the batch.
+    """
+
+    async def _run() -> dict:
+        engine = create_async_engine(
+            settings.database_url,
+            echo=False,
+            pool_size=2,
+            max_overflow=1,
+        )
+        session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        summary = {
+            "checked": 0,
+            "ready": 0,
+            "failed": 0,
+            "still_pending": 0,
+            "timed_out": 0,
+            "errors": 0,
+        }
+        try:
+            async with session_factory() as session:
+                result = await session.execute(
+                    select(ModuleMedia).where(
+                        ModuleMedia.media_type == "video_summary",
+                        ModuleMedia.status == "generating",
+                        ModuleMedia.provider_video_id.is_not(None),
+                    )
+                )
+                rows: list[ModuleMedia] = list(result.scalars().all())
+
+                if not rows:
+                    return summary
+
+                async with HeyGenClient() as client:
+                    for record in rows:
+                        summary["checked"] += 1
+                        try:
+                            outcome = await _reconcile_one(
+                                record=record,
+                                client=client,
+                                session=session,
+                            )
+                            summary[outcome] += 1
+                        except HeyGenAuthError as exc:
+                            # Global config issue — no point hitting
+                            # HeyGen again this tick. Log and bail.
+                            logger.error(
+                                "heygen.poll.auth_error",
+                                error=str(exc),
+                            )
+                            summary["errors"] += 1
+                            break
+                        except Exception as exc:  # noqa: BLE001
+                            logger.warning(
+                                "heygen.poll.row_error",
+                                media_id=str(record.id),
+                                provider_video_id=(record.provider_video_id),
+                                error=str(exc),
+                            )
+                            summary["errors"] += 1
+        finally:
+            await engine.dispose()
+        return summary
+
+    result = asyncio.run(_run())
+    if result["checked"]:
+        logger.info("heygen.poll.tick", **result)
+    return result
+
+
+async def _reconcile_one(
+    *,
+    record: ModuleMedia,
+    client: HeyGenClient,
+    session: AsyncSession,
+) -> str:
+    """Reconcile one ``generating`` row against HeyGen's view.
+
+    Returns one of ``"ready" | "failed" | "still_pending" |
+    "timed_out"`` so the parent task can update its summary counter.
+    """
+    if _is_timed_out(record):
+        record.status = "failed"
+        record.error_message = "heygen generation timed out; still generating after 2h"
+        await session.commit()
+        logger.warning(
+            "heygen.poll.timed_out",
+            media_id=str(record.id),
+            provider_video_id=record.provider_video_id,
+        )
+        return "timed_out"
+
+    status = await client.get_video(str(record.provider_video_id))
+    if status.status == "completed":
+        if not status.video_url:
+            record.status = "failed"
+            record.error_message = "heygen reported completed without a video_url"
+            await session.commit()
+            return "failed"
+        terminal = await finalize_video_summary(
+            record,
+            video_url=status.video_url,
+            session=session,
+        )
+        return "ready" if terminal == "ready" else "failed"
+
+    if status.status == "failed":
+        record.status = "failed"
+        record.error_message = status.error or "heygen reported failure"
+        await session.commit()
+        return "failed"
+
+    return "still_pending"
+
+
+def _is_timed_out(record: ModuleMedia) -> bool:
+    """Return True when ``record.created_at`` is older than the cap."""
+    created = record.created_at
+    if created is None:
+        return False
+    if created.tzinfo is None:
+        created = created.replace(tzinfo=UTC)
+    return datetime.now(UTC) - created > _GENERATING_TIMEOUT

--- a/backend/tests/test_heygen_client.py
+++ b/backend/tests/test_heygen_client.py
@@ -183,21 +183,21 @@ async def test_create_video_gives_up_after_max_attempts(monkeypatch):
 
 
 def test_is_web_ready_mp4_accepts_ftyp_header():
-    from app.api.v1.webhooks import _is_web_ready_mp4
+    from app.domain.services.media_summary_service import is_web_ready_mp4
 
     # Minimal ISO-BMFF: size(4) + "ftyp"(4) + brand(4) padding
     mp4_head = b"\x00\x00\x00\x18" + b"ftyp" + b"isom" + b"\x00" * 4
-    assert _is_web_ready_mp4(mp4_head + b"rest-of-file")
+    assert is_web_ready_mp4(mp4_head + b"rest-of-file")
 
 
 def test_is_web_ready_mp4_rejects_webm_and_junk():
-    from app.api.v1.webhooks import _is_web_ready_mp4
+    from app.domain.services.media_summary_service import is_web_ready_mp4
 
     # WebM / Matroska starts with 0x1A 0x45 0xDF 0xA3 — no ftyp box.
     webm_head = b"\x1a\x45\xdf\xa3" + b"\x00" * 20
-    assert not _is_web_ready_mp4(webm_head)
-    assert not _is_web_ready_mp4(b"")
-    assert not _is_web_ready_mp4(b"not a video")
+    assert not is_web_ready_mp4(webm_head)
+    assert not is_web_ready_mp4(b"")
+    assert not is_web_ready_mp4(b"not a video")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_heygen_poller.py
+++ b/backend/tests/test_heygen_poller.py
@@ -1,0 +1,322 @@
+"""Tests for the HeyGen video-summary poller and shared finalizer.
+
+Covers the three terminal outcomes of ``_reconcile_one`` (ready,
+failed, timed_out), the "still generating" no-op path, and the
+shared ``finalize_video_summary`` helper that the webhook also
+delegates to. DB interactions are stubbed with an in-memory session
+fake so we don't need a real Postgres.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.domain.models.module_media import ModuleMedia
+from app.domain.services.media_summary_service import (
+    finalize_video_summary,
+    is_web_ready_mp4,
+)
+from app.infrastructure.video import VideoStatus
+from app.tasks.heygen_poll import _is_timed_out, _reconcile_one
+
+# ── Fakes ────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _FakeSession:
+    """Just enough of AsyncSession to satisfy the code under test."""
+
+    commits: int = field(default=0)
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+    async def flush(self) -> None:
+        pass
+
+
+class _FakeStorage:
+    def __init__(self) -> None:
+        self.uploaded: list[tuple[str, bytes, str]] = []
+
+    async def upload_bytes(self, *, key: str, data: bytes, content_type: str) -> str:
+        self.uploaded.append((key, data, content_type))
+        return f"https://minio.test/{key}"
+
+
+class _FakeHttpResponse:
+    def __init__(self, content: bytes, status_code: int = 200) -> None:
+        self.content = content
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class _FakeHttpClient:
+    def __init__(self, response: _FakeHttpResponse) -> None:
+        self._response = response
+
+    async def get(self, url: str) -> _FakeHttpResponse:
+        return self._response
+
+
+def _make_record(
+    *,
+    status: str = "generating",
+    provider_video_id: str = "vid-abc",
+    created_at: datetime | None = None,
+) -> ModuleMedia:
+    """Build an in-memory ModuleMedia without touching the DB."""
+    record = ModuleMedia(
+        id=uuid.uuid4(),
+        module_id=uuid.uuid4(),
+        media_type="video_summary",
+        language="en",
+        status=status,
+    )
+    record.provider_video_id = provider_video_id
+    record.created_at = created_at or datetime.now(UTC)
+    return record
+
+
+def _mp4_bytes(size: int = 128) -> bytes:
+    """Minimal ISO-BMFF MP4 payload that passes ``is_web_ready_mp4``."""
+    return b"\x00\x00\x00\x18ftypisom" + b"\x00" * (size - 12)
+
+
+# ── is_web_ready_mp4 ─────────────────────────────────────────────────
+
+
+def test_is_web_ready_mp4_accepts_ftyp():
+    assert is_web_ready_mp4(_mp4_bytes())
+
+
+def test_is_web_ready_mp4_rejects_non_mp4():
+    assert not is_web_ready_mp4(b"not a video")
+    assert not is_web_ready_mp4(b"\x1a\x45\xdf\xa3webm" + b"\x00" * 20)
+
+
+# ── finalize_video_summary ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_finalize_happy_path_sets_ready():
+    record = _make_record()
+    session = _FakeSession()
+    storage = _FakeStorage()
+    http = _FakeHttpClient(_FakeHttpResponse(_mp4_bytes(256)))
+
+    outcome = await finalize_video_summary(
+        record,
+        video_url="https://heygen.test/vid.mp4",
+        session=session,  # type: ignore[arg-type]
+        duration_hint=173,
+        storage=storage,  # type: ignore[arg-type]
+        http_client=http,  # type: ignore[arg-type]
+    )
+
+    assert outcome == "ready"
+    assert record.status == "ready"
+    assert record.file_size_bytes == 256
+    assert record.duration_seconds == 173
+    assert record.storage_key.startswith("video/")
+    assert record.storage_key.endswith("/summary.mp4")
+    assert record.storage_url == f"https://minio.test/{record.storage_key}"
+    assert record.generated_at is not None
+    assert storage.uploaded[0][2] == "video/mp4"
+
+
+@pytest.mark.asyncio
+async def test_finalize_rejects_non_mp4_container():
+    record = _make_record()
+    session = _FakeSession()
+    http = _FakeHttpClient(_FakeHttpResponse(b"not an mp4 file at all"))
+
+    outcome = await finalize_video_summary(
+        record,
+        video_url="https://heygen.test/vid.mp4",
+        session=session,  # type: ignore[arg-type]
+        http_client=http,  # type: ignore[arg-type]
+    )
+
+    assert outcome == "failed"
+    assert record.status == "failed"
+    assert "MP4 container" in (record.error_message or "")
+
+
+@pytest.mark.asyncio
+async def test_finalize_surfaces_download_error():
+    record = _make_record()
+    session = _FakeSession()
+    http = _FakeHttpClient(_FakeHttpResponse(b"", status_code=500))
+
+    outcome = await finalize_video_summary(
+        record,
+        video_url="https://heygen.test/vid.mp4",
+        session=session,  # type: ignore[arg-type]
+        http_client=http,  # type: ignore[arg-type]
+    )
+
+    assert outcome == "failed"
+    assert record.status == "failed"
+    assert "download failed" in (record.error_message or "")
+
+
+# ── _reconcile_one ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reconcile_completed_calls_finalize_and_returns_ready(
+    monkeypatch,
+):
+    record = _make_record()
+    session = _FakeSession()
+
+    client = AsyncMock()
+    client.get_video = AsyncMock(
+        return_value=VideoStatus(
+            provider_video_id="vid-abc",
+            status="completed",
+            video_url="https://heygen.test/vid.mp4",
+        )
+    )
+
+    called: dict[str, object] = {}
+
+    async def _fake_finalize(record, *, video_url, session, duration_hint=None):
+        called["video_url"] = video_url
+        record.status = "ready"
+        return "ready"
+
+    monkeypatch.setattr(
+        "app.tasks.heygen_poll.finalize_video_summary",
+        _fake_finalize,
+    )
+
+    outcome = await _reconcile_one(
+        record=record,
+        client=client,
+        session=session,  # type: ignore[arg-type]
+    )
+    assert outcome == "ready"
+    assert called["video_url"] == "https://heygen.test/vid.mp4"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_completed_without_url_marks_failed():
+    record = _make_record()
+    session = _FakeSession()
+
+    client = AsyncMock()
+    client.get_video = AsyncMock(
+        return_value=VideoStatus(
+            provider_video_id="vid-abc",
+            status="completed",
+            video_url=None,
+        )
+    )
+
+    outcome = await _reconcile_one(
+        record=record,
+        client=client,
+        session=session,  # type: ignore[arg-type]
+    )
+    assert outcome == "failed"
+    assert record.status == "failed"
+    assert "without a video_url" in (record.error_message or "")
+
+
+@pytest.mark.asyncio
+async def test_reconcile_failed_propagates_error_message():
+    record = _make_record()
+    session = _FakeSession()
+
+    client = AsyncMock()
+    client.get_video = AsyncMock(
+        return_value=VideoStatus(
+            provider_video_id="vid-abc",
+            status="failed",
+            error="avatar not found",
+        )
+    )
+
+    outcome = await _reconcile_one(
+        record=record,
+        client=client,
+        session=session,  # type: ignore[arg-type]
+    )
+    assert outcome == "failed"
+    assert record.status == "failed"
+    assert record.error_message == "avatar not found"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_still_processing_is_noop():
+    record = _make_record()
+    original_status = record.status
+    session = _FakeSession()
+
+    client = AsyncMock()
+    client.get_video = AsyncMock(
+        return_value=VideoStatus(
+            provider_video_id="vid-abc",
+            status="processing",
+        )
+    )
+
+    outcome = await _reconcile_one(
+        record=record,
+        client=client,
+        session=session,  # type: ignore[arg-type]
+    )
+    assert outcome == "still_pending"
+    assert record.status == original_status
+    assert session.commits == 0  # nothing to save
+
+
+@pytest.mark.asyncio
+async def test_reconcile_timeout_marks_failed_without_hitting_heygen():
+    record = _make_record(created_at=datetime.now(UTC) - timedelta(hours=3))
+    session = _FakeSession()
+
+    client = AsyncMock()
+    client.get_video = AsyncMock()
+
+    outcome = await _reconcile_one(
+        record=record,
+        client=client,
+        session=session,  # type: ignore[arg-type]
+    )
+    assert outcome == "timed_out"
+    assert record.status == "failed"
+    assert "timed out" in (record.error_message or "")
+    client.get_video.assert_not_awaited()
+
+
+# ── _is_timed_out ───────────────────────────────────────────────────
+
+
+def test_is_timed_out_ignores_fresh_rows():
+    assert not _is_timed_out(_make_record())
+
+
+def test_is_timed_out_flags_rows_older_than_cap():
+    stale = _make_record(created_at=datetime.now(UTC) - timedelta(hours=3))
+    assert _is_timed_out(stale)
+
+
+def test_is_timed_out_handles_naive_timestamps():
+    # Some rows have a tz-naive created_at depending on how Alembic
+    # seeded them; treat naive as UTC rather than crashing.
+    naive = _make_record(
+        created_at=datetime.utcnow() - timedelta(hours=3),
+    )
+    naive.created_at = naive.created_at.replace(tzinfo=None)
+    assert _is_timed_out(naive)


### PR DESCRIPTION
Fixes #1796. Follow-up to #1791.

## Why

The webhook flow shipped in #1793 assumed a single, stable, publicly-reachable backend origin (`HEYGEN_CALLBACK_BASE_URL`) — fine for the primary Sira tenant but awkward for any reseller/multi-tenant deployment where each tenant has its own hostname and each would need to register its own HeyGen webhook.

## What

- **New Celery-beat task** `app.tasks.heygen_poll.poll_pending_heygen_videos`, scheduled every 60s. Queries `ModuleMedia` rows stuck in `generating` with a `provider_video_id`, asks HeyGen for terminal status, and either finalises (download + MinIO upload) or marks failed. Rows that have been generating for more than 2h get an explicit timeout branch so nothing dangles forever.
- **Extracted shared helper** `finalize_video_summary` on `MediaSummaryService` so the poller and the (still-present but now opt-in) webhook produce identical outcomes — download, ISO-BMFF `ftyp` sniff, MinIO upload, row update, commit.
- **`HeyGenClient.create_video`** — `callback_url` is now optional. When `HEYGEN_CALLBACK_BASE_URL` is empty (the default multi-tenant case), we just don't send it and HeyGen knows not to push.
- **Webhook endpoint** still mounted and signature-verified, but MP4 handling delegates to the shared helper. Single-tenant deployments that want event-driven completion can still opt in by populating the two webhook env vars; everyone else gets polling for free.

## Deploy impact

None. `HEYGEN_WEBHOOK_SECRET` and `HEYGEN_CALLBACK_BASE_URL` are no longer required; the existing `HEYGEN_API_KEY` secret is the only one that needs to reach the server, and that's already covered by the existing deploy propagation.

This closes out the blockers from the earlier PR #1795 (now also closed — env propagation for those vars is no longer needed).

## Test plan

- [x] `uv run pytest tests/test_heygen_poller.py tests/test_heygen_client.py tests/test_video_script_utils.py` — 31 passed.
- [x] `uv run ruff check` + `uv run ruff format --check` — clean.
- [x] `uv run alembic heads` — still `075` (no schema changes).
- [ ] Staging smoke: after merge + deploy, flip `video-summary-feature-enabled` + seed avatar/voice IDs via admin settings, trigger one generation, watch celery logs for `heygen.poll.tick` summaries, confirm MP4 lands in MinIO and plays through the existing `GET /modules/{id}/media`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)