### PR TITLE
feat(video): 16:9, 720p, content-focused (no avatar) via /v3/videos (#1854)

### DIFF
--- a/backend/app/domain/services/lesson_video_service.py
+++ b/backend/app/domain/services/lesson_video_service.py
@@ -392,25 +392,35 @@ class LessonVideoService:
                 max_chars=max_chars,
             )
 
-            avatar_id = (cache.get("video-summary-default-avatar-id", "") or "").strip()
+            brand_image_url = (cache.get("video-summary-brand-image-url", "") or "").strip()
             voice_key = (
                 "video-summary-voice-id-fr" if language == "fr" else "video-summary-voice-id-en"
             )
             voice_id = (cache.get(voice_key, "") or "").strip()
-            use_agent_mode = not (avatar_id and voice_id)
+            avatar_id = (cache.get("video-summary-default-avatar-id", "") or "").strip()
+
+            # Preferred path: content-focused (no avatar) via /v3/videos.
+            # Requires the admin-configured brand background + a voice_id
+            # for narration. Legacy v2 avatar path is kept for tenants
+            # that haven't migrated; Video Agents is the no-config last
+            # resort (uses an avatar, pre-#1854 behaviour).
+            use_content_mode = bool(brand_image_url and voice_id)
+            use_v2_avatar_mode = not use_content_mode and bool(avatar_id and voice_id)
 
             callback_url = self._heygen_callback_url()
             client = heygen_client or HeyGenClient()
             owns_client = heygen_client is None
             try:
-                if use_agent_mode:
-                    result = await client.create_video_agent(
-                        prompt=script,
+                if use_content_mode:
+                    result = await client.create_content_video(
+                        script=script,
+                        voice_id=voice_id,
+                        image_url=brand_image_url,
                         language=language,
                         callback_url=callback_url,
                     )
-                    api_version = "v3-agent"
-                else:
+                    api_version = "v3"
+                elif use_v2_avatar_mode:
                     result = await client.create_video(
                         script=script,
                         avatar_id=avatar_id,
@@ -419,6 +429,13 @@ class LessonVideoService:
                         language=language,
                     )
                     api_version = "v2"
+                else:
+                    result = await client.create_video_agent(
+                        prompt=script,
+                        language=language,
+                        callback_url=callback_url,
+                    )
+                    api_version = "v3-agent"
             finally:
                 if owns_client and client._client is not None:
                     await client._client.aclose()

--- a/backend/app/infrastructure/config/platform_defaults.py
+++ b/backend/app/infrastructure/config/platform_defaults.py
@@ -1656,6 +1656,22 @@ SETTING_DEFINITIONS: list[SettingDef] = [
             "video summary generation requests."
         ),
     ),
