### PR TITLE
fix(summative): extract client wrapper to unbreak /modules/[id]/summative (#1836)

### DIFF
--- a/frontend/app/[locale]/(app)/modules/[moduleId]/summative/page.tsx
+++ b/frontend/app/[locale]/(app)/modules/[moduleId]/summative/page.tsx
@@ -1,5 +1,5 @@
 import { getTranslations } from 'next-intl/server';
-import { SummativeAssessmentContainer } from '@/components/quiz/summative-assessment-container';
+import { SummativePageClient } from './summative-page-client';
 
 interface SummativePageProps {
   params: Promise<{
@@ -11,7 +11,7 @@ interface SummativePageProps {
 export async function generateMetadata({ params }: SummativePageProps) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'SummativeAssessment' });
-  
+
   return {
     title: t('pageTitle'),
     description: t('pageDescription'),
@@ -20,32 +20,15 @@ export async function generateMetadata({ params }: SummativePageProps) {
 
 export default async function SummativePage({ params }: SummativePageProps) {
   const { locale, moduleId } = await params;
-  
-  // Mock user data - in production this would come from auth
-  const mockUser = {
-    language: locale === 'fr' ? 'fr' : 'en',
-    country: 'senegal',
-    level: 1,
-  };
-  
+  const language = locale === 'fr' ? 'fr' : 'en';
+
   return (
-    <main className="min-h-screen bg-stone-50">
-      <div className="py-8">
-        <SummativeAssessmentContainer
-          moduleId={moduleId}
-          language={mockUser.language}
-          country={mockUser.country}
-          level={mockUser.level}
-          onComplete={() => {
-            // Handle completion - redirect to next module or dashboard
-            window.location.href = `/${locale}/modules`;
-          }}
-          onRetry={() => {
-            // Handle retry - refresh the page or re-initialize
-            window.location.reload();
-          }}
-        />
-      </div>
-    </main>
+    <SummativePageClient
+      moduleId={moduleId}
+      locale={locale}
+      language={language}
+      country="senegal"
+      level={1}
+    />
   );
 }

--- a/frontend/app/[locale]/(app)/modules/[moduleId]/summative/summative-page-client.tsx
+++ b/frontend/app/[locale]/(app)/modules/[moduleId]/summative/summative-page-client.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { SummativeAssessmentContainer } from '@/components/quiz/summative-assessment-container';
+
+interface SummativePageClientProps {
+  moduleId: string;
+  locale: string;
+  language: string;
+  country: string;
+  level: number;
+}
+
+export function SummativePageClient({
+  moduleId,
+  locale,
+  language,
+  country,
+  level,
+}: SummativePageClientProps) {
+  return (
+    <main className="min-h-screen bg-stone-50">
+      <div className="py-8">
+        <SummativeAssessmentContainer
+          moduleId={moduleId}
+          language={language}
+          country={country}
+          level={level}
+          onComplete={() => {
+            window.location.href = `/${locale}/modules`;
+          }}
+          onRetry={() => {
+            window.location.reload();
+          }}
+        />
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

- Split the summative page into a server wrapper (metadata + param resolution) and a client wrapper (owns the \`onComplete\`/\`onRetry\` closures that use \`window.location\`).
- The original page was a Server Component passing inline arrow functions to a client component, which Next.js 15 rejects across the RSC boundary. Symptom: every visit rendered \"An error occurred / Retry\" immediately.
- Latent since #104 but load-bearing after #1830 started redirecting \`?unit=summative\` to this page — cert gate was unreachable despite all 8 modules at 100%.

Fixes #1836

## Test plan
- [ ] Visit \`/fr/modules/{id}/summative\` — page renders the eligibility check / start screen, not the generic error.
- [ ] Click \"Start\", answer the generated questions, submit.
- [ ] Confirm row in \`summative_assessment_attempts\` on the tenant DB.
- [ ] After 8/8 summatives passed, confirm row in \`certificates\` and visibility at \`/fr/certificates\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)