### PR TITLE
feat(video): consistent v2 path defaults — Judy Teacher + Sylvie (#1873)

### DIFF
--- a/backend/app/infrastructure/config/platform_defaults.py
+++ b/backend/app/infrastructure/config/platform_defaults.py
@@ -1624,26 +1624,34 @@ SETTING_DEFINITIONS: list[SettingDef] = [
     SettingDef(
         "video-summary-default-avatar-id",
         "video_summary",
-        "",
+        "Judy_Teacher_Standing_public",
         "string",
         "Default HeyGen avatar ID",
         (
-            "HeyGen stock avatar_id used for all generations until "
-            "per-domain overrides land. Operator sets this per environment."
+            "HeyGen stock avatar_id used for every lesson video. "
+            "Default is ``Judy_Teacher_Standing_public`` — an explicit "
+            "teacher avatar (standing, upper body, neutral background) "
+            "paired with female voice defaults so avatar and voice "
+            "gender match. When both this and the language voice_id "
+            "are set, the service uses the v2 Direct Video path for "
+            "consistent, non-random output (vs the v3 Agents fallback "
+            "which HeyGen auto-picks an avatar each time). Admins "
+            "override per tenant via the settings UI."
         ),
     ),
     SettingDef(
         "video-summary-voice-id-fr",
         "video_summary",
-        "90bab79483c242d7b4487e5708db6744",
+        "64cc0b129ac34e04a521cb4627126923",
         "string",
         "HeyGen voice ID — French",
         (
             "HeyGen voice_id used when language=fr. Default is "
-            "``Pierre Narrateur`` — an explicitly narrator-trained male "
-            "French voice that suits lesson-summary delivery. Override "
-            "via HeyGen's voice library if a tenant wants a different "
-            "tone (Sylvie - Professional, Yves - Newscaster, etc.)."
+            "``Sylvie - Professional`` — a professional female French "
+            "voice. Chosen to gender-match the default avatar "
+            "(``Judy_Teacher_Standing_public``). Override via HeyGen's "
+            "voice library if a tenant wants a different tone "
+            "(Pierre Narrateur male, Yves Newscaster, etc.)."
         ),
     ),
     SettingDef(


### PR DESCRIPTION
## Summary

Sets HeyGen default-avatar-id to \`Judy_Teacher_Standing_public\` (only explicit teacher avatar in HeyGen's catalog of 1281) and flips FR voice to \`Sylvie Professional\` (female) so avatar+voice gender match.

With all three defaults (avatar, voice-fr, voice-en) now non-empty, the service's selection logic takes the **v2 Direct Video** path (stable, repeatable, avatar is always Judy) instead of v3-agent (random avatar per render).

## Changes

- \`video-summary-default-avatar-id\` default: \"\" → \`Judy_Teacher_Standing_public\`
- \`video-summary-voice-id-fr\` default: Pierre Narrateur (male) → Sylvie Professional (female) to match Judy
- Help text updated with alternatives

## No regression

- v3-agent path (the last known-working path on staging, rendered \`f40de84d\` to ready) stays as a fallback when admin clears avatar_id.
- Content-mode (/v3/videos type=image) stays reverted (#1871) since it requires a human face in the background.

Fixes #1873.

## Test plan

- [ ] Merge + deploy.
- [ ] \`gh workflow run staging-trigger-video.yml -f unit_id=M01-U03 -f language=fr -f force_delete=true\`.
- [ ] Celery log: \`heygen.create_video.dispatched\` (v2 path, NOT v3-agent).
- [ ] media_metadata.api_version = \"v2\".
- [ ] After ~10-15 min, row ready; video plays with Judy + Sylvie.