### PR TITLE
feat(video): Video-Agent fallback + kids-aware prompt (#1798)

### DIFF
--- a/backend/app/api/v1/module_media.py
+++ b/backend/app/api/v1/module_media.py
@@ -123,25 +123,17 @@ async def generate_module_media(
         )
 
     # Video summaries are admin-gated behind a platform-settings flag
-    # so tenants can opt in after signing the HeyGen DPA. The flag is
-    # editable from the admin Settings page without a redeploy.
-    # See issue #1791.
+    # so tenants can opt in after signing the HeyGen DPA. Avatar and
+    # voice IDs are OPTIONAL (issue #1798): when either is missing the
+    # service falls back to HeyGen's Video Agent (v3/video-agents),
+    # which auto-picks both from the narration. The admin Settings
+    # page can still seed explicit IDs for branded, predictable output.
     if be_type == "video_summary":
         _cache = SettingsCache.instance()
         if not _cache.get("video-summary-feature-enabled", False):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="video_summary feature is disabled",
-            )
-        avatar_id = _cache.get("video-summary-default-avatar-id", "") or ""
-        voice_key = (
-            "video-summary-voice-id-fr" if request.language == "fr" else "video-summary-voice-id-en"
-        )
-        voice_id = _cache.get(voice_key, "") or ""
-        if not avatar_id.strip() or not voice_id.strip():
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail=("video_summary is enabled but HeyGen avatar/voice IDs are not configured"),
             )
 
     # Check for existing ready or in-progress media

--- a/backend/app/domain/services/media_summary_service.py
+++ b/backend/app/domain/services/media_summary_service.py
@@ -107,16 +107,52 @@ def _build_video_system_prompt(
     level_labels: list[str],
     course_title: str | None,
     max_chars: int,
+    is_kids: bool = False,
+    age_range: str = "",
 ) -> str:
-    """Build a taxonomy-aware system prompt for the video script.
+    """Build a taxonomy- and audience-aware video script prompt.
 
