### PR TITLE
feat(figures): per-locale asset plumbing for Phase 2

### DIFF
--- a/backend/app/api/v1/schemas/content.py
+++ b/backend/app/api/v1/schemas/content.py
@@ -41,7 +41,13 @@ class SourceImageRef(BaseModel):
     image_type: str = Field(
         ..., description="Image type: diagram, photo, chart, formula, icon, unknown"
     )
-    storage_url: str | None = Field(None, description="CDN URL to the image")
+    storage_url: str | None = Field(
+        None, description="CDN URL to the default (usually English) image"
+    )
+    storage_url_fr: str | None = Field(
+        None,
+        description="CDN URL to the French-variant image, when Phase 2 has produced one. NULL means the backend /data endpoint will fall back to storage_url for fr requests.",
+    )
     alt_text_fr: str | None = Field(None, description="French alt text")
     alt_text_en: str | None = Field(None, description="English alt text")
 

--- a/backend/app/api/v1/source_images.py
+++ b/backend/app/api/v1/source_images.py
@@ -72,23 +72,48 @@ async def get_image_metadata(
 @router.get("/{image_id}/data")
 async def get_image_data(
     image_id: uuid.UUID,
+    lang: str | None = Query(
+        None,
+        pattern="^(fr|en)$",
+        description="Preferred locale. When 'fr' and a French variant exists, stream that instead of the default.",
+    ),
     db: AsyncSession = Depends(get_db),
 ) -> StreamingResponse:
-    """Proxy image binary from internal MinIO storage to the browser."""
+    """Proxy image binary from internal MinIO storage to the browser.
+
+    When ``lang=fr`` and the figure has a populated ``storage_url_fr``,
+    that variant is served; otherwise we fall back to the default
+    ``storage_url`` — preserving today's behaviour for every figure that
+    does not yet have a French-variant asset (issue #1834).
+    """
     result = await db.execute(select(SourceImage).where(SourceImage.id == image_id))
     img = result.scalar_one_or_none()
     if img is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Image not found")
 
-    if not img.storage_url:
+    fetch_url: str | None
+    served_locale: str
+    if lang == "fr" and img.storage_url_fr:
+        fetch_url = img.storage_url_fr
+        served_locale = "fr"
+    else:
+        fetch_url = img.storage_url
+        served_locale = "default"
+
+    if not fetch_url:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Image binary not available"
         )
 
-    logger.info("Source image data proxy", image_id=str(image_id))
+    logger.info(
+        "Source image data proxy",
+        image_id=str(image_id),
+        requested_lang=lang,
+        served_locale=served_locale,
+    )
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
-            upstream = await client.get(img.storage_url)
+            upstream = await client.get(fetch_url)
         upstream.raise_for_status()
     except httpx.HTTPError as exc:
         logger.error("Failed to fetch image from storage", image_id=str(image_id), error=str(exc))

--- a/backend/app/domain/models/source_image.py
+++ b/backend/app/domain/models/source_image.py
@@ -62,6 +62,8 @@ class SourceImage(Base):
     surrounding_text: Mapped[str | None] = mapped_column(Text, nullable=True)
     storage_key: Mapped[str | None] = mapped_column(Text, nullable=True)
     storage_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    storage_key_fr: Mapped[str | None] = mapped_column(Text, nullable=True)
+    storage_url_fr: Mapped[str | None] = mapped_column(Text, nullable=True)
     format: Mapped[str] = mapped_column(String(20), server_default="webp", nullable=False)
     width: Mapped[int | None] = mapped_column(Integer, nullable=True)
     height: Mapped[int | None] = mapped_column(Integer, nullable=True)
@@ -96,6 +98,8 @@ class SourceImage(Base):
             "surrounding_text": self.surrounding_text,
             "storage_key": self.storage_key,
             "storage_url": self.storage_url,
+            "storage_key_fr": self.storage_key_fr,
+            "storage_url_fr": self.storage_url_fr,
             "format": self.format,
             "width": self.width,
             "height": self.height,

--- a/backend/app/domain/services/lesson_service.py
+++ b/backend/app/domain/services/lesson_service.py
@@ -416,6 +416,7 @@ class LessonGenerationService:
                     attribution=db_img.attribution or ref.attribution,
                     image_type=db_img.image_type or ref.image_type,
                     storage_url=db_img.storage_url or ref.storage_url,
+                    storage_url_fr=db_img.storage_url_fr or ref.storage_url_fr,
                     alt_text_fr=db_img.alt_text_fr or ref.alt_text_fr,
                     alt_text_en=db_img.alt_text_en or ref.alt_text_en,
                 )
@@ -842,6 +843,7 @@ class LessonGenerationService:
                         attribution=img.get("attribution"),
                         image_type=img.get("image_type") or "unknown",
                         storage_url=img.get("storage_url"),
