### PR TITLE
fix(video): revert brand_image_url default (no-regression)

### DIFF
--- a/backend/app/infrastructure/config/platform_defaults.py
+++ b/backend/app/infrastructure/config/platform_defaults.py
@@ -1672,7 +1672,7 @@ SETTING_DEFINITIONS: list[SettingDef] = [
     SettingDef(
         "video-summary-brand-image-url",
         "video_summary",
-        "https://etutor.elearning.portfolio2.kimbetien.com/images/video-summary-background.png",
+        "",
         "string",
         "Video background image URL (16:9)",
         (


### PR DESCRIPTION
Content-mode via /v3/videos type=image is HeyGen photo-avatar mode — rejects non-face backgrounds. Revert the default so v3-agent (known working) kicks in. Follow-up: pick a stock avatar to switch to v2 Direct Video for consistent output.