-    The prompt is built to be *structurally* audience- and
-    course-field-aware: ignoring ``domain`` or ``audience`` is named
-    as a failure mode so the model cannot silently default to a
-    generic script. See issue #1791.
+    Two templates: adult register and a kids variant that mirrors
+    the tone of the existing ``ai-prompt-lesson-kids-system``
+    platform setting — short playful sentences, stories, child-
+    relatable examples. Selection is driven by ``is_kids``, which
+    callers derive from ``detect_audience(course)``. See #1798.
     """
     lang_label = "French" if language == "fr" else "English"
     domain = ", ".join(domain_labels) or (course_title or "the subject area")
+
+    if is_kids:
+        age_hint = age_range or "6-12"
+        return (
+            f"You write 3-minute narrated video summaries for young "
+            f"learners aged {age_hint} in West Africa.\n\n"
+            f"Output language: {lang_label}.\n"
+            f"Course field / domain: {domain}.\n"
+            f"Target audience: children aged {age_hint}.\n\n"
+            f"HARD CONSTRAINTS — your script MUST:\n"
+            f"1. Use short, simple sentences children of {age_hint} "
+            f"can follow out loud.\n"
+            f"2. Open with a concrete, child-friendly hook — a "
+            f"question, a fun fact, a tiny story — grounded in the "
+            f"domain ({domain}).\n"
+            f"3. Prefer comparisons and stories from daily life in "
+            f"West Africa (family, village, school, market, nature) "
+            f"over abstract definitions.\n"
+            f"4. Replace jargon with plain language. If a technical "
+            f"term is unavoidable, define it in the same sentence "
+            f"using a familiar comparison.\n"
+            f"5. End with a warm, encouraging 'Let's remember' "
+            f"sentence and one simple 'Try this at home' idea.\n"
+            f"6. Keep the concatenated narration under {max_chars} "
+            f"characters — this is a hard cap, not a target.\n"
+            f"7. Cover 3–6 scenes of self-contained spoken prose. "
+            f"No markdown, no bullet points, no headers, no stage "
+            f"directions, no source citations inside the narration.\n\n"
+            f"Call the `save_video_script` tool exactly once. The "
+            f"`voice_tone` should be `warm-educator` for this "
+            f"audience."
+        )
+
     audience = ", ".join(audience_labels) or "learners"
     level = ", ".join(level_labels) or "the assigned course level"
 
@@ -600,14 +636,16 @@ class MediaSummaryService:
             await session.commit()
             raise RuntimeError("video_summary feature is disabled")
 
+        # Avatar/voice are OPTIONAL (issue #1798). When both are seeded
+        # we use Direct Video (v2/video/generate) for predictable
+        # output. When either is missing we fall back to the Video
+        # Agent (v3/video-agents) which auto-picks avatar/voice from
+        # the narration — roughly 2x credits/min but zero-config for
+        # fresh tenants.
         avatar_id = (cache.get("video-summary-default-avatar-id", "") or "").strip()
         voice_key = "video-summary-voice-id-fr" if language == "fr" else "video-summary-voice-id-en"
         voice_id = (cache.get(voice_key, "") or "").strip()
-        if not avatar_id or not voice_id:
-            record.status = "failed"
-            record.error_message = "HeyGen avatar_id or voice_id not configured"
-            await session.commit()
-            raise RuntimeError("HeyGen avatar_id or voice_id not configured")
+        use_agent_mode = not (avatar_id and voice_id)
 
         max_chars = int(cache.get("video-summary-max-chars", 2000))
 
@@ -638,6 +676,10 @@ class MediaSummaryService:
             domain_labels = _labels_for(course, "domain", language)
             audience_labels = _labels_for(course, "audience", language)
             level_labels = _labels_for(course, "level", language)
+            audience_ctx = detect_audience(course)
+            age_range = (
+                f"{audience_ctx.age_min}-{audience_ctx.age_max}" if audience_ctx.is_kids else ""
+            )
 
             script, script_metadata = await self._generate_video_script(
                 module_title=module_title or f"Module {module.module_number}",
@@ -650,30 +692,44 @@ class MediaSummaryService:
                 audience_labels=audience_labels,
                 level_labels=level_labels,
                 max_chars=max_chars,
+                is_kids=audience_ctx.is_kids,
+                age_range=age_range,
             )
 
-            # callback_url is optional: when empty (the common
-            # multi-tenant case), the Celery-beat poller drives the
-            # generating→ready transition instead of relying on
-            # HeyGen push. See issue #1796.
+            # callback_url is optional (#1796): when empty the Celery
+            # poller drives the generating→ready transition.
             callback_url = self._heygen_callback_url()
             client = heygen_client or HeyGenClient()
             owns_client = heygen_client is None
             try:
-                result = await client.create_video(
-                    script=script,
-                    avatar_id=avatar_id,
-                    voice_id=voice_id,
-                    callback_url=callback_url,
-                    language=language,
-                )
+                if use_agent_mode:
+                    result = await client.create_video_agent(
+                        prompt=script,
+                        language=language,
+                        callback_url=callback_url,
+                    )
+                    api_version = "v3-agent"
+                else:
+                    result = await client.create_video(
+                        script=script,
+                        avatar_id=avatar_id,
+                        voice_id=voice_id,
+                        callback_url=callback_url,
+                        language=language,
+                    )
+                    api_version = "v2"
             finally:
                 if owns_client and client._client is not None:
                     await client._client.aclose()
 
             record.provider_video_id = result.provider_video_id
             record.script_text = script
-            record.media_metadata = script_metadata
+            # Persist the API version so the poller knows which status
+            # endpoint to hit for this row.
+            enriched_metadata = dict(script_metadata)
+            enriched_metadata["api_version"] = api_version
+            enriched_metadata["is_kids"] = audience_ctx.is_kids
+            record.media_metadata = enriched_metadata
             await session.commit()
 
             logger.info(
@@ -770,6 +826,8 @@ class MediaSummaryService:
         audience_labels: list[str],
         level_labels: list[str],
         max_chars: int,
+        is_kids: bool = False,
+        age_range: str = "",
     ) -> tuple[str, dict]:
         """Generate a HeyGen-ready narration script via Claude tool-use.
 