+                        storage_url_fr=img.get("storage_url_fr"),
                         alt_text_fr=img.get("alt_text_fr"),
                         alt_text_en=img.get("alt_text_en"),
                     )

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -541,6 +541,7 @@ class TutorService:
                                                 "attribution": meta.get("attribution"),
                                                 "image_type": meta.get("image_type", "unknown"),
                                                 "storage_url": meta.get("storage_url"),
+                                                "storage_url_fr": meta.get("storage_url_fr"),
                                                 "alt_text_fr": meta.get("alt_text_fr"),
                                                 "alt_text_en": meta.get("alt_text_en"),
                                             }
@@ -651,6 +652,7 @@ class TutorService:
                                 "attribution": meta.get("attribution"),
                                 "image_type": meta.get("image_type", "unknown"),
                                 "storage_url": meta.get("storage_url"),
+                                "storage_url_fr": meta.get("storage_url_fr"),
                                 "alt_text_fr": meta.get("alt_text_fr"),
                                 "alt_text_en": meta.get("alt_text_en"),
                             }

--- a/backend/migrations/versions/079_source_image_locale_storage.py
+++ b/backend/migrations/versions/079_source_image_locale_storage.py
@@ -1,0 +1,40 @@
+"""Add ``storage_key_fr`` and ``storage_url_fr`` columns to ``source_images``.
+
+Revision ID: 079
+Revises: 078
+Create Date: 2026-04-22
+
+Per issue #1834 (epic #1819, Phase 2 slice 1) — per-locale figure-asset
+plumbing. Today every figure on ``source_images`` has a single
+``storage_key`` / ``storage_url`` pair pointing at the raw PDF-extracted
+WebP. Phase 2 will produce French-variant assets (re-derived SVGs,
+overlaid raster, etc.) for figures whose in-image text matters.
+
+This migration adds the two nullable columns where those future variants
+will land. No code in this migration populates them — subsequent Phase 2
+slices (classifier + SVG renderer + overlay compositor) do that.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "079"
+down_revision = "078"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "source_images",
+        sa.Column("storage_key_fr", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "source_images",
+        sa.Column("storage_url_fr", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("source_images", "storage_url_fr")
+    op.drop_column("source_images", "storage_key_fr")

--- a/backend/tests/test_source_image_endpoint.py
+++ b/backend/tests/test_source_image_endpoint.py
@@ -1,0 +1,156 @@
+"""Tests for the ``/source-images/{id}/data`` endpoint lang fallback (issue #1834).
+
+The endpoint streams image bytes from MinIO. Phase 2 slice 1 adds a
+``?lang=fr|en`` query param: when ``lang=fr`` and the DB row has a
+populated ``storage_url_fr``, we fetch from that URL; otherwise we fall
+back to the default ``storage_url``. These tests exercise the routing
+logic with a mocked DB session and a mocked httpx client — no real MinIO
+or network.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import ASGITransport, AsyncClient
+
+from app.api.deps import get_db
+from app.domain.models.source_image import SourceImage
+from app.main import app
+
+
+class _FakeImageRow:
+    def __init__(self, storage_url: str | None, storage_url_fr: str | None):
+        self.id = uuid.uuid4()
+        self.storage_url = storage_url
+        self.storage_url_fr = storage_url_fr
+
+
+class _FakeSession:
+    def __init__(self, row: _FakeImageRow | None):
+        self._row = row
+
+    async def execute(self, stmt):
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=self._row)
+        return result
+
+
+@asynccontextmanager
+async def _override_db(row: _FakeImageRow | None):
+    async def _get_db_override():
+        yield _FakeSession(row)
+
+    app.dependency_overrides[get_db] = _get_db_override
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+def _fake_upstream(body: bytes, content_type: str = "image/webp"):
+    response = MagicMock()
+    response.content = body
+    response.headers = {"content-type": content_type}
+    response.raise_for_status = MagicMock()
+    return response
+
+
+@asynccontextmanager
+async def _patched_httpx(fetch_spy: MagicMock, body: bytes = b"fake-bytes"):
+    async def _get(url):
+        fetch_spy(url)
+        return _fake_upstream(body)
+
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(side_effect=_get)
+    mock_ctx = MagicMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "app.api.v1.source_images.httpx.AsyncClient",
+        return_value=mock_ctx,
+    ):
+        yield
+
+
+async def _get_data(url_suffix: str = ""):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        return await ac.get(url_suffix)
+
+
+class TestDataEndpointLangFallback:
+    async def test_no_lang_uses_default_storage_url(self):
+        row = _FakeImageRow(
+            storage_url="https://minio/default.webp",
+            storage_url_fr="https://minio/fr.webp",
+        )
+        fetch = MagicMock()
+        async with _override_db(row), _patched_httpx(fetch):
+            resp = await _get_data(f"/api/v1/source-images/{row.id}/data")
+        assert resp.status_code == 200
+        fetch.assert_called_once_with("https://minio/default.webp")
+
+    async def test_lang_en_uses_default_storage_url_even_when_fr_exists(self):
+        row = _FakeImageRow(
+            storage_url="https://minio/default.webp",
+            storage_url_fr="https://minio/fr.webp",
+        )
+        fetch = MagicMock()
+        async with _override_db(row), _patched_httpx(fetch):
+            resp = await _get_data(f"/api/v1/source-images/{row.id}/data?lang=en")
+        assert resp.status_code == 200
+        fetch.assert_called_once_with("https://minio/default.webp")
+
+    async def test_lang_fr_uses_french_variant_when_available(self):
+        row = _FakeImageRow(
+            storage_url="https://minio/default.webp",
+            storage_url_fr="https://minio/fr.webp",
+        )
+        fetch = MagicMock()
+        async with _override_db(row), _patched_httpx(fetch):
+            resp = await _get_data(f"/api/v1/source-images/{row.id}/data?lang=fr")
+        assert resp.status_code == 200
+        fetch.assert_called_once_with("https://minio/fr.webp")
+
+    async def test_lang_fr_falls_back_to_default_when_no_french_variant(self):
+        row = _FakeImageRow(
+            storage_url="https://minio/default.webp",
+            storage_url_fr=None,
+        )
+        fetch = MagicMock()
+        async with _override_db(row), _patched_httpx(fetch):
+            resp = await _get_data(f"/api/v1/source-images/{row.id}/data?lang=fr")
+        assert resp.status_code == 200
+        fetch.assert_called_once_with("https://minio/default.webp")
+
+    async def test_invalid_lang_rejected(self):
+        row = _FakeImageRow(
+            storage_url="https://minio/default.webp",
+            storage_url_fr=None,
+        )
+        fetch = MagicMock()
+        async with _override_db(row), _patched_httpx(fetch):
+            resp = await _get_data(f"/api/v1/source-images/{row.id}/data?lang=de")
+        assert resp.status_code == 422  # pydantic pattern validation
+        fetch.assert_not_called()
+
+    async def test_row_not_found_returns_404(self):
+        fetch = MagicMock()
+        some_id = uuid.uuid4()
+        async with _override_db(None), _patched_httpx(fetch):
+            resp = await _get_data(f"/api/v1/source-images/{some_id}/data")
+        assert resp.status_code == 404
+        fetch.assert_not_called()
+
+
+# Defensive: make sure the real SourceImage model has the locale columns we rely
+# on, so this file fails loudly if a future migration drops them.
+def test_source_image_model_has_locale_storage_columns():
+    columns = {c.name for c in SourceImage.__table__.columns}
+    assert "storage_url_fr" in columns
+    assert "storage_key_fr" in columns

