### PR TITLE
fix(figures): orthogonal SVG routing + drop immutable Cache-Control

### DIFF
--- a/backend/app/ai/translation/svg_rederiver.py
+++ b/backend/app/ai/translation/svg_rederiver.py
@@ -352,8 +352,55 @@ def _render_shape(node: FlowchartNode, cx: float, cy: float) -> str:
     )
 
 
+# Reserved strip on the right side of the canvas used by back-edges
+# (loopbacks) to route cleanly without crossing the main column. If no
+# back-edges are present the strip stays empty but the extra whitespace
+# is harmless.
+_MARGIN_X = 60
+
+
+def _forward_path(x1: float, y1_bottom: float, x2: float, y2_top: float) -> str:
+    """Orthogonal path from the bottom edge of one box to the top edge of another,
+    preferring a straight vertical line when the two boxes share an x column."""
+    if abs(x1 - x2) < 1:
+        return f"M{x1},{y1_bottom} L{x2},{y2_top}"
+    mid_y = (y1_bottom + y2_top) / 2
+    return f"M{x1},{y1_bottom} L{x1},{mid_y} L{x2},{mid_y} L{x2},{y2_top}"
+
+
+def _sideways_path(x1_side: float, y1: float, x2_side: float, y2: float) -> str:
+    """Horizontal path between two boxes on the same row (rare; used when two
+    nodes share a layer and we have an explicit side edge)."""
+    return f"M{x1_side},{y1} L{x2_side},{y2}"
+
+
+def _back_path(
+    x1_right: float,
+    y1: float,
+    x2_right: float,
+    y2: float,
+    margin_x: float,
+) -> str:
+    """Back-edge route: exit the right side of the source, rise up the right
+    margin strip, and re-enter the right side of the target. The terminal
+    segment goes leftward so ``orient="auto"`` points the arrow correctly."""
+    return f"M{x1_right},{y1} L{margin_x},{y1} L{margin_x},{y2} L{x2_right},{y2}"
+
+
 def render_svg(structure: FlowchartStructure) -> bytes:
-    """Render a FlowchartStructure into a self-contained SVG document."""
+    """Render a FlowchartStructure into a self-contained SVG document.
+
+    Layout strategy:
+
+    - Nodes are packed into layers via :func:`_assign_layers` (top-down DAG).
+    - Forward edges (source layer < target layer) are drawn as orthogonal
+      paths — a single straight vertical when the boxes share a column, an
+      elbow (vertical / horizontal / vertical) otherwise.
+    - Back-edges (source layer > target layer, i.e. loopbacks) are routed
+      along a reserved right-margin strip so they never cross the main
+      flow column.
+    - Same-layer edges take a short horizontal path between box sides.
+    """
     if not structure.nodes:
         raise ValueError("cannot render empty flowchart")
 
@@ -363,16 +410,20 @@ def render_svg(structure: FlowchartStructure) -> bytes:
         by_layer[layers[node.id]].append(node)
 
     max_nodes_per_layer = max(len(v) for v in by_layer.values())
-    width = (
+    content_width = (
         _PADDING * 2 + max_nodes_per_layer * _NODE_WIDTH + (max_nodes_per_layer - 1) * _COLUMN_GAP
     )
+    # Reserve a back-edge strip on the right; cheap (~60 px) even if no
+    # back-edges appear — keeps layout calculation deterministic.
+    width = content_width + _MARGIN_X
     height = _PADDING * 2 + len(by_layer) * _NODE_HEIGHT + (len(by_layer) - 1) * _ROW_GAP
+    margin_x = content_width + _MARGIN_X / 2  # centre of the margin strip
 
     positions: dict[str, tuple[float, float]] = {}
     for layer_idx in sorted(by_layer.keys()):
         layer_nodes = by_layer[layer_idx]
         row_width = len(layer_nodes) * _NODE_WIDTH + (len(layer_nodes) - 1) * _COLUMN_GAP
-        start_x = (width - row_width) / 2 + _NODE_WIDTH / 2
+        start_x = (content_width - row_width) / 2 + _NODE_WIDTH / 2
         cy = _PADDING + layer_idx * (_NODE_HEIGHT + _ROW_GAP) + _NODE_HEIGHT / 2
         for i, node in enumerate(layer_nodes):
             cx = start_x + i * (_NODE_WIDTH + _COLUMN_GAP)
@@ -391,24 +442,52 @@ def render_svg(structure: FlowchartStructure) -> bytes:
         "</defs>",
     ]
 
