### PR TITLE
fix(video): surface HTTP status + server detail on LessonVideo errors

### DIFF
--- a/frontend/components/learning/lesson-video.tsx
+++ b/frontend/components/learning/lesson-video.tsx
@@ -108,11 +108,16 @@ export function LessonVideo({ lessonId, language }: LessonVideoProps) {
         startPolling();
       }
     } catch (err: unknown) {
-      const s = (err as { status?: number })?.status;
-      if (s === 403) {
+      const e = err as { status?: number; message?: string };
+      if (e?.status === 403) {
         setError(t('featureDisabled'));
       } else {
-        setError(t('generateError'));
+        // Surface the HTTP status + server message when available so
+        // operators / testers can diagnose without opening devtools.
+        const parts = [t('generateError')];
+        if (e?.status) parts.push(`(HTTP ${e.status})`);
+        if (e?.message) parts.push(`— ${e.message}`);
+        setError(parts.join(' '));
       }
       setIsGenerating(false);
     }


### PR DESCRIPTION
Follow-up to #1805.

Staging tester saw "Video generation failed. Please try again." and nothing else when clicking Generate. The actual HTTP status was hidden behind the generic i18n message. This appends the status code and server body to the error banner so operators don't need browser devtools to diagnose.

Minimal 1-file change, no logic shift other than the visible error string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)