### PR TITLE
fix(ops): run celery worker with embedded beat (#1846)

### DIFF
--- a/backend/app/ai/rag/pipeline.py
+++ b/backend/app/ai/rag/pipeline.py
@@ -12,7 +12,7 @@ from app.ai.rag.chunker import TextChunker, detect_language, extract_text_from_p
 from app.ai.rag.embeddings import EmbeddingService
 from app.ai.rag.image_extractor import PDFImageExtractor
 from app.ai.rag.image_linker import ImageLinker
-from app.ai.translation import translate_figure_caption
+from app.ai.translation import classify_figure, translate_figure_caption
 from app.domain.models.document_chunk import DocumentChunk
 from app.domain.models.source_image import SourceImage
 from app.infrastructure.persistence.database import async_session_factory
@@ -250,6 +250,18 @@ class RAGPipeline:
                         error=str(exc),
                     )
 
+            figure_kind: str | None = None
+            try:
+                classification = await classify_figure(image_bytes=img.image_bytes)
+                figure_kind = classification.kind
+            except Exception as exc:
+                logger.warning(
+                    "Failed to classify figure, storing without figure_kind",
+                    source=source,
+                    figure_number=img.figure_number,
+                    error=str(exc),
+                )
+
             db_image = SourceImage(
                 id=uuid4(),
                 source=source,
@@ -274,6 +286,7 @@ class RAGPipeline:
                 embedding=embedding,
                 alt_text_fr=alt_text_fr,
                 alt_text_en=alt_text_en,
+                figure_kind=figure_kind,
             )
 
             session.add(db_image)

--- a/backend/app/ai/translation/__init__.py
+++ b/backend/app/ai/translation/__init__.py
@@ -1,8 +1,19 @@
-"""AI-backed translation utilities (issue #1820)."""
+"""AI-backed translation utilities (issue #1820, #1844)."""
 
+from app.ai.translation.figure_classifier import (
+    FigureClassification,
+    FigureKind,
+    classify_figure,
+)
 from app.ai.translation.figure_translator import (
     FigureTranslation,
     translate_figure_caption,
 )
 
-__all__ = ["FigureTranslation", "translate_figure_caption"]
+__all__ = [
+    "FigureClassification",
+    "FigureKind",
+    "FigureTranslation",
+    "classify_figure",
+    "translate_figure_caption",
+]

