### PR TITLE
fix(video): keep LessonVideo visible on status-fetch errors

### DIFF
--- a/frontend/components/learning/lesson-video.tsx
+++ b/frontend/components/learning/lesson-video.tsx
@@ -121,13 +121,10 @@ export function LessonVideo({ lessonId, language }: LessonVideoProps) {
   const isActivelyGenerating =
     isGenerating || status === 'generating' || status === 'pending';
 
-  if (status === 'loading' || status === 'error') {
-    // Keep the section fully invisible during the first fetch so the
-    // lesson page doesn't flash a loader the learner can't act on.
-    // Errors here are not fatal — just hide the row.
-    return null;
-  }
-
+  // Loading / error / pending / failed all fall through to the same
+  // "no video yet" card so the learner always sees the Generate
+  // button — hiding on error made the component invisible when the
+  // status fetch flaked (#1802 post-deploy regression).
   if (status === 'ready' && videoUrl) {
     return (
       <div className="flex flex-col gap-2">


### PR DESCRIPTION
Hotfix for a regression spotted on staging after #1803 + #1804 landed.

\`LessonVideo\` returned \`null\` whenever the status fetch hit anything outside \`200\` or a \`404\`-treated-as-\`pending\`. When the Celery worker is stalled (as it is right now on staging post-deploy race), the error fallthrough silently hid the component, leaving no Generate button for the user to click.

Falling through to the \`no video yet\` card in every non-\`ready\` branch keeps the button reachable. Generate failures still surface via the existing error banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)