### PR TITLE
feat(lesson UI): unify audio + video + read into a single tabbed media region

### DIFF
--- a/frontend/components/learning/lesson-audio.tsx
+++ b/frontend/components/learning/lesson-audio.tsx
@@ -13,9 +13,11 @@ const SKIP_SECONDS = 10;
 interface LessonAudioProps {
   lessonId: string;
   language: 'fr' | 'en';
+  /** Lifted whenever the player learns a real duration (in seconds). */
+  onDurationChange?: (durationSeconds: number) => void;
 }
 
-export function LessonAudio({ lessonId, language }: LessonAudioProps) {
+export function LessonAudio({ lessonId, language, onDurationChange }: LessonAudioProps) {
   const t = useTranslations('LessonAudio');
   const [status, setStatus] = useState<LessonAudioStatus>('pending');
   const [audioUrl, setAudioUrl] = useState<string | null>(null);
@@ -24,6 +26,12 @@ export function LessonAudio({ lessonId, language }: LessonAudioProps) {
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  // Hold the latest callback so polling/event handlers can read it without
+  // forcing the parent to memoize.
+  const onDurationChangeRef = useRef(onDurationChange);
+  useEffect(() => {
+    onDurationChangeRef.current = onDurationChange;
+  }, [onDurationChange]);
 
   const poll = useCallback(async () => {
     let attempts = 0;
@@ -46,6 +54,7 @@ export function LessonAudio({ lessonId, language }: LessonAudioProps) {
           setAudioUrl(resolvedUrl);
           if (data.duration_seconds) {
             setDuration(data.duration_seconds);
+            onDurationChangeRef.current?.(data.duration_seconds);
           }
           return;
         }
@@ -80,7 +89,9 @@ export function LessonAudio({ lessonId, language }: LessonAudioProps) {
     };
     const onLoadedMetadata = () => {
       if (audio.duration && isFinite(audio.duration)) {
-        setDuration(Math.round(audio.duration));
+        const rounded = Math.round(audio.duration);
+        setDuration(rounded);
+        onDurationChangeRef.current?.(rounded);
       }
     };
     const onEnded = () => {
@@ -153,7 +164,7 @@ export function LessonAudio({ lessonId, language }: LessonAudioProps) {
 
   if (status === 'failed') {
     return (
-      <div className="w-full max-w-xl mx-auto my-4">
+      <div className="w-full">
         <div className="flex items-center gap-3 bg-gray-50 border border-gray-200 rounded-lg px-4 py-3 opacity-60">
           <div className="flex-shrink-0 w-10 h-10 flex items-center justify-center rounded-full bg-gray-300 text-gray-500 min-h-11 min-w-11">
             <Volume2 className="w-4 h-4" />
@@ -167,7 +178,7 @@ export function LessonAudio({ lessonId, language }: LessonAudioProps) {
   if (status !== 'ready' || !audioUrl) {
     return (
       <div
-        className="w-full max-w-xl mx-auto my-4 rounded-lg overflow-hidden animate-pulse"
+        className="w-full rounded-lg overflow-hidden animate-pulse"
         aria-busy="true"
         aria-label={t('audioPending')}
       >
@@ -180,7 +191,7 @@ export function LessonAudio({ lessonId, language }: LessonAudioProps) {
   }
 
   return (
-    <div className="w-full max-w-xl mx-auto my-4">
+    <div className="w-full">
       <div className="flex items-center gap-2 bg-teal-50 border border-teal-200 rounded-lg px-4 py-3">
         {/* Rewind 10s */}
         <button

--- a/frontend/components/learning/lesson-media-tabs.tsx
+++ b/frontend/components/learning/lesson-media-tabs.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useCallback, useState, type ReactNode } from 'react';
+import { useTranslations } from 'next-intl';
+import { BookOpen, Headphones, Video as VideoIcon } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { LessonAudio } from './lesson-audio';
+import { LessonVideo } from './lesson-video';
+
+export type LessonMediaTab = 'read' | 'listen' | 'watch';
+
+interface LessonMediaTabsProps {
+  lessonId: string;
+  language: 'fr' | 'en';
+  /** The lesson body — illustration, intro, concepts, AOF example, synthèse, key points. */
+  readPane: ReactNode;
+  /** Fires whenever the active tab changes — lets the parent hide chrome (e.g. the refresh button) on the listen/watch panes. */
+  onActiveTabChange?: (tab: LessonMediaTab) => void;
+}
+
+/**
+ * Three-tab media region — Lire / Écouter / Regarder — that unifies the
+ * three modalities of consuming a lesson. All panes are kept mounted via
+ * Base UI's ``keepMounted`` so audio polling, audio playback continuity,
+ * and video status badging survive tab switches.
+ */
+export function LessonMediaTabs({
+  lessonId,
+  language,
+  readPane,
+  onActiveTabChange,
+}: LessonMediaTabsProps) {
+  const t = useTranslations('LessonMediaTabs');
+  const [audioDuration, setAudioDuration] = useState<number | null>(null);
+  const [isVideoGenerating, setIsVideoGenerating] = useState(false);
+
+  const handleValueChange = useCallback(
+    (value: unknown) => {
+      const tab = value as LessonMediaTab;
+      onActiveTabChange?.(tab);
+    },
+    [onActiveTabChange],
+  );
+
+  const formatDuration = (seconds: number) => {
+    const m = Math.floor(seconds / 60);
+    const s = Math.floor(seconds % 60);
+    return `${m}:${s.toString().padStart(2, '0')}`;
+  };
+
+  return (
+    <Tabs
+      defaultValue="read"
+      onValueChange={handleValueChange}
+      className="mb-6 gap-3"
+    >
+      <TabsList className="h-auto w-full justify-start gap-1 rounded-lg bg-muted p-1 overflow-x-auto">
+        <TabsTrigger
+          value="read"
+          className="min-h-11 flex-none gap-2 px-4 data-active:bg-background"
+        >
+          <BookOpen className="w-4 h-4" aria-hidden="true" />
+          <span>{t('readTab')}</span>
+        </TabsTrigger>
+        <TabsTrigger
+          value="listen"
+          className="min-h-11 flex-none gap-2 px-4 data-active:bg-background"
+        >
+          <Headphones className="w-4 h-4" aria-hidden="true" />
+          <span>
+            {t('listenTab')}
+            {audioDuration !== null && (
+              <span className="text-muted-foreground ml-1 tabular-nums">
+                ({formatDuration(audioDuration)})
+              </span>
+            )}
+          </span>
+        </TabsTrigger>
+        <TabsTrigger
+          value="watch"
+          className="min-h-11 flex-none gap-2 px-4 data-active:bg-background"
+        >
+          <VideoIcon className="w-4 h-4" aria-hidden="true" />
+          <span>{t('watchTab')}</span>
+          {isVideoGenerating && (
+            <span className="ml-1 inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-normal text-amber-700">
+              {t('generatingBadge')}
+            </span>
+          )}
+        </TabsTrigger>
+      </TabsList>
+
+      <Card>
+        <CardContent className="p-0">
+          <TabsContent
+            value="read"
+            keepMounted
+            className="data-active:min-h-[40vh]"
+          >
+            {readPane}
+          </TabsContent>
+          <TabsContent
+            value="listen"
+            keepMounted
+            className="data-active:min-h-[40vh] p-6 md:p-8"
+          >
+            <LessonAudio
+              lessonId={lessonId}
+              language={language}
+              onDurationChange={setAudioDuration}
+            />
+          </TabsContent>
+          <TabsContent
+            value="watch"
+            keepMounted
+            className="data-active:min-h-[40vh] p-6 md:p-8"
+          >
+            <LessonVideo
+              lessonId={lessonId}
+              language={language}
+              onActivelyGeneratingChange={setIsVideoGenerating}
+            />
+          </TabsContent>
+        </CardContent>
+      </Card>
+    </Tabs>
+  );
+}

--- a/frontend/components/learning/lesson-video.tsx
+++ b/frontend/components/learning/lesson-video.tsx
@@ -17,6 +17,13 @@ interface LessonVideoProps {
   lessonId: string;
   /** FR/EN follows the lesson language. */
   language: 'fr' | 'en';
+  /**
+   * Lifted whenever the "actively generating" derived state flips. Lets
+   * a parent (e.g. ``LessonMediaTabs``) badge a tab trigger while the
+   * HeyGen render is in flight without having to mirror the full status
+   * machine.
+   */
+  onActivelyGeneratingChange?: (active: boolean) => void;
 }
 
 /**
@@ -28,7 +35,11 @@ interface LessonVideoProps {
  * the HeyGen MP4 proxied through ``/api/v1/video/{id}/data`` from
  * MinIO.
  */
-export function LessonVideo({ lessonId, language }: LessonVideoProps) {
+export function LessonVideo({
+  lessonId,
+  language,
+  onActivelyGeneratingChange,
+}: LessonVideoProps) {
   const t = useTranslations('LessonVideo');
   const [status, setStatus] = useState<LessonVideoStatus | 'loading' | 'error'>(
     'loading',
@@ -47,6 +58,12 @@ export function LessonVideo({ lessonId, language }: LessonVideoProps) {
   >(null);
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
+  // Hold the latest callback so the lift-up effect below can read it
+  // without forcing the parent to memoize.
+  const onActivelyGeneratingChangeRef = useRef(onActivelyGeneratingChange);
+  useEffect(() => {
+    onActivelyGeneratingChangeRef.current = onActivelyGeneratingChange;
+  }, [onActivelyGeneratingChange]);
 
   const refresh = useCallback(async () => {
     try {
@@ -146,6 +163,10 @@ export function LessonVideo({ lessonId, language }: LessonVideoProps) {
     isGenerating ||
     (videoId !== null && (status === 'generating' || status === 'pending'));
 
+  useEffect(() => {
+    onActivelyGeneratingChangeRef.current?.(isActivelyGenerating);
+  }, [isActivelyGenerating]);
+
   // Loading / error / pending / failed all fall through to the same
   // "no video yet" card so the learner always sees the Generate
   // button — hiding on error made the component invisible when the
@@ -188,7 +209,7 @@ export function LessonVideo({ lessonId, language }: LessonVideoProps) {
   }
 
   return (
-    <div className="flex flex-col gap-2 rounded-lg border border-stone-200 bg-amber-50/40 p-3">
+    <div className="flex flex-col gap-2 w-full">
       <div className="flex items-center gap-3">
         <div
           className="w-10 h-10 rounded-full bg-amber-100 flex items-center justify-center flex-shrink-0"

--- a/frontend/components/learning/lesson-viewer.tsx
+++ b/frontend/components/learning/lesson-viewer.tsx
@@ -11,9 +11,8 @@ import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import { LessonSkeleton } from './lesson-skeleton';
-import { LessonAudio } from './lesson-audio';
-import { LessonVideo } from './lesson-video';
 import { LessonImage } from './lesson-image';
+import { LessonMediaTabs, type LessonMediaTab } from './lesson-media-tabs';
 import { SourceImage } from './source-image';
 import { SourceCitations } from './source-citations';
 import { apiFetch, checkUnitQuizPassed, ApiError } from '@/lib/api';
@@ -89,6 +88,10 @@ export function LessonViewer({
   const [forceRegenerate, setForceRegenerate] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [contentSource, setContentSource] = useState<'api' | 'indexeddb'>('api');
+  // Which media-tab pane is active. The "Actualiser le contenu" button
+  // only makes sense on the Lire pane (it regenerates lesson body, not
+  // audio/video) so we hide it on listen/watch.
+  const [activeMediaTab, setActiveMediaTab] = useState<LessonMediaTab>('read');
 
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pollStartRef = useRef<number>(0);
@@ -458,86 +461,85 @@ export function LessonViewer({
               </Badge>
             )}
           </div>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleRefresh}
-            disabled={isRefreshing || isLoading || isGenerating || !isOnline}
-            className="min-h-11 gap-1.5 text-gray-500 hover:text-gray-900"
-            title={t('refreshContent')}
-          >
-            <RefreshCw className={`w-4 h-4 ${isRefreshing ? 'animate-spin' : ''}`} />
-            <span className="hidden sm:inline">{t('refreshContent')}</span>
-          </Button>
+          {activeMediaTab === 'read' && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleRefresh}
+              disabled={isRefreshing || isLoading || isGenerating || !isOnline}
+              className="min-h-11 gap-1.5 text-gray-500 hover:text-gray-900"
+              title={t('refreshContent')}
+            >
+              <RefreshCw className={`w-4 h-4 ${isRefreshing ? 'animate-spin' : ''}`} />
+              <span className="hidden sm:inline">{t('refreshContent')}</span>
+            </Button>
+          )}
         </div>
         <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-3">
           {t('unitTitle', { unit: unitId })}
         </h1>
       </div>
 
-      {/* Audio Summary */}
-      <LessonAudio lessonId={lessonData.id} language={lessonData.language} />
+      <LessonMediaTabs
+        lessonId={lessonData.id}
+        language={lessonData.language}
+        onActiveTabChange={setActiveMediaTab}
+        readPane={
+          <div className="p-6 md:p-8">
+            {/* Lesson Illustration */}
+            <LessonImage lessonId={lessonData.id} language={lessonData.language} />
 
-      {/* Video Summary (opt-in, HeyGen-rendered) */}
-      <LessonVideo lessonId={lessonData.id} language={lessonData.language} />
+            {/* Introduction */}
+            {content.introduction && (
+              <div className="mb-8">
+                {renderContentWithImages(content.introduction)}
+              </div>
+            )}
 
-      {/* Main Content */}
-      <Card className="mb-6">
-        <CardContent className="p-6 md:p-8">
-          {/* Lesson Illustration */}
-          <LessonImage lessonId={lessonData.id} language={lessonData.language} />
-
-          {/* Introduction */}
-          {content.introduction && (
+            {/* Key Concepts */}
             <div className="mb-8">
-              {renderContentWithImages(content.introduction)}
-            </div>
-          )}
-
-          {/* Key Concepts */}
-          <div className="mb-8">
-            <div className="space-y-6">
-              {content.concepts.map((concept, index) => (
-                <div key={index}>
-                  {renderContentWithImages(concept)}
-                </div>
-              ))}
-            </div>
-          </div>
-
-          {/* West African Example */}
-          <div className="mb-8 bg-teal-50 border-l-4 border-teal-400 p-6 rounded-r-lg">
-            <div className="prose prose-teal max-w-none">
-              {renderContentWithImages(content.aof_example)}
-            </div>
-          </div>
-
-          {/* Synthesis */}
-          <div className="mb-8">
-            {renderContentWithImages(content.synthesis)}
-          </div>
-
-
-          {/* Key Points */}
-          <div className="mb-8">
-            <h2 className="text-xl font-semibold text-gray-900 mb-4">
-              {t('keyPoints')}
-            </h2>
-            <ul className="space-y-3">
-              {content.key_points.map((point, index) => (
-                <li key={index} className="flex items-start gap-3">
-                  <div className="w-2 h-2 bg-teal-500 rounded-full mt-3 flex-shrink-0" />
-                  <div className="text-base leading-relaxed text-gray-700 prose prose-gray max-w-none prose-p:text-gray-700 prose-strong:text-gray-900 prose-p:my-0">
-                    <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeKatex]} components={mdComponents}>
-                      {point}
-                    </ReactMarkdown>
+              <div className="space-y-6">
+                {content.concepts.map((concept, index) => (
+                  <div key={index}>
+                    {renderContentWithImages(concept)}
                   </div>
-                </li>
-              ))}
-            </ul>
+                ))}
+              </div>
+            </div>
+
+            {/* West African Example */}
+            <div className="mb-8 bg-teal-50 border-l-4 border-teal-400 p-6 rounded-r-lg">
+              <div className="prose prose-teal max-w-none">
+                {renderContentWithImages(content.aof_example)}
+              </div>
+            </div>
+
+            {/* Synthesis */}
+            <div className="mb-8">
+              {renderContentWithImages(content.synthesis)}
+            </div>
+
+            {/* Key Points */}
+            <div className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">
+                {t('keyPoints')}
+              </h2>
+              <ul className="space-y-3">
+                {content.key_points.map((point, index) => (
+                  <li key={index} className="flex items-start gap-3">
+                    <div className="w-2 h-2 bg-teal-500 rounded-full mt-3 flex-shrink-0" />
+                    <div className="text-base leading-relaxed text-gray-700 prose prose-gray max-w-none prose-p:text-gray-700 prose-strong:text-gray-900 prose-p:my-0">
+                      <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeKatex]} components={mdComponents}>
+                        {point}
+                      </ReactMarkdown>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
           </div>
-        </CardContent>
-      </Card>
+        }
+      />
 
       {/* Source Citations */}
       <SourceCitations sources={content.sources_cited} />

--- a/frontend/components/ui/tabs.tsx
+++ b/frontend/components/ui/tabs.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: TabsPrimitive.Root.Props) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-horizontal:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: TabsPrimitive.List.Props & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
+  return (
+    <TabsPrimitive.Tab
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
+        "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
+  return (
+    <TabsPrimitive.Panel
+      data-slot="tabs-content"
+      className={cn("flex-1 text-sm outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -749,6 +749,12 @@
     "generateError": "Video generation failed. Please try again.",
     "featureDisabled": "Video summaries are disabled for this tenant."
   },
+  "LessonMediaTabs": {
+    "readTab": "Read",
+    "listenTab": "Listen",
+    "watchTab": "Video",
+    "generatingBadge": "generating…"
+  },
   "CaseStudyViewer": {
     "error": "An error occurred",
     "streamError": "Streaming error occurred",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -749,6 +749,12 @@
     "generateError": "La génération vidéo a échoué. Veuillez réessayer.",
     "featureDisabled": "Les résumés vidéo sont désactivés pour ce tenant."
   },
+  "LessonMediaTabs": {
+    "readTab": "Lire",
+    "listenTab": "Écouter",
+    "watchTab": "Vidéo",
+    "generatingBadge": "génération…"
+  },
   "CaseStudyViewer": {
     "error": "Une erreur est survenue",
     "streamError": "Erreur lors de la diffusion en continu",


### PR DESCRIPTION
## Summary
- Replaces the three sequentially stacked media cards above the lesson body (audio, video, illustration) with a single three-tab region — **Lire / Écouter / Vidéo** — that unifies the modalities of consuming a lesson.
- The Lire pane keeps the full lesson body (illustration, intro, concepts, AOF example, synthèse, key points). Source citations + the validate-with-quiz button stay below the tab region, untouched.
- Audio + video components stripped of their outer `max-w` / border / `bg-amber` chrome since the wrapper Card now owns the surface. Audio lifts duration via `onDurationChange` so the Écouter trigger can show "(3:18)". Video lifts an `isActivelyGenerating` flag via `onActivelyGeneratingChange` so the Vidéo trigger can show a small "génération…" badge — replaces the full-width amber card that was screaming for attention during the entire HeyGen render window.
- All three panes use Base UI Tabs with `keepMounted` so audio polling, audio playback continuity across tab switches, and video status badging while the Lire pane is active all just work.
- "Actualiser le contenu" button hides on Écouter and Vidéo tabs (it only regenerates lesson body).

Fixes #1881

## Test plan
- [ ] Open the lesson from the issue (\`M01-U03\` of curriculum \`aab749f1-…\`) on staging.
- [ ] Lire is active on first paint; illustration + intro + concepts + AOF example + synthèse + key points render exactly as today.
- [ ] "Actualiser le contenu" visible on Lire, hidden on Écouter / Vidéo.
- [ ] Switch to Écouter: player immediately playable. Press play, switch back to Lire: playback continues uninterrupted.
- [ ] Switch to Vidéo while HeyGen still rendering: in-progress UI shows. Switch back to Lire: "génération…" badge visible on the Vidéo tab trigger.
- [ ] Resize to 320 px width: three triggers fit (or scroll horizontally) without layout breakage; ≥44×44 px tap targets.
- [ ] Toggle FR ↔ EN: all three tab labels and the badge translate.
- [ ] Source citations + "Validate with quiz" button render below the tab region, unchanged.
- [ ] Offline (SW active, network cut): Lire renders from cache; cached audio plays from Écouter; Vidéo degrades gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)