-    # edges first so nodes overdraw them cleanly
+    half_w = _NODE_WIDTH / 2
+    half_h = _NODE_HEIGHT / 2
+
+    # Edges first so nodes overdraw them cleanly.
     for edge in structure.edges:
         if edge.from_id not in positions or edge.to_id not in positions:
             continue
-        x1, y1 = positions[edge.from_id]
-        x2, y2 = positions[edge.to_id]
-        # attach to top/bottom of the node boxes rather than the centre
-        y1 += _NODE_HEIGHT / 2 if y2 > y1 else -_NODE_HEIGHT / 2
-        y2 += -_NODE_HEIGHT / 2 if y2 > y1 else _NODE_HEIGHT / 2
+        cx1, cy1 = positions[edge.from_id]
+        cx2, cy2 = positions[edge.to_id]
+        src_layer = layers[edge.from_id]
+        tgt_layer = layers[edge.to_id]
+
+        if tgt_layer > src_layer:
+            # Forward edge — orthogonal path from bottom to top.
+            y1 = cy1 + half_h
+            y2 = cy2 - half_h
+            d = _forward_path(cx1, y1, cx2, y2)
+            label_x = (cx1 + cx2) / 2
+            label_y = (y1 + y2) / 2 - 4
+        elif tgt_layer < src_layer:
+            # Back edge — route via the right margin strip.
+            x1 = cx1 + half_w
+            x2 = cx2 + half_w
+            d = _back_path(x1, cy1, x2, cy2, margin_x)
+            label_x = margin_x
+            label_y = (cy1 + cy2) / 2 - 4
+        else:
+            # Same layer — short horizontal between right of source and
+            # left of target (or mirrored if target is left of source).
+            if cx2 >= cx1:
+                x1 = cx1 + half_w
+                x2 = cx2 - half_w
+            else:
+                x1 = cx1 - half_w
+                x2 = cx2 + half_w
+            d = _sideways_path(x1, cy1, x2, cy2)
+            label_x = (x1 + x2) / 2
+            label_y = cy1 - 4
+
         svg_parts.append(
-            f'<path d="M{x1},{y1} L{x2},{y2}" stroke="#444" stroke-width="1.5" '
+            f'<path d="{d}" stroke="#444" stroke-width="1.5" '
             'fill="none" marker-end="url(#arrow)" />'
         )
         if edge.label:
-            lx = (x1 + x2) / 2
-            ly = (y1 + y2) / 2 - 4
             svg_parts.append(
-                f'<text x="{lx}" y="{ly}" text-anchor="middle" '
+                f'<text x="{label_x}" y="{label_y}" text-anchor="middle" '
                 f'fill="#666" font-size="{_FONT_SIZE - 2}">'
                 f"{_escape(edge.label)}</text>"
             )
@@ -417,7 +496,7 @@ def render_svg(structure: FlowchartStructure) -> bytes:
         cx, cy = positions[node.id]
         svg_parts.append(_render_shape(node, cx, cy))
         lines = _wrap(node.text)
-        # vertically centre the block of lines on cy
+        # Vertically centre the block of lines on cy.
         total_h = len(lines) * (_FONT_SIZE + 2)
         start_y = cy - total_h / 2 + _FONT_SIZE
         for i, line in enumerate(lines):

--- a/backend/app/api/v1/source_images.py
+++ b/backend/app/api/v1/source_images.py
@@ -122,8 +122,12 @@ async def get_image_data(
         ) from exc
 
     content_type = upstream.headers.get("content-type", "image/webp")
+    # Drop `immutable` — the French variant can be re-derived in place when
+    # we iterate on the Phase-2 renderer (issue #1874), and `immutable` would
+    # pin the first response to browsers forever. A few hours of caching is
+    # enough for in-session reuse; the backend itself serves fast from MinIO.
     return StreamingResponse(
         content=iter([upstream.content]),
         media_type=content_type,
-        headers={"Cache-Control": "public, max-age=31536000, immutable"},
+        headers={"Cache-Control": "public, max-age=3600"},
     )

--- a/backend/tests/test_svg_rederiver.py
+++ b/backend/tests/test_svg_rederiver.py
@@ -278,6 +278,80 @@ class TestRenderSvg:
         texts = {t.text for t in root.findall(".//text") if t.text}
         assert "Yes" in texts
 
