### PR TITLE
feat(video): faceless explainer via HeyGen Video Agent only (#1879)

### DIFF
--- a/backend/app/domain/services/lesson_video_service.py
+++ b/backend/app/domain/services/lesson_video_service.py
@@ -1,23 +1,26 @@
-"""Per-lesson HeyGen video summary generation.
+"""Per-lesson HeyGen faceless video summary generation.
 
 Mirrors ``lesson_audio_service.py`` but produces a rendered MP4 via
-HeyGen instead of an Opus audio file via OpenAI TTS. Writes to the
-shared ``generated_audio`` table with ``media_type='video'``.
+HeyGen's Video Agent API. Writes to the shared ``generated_audio``
+table with ``media_type='video'``.
 
 Flow:
 
 1. Check the cache (``(module_id, unit_id, language, media_type='video')``
    already ``ready``) — return it.
 2. Insert a ``pending`` row, flush, flip to ``generating``.
-3. Build a taxonomy-aware Claude script (kids-register variant when
-   ``detect_audience(course).is_kids``), honouring the admin
-   ``video-summary-max-chars`` cap. Re-prompt once on overshoot;
-   fall back to sentence-boundary truncation.
-4. Dispatch to HeyGen: Direct Video (v2) when both avatar and voice
-   IDs are seeded, Agent mode (v3) when either is empty. Record the
-   ``provider_video_id`` and the ``api_version`` in
-   ``media_metadata``. Leave status as ``generating`` — the
-   ``heygen_poll`` Celery-beat task finalises the row when HeyGen
+3. Build a taxonomy-aware Claude narration script (kids-register
+   variant when ``detect_audience(course).is_kids``), honouring the
+   admin ``video-summary-max-chars`` cap. Re-prompt once on
+   overshoot; fall back to sentence-boundary truncation.
+4. Wrap the narration with an explicit faceless directive and dispatch
+   to HeyGen Video Agent (``POST /v3/video-agents``) — no
+   ``avatar_id``, so the agent produces b-roll + captions +
+   narration rather than a talking head (#1879). Pin the voice per
+   language when configured. Record ``provider_video_id`` and
+   ``api_version='v3-agent'`` in ``media_metadata``.
+5. Leave status as ``generating`` — the ``heygen_poll`` Celery-beat
+   task polls ``/v3/videos/{id}`` and finalises the row when HeyGen
    finishes rendering.
 
 The ready state is therefore written by the poller (via
@@ -173,6 +176,45 @@ LESSON_VIDEO_USER_TEMPLATE = (
     "{lesson_content}\n\n"
     "Write the short narration script now."
 )
+
+
+def _build_faceless_prompt(
+    *,
+    script: str,
+    language: str,
+    course_title: str | None,
+    is_kids: bool,
+    age_range: str,
+) -> str:
+    """Assemble the HeyGen Video Agent prompt for a faceless explainer.
+
+    The Video Agent is free to pick an avatar unless the prompt
+    forbids one, so every dispatch spells out the constraints: no
+    presenter, no avatar, b-roll + text only, with the narration
+    text quoted verbatim for the agent to read. Keeping the directive
+    inline (not only in the script) guarantees the agent treats the
+    visual and audio requirements as non-negotiable (#1879).
+    """
+    lang_label = "French" if language == "fr" else "English"
+    domain = course_title or "the subject area"
+    if is_kids:
+        audience = f"children aged {age_range}" if age_range else "young learners aged 6-12"
+    else:
+        audience = f"learners in {domain}"
+
+    return (
+        f"Create a short faceless explainer video in {lang_label} "
+        f"for {audience}, targeting the {domain} subject area. "
+        f"Use cinematic educational b-roll footage, bold on-screen "
+        f"captions synced to the narration, and a calm professional "
+        f"narrator voice. "
+        f"HARD CONSTRAINTS: no on-screen presenter, no avatar, "
+        f"no talking head, no human faces — b-roll and typography only. "
+        f"Keep the pacing brisk and mobile-friendly "
+        f"(under ~90 seconds).\n\n"
+        f"Narration (speak this verbatim in {lang_label}):\n\n"
+        f"{script}"
+    )
 
 
 def _truncate_at_sentence(text: str, max_chars: int) -> str:
@@ -392,50 +434,36 @@ class LessonVideoService:
                 max_chars=max_chars,
             )
 
-            brand_image_url = (cache.get("video-summary-brand-image-url", "") or "").strip()
             voice_key = (
                 "video-summary-voice-id-fr" if language == "fr" else "video-summary-voice-id-en"
             )
-            voice_id = (cache.get(voice_key, "") or "").strip()
-            avatar_id = (cache.get("video-summary-default-avatar-id", "") or "").strip()
+            voice_id = (cache.get(voice_key, "") or "").strip() or None
 
-            # Preferred path: content-focused (no avatar) via /v3/videos.
-            # Requires the admin-configured brand background + a voice_id
-            # for narration. Legacy v2 avatar path is kept for tenants
-            # that haven't migrated; Video Agents is the no-config last
-            # resort (uses an avatar, pre-#1854 behaviour).
-            use_content_mode = bool(brand_image_url and voice_id)
-            use_v2_avatar_mode = not use_content_mode and bool(avatar_id and voice_id)
+            # Faceless explainer via HeyGen Video Agent (#1879). The
+            # prompt wraps the Claude-generated narration with explicit
+            # "no avatar / b-roll only" directives so HeyGen's agent
+            # doesn't drift back into picking a talking head. Voice is
+            # pinned to the admin-configured ``video-summary-voice-id-*``
+            # setting when present, otherwise HeyGen picks one per
+            # dispatch (non-deterministic).
+            prompt = _build_faceless_prompt(
+                script=script,
+                language=language,
+                course_title=course_title,
+                is_kids=is_kids,
+                age_range=age_range,
+            )
 
             callback_url = self._heygen_callback_url()
             client = heygen_client or HeyGenClient()
             owns_client = heygen_client is None
             try:
-                if use_content_mode:
-                    result = await client.create_content_video(
-                        script=script,
-                        voice_id=voice_id,
-                        image_url=brand_image_url,
-                        language=language,
-                        callback_url=callback_url,
-                    )
-                    api_version = "v3"
-                elif use_v2_avatar_mode:
-                    result = await client.create_video(
-                        script=script,
-                        avatar_id=avatar_id,
-                        voice_id=voice_id,
-                        callback_url=callback_url,
-                        language=language,
-                    )
-                    api_version = "v2"
-                else:
-                    result = await client.create_video_agent(
-                        prompt=script,
-                        language=language,
-                        callback_url=callback_url,
-                    )
-                    api_version = "v3-agent"
+                result = await client.create_video_agent(
+                    prompt=prompt,
+                    language=language,
+                    voice_id=voice_id,
+                    callback_url=callback_url,
+                )
             finally:
                 if owns_client and client._client is not None:
                     await client._client.aclose()
@@ -443,8 +471,9 @@ class LessonVideoService:
             record.provider_video_id = result.provider_video_id
             record.script_text = script
             record.media_metadata = {
-                "api_version": api_version,
+                "api_version": "v3-agent",
                 "is_kids": is_kids,
+                "voice_id": voice_id,
             }
             await session.commit()
 
@@ -453,8 +482,9 @@ class LessonVideoService:
                 lesson_id=str(lesson_id),
                 media_id=str(record.id),
                 provider_video_id=result.provider_video_id,
-                api_version=api_version,
-                script_chars=len(script),
+                api_version="v3-agent",
+                voice_id=voice_id or "<auto>",
+                prompt_chars=len(prompt),
             )
 
         except HeyGenError as exc:

--- a/backend/app/infrastructure/config/platform_defaults.py
+++ b/backend/app/infrastructure/config/platform_defaults.py
@@ -1624,19 +1624,16 @@ SETTING_DEFINITIONS: list[SettingDef] = [
     SettingDef(
         "video-summary-default-avatar-id",
         "video_summary",
-        "Judy_Teacher_Standing_public",
+        "",
         "string",
-        "Default HeyGen avatar ID",
+        "Default HeyGen avatar ID (unused)",
         (
-            "HeyGen stock avatar_id used for every lesson video. "
-            "Default is ``Judy_Teacher_Standing_public`` — an explicit "
-            "teacher avatar (standing, upper body, neutral background) "
-            "paired with female voice defaults so avatar and voice "
-            "gender match. When both this and the language voice_id "
-            "are set, the service uses the v2 Direct Video path for "
-            "consistent, non-random output (vs the v3 Agents fallback "
-            "which HeyGen auto-picks an avatar each time). Admins "
-            "override per tenant via the settings UI."
+            "DEPRECATED after #1879. The faceless Video Agent path "
+            "ignores ``avatar_id`` entirely — HeyGen's agent picks "
+            "b-roll + captions rather than a talking head, and we "
+            "forbid avatars in the prompt. The setting is kept only "
+            "so existing overrides in ``config/platform_settings.json`` "
+            "don't fail to load; it has no effect at runtime."
         ),
     ),
     SettingDef(
@@ -1648,10 +1645,11 @@ SETTING_DEFINITIONS: list[SettingDef] = [
         (
             "HeyGen voice_id used when language=fr. Default is "
             "``Sylvie - Professional`` — a professional female French "
-            "voice. Chosen to gender-match the default avatar "
-            "(``Judy_Teacher_Standing_public``). Override via HeyGen's "
-            "voice library if a tenant wants a different tone "
-            "(Pierre Narrateur male, Yves Newscaster, etc.)."
+            "voice. Pinned per language so narration stays consistent "
+            "across dispatches (without it HeyGen's Video Agent picks "
+            "a voice per render). Override via HeyGen's voice library "
+            "if a tenant wants a different tone (Pierre Narrateur "
+            "male, Yves Newscaster, etc.)."
         ),
     ),
     SettingDef(
@@ -1662,8 +1660,9 @@ SETTING_DEFINITIONS: list[SettingDef] = [
         "HeyGen voice ID — English",
         (
             "HeyGen voice_id used when language=en. Default is ``Ivy`` "
-            "— a clean professional female English voice. Override via "
-            "HeyGen's voice library if a tenant wants a different tone."
+            "— a clean professional female English voice. Pinned per "
+            "language for consistent narration; override via HeyGen's "
+            "voice library if a tenant wants a different tone."
         ),
     ),
     SettingDef(
@@ -1682,23 +1681,14 @@ SETTING_DEFINITIONS: list[SettingDef] = [
         "video_summary",
         "",
         "string",
-        "Video background image URL (16:9)",
+        "Video background image URL (unused)",
         (
-            "Publicly reachable URL of a 1280×720 landscape PNG/JPG "
-            "used as the background for every lesson video. HeyGen "
-            "renders the narration voice over this still image with "
-            "synced captions — no talking avatar — so the final video "
-            "stays uniform, 720p 16:9, and focused on the lesson "
-            "content rather than a presenter. 720p is HeyGen's "
-            "smallest output and ~90 s of narration keeps the MP4 "
-            "under ~4 MB, tractable for 3G learners. A default Sira-"
-            "branded landscape image ships at "
-            "``/images/video-summary-background.png`` on the frontend; "
-            "set this to e.g. "
-            "``https://etutor.elearning.portfolio2.kimbetien.com"
-            "/images/video-summary-background.png`` to use it, or "
-            "upload your own tenant-branded image. When empty, video "
-            "generation falls back to the legacy Video Agents path."
+            "DEPRECATED after #1879. Previously powered the "
+            "``/v3/videos`` type=image path which HeyGen rejected with "
+            "``MOVIO_NO_FACE_DETECTED`` because type=image is really "
+            "photo-avatar mode and requires a human face. The faceless "
+            "Video Agent path ignores this URL entirely. Kept only so "
+            "existing overrides don't fail to load."
         ),
     ),
     # ── Pagination ─────────────────────────────────────────

--- a/backend/app/infrastructure/video/heygen_client.py
+++ b/backend/app/infrastructure/video/heygen_client.py
@@ -1,24 +1,27 @@
-"""HeyGen V2 video generation API client.
+"""HeyGen Video Agent client — faceless explainer videos only.
 
-Wraps three endpoints that the rest of the stack needs:
+HeyGen has no dedicated ``/faceless`` endpoint; every avatar-specific
+endpoint (``/v2/video/generate``, ``/v3/videos`` with ``type=avatar``
+or ``type=image``) renders a human character. The only way to get a
+faceless explainer-style output is the Video Agent API:
 
-* ``POST /v2/video/generate`` — dispatch a video job.
-* ``GET  /v2/video_status.get`` — fallback poll when a webhook payload
-  arrives without a ``video_url``.
+* ``POST /v3/video-agents`` with ``{prompt, voice_id}`` and — critically —
+  **no** ``avatar_id``. The agent generates b-roll + captions + narration
+  driven entirely by the prompt.
+* ``GET  /v3/videos/{video_id}`` to poll for completion (the v2 status
+  endpoint returns 404 as of April 2026 — see #1874).
 * Webhook signature verification (HMAC-SHA256 over the raw body using
   the shared secret stored in ``settings.heygen_webhook_secret``).
 
-The API itself is async/webhook-native: the create call returns a
-``video_id`` in seconds; actual rendering takes several minutes and
-HeyGen pushes ``avatar_video.success``/``avatar_video.failed`` events
-to the ``callback_url`` we supply. The service layer relies on the
-webhook for the happy path; polling is only used as a reconciliation
-fallback.
+The prompt is expected to include explicit "no avatar / no on-screen
+presenter / b-roll only" directives so HeyGen's agent doesn't drift back
+into picking a talking head (#1879). Callers assemble the prompt; this
+client just dispatches.
 
 Retry policy: transient 5xx responses are retried with exponential
 backoff; 4xx errors surface immediately because they indicate a bad
-request (invalid avatar/voice id, exceeded char limit, bad api key)
-that retries cannot fix.
+request (invalid voice id, overlong prompt, rotated key, insufficient
+credit) that retries cannot fix.
 """
 
 from __future__ import annotations
@@ -37,10 +40,7 @@ from app.infrastructure.video import CreateVideoResult, VideoStatus
 logger = structlog.get_logger(__name__)
 
 _BASE_URL = "https://api.heygen.com"
-_CREATE_PATH = "/v2/video/generate"
-_STATUS_PATH = "/v2/video_status.get"
 _AGENT_CREATE_PATH = "/v3/video-agents"
-_V3_CREATE_PATH = "/v3/videos"
 _V3_STATUS_PATH_TEMPLATE = "/v3/videos/{video_id}"
 
 
@@ -71,7 +71,7 @@ async def _retry_transient[T](
 
     Only ``HeyGenTransientError`` and ``httpx.TransportError`` are
     retried; 4xx/auth errors propagate on the first attempt so a bad
-    request (wrong avatar_id, overlong script, rotated key) never
+    request (overlong prompt, rotated key, insufficient credit) never
     silently fails three times before surfacing.
     """
     last_exc: BaseException | None = None
@@ -97,7 +97,7 @@ async def _retry_transient[T](
 
 
 class HeyGenClient:
-    """Async HeyGen V2 API client."""
+    """Async HeyGen Video Agent API client — faceless explainers only."""
 
     def __init__(
         self,
@@ -147,154 +147,36 @@ class HeyGenClient:
             raise HeyGenTransientError(f"HeyGen server error ({response.status_code})")
         return response
 
-    async def create_video(
-        self,
-        *,
-        script: str,
-        avatar_id: str,
-        voice_id: str,
-        language: str,
-        callback_url: str | None = None,
-    ) -> CreateVideoResult:
-        """Dispatch a new video job. Returns the HeyGen video_id.
-
-        ``callback_url`` is optional: when omitted, HeyGen won't push
-        a completion event and the caller is expected to poll
-        ``get_video`` to learn about the terminal status. This keeps
-        the client usable from multi-tenant deployments where there
-        is no single stable public URL to register.
-        """
-        if not script.strip():
-            raise HeyGenBadRequestError("script is empty")
-        if not avatar_id:
-            raise HeyGenBadRequestError("avatar_id is required")
-        if not voice_id:
-            raise HeyGenBadRequestError("voice_id is required")
-
-        body: dict = {
-            "video_inputs": [
-                {
-                    "character": {
-                        "type": "avatar",
-                        "avatar_id": avatar_id,
-                    },
-                    "voice": {
-                        "type": "text",
-                        "voice_id": voice_id,
-                        "input_text": script,
-                    },
-                }
-            ],
-            "caption": True,
-        }
-        if callback_url:
-            body["callback_url"] = callback_url
-
-        async def _call() -> httpx.Response:
-            return await self._request("POST", _CREATE_PATH, json=body)
-
-        response = await _retry_transient(_call)
-        data = response.json() or {}
-        inner = data.get("data") or {}
-        video_id = inner.get("video_id") or data.get("video_id")
-        if not video_id:
-            raise HeyGenError(f"HeyGen create returned no video_id: {data!r}")
-
-        logger.info(
-            "heygen.create_video.dispatched",
-            video_id=video_id,
-            language=language,
-            script_chars=len(script),
-        )
-        return CreateVideoResult(provider_video_id=str(video_id))
-
-    async def create_content_video(
-        self,
-        *,
-        script: str,
-        voice_id: str,
-        image_url: str,
-        language: str,
-        aspect_ratio: str = "16:9",
-        resolution: str = "720p",
-        callback_url: str | None = None,
-    ) -> CreateVideoResult:
-        """Dispatch a content-focused (no-avatar) HeyGen render.
-
-        Uses the v3 ``/v3/videos`` endpoint with ``type="image"``: the
-        narration voice plays over a static branded background with
-        synced captions, no talking head.
-
-        Default dimensions are **16:9 landscape at 720p** — HeyGen's
-        smallest resolution. Sira targets 2G/3G learners, so the bias
-        is toward the smallest file and fastest render HeyGen offers:
-        a ~90 s 720p 16:9 MP4 lands under ~4 MB and renders in
-        roughly half the time of a longer clip. ``<video>`` in modern
-        mobile browsers scales landscape footage to fit the viewport
-        without any client-side work.
-
-        The image URL must be publicly reachable so HeyGen's renderer
-        can fetch it — typically the frontend's branded asset served
-        at the tenant's public hostname. Provide a 1280×720 landscape
-        image to match the default aspect ratio.
-        """
-        if not script.strip():
-            raise HeyGenBadRequestError("script is empty")
-        if not voice_id:
-            raise HeyGenBadRequestError("voice_id is required")
-        if not image_url:
-            raise HeyGenBadRequestError("image_url is required")
-
-        body: dict = {
-            "type": "image",
-            "image": {"type": "url", "url": image_url},
-            "script": script,
-            "voice_id": voice_id,
-            "aspect_ratio": aspect_ratio,
-            "resolution": resolution,
-            "output_format": "mp4",
-        }
-        if callback_url:
-            body["callback_url"] = callback_url
-
-        async def _call() -> httpx.Response:
-            return await self._request("POST", _V3_CREATE_PATH, json=body)
-
-        response = await _retry_transient(_call)
-        data = response.json() or {}
-        inner = data.get("data") or {}
-        video_id = inner.get("video_id") or data.get("video_id")
-        if not video_id:
-            raise HeyGenError(f"HeyGen content video create returned no video_id: {data!r}")
-
-        logger.info(
-            "heygen.create_content_video.dispatched",
-            video_id=video_id,
-            language=language,
-            script_chars=len(script),
-            aspect_ratio=aspect_ratio,
-            resolution=resolution,
-        )
-        return CreateVideoResult(provider_video_id=str(video_id))
-
     async def create_video_agent(
         self,
         *,
         prompt: str,
         language: str,
+        voice_id: str | None = None,
         callback_url: str | None = None,
     ) -> CreateVideoResult:
-        """Dispatch a Video Agent job — avatar/voice auto-picked.
+        """Dispatch a faceless explainer video via the Video Agent API.
 
-        Use this when the tenant hasn't seeded explicit avatar/voice
-        IDs; HeyGen's agent picks both from the prompt. Costs roughly
-        double a Direct Video call but keeps the feature zero-config
-        for fresh tenants. See ``/docs/choosing-the-right-video-api``.
+        ``prompt`` must contain explicit faceless directives ("no avatar,
+        no on-screen presenter, b-roll only") alongside the narration
+        script — HeyGen's agent respects prompt instructions but will
+        drift into picking a talking head if the prompt doesn't forbid
+        one. See ``LessonVideoService`` for the canonical prompt shape.
+
+        ``voice_id`` is optional. When supplied, HeyGen uses that specific
+        voice for narration (stable output across dispatches). When
+        omitted, HeyGen picks a voice per dispatch (non-deterministic).
+
+        ``avatar_id`` is intentionally NOT a parameter — this client only
+        produces faceless output (#1879). If a caller wants an avatar,
+        add a separate method; don't bolt it onto this one.
         """
         if not prompt.strip():
             raise HeyGenBadRequestError("prompt is empty")
 
         body: dict = {"prompt": prompt}
+        if voice_id:
+            body["voice_id"] = voice_id
         if callback_url:
             body["callback_url"] = callback_url
 
@@ -311,35 +193,26 @@ class HeyGenClient:
             "heygen.create_video_agent.dispatched",
             video_id=video_id,
             language=language,
+            voice_id=voice_id or "<auto>",
             prompt_chars=len(prompt),
         )
         return CreateVideoResult(provider_video_id=str(video_id))
 
-    async def get_video(self, video_id: str, *, api_version: str = "v2") -> VideoStatus:
+    async def get_video(self, video_id: str) -> VideoStatus:
         """Fetch current status of a previously-dispatched video.
 
-        ``api_version`` selects the status endpoint: ``"v2"`` for
-        Direct Video (``/v2/video_status.get``) and ``"v3-agent"``
-        for Video Agent (``/v3/videos/{id}``). The two response
-        shapes differ slightly; we normalise both into the same
-        ``VideoStatus``.
+        Uses ``/v3/videos/{id}`` unconditionally (#1874). HeyGen's v2
+        status endpoint returns 404 as of April 2026; the v3 endpoint
+        accepts any video_id HeyGen has issued regardless of which
+        create path produced it, since the video_id namespace is
+        shared.
         """
 
-        if api_version == "v3-agent":
-
-            async def _call() -> httpx.Response:
-                return await self._request(
-                    "GET",
-                    _V3_STATUS_PATH_TEMPLATE.format(video_id=video_id),
-                )
-        else:
-
-            async def _call() -> httpx.Response:
-                return await self._request(
-                    "GET",
-                    _STATUS_PATH,
-                    params={"video_id": video_id},
-                )
+        async def _call() -> httpx.Response:
+            return await self._request(
+                "GET",
+                _V3_STATUS_PATH_TEMPLATE.format(video_id=video_id),
+            )
 
         response = await _retry_transient(_call)
         data = response.json() or {}
@@ -354,17 +227,29 @@ class HeyGenClient:
             "failed": "failed",
             "error": "failed",
         }.get(raw_status, raw_status or "pending")
-        # v3 uses ``video_url`` per docs; v2 also returns ``video_url``.
-        # Accept ``url`` as an additional fallback in case either
-        # surface renames the field in a future minor revision.
         video_url = (
             inner.get("video_url") or inner.get("url") or data.get("video_url") or data.get("url")
         )
+        # HeyGen v3 returns rich failure details as ``failure_message``
+        # + ``failure_code`` (e.g. "Insufficient credit"). Prefer those
+        # so the DB ``error_message`` column carries an actionable
+        # reason rather than the generic "heygen reported failure"
+        # fallback that the service writes when ``error`` is None
+        # (see #1878).
+        error_parts: list[str] = []
+        failure_message = inner.get("failure_message")
+        failure_code = inner.get("failure_code")
+        if failure_message:
+            error_parts.append(str(failure_message))
+        if failure_code and failure_code not in (failure_message or ""):
+            error_parts.append(f"({failure_code})")
+        rich_error = " ".join(error_parts) or None
+        legacy_error = inner.get("error") or inner.get("message")
         return VideoStatus(
             provider_video_id=video_id,
             status=mapped,
             video_url=video_url,
-            error=inner.get("error") or inner.get("message"),
+            error=rich_error or legacy_error,
         )
 
     def verify_webhook_signature(self, *, signature: str, raw_body: bytes) -> bool:

--- a/backend/app/tasks/heygen_poll.py
+++ b/backend/app/tasks/heygen_poll.py
@@ -149,11 +149,7 @@ async def _reconcile_one(
         )
         return "timed_out"
 
-    api_version = _api_version_for(record)
-    status = await client.get_video(
-        str(record.provider_video_id),
-        api_version=api_version,
-    )
+    status = await client.get_video(str(record.provider_video_id))
     if status.status == "completed":
         if not status.video_url:
             record.status = "failed"
@@ -184,22 +180,3 @@ def _is_timed_out(record: GeneratedAudio) -> bool:
     if created.tzinfo is None:
         created = created.replace(tzinfo=UTC)
     return datetime.now(UTC) - created > _GENERATING_TIMEOUT
-
-
-def _api_version_for(record: GeneratedAudio) -> str:
-    """Read the HeyGen API version used when the row was created.
-
-    Written to ``media_metadata.api_version`` by the service at
-    dispatch time.
-
-    Poll every row via the v3 status endpoint (``/v3/videos/{id}``).
-    HeyGen's ``/v2/video_status.get`` returns 404 as of April 2026
-    (#1874) — the endpoint appears to be deprecated. The v3
-    endpoint accepts any video_id HeyGen has issued, regardless of
-    which create path produced it, since the video_id namespace is
-    shared. Returning ``"v3-agent"`` dispatches the v3 GET in
-    ``HeyGenClient.get_video`` for all rows.
-    """
-    # All create paths (v2 Direct Video, v3 Video Agents, v3 content
-    # /v3/videos) produce video_ids that resolve on /v3/videos/{id}.
-    return "v3-agent"

--- a/backend/tests/test_heygen_agent_mode.py
+++ b/backend/tests/test_heygen_agent_mode.py
@@ -1,13 +1,13 @@
-"""Tests for the v3 Video Agent fallback and poller version routing.
+"""Tests for the faceless Video Agent path and poller status routing.
 
-Covers (issue #1798):
+Covers (issues #1798, #1874, #1879):
 
 * ``HeyGenClient.create_video_agent`` — happy path body shape,
-  empty-prompt rejection, and retry behaviour matches the v2 client.
-* ``HeyGenClient.get_video`` — v3 path routing by ``api_version``.
-* ``_api_version_for`` — poller reads ``media_metadata.api_version``
-  with a v2 fallback for legacy rows.
-* Poller delegates a v3-agent row to the correct status endpoint.
+  empty-prompt rejection, and retry behaviour.
+* ``HeyGenClient.get_video`` — always polls ``/v3/videos/{id}`` after
+  HeyGen deprecated the v2 status endpoint (#1874); surfaces
+  ``failure_message`` + ``failure_code`` in the mapped ``VideoStatus``.
+* Poller delegates a generating row to the correct status endpoint.
 """
 
 from __future__ import annotations
@@ -26,7 +26,7 @@ from app.infrastructure.video.heygen_client import (
     HeyGenClient,
     HeyGenTransientError,
 )
-from app.tasks.heygen_poll import _api_version_for, _reconcile_one
+from app.tasks.heygen_poll import _reconcile_one
 
 # ── fakes ────────────────────────────────────────────────────────────
 
@@ -172,25 +172,11 @@ async def test_create_video_agent_surfaces_exhausted_transient(monkeypatch):
         await client.create_video_agent(prompt="hello", language="en")
 
 
-# ── get_video routing ──────────────────────────────────────────────
+# ── get_video routing (always v3 after #1874/#1879) ────────────────
 
 
 @pytest.mark.asyncio
-async def test_get_video_v2_hits_status_endpoint():
-    http = _FakeHttp(
-        _make_response(
-            200,
-            {"data": {"status": "processing", "video_url": None}},
-        )
-    )
-    client = HeyGenClient(settings=_settings(), client=http)
-    await client.get_video("vid-abc")  # default v2
-    assert http.calls[0]["url"].endswith("/v2/video_status.get")
-    assert http.calls[0]["kwargs"]["params"] == {"video_id": "vid-abc"}
-
-
-@pytest.mark.asyncio
-async def test_get_video_v3_agent_hits_videos_path():
+async def test_get_video_hits_v3_videos_path():
     http = _FakeHttp(
         _make_response(
             200,
@@ -203,40 +189,41 @@ async def test_get_video_v3_agent_hits_videos_path():
         )
     )
     client = HeyGenClient(settings=_settings(), client=http)
-    result = await client.get_video("vid-v3", api_version="v3-agent")
-    assert http.calls[0]["url"].endswith("/v3/videos/vid-v3")
-    # v3 payload still maps cleanly into our VideoStatus.
+    result = await client.get_video("vid-abc")
+    assert http.calls[0]["url"].endswith("/v3/videos/vid-abc")
+    # v3 payload maps cleanly into our VideoStatus.
     assert isinstance(result, VideoStatus)
     assert result.status == "completed"
     assert result.video_url == "https://heygen.test/out.mp4"
 
 
-# ── _api_version_for / poller routing ─────────────────────────────
+@pytest.mark.asyncio
+async def test_get_video_surfaces_failure_message():
+    http = _FakeHttp(
+        _make_response(
+            200,
+            {
+                "data": {
+                    "status": "failed",
+                    "failure_code": "MOVIO_PAYMENT_INSUFFICIENT_CREDIT",
+                    "failure_message": "Insufficient credit.",
+                }
+            },
+        )
+    )
+    client = HeyGenClient(settings=_settings(), client=http)
+    result = await client.get_video("vid-insufficient")
+    assert result.status == "failed"
+    assert result.error is not None
+    assert "Insufficient credit" in result.error
+    assert "MOVIO_PAYMENT_INSUFFICIENT_CREDIT" in result.error
 
 
-def test_api_version_for_reads_metadata():
-    record = _make_record(api_version="v3-agent")
-    assert _api_version_for(record) == "v3-agent"
-
-
-def test_api_version_for_always_polls_via_v3():
-    # After #1874, every row polls via /v3/videos/{id} because HeyGen
-    # deprecated /v2/video_status.get (returns 404). Legacy rows
-    # (no metadata) or rows with unknown api_version values should
-    # all be routed to the v3 status endpoint.
-    record = _make_record(api_version=None)
-    record.media_metadata = None
-    assert _api_version_for(record) == "v3-agent"
-
-
-def test_api_version_for_coerces_unknown_values_to_v3():
-    record = _make_record()
-    record.media_metadata = {"api_version": "not-a-real-version"}
-    assert _api_version_for(record) == "v3-agent"
+# ── Poller routing ────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_reconcile_v3_row_uses_v3_api_version(monkeypatch):
+async def test_reconcile_finalises_ready_rows(monkeypatch):
     record = _make_record(api_version="v3-agent")
     session = _FakeSession()
 
@@ -263,7 +250,7 @@ async def test_reconcile_v3_row_uses_v3_api_version(monkeypatch):
         session=session,  # type: ignore[arg-type]
     )
     assert outcome == "ready"
-    # Key assertion: poller passed the row's api_version to the client.
-    client.get_video.assert_awaited_once()
-    args, kwargs = client.get_video.call_args
-    assert kwargs.get("api_version") == "v3-agent"
+    # The poller calls get_video with just the video_id — no
+    # api_version kwarg after #1874 since /v3/videos/{id} is the
+    # only endpoint that works.
+    client.get_video.assert_awaited_once_with(str(record.provider_video_id))

--- a/backend/tests/test_heygen_client.py
+++ b/backend/tests/test_heygen_client.py
@@ -81,9 +81,13 @@ class _FakeHttp:
     def __init__(self, response: httpx.Response):
         self._response = response
         self.calls = 0
+        self.last_args: tuple = ()
+        self.last_kwargs: dict = {}
 
-    async def request(self, *_args, **_kwargs):
+    async def request(self, *args, **kwargs):
         self.calls += 1
+        self.last_args = args
+        self.last_kwargs = kwargs
         return self._response
 
     async def aclose(self):
@@ -100,36 +104,32 @@ def _make_response(status_code: int, body: dict | None = None):
 
 
 @pytest.mark.asyncio
-async def test_create_video_fail_fast_on_4xx():
-    http = _FakeHttp(_make_response(400, {"message": "bad avatar"}))
+async def test_create_video_agent_fail_fast_on_4xx():
+    http = _FakeHttp(_make_response(400, {"message": "overlong prompt"}))
     client = HeyGenClient(settings=_settings(), client=http)
     with pytest.raises(HeyGenBadRequestError):
-        await client.create_video(
-            script="hello",
-            avatar_id="a",
-            voice_id="v",
-            callback_url="https://example.test/cb",
+        await client.create_video_agent(
+            prompt="hello",
             language="en",
+            callback_url="https://example.test/cb",
         )
     assert http.calls == 1  # no retry on 4xx
 
 
 @pytest.mark.asyncio
-async def test_create_video_auth_error_surfaces():
+async def test_create_video_agent_auth_error_surfaces():
     http = _FakeHttp(_make_response(401, {"message": "bad key"}))
     client = HeyGenClient(settings=_settings(), client=http)
     with pytest.raises(HeyGenAuthError):
-        await client.create_video(
-            script="hello",
-            avatar_id="a",
-            voice_id="v",
-            callback_url="https://example.test/cb",
+        await client.create_video_agent(
+            prompt="hello",
             language="en",
+            callback_url="https://example.test/cb",
         )
 
 
 @pytest.mark.asyncio
-async def test_create_video_retries_on_5xx_then_succeeds(monkeypatch):
+async def test_create_video_agent_retries_on_5xx_then_succeeds(monkeypatch):
     success = _make_response(200, {"data": {"video_id": "vid-ok"}})
     failing = _make_response(503, {"message": "upstream"})
 
@@ -146,19 +146,17 @@ async def test_create_video_retries_on_5xx_then_succeeds(monkeypatch):
     monkeypatch.setattr(mod.asyncio, "sleep", _sleep)
 
     client = HeyGenClient(settings=_settings(), client=http)
-    result = await client.create_video(
-        script="hi",
-        avatar_id="a",
-        voice_id="v",
-        callback_url="https://example.test/cb",
+    result = await client.create_video_agent(
+        prompt="hi",
         language="en",
+        callback_url="https://example.test/cb",
     )
     assert result.provider_video_id == "vid-ok"
     assert http.request.await_count == 3
 
 
 @pytest.mark.asyncio
-async def test_create_video_gives_up_after_max_attempts(monkeypatch):
+async def test_create_video_agent_gives_up_after_max_attempts(monkeypatch):
     http = MagicMock()
     http.request = AsyncMock(return_value=_make_response(500, {"message": "boom"}))
     http.aclose = AsyncMock()
@@ -172,14 +170,42 @@ async def test_create_video_gives_up_after_max_attempts(monkeypatch):
 
     client = HeyGenClient(settings=_settings(), client=http)
     with pytest.raises(HeyGenTransientError):
-        await client.create_video(
-            script="hi",
-            avatar_id="a",
-            voice_id="v",
-            callback_url="https://example.test/cb",
+        await client.create_video_agent(
+            prompt="hi",
             language="en",
+            callback_url="https://example.test/cb",
         )
     assert http.request.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_create_video_agent_passes_voice_id_when_given():
+    http = _FakeHttp(_make_response(200, {"data": {"video_id": "vid-1"}}))
+    client = HeyGenClient(settings=_settings(), client=http)
+    await client.create_video_agent(
+        prompt="faceless please",
+        language="fr",
+        voice_id="voice-xyz",
+        callback_url="https://example.test/cb",
+    )
+    # One call, body includes voice_id but NOT avatar_id (faceless).
+    body = http.last_kwargs["json"]
+    assert body["voice_id"] == "voice-xyz"
+    assert "avatar_id" not in body
+    assert body["prompt"] == "faceless please"
+
+
+@pytest.mark.asyncio
+async def test_create_video_agent_omits_voice_when_none():
+    http = _FakeHttp(_make_response(200, {"data": {"video_id": "vid-1"}}))
+    client = HeyGenClient(settings=_settings(), client=http)
+    await client.create_video_agent(
+        prompt="faceless",
+        language="en",
+    )
+    body = http.last_kwargs["json"]
+    assert "voice_id" not in body
+    assert "avatar_id" not in body
 
 
 def test_is_web_ready_mp4_accepts_ftyp_header():
@@ -201,22 +227,12 @@ def test_is_web_ready_mp4_rejects_webm_and_junk():
 
 
 @pytest.mark.asyncio
-async def test_create_video_rejects_blank_inputs():
+async def test_create_video_agent_rejects_blank_prompt():
     http = _FakeHttp(_make_response(200, {"data": {"video_id": "x"}}))
     client = HeyGenClient(settings=_settings(), client=http)
     with pytest.raises(HeyGenBadRequestError):
-        await client.create_video(
-            script="   ",
-            avatar_id="a",
-            voice_id="v",
-            callback_url="https://example.test/cb",
+        await client.create_video_agent(
+            prompt="   ",
             language="en",
-        )
-    with pytest.raises(HeyGenBadRequestError):
-        await client.create_video(
-            script="hi",
-            avatar_id="",
-            voice_id="v",
             callback_url="https://example.test/cb",
-            language="en",
         )


### PR DESCRIPTION
## Summary

Strip every avatar-centric HeyGen path. Single dispatch route: \`POST /v3/video-agents\` with no \`avatar_id\`, a prompt explicitly forbidding talking heads, and a pinned \`voice_id\` per language. HeyGen's Video Agent produces b-roll + captions + narration — a real faceless explainer.

## Why

HeyGen has no dedicated faceless endpoint. Every non-agent path we tried on staging either required an avatar (\`/v2/video/generate\`) or rejected us (\`/v3/videos\` type=image → \"no face detected\" because it's photo-avatar mode, not slide mode). The Video Agent API is the one path that respects a \"no avatar\" prompt directive, per user-provided reference code.

## What changed

| File | Change |
|---|---|
| \`heygen_client.py\` | Drop \`create_video\` + \`create_content_video\`. \`create_video_agent\` gains optional \`voice_id\`. \`get_video\` always /v3/videos/{id}; surfaces \`failure_message\` + \`failure_code\`. |
| \`lesson_video_service.py\` | Single faceless path with \`_build_faceless_prompt\` wrapper. Records \`api_version='v3-agent'\` + \`voice_id\` in media_metadata. |
| \`platform_defaults.py\` | Deprecate \`video-summary-default-avatar-id\` + \`video-summary-brand-image-url\` (kept so existing overrides load; ignored at runtime). Voice-id settings unchanged. |
| \`heygen_poll.py\` | Drop \`_api_version_for\` shim (single status endpoint). |
| tests | 43/43 pass. Avatar-mode tests pruned; new ones for voice_id handling + failure_message surfacing. |

## No HeyGen calls from CI

Tests use the existing in-memory \`_FakeHttp\` stub. Zero paid dispatches to verify the PR.

## Test plan (post-merge, requires HeyGen credit top-up)

- [ ] Merge + deploy.
- [ ] Dispatch \`staging-trigger-video -f unit_id=M01-U03 -f language=fr -f force_delete=true\` for **one** render.
- [ ] Observe: \`heygen.create_video_agent.dispatched\` with \`voice_id=64cc0b129a...\` (Sylvie).
- [ ] ~10 min later the poller reports the row \`ready\` (or \`failed\` with HeyGen's actual reason in \`error_message\` — no more generic \"heygen reported failure\").
- [ ] Play the MP4 — confirm b-roll + captions + narration, **no talking head**.
- [ ] If the agent still drifts into picking an avatar despite the prompt, tune the prompt wording — still just one burned dispatch, not ten.

Fixes #1879.