### PR TITLE
fix(migration 067): DROP DEFAULT before ALTER COLUMN TYPE for enum casts

### DIFF
--- a/backend/migrations/versions/067_add_question_bank_tables.py
+++ b/backend/migrations/versions/067_add_question_bank_tables.py
@@ -76,14 +76,22 @@ def upgrade() -> None:
         sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
     )
 
-    # Cast columns to their enum types
+    # Cast columns to their enum types. Columns that were created with a
+    # server_default need the DEFAULT dropped first because Postgres will
+    # not auto-cast a VARCHAR default expression to an enum — only the
+    # column data is covered by the USING clause. Re-set the DEFAULT as an
+    # enum-typed literal after the type change.
     op.execute(
         "ALTER TABLE question_banks ALTER COLUMN bank_type TYPE questionbanktype"
         " USING bank_type::questionbanktype"
     )
+    op.execute("ALTER TABLE question_banks ALTER COLUMN status DROP DEFAULT")
     op.execute(
         "ALTER TABLE question_banks ALTER COLUMN status TYPE questionbankstatus"
         " USING status::questionbankstatus"
+    )
+    op.execute(
+        "ALTER TABLE question_banks ALTER COLUMN status SET DEFAULT 'draft'::questionbankstatus"
     )
 
     op.create_table(
@@ -109,9 +117,14 @@ def upgrade() -> None:
         sa.Column("difficulty", sa.VARCHAR(50), server_default="medium", nullable=False),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
     )
+    op.execute("ALTER TABLE qbank_questions ALTER COLUMN difficulty DROP DEFAULT")
     op.execute(
         "ALTER TABLE qbank_questions ALTER COLUMN difficulty TYPE questiondifficulty"
         " USING difficulty::questiondifficulty"
+    )
+    op.execute(
+        "ALTER TABLE qbank_questions ALTER COLUMN difficulty SET DEFAULT"
+        " 'medium'::questiondifficulty"
     )
 
     op.create_table(
@@ -132,9 +145,14 @@ def upgrade() -> None:
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
         sa.UniqueConstraint("question_id", "language", name="uq_qbank_question_audio_lang"),
     )