@@ -777,7 +835,8 @@ class MediaSummaryService:
         concatenated narration (≤ ``max_chars``) and ``metadata``
         captures the structured scene/tone information for later QA.
         Re-prompts once on overshoot, then truncates at a sentence
-        boundary as a last resort.
+        boundary as a last resort. ``is_kids`` + ``age_range`` route
+        to the kids-register system prompt (see #1798).
         """
         system_prompt = _build_video_system_prompt(
             language=language,
@@ -786,6 +845,8 @@ class MediaSummaryService:
             level_labels=level_labels,
             course_title=course_title,
             max_chars=max_chars,
+            is_kids=is_kids,
+            age_range=age_range,
         )
         unit_list = "\n".join(f"- {t}" for t in unit_titles) if unit_titles else "- (no units)"
         rag_context = _format_rag_context(rag_chunks)

--- a/backend/app/infrastructure/video/heygen_client.py
+++ b/backend/app/infrastructure/video/heygen_client.py
@@ -39,6 +39,8 @@ logger = structlog.get_logger(__name__)
 _BASE_URL = "https://api.heygen.com"
 _CREATE_PATH = "/v2/video/generate"
 _STATUS_PATH = "/v2/video_status.get"
+_AGENT_CREATE_PATH = "/v3/video-agents"
+_V3_STATUS_PATH_TEMPLATE = "/v3/videos/{video_id}"
 
 
 class HeyGenError(RuntimeError):
@@ -205,15 +207,69 @@ class HeyGenClient:
         )
         return CreateVideoResult(provider_video_id=str(video_id))
 
-    async def get_video(self, video_id: str) -> VideoStatus:
-        """Fetch current status of a previously-dispatched video."""
+    async def create_video_agent(
+        self,
+        *,
+        prompt: str,
+        language: str,
+        callback_url: str | None = None,
+    ) -> CreateVideoResult:
+        """Dispatch a Video Agent job — avatar/voice auto-picked.
+
+        Use this when the tenant hasn't seeded explicit avatar/voice
+        IDs; HeyGen's agent picks both from the prompt. Costs roughly
+        double a Direct Video call but keeps the feature zero-config
+        for fresh tenants. See ``/docs/choosing-the-right-video-api``.
+        """
+        if not prompt.strip():
+            raise HeyGenBadRequestError("prompt is empty")
+
+        body: dict = {"prompt": prompt}
+        if callback_url:
+            body["callback_url"] = callback_url
 
         async def _call() -> httpx.Response:
-            return await self._request(
-                "GET",
-                _STATUS_PATH,
-                params={"video_id": video_id},
-            )
+            return await self._request("POST", _AGENT_CREATE_PATH, json=body)
+
+        response = await _retry_transient(_call)
+        data = response.json() or {}
+        inner = data.get("data") or {}
+        video_id = inner.get("video_id") or data.get("video_id")
+        if not video_id:
+            raise HeyGenError(f"HeyGen agent create returned no video_id: {data!r}")
+        logger.info(
+            "heygen.create_video_agent.dispatched",
+            video_id=video_id,
+            language=language,
+            prompt_chars=len(prompt),
+        )
+        return CreateVideoResult(provider_video_id=str(video_id))
+
+    async def get_video(self, video_id: str, *, api_version: str = "v2") -> VideoStatus:
+        """Fetch current status of a previously-dispatched video.
+
+        ``api_version`` selects the status endpoint: ``"v2"`` for
+        Direct Video (``/v2/video_status.get``) and ``"v3-agent"``
+        for Video Agent (``/v3/videos/{id}``). The two response
+        shapes differ slightly; we normalise both into the same
+        ``VideoStatus``.
+        """
+
+        if api_version == "v3-agent":
+
+            async def _call() -> httpx.Response:
+                return await self._request(
+                    "GET",
+                    _V3_STATUS_PATH_TEMPLATE.format(video_id=video_id),
+                )
+        else:
+
+            async def _call() -> httpx.Response:
+                return await self._request(
+                    "GET",
+                    _STATUS_PATH,
+                    params={"video_id": video_id},
+                )
 
         response = await _retry_transient(_call)
         data = response.json() or {}
@@ -228,10 +284,16 @@ class HeyGenClient:
             "failed": "failed",
             "error": "failed",
         }.get(raw_status, raw_status or "pending")
+        # v3 uses ``video_url`` per docs; v2 also returns ``video_url``.
+        # Accept ``url`` as an additional fallback in case either
+        # surface renames the field in a future minor revision.
+        video_url = (
+            inner.get("video_url") or inner.get("url") or data.get("video_url") or data.get("url")
+        )
         return VideoStatus(
             provider_video_id=video_id,
             status=mapped,
-            video_url=inner.get("video_url"),
+            video_url=video_url,
             error=inner.get("error") or inner.get("message"),
         )
 

--- a/backend/app/tasks/heygen_poll.py
+++ b/backend/app/tasks/heygen_poll.py
@@ -150,7 +150,11 @@ async def _reconcile_one(
         )
         return "timed_out"
 
-    status = await client.get_video(str(record.provider_video_id))
+    api_version = _api_version_for(record)
+    status = await client.get_video(
+        str(record.provider_video_id),
+        api_version=api_version,
+    )
     if status.status == "completed":
         if not status.video_url:
             record.status = "failed"
@@ -181,3 +185,16 @@ def _is_timed_out(record: ModuleMedia) -> bool:
     if created.tzinfo is None:
         created = created.replace(tzinfo=UTC)
     return datetime.now(UTC) - created > _GENERATING_TIMEOUT
+
+
+def _api_version_for(record: ModuleMedia) -> str:
+    """Read the HeyGen API version used when the row was created.
+
+    Written to ``media_metadata.api_version`` by the service at
+    dispatch time. Legacy rows predating the poller won't have it —
+    treat them as v2 so the previous Direct-Video flow keeps working
+    after the rollout of #1798.
+    """
+    metadata = record.media_metadata or {}
+    value = metadata.get("api_version") or "v2"
+    return "v3-agent" if value == "v3-agent" else "v2"

--- a/backend/tests/test_heygen_agent_mode.py
+++ b/backend/tests/test_heygen_agent_mode.py
@@ -1,0 +1,266 @@
+"""Tests for the v3 Video Agent fallback and poller version routing.
+
+Covers (issue #1798):
+
+* ``HeyGenClient.create_video_agent`` — happy path body shape,
+  empty-prompt rejection, and retry behaviour matches the v2 client.
+* ``HeyGenClient.get_video`` — v3 path routing by ``api_version``.
+* ``_api_version_for`` — poller reads ``media_metadata.api_version``
+  with a v2 fallback for legacy rows.
+* Poller delegates a v3-agent row to the correct status endpoint.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from app.domain.models.module_media import ModuleMedia
+from app.infrastructure.video import VideoStatus
+from app.infrastructure.video.heygen_client import (
+    HeyGenBadRequestError,
+    HeyGenClient,
+    HeyGenTransientError,
+)
+from app.tasks.heygen_poll import _api_version_for, _reconcile_one
+
+# ── fakes ────────────────────────────────────────────────────────────
+
+
+def _settings(api_key: str = "ak"):
+    s = MagicMock()
+    s.heygen_api_key = api_key
+    s.heygen_webhook_secret = ""
+    s.heygen_callback_base_url = ""
+    return s
+
+
+def _make_response(status_code: int, body: dict | None = None):
+    req = httpx.Request("POST", "https://api.heygen.com/v3/video-agents")
+    return httpx.Response(status_code=status_code, json=body or {}, request=req)
+
+
+class _FakeHttp:
+    """Records calls so we can assert on URL routing and retry counts."""
+
+    def __init__(self, response: httpx.Response):
+        self._response = response
+        self.calls: list[dict[str, object]] = []
+
+    async def request(self, method: str, url: str, **kwargs):
+        self.calls.append({"method": method, "url": url, "kwargs": kwargs})
+        return self._response
+
+    async def aclose(self):
+        pass
+
+
+def _make_record(
+    *,
+    api_version: str | None = None,
+    provider_video_id: str = "vid-abc",
+) -> ModuleMedia:
+    record = ModuleMedia(
+        id=uuid.uuid4(),
+        module_id=uuid.uuid4(),
+        media_type="video_summary",
+        language="en",
+        status="generating",
+    )
+    record.provider_video_id = provider_video_id
+    record.created_at = datetime.now(UTC)
+    if api_version is not None:
+        record.media_metadata = {"api_version": api_version}
+    return record
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.commits = 0
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+    async def flush(self) -> None:
+        pass
+
+
+# ── create_video_agent ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_video_agent_sends_prompt_and_returns_video_id():
+    http = _FakeHttp(_make_response(200, {"data": {"video_id": "vid-v3"}}))
+    client = HeyGenClient(settings=_settings(), client=http)
+
+    result = await client.create_video_agent(
+        prompt="A 3-minute summary about hygiene for children",
+        language="en",
+    )
+
+    assert result.provider_video_id == "vid-v3"
+    assert len(http.calls) == 1
+    call = http.calls[0]
+    assert call["method"] == "POST"
+    assert call["url"].endswith("/v3/video-agents")
+    assert call["kwargs"]["json"]["prompt"].startswith("A 3-minute")
+    # No callback_url when not requested.
+    assert "callback_url" not in call["kwargs"]["json"]
+
+
+@pytest.mark.asyncio
+async def test_create_video_agent_includes_callback_when_provided():
+    http = _FakeHttp(_make_response(200, {"data": {"video_id": "vid-v3"}}))
+    client = HeyGenClient(settings=_settings(), client=http)
+
+    await client.create_video_agent(
+        prompt="hello",
+        language="fr",
+        callback_url="https://api.example.test/cb",
+    )
+    assert http.calls[0]["kwargs"]["json"]["callback_url"] == "https://api.example.test/cb"
+
+
+@pytest.mark.asyncio
+async def test_create_video_agent_rejects_empty_prompt():
+    http = _FakeHttp(_make_response(200, {"data": {"video_id": "x"}}))
+    client = HeyGenClient(settings=_settings(), client=http)
+    with pytest.raises(HeyGenBadRequestError):
+        await client.create_video_agent(prompt="   ", language="en")
+
+
+@pytest.mark.asyncio
+async def test_create_video_agent_retries_5xx(monkeypatch):
+    failing = _make_response(503, {"message": "upstream"})
+    ok = _make_response(200, {"data": {"video_id": "vid-v3"}})
+    http = MagicMock()
+    http.request = AsyncMock(side_effect=[failing, ok])
+    http.aclose = AsyncMock()
+
+    async def _sleep(_s):
+        return None
+
+    import app.infrastructure.video.heygen_client as mod
+
+    monkeypatch.setattr(mod.asyncio, "sleep", _sleep)
+
+    client = HeyGenClient(settings=_settings(), client=http)
+    result = await client.create_video_agent(prompt="hello", language="en")
+    assert result.provider_video_id == "vid-v3"
+    assert http.request.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_create_video_agent_surfaces_exhausted_transient(monkeypatch):
+    http = MagicMock()
+    http.request = AsyncMock(return_value=_make_response(500, {"message": "boom"}))
+    http.aclose = AsyncMock()
+
+    async def _sleep(_s):
+        return None
+
+    import app.infrastructure.video.heygen_client as mod
+
+    monkeypatch.setattr(mod.asyncio, "sleep", _sleep)
+
+    client = HeyGenClient(settings=_settings(), client=http)
+    with pytest.raises(HeyGenTransientError):
+        await client.create_video_agent(prompt="hello", language="en")
+
+
+# ── get_video routing ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_video_v2_hits_status_endpoint():
+    http = _FakeHttp(
+        _make_response(
+            200,
+            {"data": {"status": "processing", "video_url": None}},
+        )
+    )
+    client = HeyGenClient(settings=_settings(), client=http)
+    await client.get_video("vid-abc")  # default v2
+    assert http.calls[0]["url"].endswith("/v2/video_status.get")
+    assert http.calls[0]["kwargs"]["params"] == {"video_id": "vid-abc"}
+
+
+@pytest.mark.asyncio
+async def test_get_video_v3_agent_hits_videos_path():
+    http = _FakeHttp(
+        _make_response(
+            200,
+            {
+                "data": {
+                    "status": "completed",
+                    "video_url": "https://heygen.test/out.mp4",
+                }
+            },
+        )
+    )
+    client = HeyGenClient(settings=_settings(), client=http)
+    result = await client.get_video("vid-v3", api_version="v3-agent")
+    assert http.calls[0]["url"].endswith("/v3/videos/vid-v3")
+    # v3 payload still maps cleanly into our VideoStatus.
+    assert isinstance(result, VideoStatus)
+    assert result.status == "completed"
+    assert result.video_url == "https://heygen.test/out.mp4"
+
+
+# ── _api_version_for / poller routing ─────────────────────────────
+
+
+def test_api_version_for_reads_metadata():
+    record = _make_record(api_version="v3-agent")
+    assert _api_version_for(record) == "v3-agent"
+
+
+def test_api_version_for_defaults_legacy_rows_to_v2():
+    record = _make_record(api_version=None)
+    # Simulate a row written before #1798 ever ran — no metadata at all.
+    record.media_metadata = None
+    assert _api_version_for(record) == "v2"
+
+
+def test_api_version_for_coerces_unknown_values_to_v2():
+    record = _make_record()
+    record.media_metadata = {"api_version": "not-a-real-version"}
+    assert _api_version_for(record) == "v2"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_v3_row_uses_v3_api_version(monkeypatch):
+    record = _make_record(api_version="v3-agent")
+    session = _FakeSession()
+
+    client = AsyncMock()
+    client.get_video = AsyncMock(
+        return_value=VideoStatus(
+            provider_video_id="vid-v3",
+            status="completed",
+            video_url="https://heygen.test/out.mp4",
+        )
+    )
+
+    async def _fake_finalize(*args, **kwargs):
+        return "ready"
+
+    monkeypatch.setattr(
+        "app.tasks.heygen_poll.finalize_video_summary",
+        _fake_finalize,
+    )
+
+    outcome = await _reconcile_one(
+        record=record,
+        client=client,
+        session=session,  # type: ignore[arg-type]
+    )
+    assert outcome == "ready"
+    # Key assertion: poller passed the row's api_version to the client.
+    client.get_video.assert_awaited_once()
+    args, kwargs = client.get_video.call_args
+    assert kwargs.get("api_version") == "v3-agent"

--- a/backend/tests/test_video_script_utils.py
+++ b/backend/tests/test_video_script_utils.py
@@ -91,3 +91,57 @@ def test_truncate_falls_back_to_ellipsis_when_no_terminator():
     out = _truncate_at_sentence(text, max_chars=50)
     assert len(out) <= 51  # + ellipsis char
     assert out.endswith("…")
+
+
+def test_kids_prompt_differs_from_adult():
+    """A kids video should not read like a professional-audience video.
+
+    The kids branch is routed via ``is_kids`` and is expected to
+    surface child-appropriate cues (age range, encouragement, 'Try
+    this at home') that the adult branch never emits.
+    """
+    adult = _build_video_system_prompt(
+        language="en",
+        domain_labels=["Health Sciences"],
+        audience_labels=["Practicing nurse"],
+        level_labels=["Expert"],
+        course_title="Clinical epidemiology",
+        max_chars=2000,
+    )
+    kids = _build_video_system_prompt(
+        language="en",
+        domain_labels=["Health Sciences"],
+        audience_labels=["Primary school"],
+        level_labels=["Beginner"],
+        course_title="Clinical epidemiology",
+        max_chars=2000,
+        is_kids=True,
+        age_range="6-10",
+    )
+    assert adult != kids
+    # Kids-only markers.
+    assert "children aged 6-10" in kids
+    assert "Try this at home" in kids
+    assert "'Let's remember'" in kids
+    # Adult-only marker.
+    assert "authoritative" not in kids.lower() or "warm-educator" in kids
+    assert "Practicing nurse" not in kids  # kids branch ignores the adult-labels
+    # Kids branch pins voice_tone to warm-educator.
+    assert "warm-educator" in kids
+
+
+def test_kids_prompt_defaults_age_range_when_unset():
+    """Missing age_range falls back to a sensible 6-12 default."""
+    kids = _build_video_system_prompt(
+        language="fr",
+        domain_labels=[],
+        audience_labels=[],
+        level_labels=[],
+        course_title="Maths",
+        max_chars=1500,
+        is_kids=True,
+        age_range="",
+    )
+    assert "6-12" in kids
+    # Language still flows through.
+    assert "French" in kids


### PR DESCRIPTION
Fixes #1798. Follow-up to #1791 / #1796.

## Two related asks, one PR

### 1. Avatar and voice IDs are now OPTIONAL

Per HeyGen's [Choosing the right Video API](https://developers.heygen.com/docs/choosing-the-right-video-api), \`POST /v3/video-agents\` takes a prompt and auto-picks avatar + voice. No more 503-gate on missing settings — a fresh tenant can flip the feature flag and get output.

Decision logic in \`MediaSummaryService.generate_video_summary\`:

- Both \`video-summary-default-avatar-id\` and the language-matched voice ID seeded → **Direct Video** (v2/video/generate), unchanged. Predictable, branded output. ~1 credit/min.
- Either missing → **Video Agent** (v3/video-agents). Claude-generated narration becomes the agent prompt, taxonomy-aware framing survives. ~2 credits/min.

The API version is recorded on \`ModuleMedia.media_metadata.api_version\` so the Celery poller hits the matching status endpoint (\`v2/video_status.get\` or \`v3/videos/{id}\`). Legacy rows without the field default to v2.

### 2. Kids-register video prompt variant

\`_build_video_system_prompt\` now has two templates gated on \`is_kids\` (driven by the existing \`detect_audience(course)\` helper already used for audio summaries). The kids template mirrors the tone of \`ai-prompt-lesson-kids-system\` — short playful sentences, West African family/village/school/market framing, plain-language jargon substitutes, and a warm \"Let's remember\" + \"Try this at home\" close. \`voice_tone\` is pinned to \`warm-educator\` for the kids path.

The adult template stays exactly as it was.

## Changes

- \`backend/app/infrastructure/video/heygen_client.py\` — new \`create_video_agent()\`; \`get_video()\` takes \`api_version=\"v2\" | \"v3-agent\"\` and routes to the matching endpoint. Retry + HMAC semantics unchanged.
- \`backend/app/domain/services/media_summary_service.py\` — \`_build_video_system_prompt\` gets the kids branch; \`_generate_video_script\` takes \`is_kids\`/\`age_range\`; \`generate_video_summary\` branches on avatar/voice presence and writes \`api_version\` + \`is_kids\` into \`media_metadata\`.
- \`backend/app/api/v1/module_media.py\` — 503 gate on missing avatar/voice removed. Feature-flag gate retained.
- \`backend/app/tasks/heygen_poll.py\` — new \`_api_version_for(record)\` helper; \`_reconcile_one\` passes the row's version to \`client.get_video\`.
- \`backend/tests/test_heygen_agent_mode.py\` — 13 new tests (agent create + retry + empty-prompt; v2 vs v3 \`get_video\` URL routing; \`_api_version_for\` legacy / unknown / v3 cases; poller delegates correctly).
- \`backend/tests/test_video_script_utils.py\` — 2 new tests: adult vs kids prompt divergence, and the kids default age range.

## No schema / env changes

- No migration.
- No new env var.
- No new admin setting (reuses \`video-summary-default-avatar-id\` + voice IDs — treated as empty means Agent mode).

## Test plan

- [x] \`uv run pytest tests/test_heygen_*.py tests/test_video_script_utils.py\` — **44 passed**.
- [x] \`uv run ruff check . && ruff format --check .\` — clean.
- [ ] Post-merge staging smoke: flip \`video-summary-feature-enabled\` without seeding avatar/voice; trigger a generation on a seed module; watch \`heygen.poll.tick\` logs for \`api_version=v3-agent\`; confirm MP4 lands in MinIO.
- [ ] Separate smoke on a kids-audience course: confirm \`media_metadata.is_kids == true\` and the stored \`script_text\` reads in the kids register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)