### PR TITLE
fix(video): 404 surfaces as 'absent' not 'pending' — Generate button now renders (#1824)

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -736,7 +736,12 @@ export interface LessonResponse {
 // can trigger generation; the poller finalises the row when HeyGen
 // finishes rendering (~10 min P50).
 
-export type LessonVideoStatus = "pending" | "generating" | "ready" | "failed";
+export type LessonVideoStatus =
+  | "absent"
+  | "pending"
+  | "generating"
+  | "ready"
+  | "failed";
 
 export interface LessonVideoResponse {
   lesson_id: string;
@@ -786,11 +791,13 @@ export async function getLessonVideoStatus(
       duration_seconds: first.duration_seconds ?? undefined,
     };
   } catch (err: unknown) {
-    // 404 means "no video yet" — same semantics as audio; surface
-    // as ``pending`` so the UI can show a generate button.
+    // 404 means "no video row exists yet". Return the synthetic
+    // ``absent`` status so the UI can tell this apart from a real
+    // ``pending`` row and show the Generate button instead of
+    // auto-starting the poll loop. See #1824.
     const status = (err as { status?: number })?.status;
     if (status === 404) {
-      return { lesson_id: lessonId, status: "pending" };
+      return { lesson_id: lessonId, status: "absent" };
     }
     throw err;
   }


### PR DESCRIPTION
## Summary

- Root cause of the \"Generate video\" button never appearing on cached lessons: [frontend/lib/api.ts:788-794](frontend/lib/api.ts#L788) mapped \`GET /api/v1/video/lesson/{id}\` 404s to synthetic \`status: \"pending\"\`, which [frontend/components/learning/lesson-video.tsx:85-91](frontend/components/learning/lesson-video.tsx#L85) treats as \"generation in flight → auto-poll\". Spinner forever, no POST ever fired, no Celery task ever ran.
- Fix: introduce \`\"absent\"\` in \`LessonVideoStatus\`; return it on 404. The component already ignores anything other than \`pending\`/\`generating\` for auto-poll, so the Button renders naturally.

Fixes #1824.

## Test plan

- [ ] Merge + staging auto-deploy.
- [ ] Hard-refresh the app, open a cached lesson, verify **Generate video** button is visible (not a spinner).
- [ ] Click Generate — devtools Network tab shows \`POST /api/v1/video/lesson/{id}/generate\` → 202.
- [ ] Dispatch \`staging-diagnose\` after ~30 s — confirm a new row in \`generated_audio\` with \`media_type='video'\`, \`status='generating'\`, \`provider_video_id\` set.
- [ ] Wait ~10-15 min (HeyGen render) + Celery-beat poller cadence (60 s) — row flips to \`ready\`.
- [ ] Refresh the lesson — \`<video>\` plays.
- [ ] No regression for lessons whose video is already \`ready\` (should still play without polling).
- [ ] No regression for lessons whose video is truly \`pending\`/\`generating\` (should still auto-poll through to completion without a second user click).

## Not included

No backend change, no migration. Task dispatch, webhook, and poller were already implemented in #1791 / #1799 — this PR unblocks the user-facing trigger so they can exercise the pipeline.