### PR TITLE
feat(figures): SVG re-derivation of clean_flowchart figures in French

### DIFF
--- a/backend/app/ai/rag/pipeline.py
+++ b/backend/app/ai/rag/pipeline.py
@@ -12,7 +12,13 @@ from app.ai.rag.chunker import TextChunker, detect_language, extract_text_from_p
 from app.ai.rag.embeddings import EmbeddingService
 from app.ai.rag.image_extractor import PDFImageExtractor
 from app.ai.rag.image_linker import ImageLinker
-from app.ai.translation import classify_figure, translate_figure_caption
+from app.ai.translation import (
+    classify_figure,
+    extract_flowchart_structure,
+    render_svg,
+    translate_figure_caption,
+    translate_structure,
+)
 from app.domain.models.document_chunk import DocumentChunk
 from app.domain.models.source_image import SourceImage
 from app.infrastructure.persistence.database import async_session_factory
@@ -262,6 +268,31 @@ class RAGPipeline:
                     error=str(exc),
                 )
 
+            storage_key_fr: str | None = None
+            storage_url_fr: str | None = None
+            if figure_kind == "clean_flowchart":
+                try:
+                    structure = await extract_flowchart_structure(image_bytes=img.image_bytes)
+                    translated = await translate_structure(structure, target_lang="fr")
+                    svg_bytes = render_svg(translated)
+                    svg_key = (
+                        f"source-images/{prefix}/{readable_name}/"
+                        f"{img.page_number}_{safe_label}.fr.svg"
+                    )
+                    storage_url_fr = await storage.upload_bytes(
+                        key=svg_key,
+                        data=svg_bytes,
+                        content_type="image/svg+xml",
+                    )
+                    storage_key_fr = svg_key
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to re-derive flowchart as FR SVG, leaving fr variant NULL",
+                        source=source,
+                        figure_number=img.figure_number,
+                        error=str(exc),
+                    )
+
             db_image = SourceImage(
                 id=uuid4(),
                 source=source,
@@ -278,6 +309,8 @@ class RAGPipeline:
                 surrounding_text=img.surrounding_text,
                 storage_key=key,
                 storage_url=storage_url,
+                storage_key_fr=storage_key_fr,
+                storage_url_fr=storage_url_fr,
                 format="webp",
                 width=img.width,
                 height=img.height,

--- a/backend/app/ai/translation/__init__.py
+++ b/backend/app/ai/translation/__init__.py
@@ -1,4 +1,4 @@
-"""AI-backed translation utilities (issue #1820, #1844)."""
+"""AI-backed translation utilities (issue #1820, #1844, #1852)."""
 
 from app.ai.translation.figure_classifier import (
     FigureClassification,
@@ -9,11 +9,25 @@ from app.ai.translation.figure_translator import (
     FigureTranslation,
     translate_figure_caption,
 )
+from app.ai.translation.svg_rederiver import (
+    FlowchartEdge,
+    FlowchartNode,
+    FlowchartStructure,
+    extract_flowchart_structure,
+    render_svg,
+    translate_structure,
+)
 
 __all__ = [
     "FigureClassification",
     "FigureKind",
     "FigureTranslation",
+    "FlowchartEdge",
+    "FlowchartNode",
+    "FlowchartStructure",
     "classify_figure",
+    "extract_flowchart_structure",
+    "render_svg",
     "translate_figure_caption",
+    "translate_structure",
 ]

--- a/backend/app/ai/translation/svg_rederiver.py
+++ b/backend/app/ai/translation/svg_rederiver.py
@@ -1,0 +1,433 @@
+"""Re-derive a ``clean_flowchart`` figure as a translated SVG (issue #1852).
+
+Pipeline:
+
+1. ``extract_flowchart_structure`` — Claude Vision returns a logical graph of
+   nodes and edges (no pixel coordinates, no layout).
+2. ``translate_structure`` — Claude Haiku translates every ``nodes[].text``
+   and ``edges[].label`` into the target locale, preserving ids + shapes.
+3. ``render_svg`` — deterministic Python SVG emission. Auto-lays nodes on a
+   top-down DAG grid (row per layer), draws edges as arrowed paths.
+
+Returning a "tidied" layout rather than mimicking the PDF's pixel layout is a
+deliberate trade-off: Claude Vision can't reliably reproduce coordinates,
+and a clean rebuild beats a visually mangled copy.
+
+Only ``clean_flowchart`` is handled in this slice; charts/tables/complex
+diagrams come in later slices.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+from collections import defaultdict, deque
+from typing import Literal
+
+import anthropic
+import structlog
+from pydantic import BaseModel, Field, ValidationError
+
+from app.infrastructure.config.settings import get_settings
+
+logger = structlog.get_logger(__name__)
+
+
+NodeShape = Literal["rect", "diamond", "ellipse", "parallelogram"]
+
+
+class FlowchartNode(BaseModel):
+    id: str = Field(..., min_length=1)
+    text: str = Field(..., min_length=1)
+    shape: NodeShape = "rect"
+
+
+class FlowchartEdge(BaseModel):
+    from_id: str = Field(..., min_length=1)
+    to_id: str = Field(..., min_length=1)
+    label: str | None = None
+
+
+class FlowchartStructure(BaseModel):
+    nodes: list[FlowchartNode] = Field(..., min_length=1)
+    edges: list[FlowchartEdge] = Field(default_factory=list)
+
+
+_EXTRACT_MODEL = "claude-haiku-4-5"
+_TRANSLATE_MODEL = "claude-haiku-4-5"
+_MAX_TOKENS = 2048
+
+
+_EXTRACT_SYSTEM = (
+    "You extract the logical structure of a flowchart from an image. You reply "
+    "with a single JSON object and nothing else — no prose, no markdown fences."
+)
+
+_EXTRACT_USER = (
+    "Extract this flowchart's structure as a directed graph. Return JSON:\n"
+    '  {"nodes": [{"id": "n1", "text": "...", "shape": "rect"}, ...],\n'
+    '   "edges": [{"from_id": "n1", "to_id": "n2", "label": null}, ...]}\n\n'
+    "Rules:\n"
+    "- ids are short stable identifiers you invent (n1, n2, ...). Order them\n"
+    "  so that the entry point is first.\n"
+    "- text is the full label the box contains, verbatim. Preserve capitalisation,\n"
+    "  punctuation, and line breaks (keep '\\n' between lines if the box has "
+    "multiple lines).\n"
+    "- shape is one of: rect (rectangle), diamond (decision), ellipse "
+    "(start/end), parallelogram (input/output). If unsure pick rect.\n"
+    "- edges list every arrow. label is the text on the arrow if any, else null.\n"
+    "- Do NOT include coordinates, sizes, colors, or styles — only the logical\n"
+    "  graph. The renderer computes layout.\n"
+    "- Reply with JSON only."
+)
+
+
+_TRANSLATE_SYSTEM = (
+    "You translate flowchart labels into the target language. You reply with a "
+    "single JSON object and nothing else — no prose, no markdown fences."
+)
+
+_TRANSLATE_USER_TEMPLATE = (
+    "Translate every text field in this flowchart structure into {target_lang_full}. "
+    "Preserve ids, shapes, and the edges array shape. Keep the JSON structure "
+    "byte-identical except for translated strings. Preserve capitalisation style "
+    "and punctuation conventions of the target language.\n\n"
+    "Input:\n{payload}\n\n"
+    "Reply with the translated JSON only."
+)
+
+
+def _extract_json_object(text: str) -> str:
+    clean = text.strip()
+    if clean.startswith("```"):
+        first_newline = clean.find("\n")
+        if first_newline > 0:
+            clean = clean[first_newline + 1 :]
+        if clean.rstrip().endswith("```"):
+            clean = clean.rstrip()[:-3]
+    start = clean.find("{")
+    end = clean.rfind("}")
+    if start < 0 or end <= start:
+        raise ValueError("no JSON object in response")
+    body = clean[start : end + 1]
+    return re.sub(r",\s*([}\]])", r"\1", body)
+
+
+def _parse_structure(text: str) -> FlowchartStructure:
+    body = _extract_json_object(text)
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"structure response was not valid JSON: {exc}") from exc
+    try:
+        return FlowchartStructure(**payload)
+    except ValidationError as exc:
+        logger.warning(
+            "Flowchart structure failed validation",
+            payload_keys=list(payload.keys()) if isinstance(payload, dict) else None,
+        )
+        raise exc
+
+
+async def extract_flowchart_structure(
+    image_bytes: bytes,
+    image_media_type: str = "image/webp",
+    client: anthropic.AsyncAnthropic | None = None,
+) -> FlowchartStructure:
+    """Run Claude Vision to extract the logical graph of a flowchart."""
+    if not image_bytes:
+        raise ValueError("image_bytes must be non-empty")
+
+    if client is None:
+        settings = get_settings()
+        if not settings.anthropic_api_key:
+            raise ValueError("ANTHROPIC_API_KEY is required to extract flowcharts")
+        client = anthropic.AsyncAnthropic(
+            api_key=settings.anthropic_api_key,
+            timeout=90.0,
+        )
+
+    encoded = base64.standard_b64encode(image_bytes).decode("ascii")
+    response = await client.messages.create(
+        model=_EXTRACT_MODEL,
+        max_tokens=_MAX_TOKENS,
+        system=_EXTRACT_SYSTEM,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": image_media_type,
+                            "data": encoded,
+                        },
+                    },
+                    {"type": "text", "text": _EXTRACT_USER},
+                ],
+            }
+        ],
+        temperature=0.0,
+    )
+
+    text = "".join(
+        getattr(block, "text", "") for block in response.content if hasattr(block, "text")
+    )
+    if not text.strip():
+        raise ValueError("empty flowchart-structure response")
+    return _parse_structure(text)
+
+
+async def translate_structure(
+    structure: FlowchartStructure,
+    target_lang: str = "fr",
+    client: anthropic.AsyncAnthropic | None = None,
+) -> FlowchartStructure:
+    """Translate the text fields of a flowchart structure into ``target_lang``."""
+    if target_lang not in {"fr", "en"}:
+        raise ValueError(f"unsupported target_lang: {target_lang!r}")
+
+    if client is None:
+        settings = get_settings()
+        if not settings.anthropic_api_key:
+            raise ValueError("ANTHROPIC_API_KEY is required to translate flowcharts")
+        client = anthropic.AsyncAnthropic(
+            api_key=settings.anthropic_api_key,
+            timeout=60.0,
+        )
+
+    target_full = {"fr": "French", "en": "English"}[target_lang]
+    payload = structure.model_dump_json()
+    response = await client.messages.create(
+        model=_TRANSLATE_MODEL,
+        max_tokens=_MAX_TOKENS,
+        system=_TRANSLATE_SYSTEM,
+        messages=[
+            {
+                "role": "user",
+                "content": _TRANSLATE_USER_TEMPLATE.format(
+                    target_lang_full=target_full, payload=payload
+                ),
+            }
+        ],
+        temperature=0.0,
+    )
+    text = "".join(
+        getattr(block, "text", "") for block in response.content if hasattr(block, "text")
+    )
+    if not text.strip():
+        raise ValueError("empty translate-structure response")
+    translated = _parse_structure(text)
+
+    original_ids = {n.id for n in structure.nodes}
+    translated_ids = {n.id for n in translated.nodes}
+    if original_ids != translated_ids:
+        raise ValueError(
+            "translator changed node ids: "
+            f"added={translated_ids - original_ids}, "
+            f"removed={original_ids - translated_ids}"
+        )
+    return translated
+
+
+# ---------------------------------------------------------------------------
+# SVG rendering — deterministic, no external renderer
+# ---------------------------------------------------------------------------
+
+_NODE_WIDTH = 220
+_NODE_HEIGHT = 70
+_COLUMN_GAP = 40
+_ROW_GAP = 50
+_PADDING = 40
+_FONT_SIZE = 14
+_MAX_CHARS_PER_LINE = 28
+
+
+def _assign_layers(structure: FlowchartStructure) -> dict[str, int]:
+    """Assign every node a non-negative layer via topological BFS.
+
+    Nodes with no incoming edges are layer 0; downstream nodes go one
+    layer deeper via longest-path relaxation. A ``visited`` set guards
+    against cycles: each node is processed at most once, so back-edges
+    in cyclic flowcharts do NOT cause infinite re-queueing. Nodes that
+    sit entirely inside a cycle (unreachable from any source) are
+    seeded via the first node and eventually default to layer 0.
+    """
+    incoming: dict[str, list[str]] = defaultdict(list)
+    outgoing: dict[str, list[str]] = defaultdict(list)
+    ids = {n.id for n in structure.nodes}
+    for e in structure.edges:
+        if e.from_id in ids and e.to_id in ids:
+            incoming[e.to_id].append(e.from_id)
+            outgoing[e.from_id].append(e.to_id)
+
+    layer: dict[str, int] = {}
+    queue: deque[str] = deque()
+    for n in structure.nodes:
+        if not incoming[n.id]:
+            layer[n.id] = 0
+            queue.append(n.id)
+
+    # Fallback: if every node has an incoming edge (cycle at the top),
+    # seed with the first node as layer 0.
+    if not queue and structure.nodes:
+        layer[structure.nodes[0].id] = 0
+        queue.append(structure.nodes[0].id)
+
+    visited: set[str] = set()
+    while queue:
+        current = queue.popleft()
+        if current in visited:
+            continue
+        visited.add(current)
+        for nxt in outgoing[current]:
+            candidate = layer[current] + 1
+            if nxt not in layer:
+                layer[nxt] = candidate
+                queue.append(nxt)
+            elif candidate > layer[nxt] and nxt not in visited:
+                layer[nxt] = candidate
+                queue.append(nxt)
+
+    # Anything still unassigned (isolated in a pure cycle) gets layer 0.
+    for n in structure.nodes:
+        layer.setdefault(n.id, 0)
+
+    return layer
+
+
+def _wrap(text: str, max_chars: int = _MAX_CHARS_PER_LINE) -> list[str]:
+    """Wrap text into lines, respecting explicit ``\\n`` first, then word breaks."""
+    lines: list[str] = []
+    for raw in text.split("\n"):
+        words = raw.split()
+        if not words:
+            lines.append("")
+            continue
+        current = words[0]
+        for word in words[1:]:
+            if len(current) + 1 + len(word) <= max_chars:
+                current = f"{current} {word}"
+            else:
+                lines.append(current)
+                current = word
+        lines.append(current)
+    return lines
+
+
+def _escape(text: str) -> str:
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&#39;")
+    )
+
+
+def _render_shape(node: FlowchartNode, cx: float, cy: float) -> str:
+    half_w = _NODE_WIDTH / 2
+    half_h = _NODE_HEIGHT / 2
+    if node.shape == "ellipse":
+        return (
+            f'<ellipse cx="{cx}" cy="{cy}" rx="{half_w}" ry="{half_h}" '
+            f'fill="#D5E8D4" stroke="#82B366" stroke-width="1.5" />'
+        )
+    if node.shape == "diamond":
+        pts = f"{cx},{cy - half_h} {cx + half_w},{cy} {cx},{cy + half_h} {cx - half_w},{cy}"
+        return f'<polygon points="{pts}" fill="#FFF2CC" stroke="#D6B656" stroke-width="1.5" />'
+    if node.shape == "parallelogram":
+        skew = 18
+        pts = (
+            f"{cx - half_w + skew},{cy - half_h} "
+            f"{cx + half_w},{cy - half_h} "
+            f"{cx + half_w - skew},{cy + half_h} "
+            f"{cx - half_w},{cy + half_h}"
+        )
+        return f'<polygon points="{pts}" fill="#DAE8FC" stroke="#6C8EBF" stroke-width="1.5" />'
+    # default rect
+    return (
+        f'<rect x="{cx - half_w}" y="{cy - half_h}" '
+        f'width="{_NODE_WIDTH}" height="{_NODE_HEIGHT}" rx="6" '
+        f'fill="#F5F5F5" stroke="#666666" stroke-width="1.5" />'
+    )
+
+
+def render_svg(structure: FlowchartStructure) -> bytes:
+    """Render a FlowchartStructure into a self-contained SVG document."""
+    if not structure.nodes:
+        raise ValueError("cannot render empty flowchart")
+
+    layers = _assign_layers(structure)
+    by_layer: dict[int, list[FlowchartNode]] = defaultdict(list)
+    for node in structure.nodes:
+        by_layer[layers[node.id]].append(node)
+
+    max_nodes_per_layer = max(len(v) for v in by_layer.values())
+    width = (
+        _PADDING * 2 + max_nodes_per_layer * _NODE_WIDTH + (max_nodes_per_layer - 1) * _COLUMN_GAP
+    )
+    height = _PADDING * 2 + len(by_layer) * _NODE_HEIGHT + (len(by_layer) - 1) * _ROW_GAP
+
+    positions: dict[str, tuple[float, float]] = {}
+    for layer_idx in sorted(by_layer.keys()):
+        layer_nodes = by_layer[layer_idx]
+        row_width = len(layer_nodes) * _NODE_WIDTH + (len(layer_nodes) - 1) * _COLUMN_GAP
+        start_x = (width - row_width) / 2 + _NODE_WIDTH / 2
+        cy = _PADDING + layer_idx * (_NODE_HEIGHT + _ROW_GAP) + _NODE_HEIGHT / 2
+        for i, node in enumerate(layer_nodes):
+            cx = start_x + i * (_NODE_WIDTH + _COLUMN_GAP)
+            positions[node.id] = (cx, cy)
+
+    svg_parts: list[str] = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" '
+        f'viewBox="0 0 {int(width)} {int(height)}" '
+        f'font-family="Helvetica, Arial, sans-serif" '
+        f'font-size="{_FONT_SIZE}">',
+        "<defs>"
+        '<marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" '
+        'orient="auto" markerUnits="strokeWidth">'
+        '<path d="M0,0 L0,6 L9,3 z" fill="#444" />'
+        "</marker>"
+        "</defs>",
+    ]
+
+    # edges first so nodes overdraw them cleanly
+    for edge in structure.edges:
+        if edge.from_id not in positions or edge.to_id not in positions:
+            continue
+        x1, y1 = positions[edge.from_id]
+        x2, y2 = positions[edge.to_id]
+        # attach to top/bottom of the node boxes rather than the centre
+        y1 += _NODE_HEIGHT / 2 if y2 > y1 else -_NODE_HEIGHT / 2
+        y2 += -_NODE_HEIGHT / 2 if y2 > y1 else _NODE_HEIGHT / 2
+        svg_parts.append(
+            f'<path d="M{x1},{y1} L{x2},{y2}" stroke="#444" stroke-width="1.5" '
+            'fill="none" marker-end="url(#arrow)" />'
+        )
+        if edge.label:
+            lx = (x1 + x2) / 2
+            ly = (y1 + y2) / 2 - 4
+            svg_parts.append(
+                f'<text x="{lx}" y="{ly}" text-anchor="middle" '
+                f'fill="#666" font-size="{_FONT_SIZE - 2}">'
+                f"{_escape(edge.label)}</text>"
+            )
+
+    for node in structure.nodes:
+        cx, cy = positions[node.id]
+        svg_parts.append(_render_shape(node, cx, cy))
+        lines = _wrap(node.text)
+        # vertically centre the block of lines on cy
+        total_h = len(lines) * (_FONT_SIZE + 2)
+        start_y = cy - total_h / 2 + _FONT_SIZE
+        for i, line in enumerate(lines):
+            y = start_y + i * (_FONT_SIZE + 2)
+            svg_parts.append(
+                f'<text x="{cx}" y="{y}" text-anchor="middle" fill="#222">{_escape(line)}</text>'
+            )
+
+    svg_parts.append("</svg>")
+    return "\n".join(svg_parts).encode("utf-8")

--- a/backend/app/ai/translation/svg_rederiver.py
+++ b/backend/app/ai/translation/svg_rederiver.py
@@ -284,10 +284,7 @@ def _assign_layers(structure: FlowchartStructure) -> dict[str, int]:
         visited.add(current)
         for nxt in outgoing[current]:
             candidate = layer[current] + 1
-            if nxt not in layer:
-                layer[nxt] = candidate
-                queue.append(nxt)
-            elif candidate > layer[nxt] and nxt not in visited:
+            if nxt not in layer or (candidate > layer[nxt] and nxt not in visited):
                 layer[nxt] = candidate
                 queue.append(nxt)
 

--- a/backend/app/tasks/image_translation.py
+++ b/backend/app/tasks/image_translation.py
@@ -27,9 +27,16 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
-from app.ai.translation import classify_figure, translate_figure_caption
+from app.ai.translation import (
+    classify_figure,
+    extract_flowchart_structure,
+    render_svg,
+    translate_figure_caption,
+    translate_structure,
+)
 from app.domain.models.source_image import SourceImage
 from app.infrastructure.config.settings import settings
+from app.infrastructure.storage.s3 import S3StorageService
 from app.tasks.celery_app import celery_app
 
 logger = structlog.get_logger(__name__)
@@ -394,3 +401,215 @@ async def _run_kind_backfill_with_factory(
             "classified": classified,
             "failed": failed,
         }
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 slice 3 (#1852) — clean_flowchart SVG re-derivation backfill
+# ---------------------------------------------------------------------------
+
+
+class FlowchartSvgTask(Task):
+    """Celery base for the clean_flowchart SVG re-derivation backfill."""
+
+    def on_success(self, retval, task_id, args, kwargs):
+        logger.info("Flowchart SVG backfill completed", task_id=task_id, result=retval)
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        logger.error("Flowchart SVG backfill failed", task_id=task_id, exception=str(exc))
+
+
+@celery_app.task(
+    bind=True,
+    base=FlowchartSvgTask,
+    time_limit=3600,
+    soft_time_limit=3300,
+    ignore_result=True,
+    acks_late=False,
+)
+def backfill_clean_flowchart_svgs(
+    self,
+    rag_collection_id: str | None = None,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """Re-derive French SVGs for rows with ``figure_kind = 'clean_flowchart'``.
+
+    Eligible: ``figure_kind = 'clean_flowchart' AND storage_key_fr IS NULL AND
+    storage_url IS NOT NULL``. Fetches the English raster from MinIO,
+    extracts structure, translates, renders SVG, uploads, writes back
+    ``storage_key_fr`` + ``storage_url_fr``.
+    """
+    return asyncio.run(
+        _run_svg_backfill(
+            task=self,
+            rag_collection_id=rag_collection_id,
+            limit=limit,
+            dry_run=dry_run,
+        )
+    )
+
+
+async def _run_svg_backfill(
+    task: Task,
+    rag_collection_id: str | None,
+    limit: int | None,
+    dry_run: bool,
+) -> dict:
+    engine = create_async_engine(settings.database_url, pool_pre_ping=True)
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        return await _run_svg_backfill_with_factory(
+            task=task,
+            rag_collection_id=rag_collection_id,
+            limit=limit,
+            dry_run=dry_run,
+            session_factory=session_factory,
+            storage=S3StorageService(),
+        )
+    finally:
+        await engine.dispose()
+
+
+async def _run_svg_backfill_with_factory(
+    task: Task,
+    rag_collection_id: str | None,
+    limit: int | None,
+    dry_run: bool,
+    session_factory: async_sessionmaker[AsyncSession],
+    storage: S3StorageService,
+) -> dict:
+    async with session_factory() as session:
+        stmt = select(SourceImage).where(
+            SourceImage.figure_kind == "clean_flowchart",
+            SourceImage.storage_key_fr.is_(None),
+            SourceImage.storage_url.is_not(None),
+        )
+        if rag_collection_id is not None:
+            stmt = stmt.where(SourceImage.rag_collection_id == rag_collection_id)
+        if limit is not None:
+            stmt = stmt.limit(limit)
+
+        rows = (await session.execute(stmt)).scalars().all()
+        total = len(rows)
+
+        logger.info(
+            "Flowchart SVG backfill: eligible rows",
+            total=total,
+            rag_collection_id=rag_collection_id,
+            dry_run=dry_run,
+        )
+
+        task.update_state(
+            state="REDERIVING",
+            meta={
+                "step": "rederiving",
+                "total": total,
+                "processed": 0,
+                "rendered": 0,
+                "failed": 0,
+            },
+        )
+
+        if dry_run or total == 0:
+            return {
+                "status": "dry_run" if dry_run else "noop",
+                "eligible": total,
+                "rendered": 0,
+                "failed": 0,
+            }
+
+        rendered = 0
+        failed = 0
+        pending_commit = 0
+
+        async with httpx.AsyncClient(timeout=30.0) as http:
+            for idx, img in enumerate(rows):
+                try:
+                    upstream = await http.get(img.storage_url)
+                    upstream.raise_for_status()
+                    image_bytes = upstream.content
+                except Exception as exc:
+                    failed += 1
+                    logger.warning(
+                        "Failed to fetch image bytes for SVG re-derivation",
+                        source_image_id=str(img.id),
+                        storage_url=img.storage_url,
+                        error=str(exc),
+                    )
+                    continue
+
+                try:
+                    structure = await extract_flowchart_structure(image_bytes=image_bytes)
+                    translated = await translate_structure(structure, target_lang="fr")
+                    svg_bytes = render_svg(translated)
+                except Exception as exc:
+                    failed += 1
+                    logger.warning(
+                        "SVG re-derivation failed",
+                        source_image_id=str(img.id),
+                        figure_number=img.figure_number,
+                        error=str(exc),
+                    )
+                    continue
+
+                try:
+                    key = _svg_key_for(img)
+                    url = await storage.upload_bytes(
+                        key=key,
+                        data=svg_bytes,
+                        content_type="image/svg+xml",
+                    )
+                except Exception as exc:
+                    failed += 1
+                    logger.warning(
+                        "Failed to upload FR SVG to storage",
+                        source_image_id=str(img.id),
+                        error=str(exc),
+                    )
+                    continue
+
+                img.storage_key_fr = key
+                img.storage_url_fr = url
+                session.add(img)
+                rendered += 1
+                pending_commit += 1
+
+                if pending_commit >= _COMMIT_EVERY:
+                    await session.commit()
+                    pending_commit = 0
+
+                if (idx + 1) % 10 == 0 or idx + 1 == total:
+                    task.update_state(
+                        state="REDERIVING",
+                        meta={
+                            "step": "rederiving",
+                            "total": total,
+                            "processed": idx + 1,
+                            "rendered": rendered,
+                            "failed": failed,
+                        },
+                    )
+
+        if pending_commit:
+            await session.commit()
+
+        return {
+            "status": "complete",
+            "eligible": total,
+            "rendered": rendered,
+            "failed": failed,
+        }
+
+
+def _svg_key_for(img: SourceImage) -> str:
+    """Compute a deterministic MinIO key for the French-variant SVG of ``img``.
+
+    Mirrors the English-raster key computed at ingest in
+    ``RAGPipeline._process_images`` but with a ``.fr.svg`` suffix so the
+    same object path namespace is preserved and the FR variant is
+    discoverable next to its English original.
+    """
+    figure_label = img.figure_number or str(img.id)
+    safe_label = figure_label.replace(" ", "_").replace(".", "_")
+    prefix = img.rag_collection_id or img.source
+    return f"source-images/{prefix}/{img.page_number}_{safe_label}.fr.svg"

--- a/backend/tests/test_backfill_clean_flowchart_svgs.py
+++ b/backend/tests/test_backfill_clean_flowchart_svgs.py
@@ -1,0 +1,278 @@
+"""Unit tests for ``backfill_clean_flowchart_svgs`` (issue #1852).
+
+Exercises ``_run_svg_backfill_with_factory`` directly with an injected
+session factory, a mocked httpx client, mocked Claude calls (extract +
+translate), and a fake storage to avoid DB/MinIO/network.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.ai.translation.svg_rederiver import (
+    FlowchartEdge,
+    FlowchartNode,
+    FlowchartStructure,
+)
+from app.tasks import image_translation
+
+
+def _make_row(
+    storage_key_fr: str | None = None,
+    figure_kind: str = "clean_flowchart",
+    storage_url: str | None = "https://minio/default.webp",
+) -> MagicMock:
+    row = MagicMock()
+    row.id = uuid.uuid4()
+    row.source = "biology"
+    row.rag_collection_id = "course-1"
+    row.figure_kind = figure_kind
+    row.storage_url = storage_url
+    row.storage_key_fr = storage_key_fr
+    row.storage_url_fr = None
+    row.figure_number = "1.1"
+    row.page_number = 1
+    return row
+
+
+class _FakeSession:
+    def __init__(self, rows):
+        self._rows = rows
+        self.added: list[MagicMock] = []
+        self.commits = 0
+
+    async def execute(self, stmt):
+        result = MagicMock()
+        scalars = MagicMock()
+        scalars.all = MagicMock(return_value=list(self._rows))
+        result.scalars = MagicMock(return_value=scalars)
+        return result
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def commit(self):
+        self.commits += 1
+
+
+class _FakeSessionFactory:
+    def __init__(self, session: _FakeSession):
+        self._session = session
+
+    def __call__(self):
+        session = self._session
+
+        class _Ctx:
+            async def __aenter__(self):
+                return session
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        return _Ctx()
+
+
+class _FakeStorage:
+    def __init__(self):
+        self.uploads: list[tuple[str, bytes, str]] = []
+
+    async def upload_bytes(self, key: str, data: bytes, content_type: str) -> str:
+        self.uploads.append((key, data, content_type))
+        return f"https://minio/{key}"
+
+
+def _patch_httpx(response_bytes: bytes = b"fake-webp"):
+    upstream = MagicMock()
+    upstream.content = response_bytes
+    upstream.raise_for_status = MagicMock()
+
+    http_client = MagicMock()
+    http_client.get = AsyncMock(return_value=upstream)
+
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=http_client)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+
+    return patch.object(image_translation.httpx, "AsyncClient", return_value=ctx)
+
+
+def _sample_structure() -> FlowchartStructure:
+    return FlowchartStructure(
+        nodes=[
+            FlowchartNode(id="n1", text="Make an observation"),
+            FlowchartNode(id="n2", text="Ask a question"),
+        ],
+        edges=[FlowchartEdge(from_id="n1", to_id="n2")],
+    )
+
+
+class TestRunSvgBackfillWithFactory:
+    async def test_dry_run_counts_without_calling_claude(self):
+        rows = [_make_row(), _make_row()]
+        session = _FakeSession(rows)
+        task = MagicMock()
+        storage = _FakeStorage()
+
+        extract = AsyncMock(return_value=_sample_structure())
+        translate = AsyncMock(return_value=_sample_structure())
+
+        with (
+            _patch_httpx(),
+            patch.object(image_translation, "extract_flowchart_structure", new=extract),
+            patch.object(image_translation, "translate_structure", new=translate),
+        ):
+            result = await image_translation._run_svg_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=True,
+                session_factory=_FakeSessionFactory(session),
+                storage=storage,
+            )
+
+        assert result == {
+            "status": "dry_run",
+            "eligible": 2,
+            "rendered": 0,
+            "failed": 0,
+        }
+        extract.assert_not_awaited()
+        translate.assert_not_awaited()
+        assert storage.uploads == []
+        assert session.commits == 0
+
+    async def test_renders_and_uploads_all_eligible_rows(self):
+        rows = [_make_row(), _make_row()]
+        session = _FakeSession(rows)
+        task = MagicMock()
+        storage = _FakeStorage()
+
+        extract = AsyncMock(return_value=_sample_structure())
+        translate = AsyncMock(return_value=_sample_structure())
+
+        with (
+            _patch_httpx(),
+            patch.object(image_translation, "extract_flowchart_structure", new=extract),
+            patch.object(image_translation, "translate_structure", new=translate),
+        ):
+            result = await image_translation._run_svg_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=False,
+                session_factory=_FakeSessionFactory(session),
+                storage=storage,
+            )
+
+        assert result["status"] == "complete"
+        assert result["rendered"] == 2
+        assert result["failed"] == 0
+        assert len(storage.uploads) == 2
+        for key, data, content_type in storage.uploads:
+            assert key.endswith(".fr.svg")
+            assert content_type == "image/svg+xml"
+            assert data.startswith(b"<svg")
+        for row in rows:
+            assert row.storage_key_fr.endswith(".fr.svg")
+            assert row.storage_url_fr.startswith("https://minio/")
+
+    async def test_extract_failure_does_not_abort_batch(self):
+        rows = [_make_row(), _make_row(), _make_row()]
+        session = _FakeSession(rows)
+        task = MagicMock()
+        storage = _FakeStorage()
+
+        extract = AsyncMock(
+            side_effect=[
+                _sample_structure(),
+                ValueError("vision timed out"),
+                _sample_structure(),
+            ]
+        )
+        translate = AsyncMock(return_value=_sample_structure())
+
+        with (
+            _patch_httpx(),
+            patch.object(image_translation, "extract_flowchart_structure", new=extract),
+            patch.object(image_translation, "translate_structure", new=translate),
+        ):
+            result = await image_translation._run_svg_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=False,
+                session_factory=_FakeSessionFactory(session),
+                storage=storage,
+            )
+
+        assert result["rendered"] == 2
+        assert result["failed"] == 1
+        assert len(storage.uploads) == 2
+        assert rows[0].storage_key_fr is not None
+        assert rows[1].storage_key_fr is None
+        assert rows[2].storage_key_fr is not None
+
+    async def test_upload_failure_does_not_abort_batch(self):
+        rows = [_make_row(), _make_row()]
+        session = _FakeSession(rows)
+        task = MagicMock()
+
+        class _FailingStorage:
+            def __init__(self):
+                self.calls = 0
+
+            async def upload_bytes(self, key, data, content_type):
+                self.calls += 1
+                if self.calls == 1:
+                    raise RuntimeError("minio down")
+                return f"https://minio/{key}"
+
+        storage = _FailingStorage()
+
+        extract = AsyncMock(return_value=_sample_structure())
+        translate = AsyncMock(return_value=_sample_structure())
+
+        with (
+            _patch_httpx(),
+            patch.object(image_translation, "extract_flowchart_structure", new=extract),
+            patch.object(image_translation, "translate_structure", new=translate),
+        ):
+            result = await image_translation._run_svg_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=False,
+                session_factory=_FakeSessionFactory(session),
+                storage=storage,
+            )
+
+        assert result["rendered"] == 1
+        assert result["failed"] == 1
+
+    async def test_empty_eligible_set_returns_noop(self):
+        session = _FakeSession([])
+        task = MagicMock()
+        storage = _FakeStorage()
+
+        extract = AsyncMock(return_value=_sample_structure())
+        translate = AsyncMock(return_value=_sample_structure())
+
+        with (
+            _patch_httpx(),
+            patch.object(image_translation, "extract_flowchart_structure", new=extract),
+            patch.object(image_translation, "translate_structure", new=translate),
+        ):
+            result = await image_translation._run_svg_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=False,
+                session_factory=_FakeSessionFactory(session),
+                storage=storage,
+            )
+
+        assert result["status"] == "noop"
+        assert result["eligible"] == 0
+        extract.assert_not_awaited()
+        translate.assert_not_awaited()

