### PR TITLE
fix(lessons): rehydrate source_image_refs from DB on cache read

### DIFF
--- a/backend/app/domain/services/lesson_service.py
+++ b/backend/app/domain/services/lesson_service.py
@@ -368,6 +368,60 @@ class LessonGenerationService:
                 event="error", data={"error": "generation_failed", "message": str(e)}
             )
 
+    @staticmethod
+    async def _rehydrate_source_image_refs(
+        raw_refs: list,
+        session: AsyncSession | None,
+    ) -> list[SourceImageRef]:
+        """Re-apply current DB values (especially FR/EN captions + alt text) to
+        cached ``source_image_refs`` before returning a cached lesson.
+
+        Lessons generated before the figure-translation backfill (#1820) baked
+        the raw English caption into both ``caption_fr`` and ``caption_en``.
+        Cached JSON can't know about later translations, so we hydrate the
+        per-locale fields from ``source_images`` on every read. Falls back to
+        the cached values when the row can no longer be found.
+        """
+        parsed: list[SourceImageRef] = []
+        ids: list[uuid.UUID] = []
+        for ref in raw_refs:
+            if not isinstance(ref, dict):
+                continue
+            parsed.append(SourceImageRef(**ref))
+            try:
+                ids.append(uuid.UUID(ref.get("id")))
+            except (TypeError, ValueError):
+                continue
+
+        if not parsed or session is None or not ids:
+            return parsed
+
+        rows = await session.execute(select(SourceImage).where(SourceImage.id.in_(ids)))
+        by_id = {str(r.id): r for r in rows.scalars().all()}
+
+        rehydrated: list[SourceImageRef] = []
+        for ref in parsed:
+            db_img = by_id.get(ref.id)
+            if db_img is None:
+                rehydrated.append(ref)
+                continue
+            caption = db_img.caption or ref.caption
+            rehydrated.append(
+                SourceImageRef(
+                    id=ref.id,
+                    figure_number=db_img.figure_number or ref.figure_number,
+                    caption=caption,
+                    caption_fr=db_img.caption_fr or caption,
+                    caption_en=db_img.caption_en or caption,
+                    attribution=db_img.attribution or ref.attribution,
+                    image_type=db_img.image_type or ref.image_type,
+                    storage_url=db_img.storage_url or ref.storage_url,
+                    alt_text_fr=db_img.alt_text_fr or ref.alt_text_fr,
+                    alt_text_en=db_img.alt_text_en or ref.alt_text_en,
+                )
+            )
+        return rehydrated
+
     async def _get_cached_lesson(
         self,
         module_id: uuid.UUID,
@@ -415,7 +469,7 @@ class LessonGenerationService:
 
         if cached_content:
             raw_refs = cached_content.content.get("source_image_refs", [])
-            source_image_refs = [SourceImageRef(**ref) for ref in raw_refs if isinstance(ref, dict)]
+            source_image_refs = await self._rehydrate_source_image_refs(raw_refs, session)
 
             content_dict = cached_content.content
             all_text_fields = " ".join(

--- a/backend/tests/test_source_image_injection.py
+++ b/backend/tests/test_source_image_injection.py
@@ -323,3 +323,141 @@ class TestExtractSourceImageRefs:
         result = await LessonGenerationService._extract_source_image_refs(text, linked)
         assert result[0].caption_fr == "Méthode scientifique"
         assert result[0].caption_en == "Scientific method"
+
+
+# ---------------------------------------------------------------------------
+# Tests: LessonGenerationService._rehydrate_source_image_refs
+# ---------------------------------------------------------------------------
+
+
+def _make_db_image(
+    img_id,
+    caption="English caption",
+    caption_fr=None,
+    caption_en=None,
+    alt_text_fr=None,
+    alt_text_en=None,
+    storage_url="https://cdn.example.com/x.webp",
+    figure_number="1.1",
+    image_type="diagram",
+    attribution=None,
+):
+    m = MagicMock()
+    m.id = img_id
+    m.caption = caption
+    m.caption_fr = caption_fr
+    m.caption_en = caption_en
+    m.alt_text_fr = alt_text_fr
+    m.alt_text_en = alt_text_en
+    m.storage_url = storage_url
+    m.figure_number = figure_number
+    m.image_type = image_type
+    m.attribution = attribution
+    return m
+
+
+class _FakeSession:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def execute(self, stmt):
+        result = MagicMock()
+        scalars = MagicMock()
+        scalars.all = MagicMock(return_value=list(self._rows))
+        result.scalars = MagicMock(return_value=scalars)
+        return result
+
+
+class TestRehydrateSourceImageRefs:
+    async def test_overlays_fresh_db_translations_over_cached_refs(self):
+        img_id = uuid.uuid4()
+        cached = [
+            {
+                "id": str(img_id),
+                "figure_number": "1.1",
+                "caption": "English caption",
+                "caption_fr": "English caption",
+                "caption_en": "English caption",
+                "image_type": "diagram",
+                "storage_url": "https://cdn.example.com/x.webp",
+                "alt_text_fr": None,
+                "alt_text_en": None,
+            }
+        ]
+        db_row = _make_db_image(
+            img_id,
+            caption="English caption",
+            caption_fr="Légende française",
+            caption_en="English caption",
+            alt_text_fr="Texte alt FR",
+            alt_text_en="Alt text EN",
+        )
+        session = _FakeSession([db_row])
+        out = await LessonGenerationService._rehydrate_source_image_refs(cached, session)
+        assert len(out) == 1
+        assert out[0].caption_fr == "Légende française"
+        assert out[0].caption_en == "English caption"
+        assert out[0].alt_text_fr == "Texte alt FR"
+        assert out[0].alt_text_en == "Alt text EN"
+
+    async def test_keeps_cached_values_when_db_row_not_found(self):
+        img_id = uuid.uuid4()
+        cached = [
+            {
+                "id": str(img_id),
+                "caption": "Cached only",
+                "caption_fr": "Cached only",
+                "caption_en": "Cached only",
+                "image_type": "diagram",
+            }
+        ]
+        session = _FakeSession([])  # DB returns nothing
+        out = await LessonGenerationService._rehydrate_source_image_refs(cached, session)
+        assert out[0].caption_fr == "Cached only"
+
+    async def test_falls_back_to_caption_when_db_locale_fields_still_null(self):
+        img_id = uuid.uuid4()
+        cached = [
+            {
+                "id": str(img_id),
+                "caption": "Pre-backfill",
+                "caption_fr": "Pre-backfill",
+                "caption_en": "Pre-backfill",
+                "image_type": "diagram",
+            }
+        ]
+        db_row = _make_db_image(
+            img_id,
+            caption="Pre-backfill",
+            caption_fr=None,
+            caption_en=None,
+        )
+        session = _FakeSession([db_row])
+        out = await LessonGenerationService._rehydrate_source_image_refs(cached, session)
+        assert out[0].caption_fr == "Pre-backfill"
+        assert out[0].caption_en == "Pre-backfill"
+
+    async def test_session_none_returns_refs_unchanged(self):
+        img_id = str(uuid.uuid4())
+        cached = [
+            {
+                "id": img_id,
+                "caption": "x",
+                "caption_fr": "x",
+                "caption_en": "x",
+                "image_type": "diagram",
+            }
+        ]
+        out = await LessonGenerationService._rehydrate_source_image_refs(cached, None)
+        assert len(out) == 1
+        assert out[0].id == img_id
+
+    async def test_skips_invalid_ref_entries(self):
+        cached = [
+            {"id": str(uuid.uuid4()), "image_type": "diagram"},
+            "not a dict",
+            {"id": "not-a-uuid", "image_type": "diagram"},
+        ]
+        session = _FakeSession([])
+        out = await LessonGenerationService._rehydrate_source_image_refs(cached, session)
+        assert len(out) == 2  # second entry skipped entirely; third parsed but no DB overlay


### PR DESCRIPTION
Part of #1820. Follow-up to PR #1823 / PR #1829.

## Symptom

After translating a source_image on staging, visiting the \`/fr/...\` lesson that references it still rendered the English caption. The translation was present in the DB but never surfaced to the user.

## Root cause

When a lesson is generated, \`_cache_lesson_content\` serialises the current \`source_image_refs\` array into \`generated_content.content\` JSON. On cache read, \`_get_cached_lesson\` just reconstructed \`SourceImageRef\` objects directly from that frozen JSON — so any translations added to \`source_images\` after the lesson was cached never reached the response.

Concretely: pre-PR #1823 lessons have \`caption_fr = <English>\` (the old duplicate-into-both behaviour), and no amount of backfilling \`source_images\` would change what a cached \`/fr/...\` page shows.

## Fix

On every cache read, look up the current \`source_images\` rows for the cached refs and overlay the per-locale fields. Falls back to the cached value when:
- the row no longer exists (deleted figure)
- the DB row still has NULL locale columns (pre-backfill)

## Scope

- \`_get_cached_lesson\` in \`backend/app/domain/services/lesson_service.py\`
- New static helper \`_rehydrate_source_image_refs\` on \`LessonGenerationService\`
- 5 new unit tests covering: overlay happy path, DB-row-missing fallback, NULL-locale fallback, session-None no-op, skip-invalid-entries

No frontend change. No migration. No cache invalidation needed — existing cached rows get fresh translations on next read.

## Test plan

- [x] \`uv run pytest tests/test_source_image_injection.py tests/test_figure_translator.py tests/test_backfill_image_translations.py\` — 42 passed
- [x] \`uv run ruff check\` + \`ruff format --check\` clean
- [ ] After deploy: reload \`https://etutor.elearning.portfolio2.kimbetien.com/fr/modules/aab749f1-fba3-45d3-bcff-e0f4f925475a/lessons/M01-U01\` and confirm the figure now carries the French caption (the underlying image was translated during #1820 staging verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)