### PR TITLE
fix(video): poll all rows via /v3/videos/{id} — v2 status endpoint 404s (#1874)

### DIFF
--- a/backend/app/tasks/heygen_poll.py
+++ b/backend/app/tasks/heygen_poll.py
@@ -190,16 +190,16 @@ def _api_version_for(record: GeneratedAudio) -> str:
     """Read the HeyGen API version used when the row was created.
 
     Written to ``media_metadata.api_version`` by the service at
-    dispatch time. Legacy rows predating the poller won't have it —
-    treat them as v2 so the previous Direct-Video flow keeps working
-    after the rollout of #1798.
+    dispatch time.
 
-    ``v3`` (content-focused /v3/videos, #1854) and ``v3-agent``
-    (Video Agents) both use the same status endpoint path
-    (``/v3/videos/{id}``), so HeyGenClient treats them identically.
+    Poll every row via the v3 status endpoint (``/v3/videos/{id}``).
+    HeyGen's ``/v2/video_status.get`` returns 404 as of April 2026
+    (#1874) — the endpoint appears to be deprecated. The v3
+    endpoint accepts any video_id HeyGen has issued, regardless of
+    which create path produced it, since the video_id namespace is
+    shared. Returning ``"v3-agent"`` dispatches the v3 GET in
+    ``HeyGenClient.get_video`` for all rows.
     """
-    metadata = record.media_metadata or {}
-    value = metadata.get("api_version") or "v2"
-    if value in ("v3", "v3-agent"):
-        return "v3-agent"
-    return "v2"
+    # All create paths (v2 Direct Video, v3 Video Agents, v3 content
+    # /v3/videos) produce video_ids that resolve on /v3/videos/{id}.
+    return "v3-agent"

--- a/backend/tests/test_heygen_agent_mode.py
+++ b/backend/tests/test_heygen_agent_mode.py
@@ -219,17 +219,20 @@ def test_api_version_for_reads_metadata():
     assert _api_version_for(record) == "v3-agent"
 
 
-def test_api_version_for_defaults_legacy_rows_to_v2():
+def test_api_version_for_always_polls_via_v3():
+    # After #1874, every row polls via /v3/videos/{id} because HeyGen
+    # deprecated /v2/video_status.get (returns 404). Legacy rows
+    # (no metadata) or rows with unknown api_version values should
+    # all be routed to the v3 status endpoint.
     record = _make_record(api_version=None)
-    # Simulate a row written before #1798 ever ran — no metadata at all.
     record.media_metadata = None
-    assert _api_version_for(record) == "v2"
+    assert _api_version_for(record) == "v3-agent"
 
 
-def test_api_version_for_coerces_unknown_values_to_v2():
+def test_api_version_for_coerces_unknown_values_to_v3():
     record = _make_record()
     record.media_metadata = {"api_version": "not-a-real-version"}
-    assert _api_version_for(record) == "v2"
+    assert _api_version_for(record) == "v3-agent"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Row 557fe1c9 (M01-U03 fr, v2 Direct Video) stuck generating because HeyGen's `/v2/video_status.get` returns 404 for its video_id. The v3 endpoint (`/v3/videos/{id}`) works for every dispatch type. Simplify `_api_version_for` to always use v3. Fixes #1874.