--- a/backend/tests/test_svg_rederiver.py
+++ b/backend/tests/test_svg_rederiver.py
@@ -1,0 +1,295 @@
+"""Unit tests for the flowchart SVG re-deriver (issue #1852)."""
+
+from __future__ import annotations
+
+import json
+import xml.etree.ElementTree as ET
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from app.ai.translation.svg_rederiver import (
+    FlowchartEdge,
+    FlowchartNode,
+    FlowchartStructure,
+    _assign_layers,
+    _escape,
+    _wrap,
+    extract_flowchart_structure,
+    render_svg,
+    translate_structure,
+)
+
+
+def _mock_anthropic_response(text: str) -> MagicMock:
+    msg = MagicMock()
+    msg.content = [SimpleNamespace(text=text)]
+    return msg
+
+
+def _mock_client(text: str) -> MagicMock:
+    client = MagicMock()
+    client.messages = MagicMock()
+    client.messages.create = AsyncMock(return_value=_mock_anthropic_response(text))
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Parsing / layout helpers
+# ---------------------------------------------------------------------------
+
+
+class TestWrap:
+    def test_short_text_single_line(self):
+        assert _wrap("Hello") == ["Hello"]
+
+    def test_wraps_on_spaces(self):
+        lines = _wrap("This is a rather long sentence that should wrap", max_chars=12)
+        assert all(len(line) <= 12 for line in lines)
+        assert " ".join(lines) == "This is a rather long sentence that should wrap"
+
+    def test_explicit_newlines_preserved(self):
+        assert _wrap("line1\nline2") == ["line1", "line2"]
+
+
+class TestEscape:
+    def test_escapes_xml_metachars(self):
+        assert _escape("A & <B> \"quote'") == "A &amp; &lt;B&gt; &quot;quote&#39;"
+
+
+class TestAssignLayers:
+    def test_linear_chain_produces_sequential_layers(self):
+        structure = FlowchartStructure(
+            nodes=[
+                FlowchartNode(id="a", text="A"),
+                FlowchartNode(id="b", text="B"),
+                FlowchartNode(id="c", text="C"),
+            ],
+            edges=[
+                FlowchartEdge(from_id="a", to_id="b"),
+                FlowchartEdge(from_id="b", to_id="c"),
+            ],
+        )
+        layers = _assign_layers(structure)
+        assert layers == {"a": 0, "b": 1, "c": 2}
+
+    def test_branching_same_layer(self):
+        structure = FlowchartStructure(
+            nodes=[
+                FlowchartNode(id="root", text="root"),
+                FlowchartNode(id="left", text="left"),
+                FlowchartNode(id="right", text="right"),
+            ],
+            edges=[
+                FlowchartEdge(from_id="root", to_id="left"),
+                FlowchartEdge(from_id="root", to_id="right"),
+            ],
+        )
+        layers = _assign_layers(structure)
+        assert layers["root"] == 0
+        assert layers["left"] == 1
+        assert layers["right"] == 1
+
+    def test_cycle_does_not_loop_forever(self):
+        structure = FlowchartStructure(
+            nodes=[
+                FlowchartNode(id="a", text="A"),
+                FlowchartNode(id="b", text="B"),
+            ],
+            edges=[
+                FlowchartEdge(from_id="a", to_id="b"),
+                FlowchartEdge(from_id="b", to_id="a"),
+            ],
+        )
+        layers = _assign_layers(structure)
+        assert set(layers.keys()) == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# Structure extraction (Claude Vision mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFlowchartStructure:
+    async def test_happy_path_parses_structure(self):
+        payload = {
+            "nodes": [
+                {"id": "n1", "text": "Make an observation", "shape": "rect"},
+                {"id": "n2", "text": "Ask a question", "shape": "rect"},
+            ],
+            "edges": [{"from_id": "n1", "to_id": "n2"}],
+        }
+        client = _mock_client(json.dumps(payload))
+        result = await extract_flowchart_structure(b"fake-webp", client=client)
+        assert isinstance(result, FlowchartStructure)
+        assert result.nodes[0].text == "Make an observation"
+        assert result.edges[0].from_id == "n1"
+        assert result.edges[0].label is None
+
+    async def test_strips_markdown_fences(self):
+        payload = {
+            "nodes": [{"id": "n1", "text": "Start"}],
+            "edges": [],
+        }
+        fenced = f"```json\n{json.dumps(payload)}\n```"
+        client = _mock_client(fenced)
+        result = await extract_flowchart_structure(b"fake-webp", client=client)
+        assert result.nodes[0].text == "Start"
+
+    async def test_empty_bytes_rejected(self):
+        client = _mock_client("{}")
+        with pytest.raises(ValueError, match="non-empty"):
+            await extract_flowchart_structure(b"", client=client)
+        client.messages.create.assert_not_awaited()
+
+    async def test_invalid_json_raises(self):
+        client = _mock_client("not json")
+        with pytest.raises(ValueError):
+            await extract_flowchart_structure(b"fake-webp", client=client)
+
+    async def test_missing_nodes_fails_validation(self):
+        client = _mock_client(json.dumps({"edges": []}))
+        with pytest.raises(ValidationError):
+            await extract_flowchart_structure(b"fake-webp", client=client)
+
+    async def test_empty_nodes_list_rejected(self):
+        # nodes must be min_length=1 per the schema — reply missing content
+        client = _mock_client(json.dumps({"nodes": [], "edges": []}))
+        with pytest.raises(ValidationError):
+            await extract_flowchart_structure(b"fake-webp", client=client)
+
+
+# ---------------------------------------------------------------------------
+# Translation
+# ---------------------------------------------------------------------------
+
+
+class TestTranslateStructure:
+    async def test_preserves_ids_and_structure(self):
+        source = FlowchartStructure(
+            nodes=[
+                FlowchartNode(id="n1", text="Make an observation"),
+                FlowchartNode(id="n2", text="Ask a question"),
+            ],
+            edges=[FlowchartEdge(from_id="n1", to_id="n2")],
+        )
+        translated_payload = {
+            "nodes": [
+                {"id": "n1", "text": "Faire une observation", "shape": "rect"},
+                {"id": "n2", "text": "Poser une question", "shape": "rect"},
+            ],
+            "edges": [{"from_id": "n1", "to_id": "n2"}],
+        }
+        client = _mock_client(json.dumps(translated_payload))
+        out = await translate_structure(source, target_lang="fr", client=client)
+        assert [n.id for n in out.nodes] == ["n1", "n2"]
+        assert out.nodes[0].text == "Faire une observation"
+
+    async def test_rejects_unsupported_target_lang(self):
+        source = FlowchartStructure(nodes=[FlowchartNode(id="n1", text="x")])
+        with pytest.raises(ValueError, match="unsupported target_lang"):
+            await translate_structure(source, target_lang="de")
+
+    async def test_raises_when_translator_changes_ids(self):
+        source = FlowchartStructure(
+            nodes=[FlowchartNode(id="n1", text="Start")],
+            edges=[],
+        )
+        rogue_payload = {
+            "nodes": [{"id": "node_1", "text": "Démarrer", "shape": "rect"}],
+            "edges": [],
+        }
+        client = _mock_client(json.dumps(rogue_payload))
+        with pytest.raises(ValueError, match="changed node ids"):
+            await translate_structure(source, target_lang="fr", client=client)
+
+
+# ---------------------------------------------------------------------------
+# SVG rendering
+# ---------------------------------------------------------------------------
+
+
+class TestRenderSvg:
+    def _parse(self, svg_bytes: bytes) -> ET.Element:
+        # Strips default namespace so findall is simpler
+        text = svg_bytes.decode("utf-8").replace(' xmlns="http://www.w3.org/2000/svg"', "")
+        return ET.fromstring(text)
+
+    def test_basic_flowchart_renders_valid_xml(self):
+        structure = FlowchartStructure(
+            nodes=[
+                FlowchartNode(id="n1", text="Make an observation"),
+                FlowchartNode(id="n2", text="Ask a question"),
+            ],
+            edges=[FlowchartEdge(from_id="n1", to_id="n2")],
+        )
+        svg = render_svg(structure)
+        root = self._parse(svg)
+        assert root.tag == "svg"
+        rects = root.findall(".//rect")
+        assert len(rects) == 2
+        paths = root.findall(".//path")
+        # one arrow marker defs path + one edge path
+        assert len(paths) >= 2
+        texts = {t.text for t in root.findall(".//text") if t.text}
+        assert any("Make" in t for t in texts)
+        assert any("Ask" in t for t in texts)
+
+    def test_all_shapes_supported(self):
+        structure = FlowchartStructure(
+            nodes=[
+                FlowchartNode(id="r", text="rect", shape="rect"),
+                FlowchartNode(id="d", text="diamond", shape="diamond"),
+                FlowchartNode(id="e", text="ellipse", shape="ellipse"),
+                FlowchartNode(id="p", text="par", shape="parallelogram"),
+            ],
+            edges=[],
+        )
+        svg = render_svg(structure)
+        root = self._parse(svg)
+        assert root.findall(".//rect")
+        assert root.findall(".//ellipse")
+        # polygon used for both diamond and parallelogram
+        assert len(root.findall(".//polygon")) == 2
+
+    def test_xml_special_chars_escaped(self):
+        structure = FlowchartStructure(
+            nodes=[FlowchartNode(id="n1", text='A & <B> "quote"')],
+            edges=[],
+        )
+        svg = render_svg(structure)
+        # must parse as valid XML
+        root = self._parse(svg)
+        texts = [t.text for t in root.findall(".//text") if t.text]
+        assert any("A &" in t or "A &amp" in t for t in texts) or any("A & <B>" in t for t in texts)
+
+    def test_edge_labels_rendered(self):
+        structure = FlowchartStructure(
+            nodes=[
+                FlowchartNode(id="a", text="A"),
+                FlowchartNode(id="b", text="B"),
+            ],
+            edges=[FlowchartEdge(from_id="a", to_id="b", label="Yes")],
+        )
+        svg = render_svg(structure)
+        root = self._parse(svg)
+        texts = {t.text for t in root.findall(".//text") if t.text}
+        assert "Yes" in texts
+
+    def test_empty_flowchart_raises(self):
+        # Can't create via Pydantic (min_length=1), so test the renderer
+        # directly with a pre-built object
+        empty = FlowchartStructure.model_construct(nodes=[], edges=[])
+        with pytest.raises(ValueError):
+            render_svg(empty)
+
+    def test_output_is_bytes(self):
+        structure = FlowchartStructure(
+            nodes=[FlowchartNode(id="n1", text="Start")],
+            edges=[],
+        )
+        svg = render_svg(structure)
+        assert isinstance(svg, bytes)
+        assert svg.startswith(b"<svg")


