### PR TITLE
fix(figures): bypass Next optimizer for source_image figures

### DIFF
--- a/frontend/components/learning/source-image.tsx
+++ b/frontend/components/learning/source-image.tsx
@@ -48,14 +48,18 @@ export function SourceImage({
           <Image
             src={imageUrl}
             alt={altText}
-            // Upstream WebP dimensions vary per figure; 1024×768 is the ceiling
-            // for the source library. Next uses this to compute the srcset
-            // ladder (deviceSizes in next.config.ts); CSS (w-full h-auto)
-            // lets the browser size it against the 768px max-width container.
+            // Bypass Next's image optimizer: upstream widths are arbitrary
+            // (SVG re-derives, scanned PDF crops, etc.), so Next can't build
+            // a safe srcset from deviceSizes — 1024 isn't in the ladder and
+            // /_next/image returns 400, leaving the tile blank. The backend
+            // /data endpoint already serves immutable webp/svg with a
+            // year-long Cache-Control. Mirrors the fix in lesson-image.tsx
+            // from #1616 and #1857.
             width={1024}
             height={768}
             sizes="(max-width: 768px) 100vw, 768px"
             loading="lazy"
+            unoptimized
             className={`w-full h-auto object-contain rounded-lg transition-opacity duration-300 ${
               isVisible ? 'opacity-100' : 'opacity-0'
             }`}
@@ -99,6 +103,7 @@ export function SourceImage({
             width={1920}
             height={1080}
             sizes="100vw"
+            unoptimized
             className="max-w-full max-h-[80vh] w-auto h-auto object-contain rounded-lg"
             onClick={(e) => e.stopPropagation()}
             priority


### PR DESCRIPTION
Fixes #1857. Hotfix unblocking visual verification of #1853 (slice 3 SVG re-derivation).

## Symptom

Every lesson figure rendered as an empty white tile with only the caption below. The scientific-method figure on `/fr/modules/.../lessons/M01-U01` visibly reproduces it.

## Root cause

The backend `/data` endpoint serves the WebP fine (HTTP 200, ~138 KB). Next.js's image optimizer at `/_next/image?url=ENCODED&w=1024&q=75` returns:

```
HTTP 400 — "w" parameter (width) of 1024 is not allowed
```

`<SourceImage>` uses `<Image width={1024} height={768}>`, but 1024 is not in `deviceSizes` / `imageSizes` in `next.config.ts`. Next rejects the fallback width, `onLoad` never fires, `isVisible` stays `false`, tile sits at `opacity-0` → blank.

## Fix

Add `unoptimized` on both `<Image>` instances (inline figure + fullscreen modal). The backend already serves immutable WebP/SVG with a year-long `Cache-Control`; the optimizer adds nothing and caused the 400.

Mirrors the exact same fix `lesson-image.tsx` received in #1616 (`f4318829`) — that PR fixed the lesson hero image; this one fixes the inline figures within lesson prose.

## Test plan

- [x] Reproduced the 400 directly: `curl -i '.../_next/image?url=...&w=1024&q=75'` returns 400 with the quoted error.
- [x] Traced the failure through DevTools (Playwright): 1 console error on the malformed Next-image URL; the direct backend URL serves the WebP correctly.
- [ ] After deploy: reload a `/fr/...` lesson with a figure — tile now shows the image. Same for `/en/...`. Fullscreen modal opens with the image.
- [ ] Staging visual spot-check of the 5 `.fr.svg` files from slice-3 backfill via the `/fr/...` view.

No backend change. No schema change. Existing tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)