+    op.execute("ALTER TABLE qbank_question_audio ALTER COLUMN status DROP DEFAULT")
     op.execute(
         "ALTER TABLE qbank_question_audio ALTER COLUMN status TYPE qbankaudiostatus"
         " USING status::qbankaudiostatus"
+    )
+    op.execute(
+        "ALTER TABLE qbank_question_audio ALTER COLUMN status SET DEFAULT"
+        " 'pending'::qbankaudiostatus"
     )
 
     op.create_table(

--- a/backend/tests/test_migration_067_enum_defaults.py
+++ b/backend/tests/test_migration_067_enum_defaults.py
@@ -1,0 +1,80 @@
+"""Regression: migration 067 must DROP DEFAULT before ALTER COLUMN TYPE for
+every column whose initial VARCHAR has a server_default — otherwise Postgres
+refuses the cast with `DatatypeMismatchError: default for column cannot be
+cast automatically`.
+
+Seen on prod 2026-04-21 while provisioning a fresh tenant; 067 failed at
+`ALTER TABLE question_banks ALTER COLUMN status TYPE questionbankstatus`
+because the VARCHAR default 'draft' couldn't be auto-cast to the enum."""
+
+import re
+from pathlib import Path
+
+_MIG = (
+    Path(__file__).resolve().parents[1]
+    / "migrations"
+    / "versions"
+    / "067_add_question_bank_tables.py"
+)
+
+
+def _source() -> str:
+    return _MIG.read_text()
+
+
+def test_migration_067_exists() -> None:
+    assert _MIG.exists(), "migration 067 source must be findable"
+
+
+def _altered_cols_with_default() -> list[tuple[str, str, str]]:
+    """Return (table, column, default_value) for each ALTER TYPE whose column
+    was created with a `server_default=` kwarg."""
+    src = _source()
+    alters = re.findall(
+        r"ALTER TABLE (\w+) ALTER COLUMN (\w+) TYPE (\w+)",
+        src,
+    )
+    with_default = []
+    for table, column, _enum in alters:
+        col_def_pattern = rf'sa\.Column\(\s*"{re.escape(column)}",\s*sa\.VARCHAR\([^)]*\),\s*server_default="([^"]+)"'
+        m = re.search(col_def_pattern, src)
+        if m:
+            with_default.append((table, column, m.group(1)))
+    return with_default
+
+
+def test_every_default_column_drops_default_before_alter_type() -> None:
+    """For each ALTER COLUMN TYPE whose column has a server_default, there
+    must be a matching DROP DEFAULT ahead of the ALTER and a SET DEFAULT
+    after. Order: DROP DEFAULT → ALTER TYPE → SET DEFAULT."""
+    src = _source()
+    cols = _altered_cols_with_default()
+    assert cols, "expected at least one VARCHAR-with-default to be cast to an enum"
+
+    for table, column, _default in cols:
+        drop_idx = src.find(f"ALTER TABLE {table} ALTER COLUMN {column} DROP DEFAULT")
+        alter_idx = src.find(f"ALTER TABLE {table} ALTER COLUMN {column} TYPE")
+        set_idx = src.find(f"ALTER TABLE {table} ALTER COLUMN {column} SET DEFAULT")
+
+        assert drop_idx >= 0, f"{table}.{column}: missing DROP DEFAULT before ALTER TYPE"
+        assert alter_idx >= 0, f"{table}.{column}: missing ALTER TYPE (regression)"
+        assert set_idx >= 0, f"{table}.{column}: missing SET DEFAULT after ALTER TYPE"
+        assert drop_idx < alter_idx < set_idx, (
+            f"{table}.{column}: statements must be ordered DROP → TYPE → SET, got "
+            f"drop={drop_idx} type={alter_idx} set={set_idx}"
+        )
+
+
+def test_downgrade_unchanged() -> None:
+    """downgrade() drops the tables; nothing about the upgrade fix should
+    change how rollback works."""
+    src = _source()
+    # The downgrade block must still drop the same tables in the same order.
+    for table in (
+        "qbank_test_attempts",
+        "qbank_tests",
+        "qbank_question_audio",
+        "qbank_questions",
+        "question_banks",
+    ):
+        assert f'op.drop_table("{table}")' in src, f"downgrade must still drop {table}"


### PR DESCRIPTION
## Summary

Migration 067 crashes on a fresh DB at \`ALTER TABLE question_banks ALTER COLUMN status TYPE questionbankstatus\` because Postgres can't auto-cast a VARCHAR \`server_default='draft'\` to the enum.

Fix: wrap each affected ALTER TYPE with DROP DEFAULT → ALTER TYPE → SET DEFAULT. Three columns:
- \`question_banks.status\`
- \`qbank_questions.difficulty\`
- \`qbank_question_audio.status\`

The two type-casts without server_default (\`bank_type\`, \`qbank_tests.mode\`) need no change.

## Context

Surfaced today while a fresh demo tenant was provisioning on prod via the sira-reseller-console. The console's drift heal was correctly landing alembic_version from 068 → 066 then replaying 067; 067 itself was the broken link.

## Regression safety

- Existing prod tenants that already ran 067 are unaffected — alembic records revisions once.
- \`downgrade()\` unchanged.
- \`santepublique_aof\` (stamped at 068) never re-runs 067.

## Test plan

- [x] Regression test at \`backend/tests/test_migration_067_enum_defaults.py\` asserts DROP → TYPE → SET ordering for every ALTER TYPE whose column has a server_default.
- [x] \`uv run pytest tests/test_migration_067_enum_defaults.py\` green
- [x] \`uv run ruff check\` + format clean
- [ ] Post-merge: recreate demo tenant on prod console, expect \`alembic_upgrade\` step to walk 066 → 077 cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)