### PR TITLE
fix(celery): refresh SettingsCache in each forked worker (#1841)

### DIFF
--- a/.github/workflows/staging-trigger-video.yml
+++ b/.github/workflows/staging-trigger-video.yml
@@ -51,7 +51,6 @@ jobs:
                   WHERE module_id = '$MODULE_ID'
                     AND content->>'unit_id' = '$UNIT_ID'
                     AND language = '$LANGUAGE'
-                  ORDER BY created_at DESC
                   LIMIT 1")
             LESSON_ID=$(echo "$LESSON_ID" | tr -d '[:space:]')
             if [ -z "$LESSON_ID" ]; then

--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -3,7 +3,7 @@
 import structlog
 from celery import Celery
 from celery.schedules import crontab
-from celery.signals import worker_ready
+from celery.signals import worker_process_init, worker_ready
 
 import app.domain.models  # noqa: F401 — register all SQLAlchemy models with the mapper
 from app.domain.services.platform_settings_service import SettingsCache
@@ -105,6 +105,21 @@ def _on_worker_ready(**kwargs):
         logger.info("settings_cache.loaded_on_worker_start")
     except Exception as exc:
         logger.warning("settings_cache.load_skipped_on_worker_start", error=str(exc))
+
+
+@worker_process_init.connect
+def _on_worker_process_init(**kwargs):
+    # worker_ready fires only in the MainProcess AFTER fork, so the
+    # ForkPoolWorker children that actually execute tasks inherit an
+    # empty cache. Refresh in each child too, or every gated task
+    # silently returns {'status': 'skipped', 'reason': 'feature_off'}.
+    try:
+        SettingsCache.instance().refresh()
+        logger.info("settings_cache.loaded_on_worker_process_init")
+    except Exception as exc:
+        logger.warning(
+            "settings_cache.load_skipped_on_worker_process_init", error=str(exc)
+        )
 
 
 if __name__ == "__main__":

--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -117,9 +117,7 @@ def _on_worker_process_init(**kwargs):
         SettingsCache.instance().refresh()
         logger.info("settings_cache.loaded_on_worker_process_init")
     except Exception as exc:
-        logger.warning(
-            "settings_cache.load_skipped_on_worker_process_init", error=str(exc)
-        )
+        logger.warning("settings_cache.load_skipped_on_worker_process_init", error=str(exc))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

\`@worker_ready.connect\` fires in the MainProcess *after* it has forked \`--concurrency=4\` children. The children inherit an **empty** \`SettingsCache\`, so every setting-gated task reads defaults. Observed: \`generate_lesson_video\` returning \`{status: skipped, reason: feature_off}\` within 6 ms of receiving the task despite \`video-summary-feature-enabled: true\` in staging's platform settings JSON.

Adds \`@worker_process_init.connect\` which fires in each forked child right after fork.

Fixes #1841.

## Test plan

- [ ] Merge + staging deploy.
- [ ] \`gh workflow run staging-trigger-video.yml -f unit_id=M01-U01 -f language=fr\`.
- [ ] Celery log shows \`settings_cache.loaded_on_worker_process_init\` per forked child.
- [ ] Task result no longer \`skipped/feature_off\`; proceeds into \`LessonVideoService.generate_for_lesson\`.
- [ ] New row in \`generated_audio\` with \`media_type='video'\`, \`provider_video_id\` set.
- [ ] ~10-15 min later: row flips to \`ready\`.