### PR TITLE
fix(audio): filter GeneratedAudio by media_type — cached lessons stuck generating (#1815)

### DIFF
--- a/.github/workflows/staging-diagnose.yml
+++ b/.github/workflows/staging-diagnose.yml
@@ -92,15 +92,18 @@ jobs:
 
             echo
             echo "=============================================="
-            echo "HEYGEN_* env in backend container"
+            echo "HEYGEN_* env presence (values redacted)"
             echo "=============================================="
-            docker compose exec -T backend env | grep -E '^HEYGEN_' || echo "(no HEYGEN_ vars in backend env — this is the bug)"
-
-            echo
-            echo "=============================================="
-            echo "HEYGEN_* env in celery-worker container"
-            echo "=============================================="
-            docker compose exec -T celery-worker env | grep -E '^HEYGEN_' || echo "(no HEYGEN_ vars in celery-worker env — this is the bug)"
+            for svc in backend celery-worker; do
+              echo "--- $svc ---"
+              docker compose exec -T "$svc" env \
+                | grep -E '^HEYGEN_' \
+                | awk -F= '{
+                    val_len = length($0) - length($1) - 1;
+                    printf "%s=<set, %d chars>\n", $1, val_len
+                  }' \
+                || echo "(no HEYGEN_ vars — propagation is broken)"
+            done
 
             echo
             echo "=============================================="
@@ -117,3 +120,23 @@ jobs:
             docker compose logs --tail=300 celery-worker 2>&1 \
               | grep -E 'generate_lesson_video|LessonVideoService|heygen\.|HeyGenAuthError|HeyGenError|video-summary' \
               | tail -30 || true
+
+            echo
+            echo "=============================================="
+            echo "Test lesson rows: generated_audio for M01-U01/U03"
+            echo "=============================================="
+            docker compose exec -T postgres \
+              psql -U postgres santepublique_aof \
+              -c "SELECT id, media_type, language, status, provider_video_id, error_message, created_at, generated_at
+                  FROM generated_audio
+                  WHERE module_id = 'aab749f1-fba3-45d3-bcff-e0f4f925475a'
+                    AND unit_id IN ('M01-U01', 'M01-U03')
+                  ORDER BY unit_id, media_type, created_at DESC" || true
+
+            echo
+            echo "=============================================="
+            echo "Celery: last 500 lines, broad task-lifecycle grep"
+            echo "=============================================="
+            docker compose logs --tail=500 celery-worker 2>&1 \
+              | grep -E 'Task (received|succeeded|failed)|generate_lesson_video|generate_lesson_audio|Traceback|ERROR/' \
+              | tail -80 || true

--- a/backend/app/api/v1/lesson_audio.py
+++ b/backend/app/api/v1/lesson_audio.py
@@ -81,12 +81,15 @@ async def get_lesson_audio(
             detail={"error": "lesson_not_found", "message": f"Lesson {lesson_id} not found"},
         )
 
-    # Query audio by (module_id, unit_id, language) — shared across all countries
+    # Query audio by (module_id, unit_id, language) — shared across all countries.
+    # Filter by media_type='audio' so video rows (same table since #1802)
+    # never leak into the audio UI response.
     result = await db.execute(
         select(GeneratedAudio).where(
             GeneratedAudio.module_id == lesson_meta.module_id,
             GeneratedAudio.unit_id == lesson_meta.unit_id,
             GeneratedAudio.language == lesson_meta.language,
+            GeneratedAudio.media_type == "audio",
         )
     )
     db_audio = result.scalars().all()

--- a/backend/app/domain/services/lesson_audio_service.py
+++ b/backend/app/domain/services/lesson_audio_service.py
@@ -129,6 +129,7 @@ class LessonAudioService:
             unit_id=unit_id,
             language=language,
             status="pending",
+            media_type="audio",
         )
         session.add(record)
         try:
@@ -240,6 +241,7 @@ class LessonAudioService:
                 GeneratedAudio.unit_id == unit_id,
                 GeneratedAudio.language == language,
                 GeneratedAudio.status == "ready",
+                GeneratedAudio.media_type == "audio",
             )
             .order_by(GeneratedAudio.created_at.desc())
             .limit(1)

--- a/backend/app/domain/services/lesson_service.py
+++ b/backend/app/domain/services/lesson_service.py
@@ -883,7 +883,10 @@ class LessonGenerationService:
             )
 
         try:
-            # Audio is shared per (module, unit, language) — skip if one already exists
+            # Audio is shared per (module, unit, language) — skip if one
+            # already exists. Filter by media_type='audio' so a sibling
+            # video row (same table since #1802) does not masquerade as
+            # audio and block dispatch. See issue #1802 regression notes.
             from app.domain.models.generated_audio import GeneratedAudio
 
             existing_audio = await session.execute(
@@ -892,6 +895,7 @@ class LessonGenerationService:
                     GeneratedAudio.module_id == cached_content.module_id,
                     GeneratedAudio.unit_id == lesson_response.unit_id,
                     GeneratedAudio.language == lesson_response.language,
+                    GeneratedAudio.media_type == "audio",
                 )
                 .limit(1)
             )

--- a/backend/scripts/regenerate_audio.py
+++ b/backend/scripts/regenerate_audio.py
@@ -44,7 +44,10 @@ async def main(course_slug: str | None, dry_run: bool):
         # Build query: all "ready" audio, optionally filtered by course
         query = (
             select(GeneratedAudio)
-            .where(GeneratedAudio.status == "ready")
+            .where(
+                GeneratedAudio.status == "ready",
+                GeneratedAudio.media_type == "audio",
+            )
             .options(selectinload(GeneratedAudio.module))
         )
 


### PR DESCRIPTION
## Summary

- Audio regression from #1802: `generated_audio` queries didn't filter by `media_type='audio'`, so a sibling video row (even a failed one) silently blocked audio dispatch → user sees "Generating audio summary…" forever on cached lessons.
- Adds `media_type='audio'` filter to three audio-side queries + sets `media_type` explicitly on insert + patches the `scripts/regenerate_audio.py` one-off.
- Extends `staging-diagnose.yml` with targeted SQL for the test lesson rows, broader celery task-lifecycle grep, and folds #1813 (secret redaction on HEYGEN_* env dump).

Fixes #1815.

## Test plan

- [ ] Merge + staging deploy succeeds (CI green, containers healthy).
- [ ] Dispatch `staging-diagnose` — confirm `HEYGEN_*` lines show `<set, N chars>` rather than raw values; confirm the M01-U0x row dump prints.
- [ ] If the dump shows a video row on M01-U03 (audio-blocking), run the manual DELETE documented in the plan via psql in the diagnose output, then re-visit the lesson.
- [ ] Visit a cached lesson (`M01-U03`) as an authenticated learner — audio card transitions to ready and plays.
- [ ] Confirm `GET /api/v1/audio/lesson/<id>` response now contains only the audio row (no video leakage).
- [ ] No regression for first-visit lessons — cache-miss path still dispatches `generate_lesson_audio` and reaches ready.

## Out of scope

Video-side "no row ever inserted" bug (probably missing commit / early raise). Tracked separately — pending the extended diagnostic output added here to identify B1/B2/B3.