### PR TITLE
fix(backfill): use task-scoped async engine to avoid cross-loop pool reuse

### DIFF
--- a/backend/app/tasks/image_translation.py
+++ b/backend/app/tasks/image_translation.py
@@ -20,10 +20,15 @@ import asyncio
 import structlog
 from celery import Task
 from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 
 from app.ai.translation import translate_figure_caption
 from app.domain.models.source_image import SourceImage
-from app.infrastructure.persistence.database import async_session_factory
+from app.infrastructure.config.settings import settings
 from app.tasks.celery_app import celery_app
 
 logger = structlog.get_logger(__name__)
@@ -82,7 +87,34 @@ async def _run_backfill(
     limit: int | None,
     dry_run: bool,
 ) -> dict:
-    async with async_session_factory() as session:
+    # The module-level engine in app.infrastructure.persistence.database is
+    # bound to whichever event loop first touches it. Celery wraps this task
+    # in asyncio.run(), which creates a fresh loop per invocation — the second
+    # call finds pooled connections attached to the first (now-closed) loop
+    # and raises "attached to a different loop" (#1827). Own the engine for
+    # the task's lifetime and dispose on exit.
+    engine = create_async_engine(settings.database_url, pool_pre_ping=True)
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        return await _run_backfill_with_factory(
+            task=task,
+            rag_collection_id=rag_collection_id,
+            limit=limit,
+            dry_run=dry_run,
+            session_factory=session_factory,
+        )
+    finally:
+        await engine.dispose()
+
+
+async def _run_backfill_with_factory(
+    task: Task,
+    rag_collection_id: str | None,
+    limit: int | None,
+    dry_run: bool,
+    session_factory: async_sessionmaker[AsyncSession],
+) -> dict:
+    async with session_factory() as session:
         stmt = select(SourceImage).where(
             SourceImage.caption.is_not(None),
             func.length(func.trim(SourceImage.caption)) > 0,

--- a/backend/tests/test_backfill_image_translations.py
+++ b/backend/tests/test_backfill_image_translations.py
@@ -1,14 +1,13 @@
 """Unit tests for the ``backfill_image_translations`` Celery task (issue #1820).
 
-The task's logic lives in ``_run_backfill``. We exercise it directly with a
-mocked session factory and a mocked translator so the test stays fast and
-has no DB dependency.
+The task's real work lives in ``_run_backfill_with_factory``. We exercise
+that directly with an injected session factory and a mocked translator so
+the tests stay fast and have no DB dependency.
 """
 
 from __future__ import annotations
 
 import uuid
-from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from app.ai.translation.figure_translator import FigureTranslation
@@ -60,12 +59,23 @@ class _FakeSession:
         self.commits += 1
 
 
-def _patch_session_factory(session: _FakeSession):
-    @asynccontextmanager
-    async def _factory():
-        yield session
+class _FakeSessionFactory:
+    """Callable returning an async-context manager that yields a fake session."""
 
-    return patch.object(image_translation, "async_session_factory", _factory)
+    def __init__(self, session: _FakeSession):
+        self._session = session
+
+    def __call__(self):
+        session = self._session
+
+        class _Ctx:
+            async def __aenter__(self):
+                return session
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        return _Ctx()
 
 
 def _translation(fr: str = "fr", en: str = "en") -> FigureTranslation:
@@ -77,21 +87,22 @@ def _translation(fr: str = "fr", en: str = "en") -> FigureTranslation:
     )
 
 
-class TestRunBackfill:
+class TestRunBackfillWithFactory:
     async def test_dry_run_counts_without_calling_translator(self):
         rows = [_make_row(), _make_row()]
         session = _FakeSession(rows)
         task = MagicMock()