### PR DESCRIPTION
Fixes #1852. Third slice of epic #1819 / Phase 2 — **first slice with visible UI change**. Builds on #1834 (plumbing) and #1844 (classifier).

## What users will see

French learners opening a lesson that contains a `clean_flowchart` figure now see the diagram with all labels translated — boxes, arrows, decision diamonds — not just the caption below the image. English learners see the original raster unchanged.

## Summary

Per clean_flowchart figure at ingest (and via a backfill task for existing rows):

1. `extract_flowchart_structure` — Claude Vision → logical graph (no pixel coordinates). Pydantic-validated.
2. `translate_structure` — Claude Haiku translates every text field; preserves ids/shapes; raises if the translator drops or invents ids.
3. `render_svg` — pure-Python SVG emission with a top-down DAG layout. Rect / diamond / ellipse / parallelogram shapes. Cycle-safe via `visited`-set in `_assign_layers`.
4. Upload to MinIO as `*.fr.svg`, store `storage_key_fr` + `storage_url_fr`.
5. Slice 1's `/data?lang=fr` endpoint serves it automatically — no new endpoint, no frontend change.

Any stage failing leaves the FR variant NULL; the endpoint's fallback then serves the original English raster, so **zero regression**.

## Layout trade-off

Rebuild, not pixel-copy. Claude Vision can't reliably return PDF coordinates; a clean DAG layout beats a visually-mangled approximation. Acceptable for slice 3; later slices can refine per figure kind.

## Test plan

- [x] `uv run ruff check && uv run ruff format --check` — clean on touched files
- [x] `uv run pytest` (slice 1-3 suites) — **105 pass**, 27 new for this slice
- [x] `_assign_layers` cycle test — **terminates** (this was the real reason pytest was hanging in the first pass; fixed with a visited-set guard)
- [x] SVG output parses as valid XML across all shapes; edge labels render; metachars escaped
- [ ] Staging after deploy:
  - [ ] Dry-run `backfill_clean_flowchart_svgs` to see how many flowcharts exist
  - [ ] Real bounded run on 10 rows; manually inspect the resulting `.fr.svg` in a browser
  - [ ] Load a `/fr/...` lesson that contains a flowchart — confirm the French SVG renders
  - [ ] `/en/...` unchanged (raster)
  - [ ] Flip `storage_key_fr` to NULL on one test row and confirm the `/fr/...` path gracefully falls back to the English raster

## Out of scope (later slices)

- Slice 4: `chart` kind — needs a different Vision prompt and a chart-specific renderer.
- Slice 5: `complex_diagram` — raster + numbered-badge overlay.
- Slice 6: `photo_with_callouts` overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)