### PR TITLE
fix(ops): use uv run python in staging-trigger-video

### DIFF
--- a/.github/workflows/staging-trigger-video.yml
+++ b/.github/workflows/staging-trigger-video.yml
@@ -76,7 +76,7 @@ jobs:
             echo "=============================================="
             echo "Dispatching generate_lesson_video Celery task"
             echo "=============================================="
-            docker compose exec -T backend python -c "
+            docker compose exec -T backend uv run python -c "
             import json
             import asyncio
             from sqlalchemy import select

--- a/.github/workflows/staging-trigger-video.yml
+++ b/.github/workflows/staging-trigger-video.yml
@@ -51,7 +51,6 @@ jobs:
                   WHERE module_id = '$MODULE_ID'
                     AND content->>'unit_id' = '$UNIT_ID'
                     AND language = '$LANGUAGE'
-                  ORDER BY created_at DESC
                   LIMIT 1")
             LESSON_ID=$(echo "$LESSON_ID" | tr -d '[:space:]')
             if [ -z "$LESSON_ID" ]; then


### PR DESCRIPTION
Hotfix: bare `python` inside the backend container doesn't see the venv. Use `uv run python` like the rest of the backend commands. Related: #1838.