-        with (
-            _patch_session_factory(session),
-            patch.object(
-                image_translation,
-                "translate_figure_caption",
-                new=AsyncMock(return_value=_translation()),
-            ) as mock_tx,
-        ):
-            result = await image_translation._run_backfill(
-                task=task, rag_collection_id=None, limit=None, dry_run=True
+        with patch.object(
+            image_translation,
+            "translate_figure_caption",
+            new=AsyncMock(return_value=_translation()),
+        ) as mock_tx:
+            result = await image_translation._run_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=True,
+                session_factory=_FakeSessionFactory(session),
             )
         assert result == {
             "status": "dry_run",
@@ -106,16 +117,17 @@ class TestRunBackfill:
         rows = [_make_row(), _make_row()]
         session = _FakeSession(rows)
         task = MagicMock()
-        with (
-            _patch_session_factory(session),
-            patch.object(
-                image_translation,
-                "translate_figure_caption",
-                new=AsyncMock(return_value=_translation()),
-            ) as mock_tx,
-        ):
-            result = await image_translation._run_backfill(
-                task=task, rag_collection_id=None, limit=None, dry_run=False
+        with patch.object(
+            image_translation,
+            "translate_figure_caption",
+            new=AsyncMock(return_value=_translation()),
+        ) as mock_tx:
+            result = await image_translation._run_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=False,
+                session_factory=_FakeSessionFactory(session),
             )
         assert result["status"] == "complete"
         assert result["eligible"] == 2
@@ -133,20 +145,14 @@ class TestRunBackfill:
         rows = [_make_row(), _make_row(), _make_row()]
         session = _FakeSession(rows)
         task = MagicMock()
-
-        side_effects = [
-            _translation(),
-            ValueError("transient"),
-            _translation(),
-        ]
-        mock_tx = AsyncMock(side_effect=side_effects)
-
-        with (
-            _patch_session_factory(session),
-            patch.object(image_translation, "translate_figure_caption", new=mock_tx),
-        ):
-            result = await image_translation._run_backfill(
-                task=task, rag_collection_id=None, limit=None, dry_run=False
+        mock_tx = AsyncMock(side_effect=[_translation(), ValueError("transient"), _translation()])
+        with patch.object(image_translation, "translate_figure_caption", new=mock_tx):
+            result = await image_translation._run_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=False,
+                session_factory=_FakeSessionFactory(session),
             )
         assert result == {
             "status": "complete",
@@ -161,16 +167,17 @@ class TestRunBackfill:
     async def test_empty_eligible_set_returns_noop(self):
         session = _FakeSession([])
         task = MagicMock()
-        with (
-            _patch_session_factory(session),
-            patch.object(
-                image_translation,
-                "translate_figure_caption",
-                new=AsyncMock(return_value=_translation()),
-            ) as mock_tx,
-        ):
-            result = await image_translation._run_backfill(
-                task=task, rag_collection_id=None, limit=None, dry_run=False
+        with patch.object(
+            image_translation,
+            "translate_figure_caption",
+            new=AsyncMock(return_value=_translation()),
+        ) as mock_tx:
+            result = await image_translation._run_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=False,
+                session_factory=_FakeSessionFactory(session),
             )
         assert result["status"] == "noop"
         assert result["eligible"] == 0

--- a/frontend/components/learning/lesson-video.tsx
+++ b/frontend/components/learning/lesson-video.tsx
@@ -34,6 +34,7 @@ export function LessonVideo({ lessonId, language }: LessonVideoProps) {
     'loading',
   );
   const [videoUrl, setVideoUrl] = useState<string | null>(null);
+  const [videoId, setVideoId] = useState<string | null>(null);
   const [isGenerating, setIsGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -42,6 +43,7 @@ export function LessonVideo({ lessonId, language }: LessonVideoProps) {
     try {
       const data = await getLessonVideoStatus(lessonId);
       setStatus(data.status);
+      setVideoId(data.video_id ?? null);
       if (data.status === 'ready' && data.url) {
         const resolved = data.url.startsWith('/')
           ? `${API_BASE}${data.url}`
@@ -50,10 +52,11 @@ export function LessonVideo({ lessonId, language }: LessonVideoProps) {
       } else {
         setVideoUrl(null);
       }
-      return data.status;
+      return data;
     } catch {
       setStatus('error');
-      return 'error' as const;
+      setVideoId(null);
+      return null;
     }
   }, [lessonId]);
 
@@ -66,8 +69,9 @@ export function LessonVideo({ lessonId, language }: LessonVideoProps) {
         return;
       }
       attempts++;
-      const s = await refresh();
-      if (s === 'ready' || s === 'failed' || s === 'error') {
+      const data = await refresh();
+      const s = data?.status ?? 'error';
+      if (s === 'ready' || s === 'failed' || s === 'absent') {
         setIsGenerating(false);
         return;
       }
@@ -82,10 +86,16 @@ export function LessonVideo({ lessonId, language }: LessonVideoProps) {
     // itself resolves language from the lesson, so this is a belt-
     // and-suspenders refresh.
     void language;
-    refresh().then((s) => {
-      // Already-in-flight generation: pick up the poll loop so the UI
-      // transitions without the user clicking again.
-      if (s === 'generating' || s === 'pending') {
+    refresh().then((data) => {
+      // Only auto-resume polling when a real row exists and is in-
+      // flight. Guarding on ``data.video_id`` defends against every
+      // code path that surfaces a synthetic ``pending`` without an
+      // actual DB row (#1824): 404 → 'absent', empty list → old
+      // fallback, etc. No row → user must click Generate first.
+      if (
+        data?.video_id &&
+        (data.status === 'generating' || data.status === 'pending')
+      ) {
         setIsGenerating(true);
         startPolling();
       }
@@ -100,6 +110,7 @@ export function LessonVideo({ lessonId, language }: LessonVideoProps) {
     setError(null);
     try {
       const result = await generateLessonVideo(lessonId);
+      setVideoId(result.video_id);
       if (result.status === 'ready') {
         await refresh();
         setIsGenerating(false);
@@ -118,8 +129,13 @@ export function LessonVideo({ lessonId, language }: LessonVideoProps) {
     }
   };
 
+  // Only show the generating UI when a row actually exists (or we
+  // just clicked Generate). A synthetic ``pending`` without a row
+  // has bitten us twice (#1824); require ``videoId`` as the ground
+  // truth that a DB row was dispatched.
   const isActivelyGenerating =
-    isGenerating || status === 'generating' || status === 'pending';
+    isGenerating ||
+    (videoId !== null && (status === 'generating' || status === 'pending'));
 
   // Loading / error / pending / failed all fall through to the same
   // "no video yet" card so the learner always sees the Generate


### PR DESCRIPTION
Fixes #1827. Follow-up to #1820 / PR #1823.

## Symptom

On staging, running `backfill_image_translations` twice in the same Celery worker raised:

\`\`\`
RuntimeError: Task <_run_backfill() ...> got Future <...> attached to a different loop
\`\`\`

First invocation works (bounded dry-run with \`limit=20\` succeeded on staging), subsequent invocations fail.

## Root cause

`app/infrastructure/persistence/database.py` exposes a module-level async engine + sessionmaker bound to whichever event loop first uses it. The backfill task wraps \`_run_backfill\` in \`asyncio.run(...)\`, which creates a fresh loop per invocation. Connections held in the pool from the first loop are stale when that loop closes, so the second call trips when SQLAlchemy tries to reuse them.

## Fix

- \`_run_backfill\` now creates its own \`create_async_engine\` + \`async_sessionmaker\` and disposes the engine in a \`finally\` block. Each \`asyncio.run()\` invocation gets a fresh pool bound to its own loop.
- Query/commit logic moves to \`_run_backfill_with_factory(session_factory=...)\`, which the tests exercise directly — no more monkeypatching a module-level global.

## Test plan

- [x] `uv run pytest tests/test_backfill_image_translations.py tests/test_figure_translator.py tests/test_source_image_injection.py` — 37 passed
- [x] `uv run ruff check` clean, `uv run ruff format --check` clean
- [ ] Staging: re-run dispatch of \`app.tasks.image_translation.backfill_image_translations\` with \`dry_run=True\` (no \`limit\`) and confirm it returns \`{"status": "dry_run", "eligible": N}\` for the full eligible set without the loop error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)