--- a/backend/app/ai/translation/figure_classifier.py
+++ b/backend/app/ai/translation/figure_classifier.py
@@ -1,0 +1,213 @@
+"""Classify a figure into a Phase-2 routing kind via Claude Vision (issue #1844).
+
+Given the WebP bytes of a figure extracted from a PDF, Claude Haiku with
+vision returns one of a fixed set of ``FigureKind`` values. The value is
+stored on ``source_images.figure_kind`` and later Phase-2 slices use it
+to decide how (or whether) to produce a French variant:
+
+- ``clean_flowchart`` / ``chart`` → slice 3 re-derives as SVG.
+- ``complex_diagram`` → slice 4 produces raster + numbered-badge overlay.
+- ``photo_with_callouts`` → slice 5 overlays translated callouts.
+- ``photo`` / ``decorative`` → caption-only (already covered by Phase 1).
+- ``formula`` / ``micrograph`` → never re-derive (caption-only).
+- ``table`` → future slice may reconstruct as semantic HTML.
+
+One Claude Haiku call per figure. The prompt enforces single JSON output;
+the caller raises on failures rather than guessing a default.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+from typing import Literal
+
+import anthropic
+import structlog
+from pydantic import BaseModel, Field, ValidationError
+
+from app.infrastructure.config.settings import get_settings
+
+logger = structlog.get_logger(__name__)
+
+
+FigureKind = Literal[
+    "clean_flowchart",
+    "chart",
+    "table",
+    "photo",
+    "photo_with_callouts",
+    "formula",
+    "micrograph",
+    "decorative",
+    "complex_diagram",
+]
+
+_ALLOWED_KINDS: set[str] = {
+    "clean_flowchart",
+    "chart",
+    "table",
+    "photo",
+    "photo_with_callouts",
+    "formula",
+    "micrograph",
+    "decorative",
+    "complex_diagram",
+}
+
+_CLASSIFIER_MODEL = "claude-haiku-4-5"
+_MAX_TOKENS = 128
+
+_SYSTEM_PROMPT = (
+    "You classify figures extracted from academic textbooks into one of a "
+    "fixed set of kinds so that a downstream localisation pipeline can "
+    "decide how to translate them. Reply with a single JSON object and "
+    "nothing else — no prose, no markdown fences."
+)
+
+_USER_PROMPT = (
+    "Classify this figure into exactly ONE of these kinds:\n\n"
+    "- clean_flowchart: boxes/ovals connected by arrows, clearly readable\n"
+    "  text labels inside each node. Typically used for processes, "
+    "decision flows, algorithms.\n"
+    "- chart: bar/line/pie/scatter chart with axes, labels, a legend. "
+    "Data visualisation, not a flow.\n"
+    "- table: a grid of rows and columns with header cells. Tabular data.\n"
+    "- photo: a real photograph with no embedded text labels.\n"
+    "- photo_with_callouts: a photograph or micrograph with arrows / "
+    "leader lines pointing to labelled features.\n"
+    "- formula: a typeset mathematical or chemical equation.\n"
+    "- micrograph: a microscopy image (cells, tissue, crystals), with or "
+    "without arrows. Prefer this over 'photo_with_callouts' when the "
+    "image itself is microscopy.\n"
+    "- decorative: small icon, border, or purely visual element carrying "
+    "no information.\n"
+    "- complex_diagram: anatomical plate, multi-panel figure, dense "
+    "labelled illustration with many text annotations. Anything that is "
+    "clearly a diagram but too dense for clean_flowchart.\n\n"
+    "Reply with a JSON object containing exactly one field:\n"
+    '  {"kind": "<one of the values above>"}\n\n'
+    "Rules:\n"
+    "- Pick the single best fit. If torn between two, prefer the more "
+    "conservative classification (e.g. complex_diagram over "
+    "clean_flowchart when in doubt, photo over photo_with_callouts).\n"
+    "- Do not invent new kinds. Reply with JSON only."
+)
+
+
+class FigureClassification(BaseModel):
+    """Validated classifier output."""
+
+    kind: FigureKind = Field(..., description="One of the allowed FigureKind values.")
+
+
+def _extract_json_object(text: str) -> str:
+    """Strip markdown fences and isolate the first JSON object in the response."""
+    clean = text.strip()
+    if clean.startswith("```"):
+        first_newline = clean.find("\n")
+        if first_newline > 0:
+            clean = clean[first_newline + 1 :]
+        if clean.rstrip().endswith("```"):
+            clean = clean.rstrip()[:-3]
+    start = clean.find("{")
+    end = clean.rfind("}")
+    if start < 0 or end <= start:
+        raise ValueError("no JSON object in classifier response")
+    body = clean[start : end + 1]
+    return re.sub(r",\s*([}\]])", r"\1", body)
+
+
+async def classify_figure(
+    image_bytes: bytes,
+    image_media_type: str = "image/webp",
+    client: anthropic.AsyncAnthropic | None = None,
+) -> FigureClassification:
+    """Classify a figure into a :data:`FigureKind`.
+
+    Args:
+        image_bytes: Raw bytes of the figure asset (WebP as stored in MinIO).
+        image_media_type: MIME type for the Anthropic vision payload.
+            Defaults to the project's WebP storage format.
+        client: Optional injected ``AsyncAnthropic`` client (for tests).
+
+    Returns:
+        :class:`FigureClassification` — ``.kind`` guaranteed to be one of
+        the allowed values (validated by Pydantic's ``Literal`` typing).
+
+    Raises:
+        ValueError: empty input, malformed model output, or unknown kind.
+        ValidationError: model output parsed but fails schema validation.
+    """
+    if not image_bytes:
+        raise ValueError("image_bytes must be non-empty")
+
+    if client is None:
+        settings = get_settings()
+        if not settings.anthropic_api_key:
+            raise ValueError("ANTHROPIC_API_KEY is required to classify figures")
+        client = anthropic.AsyncAnthropic(
+            api_key=settings.anthropic_api_key,
+            timeout=60.0,
+        )
+
+    encoded = base64.standard_b64encode(image_bytes).decode("ascii")
+    response = await client.messages.create(
+        model=_CLASSIFIER_MODEL,
+        max_tokens=_MAX_TOKENS,
+        system=_SYSTEM_PROMPT,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": image_media_type,
+                            "data": encoded,
+                        },
+                    },
+                    {"type": "text", "text": _USER_PROMPT},
+                ],
+            }
+        ],
+        temperature=0.0,
+    )
+
+    text = ""
+    for block in response.content:
+        if hasattr(block, "text"):
+            text += block.text
+    if not text.strip():
+        raise ValueError("empty classifier response")
+
+    body = _extract_json_object(text)
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "Figure classifier produced invalid JSON",
+            preview=text[:200],
+            error=str(exc),
+        )
+        raise ValueError(f"classifier returned invalid JSON: {exc}") from exc
+
+    if isinstance(payload, dict):
+        kind = payload.get("kind")
+        if kind is not None and kind not in _ALLOWED_KINDS:
+            logger.warning(
+                "Classifier returned unknown kind; rejecting",
+                kind=kind,
+            )
+            raise ValueError(f"classifier returned unknown kind: {kind!r}")
+
+    try:
+        return FigureClassification(**payload)
+    except ValidationError as exc:
+        logger.warning(
+            "Figure classifier response failed validation",
+            payload_keys=list(payload.keys()) if isinstance(payload, dict) else None,
+        )
+        raise exc

--- a/backend/app/domain/models/source_image.py
+++ b/backend/app/domain/models/source_image.py
@@ -72,6 +72,7 @@ class SourceImage(Base):
     embedding: Mapped[list[float] | None] = mapped_column(ARRAY(Float), nullable=True)
     alt_text_fr: Mapped[str | None] = mapped_column(Text, nullable=True)
     alt_text_en: Mapped[str | None] = mapped_column(Text, nullable=True)
+    figure_kind: Mapped[str | None] = mapped_column(Text, nullable=True)
     semantic_tags: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
 
@@ -107,6 +108,7 @@ class SourceImage(Base):
             "original_format": self.original_format,
             "alt_text_fr": self.alt_text_fr,
             "alt_text_en": self.alt_text_en,
+            "figure_kind": self.figure_kind,
             "semantic_tags": self.semantic_tags,
             "created_at": self.created_at.isoformat() if self.created_at else None,
         }

--- a/backend/app/tasks/image_translation.py
+++ b/backend/app/tasks/image_translation.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 
+import httpx
 import structlog
 from celery import Task
 from sqlalchemy import func, or_, select
@@ -26,7 +27,7 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
-from app.ai.translation import translate_figure_caption
+from app.ai.translation import classify_figure, translate_figure_caption
 from app.domain.models.source_image import SourceImage
 from app.infrastructure.config.settings import settings
 from app.tasks.celery_app import celery_app
@@ -211,5 +212,185 @@ async def _run_backfill_with_factory(
             "status": "complete",
             "eligible": total,
             "translated": translated,
+            "failed": failed,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 slice 2 (#1844) — figure-kind classifier backfill
+# ---------------------------------------------------------------------------
+
+
+class FigureClassificationTask(Task):
+    """Celery base for the figure-kind classifier backfill."""
+
+    def on_success(self, retval, task_id, args, kwargs):
+        logger.info("Figure-kind backfill completed", task_id=task_id, result=retval)
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        logger.error("Figure-kind backfill failed", task_id=task_id, exception=str(exc))
+
+
+@celery_app.task(
+    bind=True,
+    base=FigureClassificationTask,
+    time_limit=3600,
+    soft_time_limit=3300,
+    ignore_result=True,
+    acks_late=False,
+)
+def backfill_figure_kinds(
+    self,
+    rag_collection_id: str | None = None,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """Classify ``source_images`` rows that have no ``figure_kind`` yet.
+
+    Args:
+        rag_collection_id: Limit backfill to a single course's RAG collection.
+            None processes every eligible row across all courses.
+        limit: Maximum number of rows to process in this invocation.
+        dry_run: If True, count eligible rows and log a preview but do not
+            call Claude or write to the DB.
+    """
+    return asyncio.run(
+        _run_kind_backfill(
+            task=self,
+            rag_collection_id=rag_collection_id,
+            limit=limit,
+            dry_run=dry_run,
+        )
+    )
+
+
+async def _run_kind_backfill(
+    task: Task,
+    rag_collection_id: str | None,
+    limit: int | None,
+    dry_run: bool,
+) -> dict:
+    # Same task-scoped engine pattern as _run_backfill — each asyncio.run()
+    # invocation gets its own pool bound to its own loop (#1827).
+    engine = create_async_engine(settings.database_url, pool_pre_ping=True)
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        return await _run_kind_backfill_with_factory(
+            task=task,
+            rag_collection_id=rag_collection_id,
+            limit=limit,
+            dry_run=dry_run,
+            session_factory=session_factory,
+        )
+    finally:
+        await engine.dispose()
+
+
+async def _run_kind_backfill_with_factory(
+    task: Task,
+    rag_collection_id: str | None,
+    limit: int | None,
+    dry_run: bool,
+    session_factory: async_sessionmaker[AsyncSession],
+) -> dict:
+    async with session_factory() as session:
+        stmt = select(SourceImage).where(
+            SourceImage.figure_kind.is_(None),
+            SourceImage.storage_url.is_not(None),
+        )
+        if rag_collection_id is not None:
+            stmt = stmt.where(SourceImage.rag_collection_id == rag_collection_id)
+        if limit is not None:
+            stmt = stmt.limit(limit)
+
+        rows = (await session.execute(stmt)).scalars().all()
+        total = len(rows)
+
+        logger.info(
+            "Figure-kind backfill: eligible rows",
+            total=total,
+            rag_collection_id=rag_collection_id,
+            dry_run=dry_run,
+        )
+
+        task.update_state(
+            state="CLASSIFYING",
+            meta={
+                "step": "classifying",
+                "total": total,
+                "processed": 0,
+                "classified": 0,
+                "failed": 0,
+            },
+        )
+
+        if dry_run or total == 0:
+            return {
+                "status": "dry_run" if dry_run else "noop",
+                "eligible": total,
+                "classified": 0,
+                "failed": 0,
+            }
+
+        classified = 0
+        failed = 0
+        pending_commit = 0
+
+        async with httpx.AsyncClient(timeout=30.0) as http:
+            for idx, img in enumerate(rows):
+                try:
+                    upstream = await http.get(img.storage_url)
+                    upstream.raise_for_status()
+                    image_bytes = upstream.content
+                except Exception as exc:
+                    failed += 1
+                    logger.warning(
+                        "Failed to fetch image bytes for classification, skipping",
+                        source_image_id=str(img.id),
+                        storage_url=img.storage_url,
+                        error=str(exc),
+                    )
+                    continue
+
+                try:
+                    classification = await classify_figure(image_bytes=image_bytes)
+                except Exception as exc:
+                    failed += 1
+                    logger.warning(
+                        "Classification failed for source image, skipping",
+                        source_image_id=str(img.id),
+                        figure_number=img.figure_number,
+                        error=str(exc),
+                    )
+                    continue
+
+                img.figure_kind = classification.kind
+                session.add(img)
+                classified += 1
+                pending_commit += 1
+
+                if pending_commit >= _COMMIT_EVERY:
+                    await session.commit()
+                    pending_commit = 0
+
+                if (idx + 1) % 10 == 0 or idx + 1 == total:
+                    task.update_state(
+                        state="CLASSIFYING",
+                        meta={
+                            "step": "classifying",
+                            "total": total,
+                            "processed": idx + 1,
+                            "classified": classified,
+                            "failed": failed,
+                        },
+                    )
+
+        if pending_commit:
+            await session.commit()
+
+        return {
+            "status": "complete",
+            "eligible": total,
+            "classified": classified,
             "failed": failed,
         }

--- a/backend/migrations/versions/080_source_image_figure_kind.py
+++ b/backend/migrations/versions/080_source_image_figure_kind.py
@@ -1,0 +1,35 @@
+"""Add ``figure_kind`` column to ``source_images``.
+
+Revision ID: 080
+Revises: 079
+Create Date: 2026-04-22
+
+Per issue #1844 (epic #1819, Phase 2 slice 2). Stores the Claude-Vision
+classification of each figure — ``clean_flowchart``, ``chart``, ``table``,
+``photo``, ``photo_with_callouts``, ``formula``, ``micrograph``,
+``decorative``, or ``complex_diagram``. Later slices (3+) use this to
+route figures through different translation strategies (SVG re-derive,
+raster+overlay, caption-only, etc.).
+
+Stored as ``Text`` (not an enum) so we can add new kinds in later slices
+without another migration.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "080"
+down_revision = "079"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "source_images",
+        sa.Column("figure_kind", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("source_images", "figure_kind")

--- a/backend/tests/test_backfill_figure_kinds.py
+++ b/backend/tests/test_backfill_figure_kinds.py
@@ -1,0 +1,229 @@
+"""Unit tests for the ``backfill_figure_kinds`` Celery task (issue #1844).
+
+Exercises ``_run_kind_backfill_with_factory`` directly with an injected
+session factory, a mocked classifier, and a mocked httpx client so the
+test has no DB, no MinIO, and no network dependency.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.ai.translation.figure_classifier import FigureClassification
+from app.tasks import image_translation
+
+
+def _make_row(
+    figure_kind: str | None = None,
+    storage_url: str | None = "https://minio/default.webp",
+    rag_collection_id: str | None = "course-1",
+) -> MagicMock:
+    row = MagicMock()
+    row.id = uuid.uuid4()
+    row.figure_kind = figure_kind
+    row.storage_url = storage_url
+    row.rag_collection_id = rag_collection_id
+    row.figure_number = "1.1"
+    return row
+
+
+class _FakeSession:
+    def __init__(self, rows):
+        self._rows = rows
+        self.added: list[MagicMock] = []
+        self.commits = 0
+
+    async def execute(self, stmt):
+        result = MagicMock()
+        scalars = MagicMock()
+        scalars.all = MagicMock(return_value=list(self._rows))
+        result.scalars = MagicMock(return_value=scalars)
+        return result
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def commit(self):
+        self.commits += 1
+
+
+class _FakeSessionFactory:
+    def __init__(self, session: _FakeSession):
+        self._session = session
+
+    def __call__(self):
+        session = self._session
+
+        class _Ctx:
+            async def __aenter__(self):
+                return session
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        return _Ctx()
+
+
+def _patch_httpx(response_bytes: bytes = b"fake-webp-bytes"):
+    """Patch httpx.AsyncClient used by _run_kind_backfill_with_factory."""
+    upstream = MagicMock()
+    upstream.content = response_bytes
+    upstream.raise_for_status = MagicMock()
+
+    http_client = MagicMock()
+    http_client.get = AsyncMock(return_value=upstream)
+
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=http_client)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+
+    return patch.object(
+        image_translation.httpx,
+        "AsyncClient",
+        return_value=ctx,
+    ), http_client
+
+
+class TestRunKindBackfillWithFactory:
+    async def test_dry_run_counts_without_calling_classifier(self):
+        rows = [_make_row(), _make_row()]
+        session = _FakeSession(rows)
+        task = MagicMock()
+        httpx_patch, _ = _patch_httpx()
+        classifier = AsyncMock(return_value=FigureClassification(kind="chart"))
+
+        with (
+            httpx_patch,
+            patch.object(image_translation, "classify_figure", new=classifier),
+        ):
+            result = await image_translation._run_kind_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=True,
+                session_factory=_FakeSessionFactory(session),
+            )
+
+        assert result == {
+            "status": "dry_run",
+            "eligible": 2,
+            "classified": 0,
+            "failed": 0,
+        }
+        classifier.assert_not_awaited()
+        assert session.commits == 0
+
+    async def test_classifies_all_eligible_rows(self):
+        rows = [_make_row(), _make_row(), _make_row()]
+        session = _FakeSession(rows)
+        task = MagicMock()
+        httpx_patch, _ = _patch_httpx()
+        classifier = AsyncMock(return_value=FigureClassification(kind="clean_flowchart"))
+
+        with (
+            httpx_patch,
+            patch.object(image_translation, "classify_figure", new=classifier),
+        ):
+            result = await image_translation._run_kind_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=False,
+                session_factory=_FakeSessionFactory(session),
+            )
+
+        assert result["status"] == "complete"
+        assert result["classified"] == 3
+        assert result["failed"] == 0
+        for row in rows:
+            assert row.figure_kind == "clean_flowchart"
+        assert classifier.await_count == 3
+        assert session.commits >= 1
+
+    async def test_classifier_failure_does_not_abort_batch(self):
+        rows = [_make_row(), _make_row(), _make_row()]
+        session = _FakeSession(rows)
+        task = MagicMock()
+        httpx_patch, _ = _patch_httpx()
+        classifier = AsyncMock(
+            side_effect=[
+                FigureClassification(kind="chart"),
+                ValueError("vision timeout"),
+                FigureClassification(kind="photo"),
+            ]
+        )
+
+        with (
+            httpx_patch,
+            patch.object(image_translation, "classify_figure", new=classifier),
+        ):
+            result = await image_translation._run_kind_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=False,
+                session_factory=_FakeSessionFactory(session),
+            )
+
+        assert result["classified"] == 2
+        assert result["failed"] == 1
+        assert rows[0].figure_kind == "chart"
+        assert rows[1].figure_kind is None
+        assert rows[2].figure_kind == "photo"
+
+    async def test_httpx_failure_does_not_abort_batch(self):
+        rows = [_make_row(), _make_row()]
+        session = _FakeSession(rows)
+        task = MagicMock()
+
+        upstream_ok = MagicMock()
+        upstream_ok.content = b"ok"
+        upstream_ok.raise_for_status = MagicMock()
+        http_client = MagicMock()
+        http_client.get = AsyncMock(side_effect=[Exception("network"), upstream_ok])
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=http_client)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+
+        classifier = AsyncMock(return_value=FigureClassification(kind="photo"))
+
+        with (
+            patch.object(image_translation.httpx, "AsyncClient", return_value=ctx),
+            patch.object(image_translation, "classify_figure", new=classifier),
+        ):
+            result = await image_translation._run_kind_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=False,
+                session_factory=_FakeSessionFactory(session),
+            )
+
+        assert result["classified"] == 1
+        assert result["failed"] == 1
+        assert rows[0].figure_kind is None
+        assert rows[1].figure_kind == "photo"
+        classifier.assert_awaited_once()
+
+    async def test_empty_eligible_set_returns_noop(self):
+        session = _FakeSession([])
+        task = MagicMock()
+        httpx_patch, _ = _patch_httpx()
+        classifier = AsyncMock(return_value=FigureClassification(kind="chart"))
+
+        with (
+            httpx_patch,
+            patch.object(image_translation, "classify_figure", new=classifier),
+        ):
+            result = await image_translation._run_kind_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=False,
+                session_factory=_FakeSessionFactory(session),
+            )
+
+        assert result["status"] == "noop"
+        assert result["eligible"] == 0
+        classifier.assert_not_awaited()

--- a/backend/tests/test_figure_classifier.py
+++ b/backend/tests/test_figure_classifier.py
@@ -1,0 +1,122 @@
+"""Unit tests for ``classify_figure`` (issue #1844)."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from app.ai.translation.figure_classifier import (
+    FigureClassification,
+    _extract_json_object,
+    classify_figure,
+)
+
+
+def _mock_anthropic_response(text: str) -> MagicMock:
+    msg = MagicMock()
+    msg.content = [SimpleNamespace(text=text)]
+    return msg
+
+
+def _mock_client(text: str) -> MagicMock:
+    client = MagicMock()
+    client.messages = MagicMock()
+    client.messages.create = AsyncMock(return_value=_mock_anthropic_response(text))
+    return client
+
+
+class TestExtractJsonObject:
+    def test_plain_json_passes_through(self):
+        body = _extract_json_object('{"kind": "chart"}')
+        assert json.loads(body) == {"kind": "chart"}
+
+    def test_strips_markdown_fences(self):
+        body = _extract_json_object('```json\n{"kind": "photo"}\n```')
+        assert json.loads(body) == {"kind": "photo"}
+
+    def test_raises_when_no_object(self):
+        with pytest.raises(ValueError, match="no JSON object"):
+            _extract_json_object("Sorry, I cannot classify this image.")
+
+
+class TestClassifyFigure:
+    async def test_happy_path_returns_valid_kind(self):
+        client = _mock_client(json.dumps({"kind": "clean_flowchart"}))
+        result = await classify_figure(image_bytes=b"fake-webp", client=client)
+        assert isinstance(result, FigureClassification)
+        assert result.kind == "clean_flowchart"
+
+    @pytest.mark.parametrize(
+        "kind",
+        [
+            "clean_flowchart",
+            "chart",
+            "table",
+            "photo",
+            "photo_with_callouts",
+            "formula",
+            "micrograph",
+            "decorative",
+            "complex_diagram",
+        ],
+    )
+    async def test_each_allowed_kind_parses(self, kind: str):
+        client = _mock_client(json.dumps({"kind": kind}))
+        result = await classify_figure(image_bytes=b"fake-webp", client=client)
+        assert result.kind == kind
+
+    async def test_markdown_fenced_response_is_parsed(self):
+        fenced = '```json\n{"kind": "table"}\n```'
+        client = _mock_client(fenced)
+        result = await classify_figure(image_bytes=b"fake-webp", client=client)
+        assert result.kind == "table"
+
+    async def test_empty_bytes_rejected_before_api_call(self):
+        client = _mock_client('{"kind": "photo"}')
+        with pytest.raises(ValueError, match="non-empty"):
+            await classify_figure(image_bytes=b"", client=client)
+        client.messages.create.assert_not_awaited()
+
+    async def test_unknown_kind_rejected(self):
+        client = _mock_client(json.dumps({"kind": "screenshot_of_tweet"}))
+        with pytest.raises(ValueError, match="unknown kind"):
+            await classify_figure(image_bytes=b"fake-webp", client=client)
+
+    async def test_invalid_json_raises_value_error(self):
+        client = _mock_client("Not JSON at all")
+        with pytest.raises(ValueError):
+            await classify_figure(image_bytes=b"fake-webp", client=client)
+
+    async def test_missing_kind_field_raises_validation_error(self):
+        client = _mock_client(json.dumps({"confidence": 0.9}))
+        with pytest.raises(ValidationError):
+            await classify_figure(image_bytes=b"fake-webp", client=client)
+
+    async def test_empty_text_response_raises(self):
+        client = _mock_client("")
+        with pytest.raises(ValueError, match="empty classifier response"):
+            await classify_figure(image_bytes=b"fake-webp", client=client)
+
+    async def test_image_bytes_sent_as_base64_in_vision_payload(self):
+        client = _mock_client(json.dumps({"kind": "photo"}))
+        await classify_figure(
+            image_bytes=b"hello-world-bytes",
+            image_media_type="image/png",
+            client=client,
+        )
+        call = client.messages.create.await_args
+        user_content = call.kwargs["messages"][0]["content"]
+        # First block is the image, second is text.
+        image_block = user_content[0]
+        assert image_block["type"] == "image"
+        assert image_block["source"]["media_type"] == "image/png"
+        # base64 of b"hello-world-bytes"
+        import base64
+
+        assert image_block["source"]["data"] == base64.standard_b64encode(
+            b"hello-world-bytes"
+        ).decode("ascii")

--- a/docker-compose.prod.sira-donnia.yml
+++ b/docker-compose.prod.sira-donnia.yml
@@ -159,7 +159,12 @@ services:
     # translate(Qk) for language X can run on one worker while
     # generate_audio(Qj) for language Y runs on another, bounded by
     # sidecar semaphores (NLLB=1, MMS=2).
-    command: uv run celery -A app.tasks.celery_app worker --loglevel=info --concurrency=4
+    # -B runs an embedded beat scheduler so the beat_schedule entries in
+    # app/tasks/celery_app.py (heygen poll every 60s, subscription expiry,
+    # SMS relay heartbeat, etc.) actually fire. Safe for this single-node
+    # deployment; split to a dedicated celery-beat service if we ever scale
+    # to multiple worker containers (#1846).
+    command: uv run celery -A app.tasks.celery_app worker -B --loglevel=info --concurrency=4
     environment:
       DATABASE_URL: postgresql+asyncpg://postgres:${POSTGRES_PASSWORD}@postgres:5432/santepublique_aof
       REDIS_URL: redis://redis:6379/0

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -159,7 +159,12 @@ services:
     # translate(Qk) for language X can run on one worker while
     # generate_audio(Qj) for language Y runs on another, bounded by
     # sidecar semaphores (NLLB=1, MMS=2).
-    command: uv run celery -A app.tasks.celery_app worker --loglevel=info --concurrency=4
+    # -B runs an embedded beat scheduler so the beat_schedule entries in
+    # app/tasks/celery_app.py (heygen poll every 60s, subscription expiry,
+    # SMS relay heartbeat, etc.) actually fire. Safe for this single-node
+    # deployment; split to a dedicated celery-beat service if we ever scale
+    # to multiple worker containers (#1846).
+    command: uv run celery -A app.tasks.celery_app worker -B --loglevel=info --concurrency=4
     environment:
       DATABASE_URL: postgresql+asyncpg://postgres:${POSTGRES_PASSWORD}@postgres:5432/santepublique_aof
       REDIS_URL: redis://redis:6379/0


### PR DESCRIPTION
## Summary

Staging's celery worker was started without \`--beat\` and with no separate \`celery-beat\` service. \`beat_schedule\` entries in \`app/tasks/celery_app.py\` never fired — discovered while debugging why rendered HeyGen videos sat at \`status=generating\` forever: the \`poll_pending_heygen_videos\` task that polls HeyGen for completion never ran.

Adds \`-B\` so the worker runs embedded beat. Applies to both the generic prod compose and the sira-donnia variant.

## Impact (was silent)

Scheduled tasks that were dead until now:
- \`poll-heygen-videos\` — 60s (this is why video generation stalls at generating)
- \`expire-subscriptions\` — daily 00:30
- \`check-relay-heartbeat\` — every 15 min
- \`cleanup-expired-uploads\` — hourly
- \`cleanup-expired-cache\` — every 6h
- \`refresh-dhis2-data\` — daily
- \`refresh-who-data\` — weekly

Fixes #1846.

## Test plan

- [ ] Merge + staging deploy.
- [ ] Celery log shows \`beat: Starting\` and \`Scheduler: Sending due task poll-heygen-videos\`.
- [ ] Within ~2 min the existing \`generating\` video row (f40de84d-...) flips to \`ready\` with a populated \`storage_url\`.
- [ ] Reload the lesson; \`<video>\` element plays.

## Note on scale-out

If we ever run multiple worker containers, embedded \`-B\` fires in each one — double-scheduling. At that point split out a dedicated \`celery-beat\` service. Out of scope here.