### PR TITLE
fix(deploy): propagate HEYGEN_API_KEY to backend + celery-worker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -292,12 +292,16 @@ jobs:
           SMS_RELAY_TRUSTED_SENDERS: ${{ secrets.SMS_RELAY_TRUSTED_SENDERS }}
           MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
           MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+          # HeyGen lesson-video summaries (#1802). Only HEYGEN_API_KEY is
+          # needed: we use polling, not webhooks, so the webhook secret
+          # and callback base URL are unnecessary.
+          HEYGEN_API_KEY: ${{ secrets.HEYGEN_API_KEY }}
           DEPLOY_SHA: ${{ github.sha }}
         with:
           host: 167.86.115.58
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_KEY }}
-          envs: GHCR_USER,GHCR_TOKEN,POSTGRES_PASSWORD,ANTHROPIC_API_KEY,OPENAI_API_KEY,GOOGLE_API_KEY,SENTRY_DSN,NEXT_PUBLIC_SENTRY_DSN,NEXT_PUBLIC_POSTHOG_KEY,NEXT_PUBLIC_POSTHOG_HOST,SMS_RELAY_API_KEY,SMS_RELAY_TRUSTED_SENDERS,MINIO_ACCESS_KEY,MINIO_SECRET_KEY,DEPLOY_SHA
+          envs: GHCR_USER,GHCR_TOKEN,POSTGRES_PASSWORD,ANTHROPIC_API_KEY,OPENAI_API_KEY,GOOGLE_API_KEY,SENTRY_DSN,NEXT_PUBLIC_SENTRY_DSN,NEXT_PUBLIC_POSTHOG_KEY,NEXT_PUBLIC_POSTHOG_HOST,SMS_RELAY_API_KEY,SMS_RELAY_TRUSTED_SENDERS,MINIO_ACCESS_KEY,MINIO_SECRET_KEY,HEYGEN_API_KEY,DEPLOY_SHA
           script: |
             set -e
             cd ~/etutor
@@ -322,6 +326,7 @@ jobs:
             SMS_RELAY_TRUSTED_SENDERS=${SMS_RELAY_TRUSTED_SENDERS}
             MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
             MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
+            HEYGEN_API_KEY=${HEYGEN_API_KEY}
             EOF
 
             # Pull new images (only changed layers transferred)
@@ -432,6 +437,9 @@ jobs:
           SMS_RELAY_TRUSTED_SENDERS: ${{ secrets.PROD_SMS_RELAY_TRUSTED_SENDERS || secrets.SMS_RELAY_TRUSTED_SENDERS }}
           MINIO_ACCESS_KEY: ${{ secrets.PROD_MINIO_ACCESS_KEY || secrets.MINIO_ACCESS_KEY }}
           MINIO_SECRET_KEY: ${{ secrets.PROD_MINIO_SECRET_KEY || secrets.MINIO_SECRET_KEY }}
+          # HeyGen lesson-video summaries (#1802). Only HEYGEN_API_KEY is
+          # needed: polling-only, no webhooks.
+          HEYGEN_API_KEY: ${{ secrets.PROD_HEYGEN_API_KEY || secrets.HEYGEN_API_KEY }}
           DEPLOY_SHA: ${{ github.sha }}
         with:
           host: 94.250.201.110
@@ -439,7 +447,7 @@ jobs:
           # SSH key for the prod host — MUST be set explicitly as PROD_*
           # (staging DEPLOY_SSH_KEY won't have access to 94.250.201.110).
           key: ${{ secrets.PROD_DEPLOY_SSH_KEY }}
-          envs: GHCR_USER,GHCR_TOKEN,POSTGRES_PASSWORD,ANTHROPIC_API_KEY,OPENAI_API_KEY,GOOGLE_API_KEY,SENTRY_DSN,NEXT_PUBLIC_SENTRY_DSN,NEXT_PUBLIC_POSTHOG_KEY,NEXT_PUBLIC_POSTHOG_HOST,SMS_RELAY_API_KEY,SMS_RELAY_TRUSTED_SENDERS,MINIO_ACCESS_KEY,MINIO_SECRET_KEY,DEPLOY_SHA
+          envs: GHCR_USER,GHCR_TOKEN,POSTGRES_PASSWORD,ANTHROPIC_API_KEY,OPENAI_API_KEY,GOOGLE_API_KEY,SENTRY_DSN,NEXT_PUBLIC_SENTRY_DSN,NEXT_PUBLIC_POSTHOG_KEY,NEXT_PUBLIC_POSTHOG_HOST,SMS_RELAY_API_KEY,SMS_RELAY_TRUSTED_SENDERS,MINIO_ACCESS_KEY,MINIO_SECRET_KEY,HEYGEN_API_KEY,DEPLOY_SHA
           script: |
             set -e
             cd ~/etutor
@@ -460,6 +468,7 @@ jobs:
             SMS_RELAY_TRUSTED_SENDERS=${SMS_RELAY_TRUSTED_SENDERS}
             MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
             MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
+            HEYGEN_API_KEY=${HEYGEN_API_KEY}
             EOF
 
             # Pull new images. mms-tts is an optional sidecar (audio TTS);

--- a/docker-compose.prod.sira-donnia.yml
+++ b/docker-compose.prod.sira-donnia.yml
@@ -81,6 +81,7 @@ services:
       APP_ENV: production
       CORS_ORIGINS: https://app.sira-donnia.org
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      HEYGEN_API_KEY: ${HEYGEN_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}
       SENTRY_DSN: ${SENTRY_DSN}
@@ -165,6 +166,7 @@ services:
       APP_ENV: production
       CORS_ORIGINS: https://app.sira-donnia.org
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      HEYGEN_API_KEY: ${HEYGEN_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}
       SENTRY_DSN: ${SENTRY_DSN}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -81,6 +81,7 @@ services:
       APP_ENV: production
       CORS_ORIGINS: https://etutor.elearning.portfolio2.kimbetien.com
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      HEYGEN_API_KEY: ${HEYGEN_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}
       SENTRY_DSN: ${SENTRY_DSN}
@@ -165,6 +166,7 @@ services:
       APP_ENV: production
       CORS_ORIGINS: https://etutor.elearning.portfolio2.kimbetien.com
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      HEYGEN_API_KEY: ${HEYGEN_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}
       SENTRY_DSN: ${SENTRY_DSN}


### PR DESCRIPTION
Root-cause fix for the staging video-generation regression.

Post-#1802 diagnostic found `HEYGEN_API_KEY` missing from the backend container env — every HeyGen call raised `HeyGenAuthError` at the header-check before HTTP. Restores the propagation chain (workflow env → `.env` heredoc → compose `environment:`) that got lost when #1795 was closed during the webhook→polling switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)