### PR TITLE
fix(video): make migration 076 constraint-drop idempotent

### DIFF
--- a/backend/migrations/versions/076_extend_generated_audio_for_video.py
+++ b/backend/migrations/versions/076_extend_generated_audio_for_video.py
@@ -68,10 +68,36 @@ def upgrade() -> None:
 
     # Backfill is covered by the server_default; drop the old unique
     # constraint and replace it with the 4-tuple variant.
-    op.drop_constraint(
-        "uq_generated_audio_module_unit_lang",
-        "generated_audio",
-        type_="unique",
+    #
+    # Defensive drop: the constraint name baked into the model
+    # (``uq_generated_audio_module_unit_lang``) wasn't actually the
+    # name Postgres assigned on every environment — staging's DB
+    # ended up with a differently-named (or no) constraint for the
+    # legacy 3-tuple, so a plain ``op.drop_constraint`` fails with
+    # ``UndefinedObjectError``. Pulling the actual pg_constraint
+    # rows and dropping each by its live name keeps the migration
+    # idempotent across environments that drifted.
+    op.execute(
+        """
+        DO $$
+        DECLARE
+            c text;
+        BEGIN
+            FOR c IN
+                SELECT con.conname
+                FROM pg_constraint con
+                JOIN pg_class cls ON cls.oid = con.conrelid
+                WHERE cls.relname = 'generated_audio'
+                  AND con.contype = 'u'
+                  AND con.conname <> 'uq_generated_audio_module_unit_mediatype_lang'
+            LOOP
+                EXECUTE format(
+                    'ALTER TABLE generated_audio DROP CONSTRAINT %I',
+                    c
+                );
+            END LOOP;
+        END $$;
+        """
     )
     op.create_unique_constraint(
         "uq_generated_audio_module_unit_mediatype_lang",


### PR DESCRIPTION
Hotfix for the failed #1803 staging deploy.

## Problem

Migration 076 runs \`op.drop_constraint(\"uq_generated_audio_module_unit_lang\", ...)\` — the name baked into the \`GeneratedAudio\` model. On staging the live unique constraint on the legacy 3-tuple (\`module_id, unit_id, language\`) was named differently, so the drop raised \`UndefinedObjectError\` and rolled the whole migration back. The #1803 build + container swap succeeded but the schema never advanced, leaving the new code running against the old schema — any query that filters on \`generated_audio.media_type\` now 500s.

## Fix

Replace the named \`drop_constraint\` with a PL/pgSQL block that walks \`pg_constraint\`, finds every unique constraint on \`generated_audio\` that isn't the new 4-tuple one, and drops each by its live name. Idempotent across environments whose constraint drifted (or never existed).

## Test plan

- [x] \`uv run ruff check\` + \`ruff format --check\` — clean.
- [x] \`uv run alembic heads\` — 077 still head, no chain change.
- [ ] Merge, redeploy staging, confirm \`alembic upgrade head\` succeeds and \`/api/v1/video/lesson/<uuid>\` returns 401/404 (not 500) under an authenticated call.

## Safe to deploy against any env

- Constraint exists with model-expected name → dropped.
- Constraint exists with Postgres-assigned name → dropped.
- Constraint doesn't exist → no-op (the DO block finds nothing to drop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)