### PR TITLE
feat(video): default brand-image-url to staging asset

### DIFF
--- a/backend/app/infrastructure/config/platform_defaults.py
+++ b/backend/app/infrastructure/config/platform_defaults.py
@@ -1672,7 +1672,7 @@ SETTING_DEFINITIONS: list[SettingDef] = [
     SettingDef(
         "video-summary-brand-image-url",
         "video_summary",
-        "",
+        "https://etutor.elearning.portfolio2.kimbetien.com/images/video-summary-background.png",
         "string",
         "Video background image URL (16:9)",
         (


### PR DESCRIPTION
Non-empty default so content-video mode triggers. Other tenants override via admin settings.