--- a/backend/tests/test_source_image_injection.py
+++ b/backend/tests/test_source_image_injection.py
@@ -37,6 +37,7 @@ def _make_image_meta(
     caption_en=None,
     image_type="diagram",
     storage_url="https://cdn.example.com/img/test.webp",
+    storage_url_fr=None,
     alt_text_fr="Diagramme",
     alt_text_en="Diagram",
 ):
@@ -48,6 +49,7 @@ def _make_image_meta(
         "caption_en": caption_en,
         "image_type": image_type,
         "storage_url": storage_url,
+        "storage_url_fr": storage_url_fr,
         "alt_text_fr": alt_text_fr,
         "alt_text_en": alt_text_en,
     }
@@ -338,6 +340,7 @@ def _make_db_image(
     alt_text_fr=None,
     alt_text_en=None,
     storage_url="https://cdn.example.com/x.webp",
+    storage_url_fr=None,
     figure_number="1.1",
     image_type="diagram",
     attribution=None,
@@ -350,6 +353,7 @@ def _make_db_image(
     m.alt_text_fr = alt_text_fr
     m.alt_text_en = alt_text_en
     m.storage_url = storage_url
+    m.storage_url_fr = storage_url_fr
     m.figure_number = figure_number
     m.image_type = image_type
     m.attribution = attribution
@@ -461,3 +465,63 @@ class TestRehydrateSourceImageRefs:
         session = _FakeSession([])
         out = await LessonGenerationService._rehydrate_source_image_refs(cached, session)
         assert len(out) == 2  # second entry skipped entirely; third parsed but no DB overlay
+
+    async def test_overlays_storage_url_fr_from_db(self):
+        img_id = uuid.uuid4()
+        cached = [
+            {
+                "id": str(img_id),
+                "caption": "English caption",
+                "image_type": "diagram",
+                "storage_url": "https://cdn.example.com/default.webp",
+                "storage_url_fr": None,
+            }
+        ]
+        db_row = _make_db_image(
+            img_id,
+            storage_url="https://cdn.example.com/default.webp",
+            storage_url_fr="https://cdn.example.com/fr.webp",
+        )
+        session = _FakeSession([db_row])
+        out = await LessonGenerationService._rehydrate_source_image_refs(cached, session)
+        assert out[0].storage_url_fr == "https://cdn.example.com/fr.webp"
+
+    async def test_storage_url_fr_null_when_no_french_variant(self):
+        img_id = uuid.uuid4()
+        cached = [
+            {
+                "id": str(img_id),
+                "caption": "English caption",
+                "image_type": "diagram",
+                "storage_url": "https://cdn.example.com/default.webp",
+            }
+        ]
+        db_row = _make_db_image(img_id, storage_url_fr=None)
+        session = _FakeSession([db_row])
+        out = await LessonGenerationService._rehydrate_source_image_refs(cached, session)
+        assert out[0].storage_url_fr is None
+
+
+class TestExtractSourceImageRefsStorageUrlFr:
+    async def test_storage_url_fr_passed_through_from_img_meta(self):
+        img_id = str(uuid.uuid4())
+        text = f"{{{{source_image:{img_id}}}}}"
+        img_meta = _make_image_meta(
+            img_id=uuid.UUID(img_id),
+            storage_url="https://cdn.example.com/default.webp",
+            storage_url_fr="https://cdn.example.com/fr.webp",
+        )
+        linked = {uuid.uuid4(): [img_meta]}
+        result = await LessonGenerationService._extract_source_image_refs(text, linked)
+        assert result[0].storage_url_fr == "https://cdn.example.com/fr.webp"
+
+    async def test_storage_url_fr_null_when_not_in_meta(self):
+        img_id = str(uuid.uuid4())
+        text = f"{{{{source_image:{img_id}}}}}"
+        img_meta = _make_image_meta(
+            img_id=uuid.UUID(img_id),
+            storage_url="https://cdn.example.com/default.webp",
+        )
+        linked = {uuid.uuid4(): [img_meta]}
+        result = await LessonGenerationService._extract_source_image_refs(text, linked)
+        assert result[0].storage_url_fr is None

--- a/frontend/components/learning/source-image.tsx
+++ b/frontend/components/learning/source-image.tsx
@@ -22,7 +22,7 @@ export function SourceImage({
   alt_text_en,
   language,
 }: SourceImageProps) {
-  const imageUrl = `${API_BASE}/api/v1/source-images/${id}/data`;
+  const imageUrl = `${API_BASE}/api/v1/source-images/${id}/data?lang=${language}`;
   const t = useTranslations('SourceImage');
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [isVisible, setIsVisible] = useState(false);


### PR DESCRIPTION
Fixes #1834. First slice of epic #1819 / Phase 2 (#1821 stays the overall Phase-2 tracker).

## Summary

Foundation PR for serving French-variant figure assets. **No visible change** yet — subsequent Phase 2 slices (classifier, Claude-Vision SVG renderer, overlay compositor) will populate the new column.

- Alembic `079` adds `storage_key_fr` + `storage_url_fr` to `source_images` (nullable, mirrors existing `storage_key`/`storage_url`).
- `GET /api/v1/source-images/{id}/data` accepts `?lang=fr|en`. When `lang=fr` and `storage_url_fr` is set, streams the French variant; otherwise falls back to the default.
- `SourceImageRef` schema adds `storage_url_fr`. Rehydration + both `tutor_service` serialisation sites + `lesson_service` pass it through.
- Frontend `<SourceImage>` appends `?lang=${language}` to the data URL.

## Test plan

- [x] `uv run ruff check && uv run ruff format --check` clean on touched files
- [x] `uv run pytest tests/test_source_image_endpoint.py tests/test_source_image_injection.py tests/test_figure_translator.py tests/test_backfill_image_translations.py tests/test_tutor_source_image.py` — 76 pass
- [x] New endpoint tests cover: no lang, `lang=en`, `lang=fr` with FR variant, `lang=fr` with no FR variant (fallback), invalid lang rejected, 404 on missing row
- [ ] Staging after deploy + migration:
  - [ ] Load `/fr/...` lesson with a figure → unchanged behavior (falls back because `storage_url_fr` is NULL everywhere)
  - [ ] Load `/en/...` → unchanged
  - [ ] `UPDATE source_images SET storage_url_fr = storage_url WHERE id = '<one id>'`, reload `/fr/...`, confirm endpoint serves via the new code path

## Out of scope

- Anything that populates `storage_key_fr` / `storage_url_fr` (classifier + SVG renderer + overlays come in later slices).
- Backfill task for generating French variants.
- Frontend fallback UI — endpoint handles it transparently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)