### PR TITLE
fix(ops): drop ORDER BY created_at from staging-trigger-video lookup

### DIFF
--- a/.github/workflows/staging-trigger-video.yml
+++ b/.github/workflows/staging-trigger-video.yml
@@ -51,7 +51,6 @@ jobs:
                   WHERE module_id = '$MODULE_ID'
                     AND content->>'unit_id' = '$UNIT_ID'
                     AND language = '$LANGUAGE'
-                  ORDER BY created_at DESC
                   LIMIT 1")
             LESSON_ID=$(echo "$LESSON_ID" | tr -d '[:space:]')
             if [ -z "$LESSON_ID" ]; then


### PR DESCRIPTION
One-line fix: `generated_content` has no `created_at` column. `(module_id, content->>unit_id, language)` is already unique so `LIMIT 1` suffices. Hotfix for #1838.