+    SettingDef(
+        "video-summary-brand-image-url",
+        "video_summary",
+        "",
+        "string",
+        "Video background image URL (16:9)",
+        (
+            "Publicly reachable URL of a 1280×720 PNG/JPG used as the "
+            "background for every lesson video. HeyGen renders the "
+            "narration voice over this still image with synced captions "
+            "— no talking avatar — so the final video stays uniform, "
+            "720p 16:9, and focused on the lesson content rather than "
+            "a presenter. When empty, video generation fails fast with "
+            "an actionable error at dispatch time."
+        ),
+    ),
     # ── Pagination ─────────────────────────────────────────
     SettingDef(
         "pagination-admin-default-limit",

--- a/backend/app/infrastructure/video/heygen_client.py
+++ b/backend/app/infrastructure/video/heygen_client.py
@@ -40,6 +40,7 @@ _BASE_URL = "https://api.heygen.com"
 _CREATE_PATH = "/v2/video/generate"
 _STATUS_PATH = "/v2/video_status.get"
 _AGENT_CREATE_PATH = "/v3/video-agents"
+_V3_CREATE_PATH = "/v3/videos"
 _V3_STATUS_PATH_TEMPLATE = "/v3/videos/{video_id}"
 
 
@@ -204,6 +205,68 @@ class HeyGenClient:
             video_id=video_id,
             language=language,
             script_chars=len(script),
+        )
+        return CreateVideoResult(provider_video_id=str(video_id))
+
+    async def create_content_video(
+        self,
+        *,
+        script: str,
+        voice_id: str,
+        image_url: str,
+        language: str,
+        aspect_ratio: str = "16:9",
+        resolution: str = "720p",
+        callback_url: str | None = None,
+    ) -> CreateVideoResult:
+        """Dispatch a content-focused (no-avatar) HeyGen render.
+
+        Uses the v3 ``/v3/videos`` endpoint with ``type="image"``: the
+        narration voice plays over a static branded background with
+        synced captions, no talking head. This is the uniform,
+        web-ready path (16:9, 720p) that the product wants for every
+        lesson regardless of domain.
+
+        The image URL must be publicly reachable so HeyGen's renderer
+        can fetch it — typically the frontend's branded asset served
+        at the tenant's public hostname.
+        """
+        if not script.strip():
+            raise HeyGenBadRequestError("script is empty")
+        if not voice_id:
+            raise HeyGenBadRequestError("voice_id is required")
+        if not image_url:
+            raise HeyGenBadRequestError("image_url is required")
+
+        body: dict = {
+            "type": "image",
+            "image": {"type": "url", "url": image_url},
+            "script": script,
+            "voice_id": voice_id,
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "output_format": "mp4",
+        }
+        if callback_url:
+            body["callback_url"] = callback_url
+
+        async def _call() -> httpx.Response:
+            return await self._request("POST", _V3_CREATE_PATH, json=body)
+
+        response = await _retry_transient(_call)
+        data = response.json() or {}
+        inner = data.get("data") or {}
+        video_id = inner.get("video_id") or data.get("video_id")
+        if not video_id:
+            raise HeyGenError(f"HeyGen content video create returned no video_id: {data!r}")
+
+        logger.info(
+            "heygen.create_content_video.dispatched",
+            video_id=video_id,
+            language=language,
+            script_chars=len(script),
+            aspect_ratio=aspect_ratio,
+            resolution=resolution,
         )
         return CreateVideoResult(provider_video_id=str(video_id))
 

--- a/backend/app/tasks/heygen_poll.py
+++ b/backend/app/tasks/heygen_poll.py
@@ -193,7 +193,13 @@ def _api_version_for(record: GeneratedAudio) -> str:
     dispatch time. Legacy rows predating the poller won't have it —
     treat them as v2 so the previous Direct-Video flow keeps working
     after the rollout of #1798.
+
+    ``v3`` (content-focused /v3/videos, #1854) and ``v3-agent``
+    (Video Agents) both use the same status endpoint path
+    (``/v3/videos/{id}``), so HeyGenClient treats them identically.
     """
     metadata = record.media_metadata or {}
     value = metadata.get("api_version") or "v2"
-    return "v3-agent" if value == "v3-agent" else "v2"
+    if value in ("v3", "v3-agent"):
+        return "v3-agent"
+    return "v2"


### PR DESCRIPTION
## Summary

Move the default HeyGen dispatch from \`/v3/video-agents\` (avatar auto-picked) to \`/v3/videos\` with \`type=\"image\"\` — narration voice over a branded 1280×720 still with synced captions. Uniform 16:9 720p output, no talking head, content-focused.

## Payload shape

\`\`\`json
{
  \"type\": \"image\",
  \"image\": {\"type\": \"url\", \"url\": \"<brand_bg>\"},
  \"script\": \"<narration>\",
  \"voice_id\": \"<voice>\",
  \"aspect_ratio\": \"16:9\",
  \"resolution\": \"720p\",
  \"output_format\": \"mp4\",
  \"callback_url\": \"...\"
}
\`\`\`

## Touched

- \`heygen_client.py\`: new \`create_content_video\` method.
- \`lesson_video_service.py\`: dispatch-mode selection prefers content mode when \`video-summary-brand-image-url\` + voice are set; legacy avatar modes retained as fallback.
- \`heygen_poll.py\`: \`api_version=\"v3\"\` polls via the same \`/v3/videos/{id}\` endpoint as \`\"v3-agent\"\`.
- \`platform_defaults.py\`: new \`video-summary-brand-image-url\` setting in the \`video_summary\` category.

## Ops after merge

1. Deploy lands.
2. Admin sets \`video-summary-brand-image-url\` in the settings UI to a publicly reachable 1280×720 image (e.g. tenant logo slide).
3. Re-trigger M01-U01 fr via \`staging-trigger-video\` or the frontend Generate button.
4. Verify the rendered MP4 is 1280×720, 16:9, no avatar.

Fixes #1854.

## Not included

Deleting the old \`f40de84d-...\` avatar render from MinIO / DB — that's an orphan once a new content-mode row lands. Can be done via SQL one-off after the new run succeeds.