+    def test_linear_chain_uses_straight_vertical(self):
+        # Two nodes stacked in the same column should produce a single
+        # straight-vertical edge path (no elbows).
+        structure = FlowchartStructure(
+            nodes=[
+                FlowchartNode(id="a", text="A"),
+                FlowchartNode(id="b", text="B"),
+            ],
+            edges=[FlowchartEdge(from_id="a", to_id="b")],
+        )
+        svg = render_svg(structure)
+        root = self._parse(svg)
+        edge_paths = [p.get("d", "") for p in root.findall(".//path") if p.get("marker-end")]
+        assert len(edge_paths) == 1
+        d = edge_paths[0]
+        # "M{x},{y1} L{x},{y2}" — one M, one L, no second L.
+        assert d.count("L") == 1
+
+    def test_branch_edges_use_elbow_paths(self):
+        # root → left + root → right should both produce elbow paths
+        # (3 segments: vertical, horizontal, vertical).
+        structure = FlowchartStructure(
+            nodes=[
+                FlowchartNode(id="root", text="root"),
+                FlowchartNode(id="left", text="left"),
+                FlowchartNode(id="right", text="right"),
+            ],
+            edges=[
+                FlowchartEdge(from_id="root", to_id="left"),
+                FlowchartEdge(from_id="root", to_id="right"),
+            ],
+        )
+        svg = render_svg(structure)
+        root = self._parse(svg)
+        edge_paths = [p.get("d", "") for p in root.findall(".//path") if p.get("marker-end")]
+        assert len(edge_paths) == 2
+        for d in edge_paths:
+            # Elbow path has exactly 3 L commands.
+            assert d.count("L") == 3
+
+    def test_back_edge_routed_via_right_margin(self):
+        # A cycle (a → b → a) means the second edge is a back-edge and
+        # must exit the right side of its source, not cross back up
+        # through the node column.
+        structure = FlowchartStructure(
+            nodes=[
+                FlowchartNode(id="a", text="A"),
+                FlowchartNode(id="b", text="B"),
+            ],
+            edges=[
+                FlowchartEdge(from_id="a", to_id="b"),
+                FlowchartEdge(from_id="b", to_id="a"),
+            ],
+        )
+        svg = render_svg(structure)
+        root = self._parse(svg)
+        view_box = root.get("viewBox", "")
+        # viewBox is "0 0 WIDTH HEIGHT"; back-edge renderer should push
+        # total width above the content area.
+        view_parts = view_box.split()
+        assert len(view_parts) == 4
+        total_width = float(view_parts[2])
+        edge_paths = [p.get("d", "") for p in root.findall(".//path") if p.get("marker-end")]
+        # Back-edge path starts from the right side of the source box and
+        # the second point is close to the right margin (within a few px).
+        # Pick the longer path — forward edges are short, back paths are
+        # 3 segments + extra horizontal span.
+        back = max(edge_paths, key=len)
+        first_seg = back.split("L")[1]
+        # "L{margin_x},{y}" → first value close to (content_width +
+        # margin_x / 2). Just assert it's in the right half of the canvas.
+        margin_x_used = float(first_seg.split(",")[0].strip())
+        assert margin_x_used > total_width * 0.7
+
     def test_empty_flowchart_raises(self):
         # Can't create via Pydantic (min_length=1), so test the renderer
         # directly with a pre-built object


### PR DESCRIPTION
Fixes #1874. Follow-up to #1852.

## Two issues

1. **Frozen cache**. `/data` sent `Cache-Control: public, max-age=31536000, immutable`, so once a browser cached the English raster at `?lang=fr`, subsequent French SVG uploads never took effect. Phase-2 explicitly iterates on variants; `immutable` was wrong.
2. **Spaghetti diagrams**. The renderer drew every edge as a direct diagonal. For the scientific-method figure (branch + loopback) the branch diagonals crossed each other and the back-edge ran straight across the centre.

## Fix

- Endpoint now returns `Cache-Control: public, max-age=3600` (no `immutable`).
- `render_svg` classifies edges by layer relationship:
  - Forward, same column → straight vertical.
  - Forward, different column → 3-segment elbow.
  - Same layer → horizontal.
  - Back-edge → reserved right-margin strip (exit right, up/down, re-enter from right side).
- Canvas widens by a fixed ~60 px to reserve the margin strip unconditionally.

## Test plan

- [x] `uv run ruff check && ruff format --check` clean
- [x] `uv run pytest tests/test_svg_rederiver.py tests/test_backfill_clean_flowchart_svgs.py tests/test_source_image_endpoint.py tests/test_figure_classifier.py tests/test_backfill_figure_kinds.py` — 62 pass
- [x] New tests for straight-vertical, elbow branch, and margin-routed back-edge
- [ ] Staging: redeploy, re-render the scientific-method flowchart (figure `1287d0ba`), confirm the arrows no longer cross and the loopback runs up the right side

🤖 Generated with [Claude Code](https://claude.com/claude-code)