### PR TITLE
fix(video): /video/{id}/data public so <video> element can play (#1850)

### DIFF
--- a/backend/app/api/v1/lesson_video.py
+++ b/backend/app/api/v1/lesson_video.py
@@ -317,10 +317,17 @@ async def get_video_status(
 )
 async def get_video_data(
     video_id: UUID,
-    _current_user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db_session),
 ) -> Response:
-    """Proxy the MP4 bytes from MinIO (internal URL not browser-reachable)."""
+    """Proxy the MP4 bytes from MinIO (internal URL not browser-reachable).
+
+    Public (no ``get_current_user``) because native ``<video src=...>``
+    elements do not send ``Authorization`` headers. Mirrors the audio
+    ``/{audio_id}/data`` contract. Access control is upstream: the
+    lesson-video rows themselves are only written by authenticated
+    dispatches, and the ``status='ready'`` + ``media_type='video'``
+    gates prevent serving in-progress or non-video rows.
+    """
     result = await db.execute(
         select(GeneratedAudio).where(
             GeneratedAudio.id == video_id,


### PR DESCRIPTION
## Summary

- Row is \`ready\` with storage_key populated + MP4 in MinIO, but \`<video>\` player stays blank.
- Root cause: \`get_video_data\` required \`get_current_user\`, but native \`<video>\` elements don't send \`Authorization\` headers.
- Fix: drop auth dep; mirror \`get_audio_data\` which is already public for the same reason.

Access control stays intact upstream: only authenticated dispatches create rows, endpoint filters \`media_type='video' AND status='ready'\`, and the UUID is unguessable.

Fixes #1850.

## Test plan

- [ ] Merge + staging deploy.
- [ ] Hard-refresh M01-U01 fr; \`<video>\` loads + plays the HeyGen MP4.
- [ ] Network tab: \`GET /api/v1/video/{id}/data\` returns 200 with video/mp4 Content-Type.