### PR TITLE
feat(figures): raster + numbered-badge overlay for complex_diagram

### DIFF
--- a/backend/app/ai/rag/pipeline.py
+++ b/backend/app/ai/rag/pipeline.py
@@ -15,8 +15,11 @@ from app.ai.rag.image_linker import ImageLinker
 from app.ai.translation import (
     classify_figure,
     extract_flowchart_structure,
+    extract_label_positions,
+    render_overlay_svg,
     render_svg,
     translate_figure_caption,
+    translate_labels,
     translate_structure,
 )
 from app.domain.models.document_chunk import DocumentChunk
@@ -288,6 +291,33 @@ class RAGPipeline:
                 except Exception as exc:
                     logger.warning(
                         "Failed to re-derive flowchart as FR SVG, leaving fr variant NULL",
+                        source=source,
+                        figure_number=img.figure_number,
+                        error=str(exc),
+                    )
+            elif figure_kind == "complex_diagram":
+                try:
+                    positions = await extract_label_positions(image_bytes=img.image_bytes)
+                    translated_positions = await translate_labels(positions, target_lang="fr")
+                    svg_bytes = render_overlay_svg(
+                        image_bytes=img.image_bytes,
+                        width_px=img.width or 1024,
+                        height_px=img.height or 768,
+                        labels=translated_positions,
+                    )
+                    svg_key = (
+                        f"source-images/{prefix}/{readable_name}/"
+                        f"{img.page_number}_{safe_label}.fr.svg"
+                    )
+                    storage_url_fr = await storage.upload_bytes(
+                        key=svg_key,
+                        data=svg_bytes,
+                        content_type="image/svg+xml",
+                    )
+                    storage_key_fr = svg_key
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to build FR overlay for complex_diagram, leaving fr variant NULL",
                         source=source,
                         figure_number=img.figure_number,
                         error=str(exc),

--- a/backend/app/ai/translation/__init__.py
+++ b/backend/app/ai/translation/__init__.py
@@ -1,5 +1,12 @@
-"""AI-backed translation utilities (issue #1820, #1844, #1852)."""
+"""AI-backed translation utilities (issues #1820, #1844, #1852, #1883)."""
 
+from app.ai.translation.complex_overlay import (
+    DiagramLabel,
+    DiagramLabels,
+    extract_label_positions,
+    render_overlay_svg,
+    translate_labels,
+)
 from app.ai.translation.figure_classifier import (
     FigureClassification,
     FigureKind,
@@ -19,6 +26,8 @@ from app.ai.translation.svg_rederiver import (
 )
 
 __all__ = [
+    "DiagramLabel",
+    "DiagramLabels",
     "FigureClassification",
     "FigureKind",
     "FigureTranslation",
@@ -27,7 +36,10 @@ __all__ = [
     "FlowchartStructure",
     "classify_figure",
     "extract_flowchart_structure",
+    "extract_label_positions",
+    "render_overlay_svg",
     "render_svg",
     "translate_figure_caption",
+    "translate_labels",
     "translate_structure",
 ]

--- a/backend/app/ai/translation/complex_overlay.py
+++ b/backend/app/ai/translation/complex_overlay.py
@@ -1,0 +1,368 @@
+"""Re-derive a ``complex_diagram`` figure as a raster + numbered-badge overlay
++ French legend (issue #1883, Phase 2 slice 2.4).
+
+``clean_flowchart`` figures can be rebuilt from scratch as SVG because the
+source is already a clean logical graph (boxes + arrows). Complex diagrams —
+anatomy plates, multi-panel figures, dense labelled illustrations — can't:
+Claude Vision can't reproduce the imagery faithfully and a rebuild produces a
+mangled copy. Strategy here is opposite: **keep the original raster untouched,
+overlay small numbered badges on top of each translatable label, and put a
+``1 — Noyau, 2 — Membrane...`` legend below the image**. Every label is
+translated; the visual fidelity of the underlying figure is preserved.
+
+Pipeline:
+
+1. ``extract_label_positions`` — Claude Vision returns a list of labels with
+   approximate percentage coordinates relative to the image (not pixel-
+   accurate; badges just need to sit near the right area).
+2. ``translate_labels`` — single Claude Haiku call translates the text of
+   every label to the target locale, preserving ids and coordinates.
+3. ``render_overlay_svg`` — produces one self-contained SVG:
+   - the raster is embedded via a base64 ``<image href="data:image/webp;base64,...">``
+   - numbered ``<circle>`` badges are drawn on top at each label's position
+   - a legend strip below the image maps each badge number to its translated
+     term.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+from typing import Any
+
+import anthropic
+import structlog
+from pydantic import BaseModel, Field, ValidationError, field_validator
+
+from app.infrastructure.config.settings import get_settings
+
+logger = structlog.get_logger(__name__)
+
+
+class DiagramLabel(BaseModel):
+    id: str = Field(..., min_length=1)
+    text: str = Field(..., min_length=1)
+    # Percentage of image width/height (0.0-100.0). Claude Vision isn't
+    # pixel-accurate, so we don't pretend — percentages keep the renderer
+    # independent of the source image's resolution.
+    x_pct: float = Field(..., ge=0.0, le=100.0)
+    y_pct: float = Field(..., ge=0.0, le=100.0)
+
+    @field_validator("x_pct", "y_pct", mode="before")
+    @classmethod
+    def _coerce_percentage(cls, value: Any) -> Any:
+        # Tolerate integer literals ("45") and 0-1 fractions ("0.45") from
+        # the model. Convert fractions to percentages so downstream code has
+        # one invariant.
+        if isinstance(value, int | float) and 0.0 < value <= 1.0:
+            return float(value) * 100.0
+        return value
+
+
+class DiagramLabels(BaseModel):
+    labels: list[DiagramLabel] = Field(..., min_length=1)
+
+
+_EXTRACT_MODEL = "claude-haiku-4-5"
+_TRANSLATE_MODEL = "claude-haiku-4-5"
+_MAX_TOKENS = 2048
+
+
+_EXTRACT_SYSTEM = (
+    "You locate every text label drawn ON TOP of a complex diagram image and "
+    "return their approximate positions. Reply with a single JSON object and "
+    "nothing else — no prose, no markdown fences."
+)
+
+_EXTRACT_USER = (
+    "Find every text label that is drawn on or immediately next to a structure "
+    "in this diagram. Return JSON:\n"
+    '  {"labels": [{"id": "n1", "text": "...", "x_pct": 42.5, "y_pct": 17.0}, ...]}\n\n'
+    "Rules:\n"
+    "- ids are short stable identifiers you invent (n1, n2, …) in the order you\n"
+    "  want them numbered in the final legend.\n"
+    "- text is the label verbatim — preserve capitalisation, accents, and\n"
+    "  punctuation. Do not invent, translate, or abbreviate.\n"
+    "- x_pct / y_pct are the position of the label's leftmost character, as a\n"
+    "  percentage (0–100) of the image's width and height. (0,0) is the top-\n"
+    "  left corner. Approximate is fine; we just need the badge to land near\n"
+    "  the label.\n"
+    "- Include only labels that ARE text visible inside/next to the figure.\n"
+    "  Skip figure captions / attribution / axis titles that live outside the\n"
+    "  image proper. Skip any text that is part of a scale bar.\n"
+    "- Do NOT return label order guesses, coordinates in pixels, or any other\n"
+    "  field. Reply with JSON only."
+)
+
+
+_TRANSLATE_SYSTEM = (
+    "You translate the text fields of a labelled diagram into the target "
+    "language. Reply with a single JSON object and nothing else."
+)
+
+_TRANSLATE_USER_TEMPLATE = (
+    "Translate every ``text`` field in this labelled diagram into "
+    "{target_lang_full}. Preserve ids and coordinates byte-identical; only "
+    "translate the text. Use natural terminology for the subject — if the "
+    "label is a scientific term (anatomy, biology, chemistry) use the "
+    "standard French term, not a literal translation.\n\n"
+    "Input:\n{payload}\n\n"
+    "Reply with the translated JSON only."
+)
+
+
+def _extract_json_object(text: str) -> str:
+    clean = text.strip()
+    if clean.startswith("```"):
+        first_newline = clean.find("\n")
+        if first_newline > 0:
+            clean = clean[first_newline + 1 :]
+        if clean.rstrip().endswith("```"):
+            clean = clean.rstrip()[:-3]
+    start = clean.find("{")
+    end = clean.rfind("}")
+    if start < 0 or end <= start:
+        raise ValueError("no JSON object in response")
+    body = clean[start : end + 1]
+    return re.sub(r",\s*([}\]])", r"\1", body)
+
+
+def _parse_labels(text: str) -> DiagramLabels:
+    body = _extract_json_object(text)
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"labels response was not valid JSON: {exc}") from exc
+    try:
+        return DiagramLabels(**payload)
+    except ValidationError:
+        logger.warning(
+            "DiagramLabels failed validation",
+            payload_keys=list(payload.keys()) if isinstance(payload, dict) else None,
+        )
+        raise
+
+
+async def extract_label_positions(
+    image_bytes: bytes,
+    image_media_type: str = "image/webp",
+    client: anthropic.AsyncAnthropic | None = None,
+) -> DiagramLabels:
+    """Claude Vision call: return every visible label + its approximate position."""
+    if not image_bytes:
+        raise ValueError("image_bytes must be non-empty")
+    if client is None:
+        settings = get_settings()
+        if not settings.anthropic_api_key:
+            raise ValueError("ANTHROPIC_API_KEY is required to extract labels")
+        client = anthropic.AsyncAnthropic(
+            api_key=settings.anthropic_api_key,
+            timeout=90.0,
+        )
+
+    encoded = base64.standard_b64encode(image_bytes).decode("ascii")
+    response = await client.messages.create(
+        model=_EXTRACT_MODEL,
+        max_tokens=_MAX_TOKENS,
+        system=_EXTRACT_SYSTEM,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": image_media_type,
+                            "data": encoded,
+                        },
+                    },
+                    {"type": "text", "text": _EXTRACT_USER},
+                ],
+            }
+        ],
+        temperature=0.0,
+    )
+
+    text = "".join(
+        getattr(block, "text", "") for block in response.content if hasattr(block, "text")
+    )
+    if not text.strip():
+        raise ValueError("empty label-extraction response")
+    return _parse_labels(text)
+
+
+async def translate_labels(
+    labels: DiagramLabels,
+    target_lang: str = "fr",
+    client: anthropic.AsyncAnthropic | None = None,
+) -> DiagramLabels:
+    """Translate every label's text into ``target_lang``, preserving ids and positions."""
+    if target_lang not in {"fr", "en"}:
+        raise ValueError(f"unsupported target_lang: {target_lang!r}")
+    if client is None:
+        settings = get_settings()
+        if not settings.anthropic_api_key:
+            raise ValueError("ANTHROPIC_API_KEY is required to translate labels")
+        client = anthropic.AsyncAnthropic(
+            api_key=settings.anthropic_api_key,
+            timeout=60.0,
+        )
+
+    target_full = {"fr": "French", "en": "English"}[target_lang]
+    payload = labels.model_dump_json()
+    response = await client.messages.create(
+        model=_TRANSLATE_MODEL,
+        max_tokens=_MAX_TOKENS,
+        system=_TRANSLATE_SYSTEM,
+        messages=[
+            {
+                "role": "user",
+                "content": _TRANSLATE_USER_TEMPLATE.format(
+                    target_lang_full=target_full, payload=payload
+                ),
+            }
+        ],
+        temperature=0.0,
+    )
+    text = "".join(
+        getattr(block, "text", "") for block in response.content if hasattr(block, "text")
+    )
+    if not text.strip():
+        raise ValueError("empty label-translation response")
+    translated = _parse_labels(text)
+
+    original_ids = {label.id for label in labels.labels}
+    translated_ids = {label.id for label in translated.labels}
+    if original_ids != translated_ids:
+        raise ValueError(
+            "translator changed label ids: "
+            f"added={translated_ids - original_ids}, "
+            f"removed={original_ids - translated_ids}"
+        )
+    return translated
+
+
+# ---------------------------------------------------------------------------
+# SVG rendering
+# ---------------------------------------------------------------------------
+
+_BADGE_RADIUS_FRACTION = 0.02  # fraction of min(width, height)
+_BADGE_MIN_RADIUS = 10
+_BADGE_MAX_RADIUS = 22
+_LEGEND_FONT_SIZE = 14
+_LEGEND_LINE_HEIGHT = 20
+_LEGEND_PADDING = 20
+_LEGEND_MAX_CHARS_PER_LINE = 80
+
+
+def _escape(text: str) -> str:
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&#39;")
+    )
+
+
+def _wrap_legend_line(number: int, text: str, max_chars: int) -> list[str]:
+    """Wrap a `N — text` line at word boundaries, returning visible lines."""
+    prefix = f"{number} — "
+    budget = max(1, max_chars - len(prefix))
+    words = text.split()
+    if not words:
+        return [prefix.rstrip()]
+    lines: list[str] = []
+    current = words[0]
+    for word in words[1:]:
+        if len(current) + 1 + len(word) <= budget:
+            current = f"{current} {word}"
+        else:
+            lines.append(current)
+            current = word
+    lines.append(current)
+    # The first line includes the prefix; continuation lines are indented to
+    # match visually.
+    indent = " " * len(prefix)
+    return [prefix + lines[0]] + [indent + line for line in lines[1:]]
+
+
+def render_overlay_svg(
+    image_bytes: bytes,
+    width_px: int,
+    height_px: int,
+    labels: DiagramLabels,
+    image_media_type: str = "image/webp",
+) -> bytes:
+    """Render a ``complex_diagram`` figure as raster + badge overlay + legend.
+
+    Produces a single self-contained SVG document: the source raster is
+    embedded base64, numbered badges sit on top at each label's position, and
+    a legend strip below maps ``N — translated term`` for each badge.
+    """
+    if not image_bytes:
+        raise ValueError("image_bytes must be non-empty")
+    if width_px <= 0 or height_px <= 0:
+        raise ValueError("width_px and height_px must be positive")
+    if not labels.labels:
+        raise ValueError("labels must be non-empty")
+
+    badge_radius = max(
+        _BADGE_MIN_RADIUS,
+        min(_BADGE_MAX_RADIUS, int(min(width_px, height_px) * _BADGE_RADIUS_FRACTION)),
+    )
+    font_size_badge = max(10, int(badge_radius * 1.1))
+
+    # Legend rows: one entry per label, possibly wrapping onto multiple lines.
+    legend_lines: list[str] = []
+    for i, label in enumerate(labels.labels, start=1):
+        legend_lines.extend(_wrap_legend_line(i, label.text, _LEGEND_MAX_CHARS_PER_LINE))
+
+    legend_height = _LEGEND_PADDING * 2 + len(legend_lines) * _LEGEND_LINE_HEIGHT
+    total_height = height_px + legend_height
+
+    encoded_image = base64.standard_b64encode(image_bytes).decode("ascii")
+
+    svg_parts: list[str] = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" '
+        f'viewBox="0 0 {width_px} {total_height}" '
+        f'font-family="Helvetica, Arial, sans-serif" font-size="{_LEGEND_FONT_SIZE}">'
+    ]
+
+    # Base raster (encoded inline so the SVG is a self-contained asset).
+    svg_parts.append(
+        f'<image x="0" y="0" width="{width_px}" height="{height_px}" '
+        f'xlink:href="data:{image_media_type};base64,{encoded_image}" />'
+    )
+
+    # Numbered badges over the raster.
+    for i, label in enumerate(labels.labels, start=1):
+        cx = round(label.x_pct / 100.0 * width_px, 2)
+        cy = round(label.y_pct / 100.0 * height_px, 2)
+        svg_parts.append(
+            f'<circle cx="{cx}" cy="{cy}" r="{badge_radius}" '
+            f'fill="#FFCA28" stroke="#5D4037" stroke-width="1.5" opacity="0.95" />'
+        )
+        svg_parts.append(
+            f'<text x="{cx}" y="{cy + font_size_badge * 0.35:.2f}" '
+            f'text-anchor="middle" font-size="{font_size_badge}" '
+            f'font-weight="700" fill="#3E2723">{i}</text>'
+        )
+
+    # Legend strip below the image.
+    svg_parts.append(
+        f'<rect x="0" y="{height_px}" width="{width_px}" height="{legend_height}" '
+        f'fill="#FAFAFA" stroke="#E0E0E0" stroke-width="1" />'
+    )
+    y = height_px + _LEGEND_PADDING + _LEGEND_FONT_SIZE
+    for line in legend_lines:
+        svg_parts.append(
+            f'<text x="{_LEGEND_PADDING}" y="{y}" fill="#212121" '
+            f'xml:space="preserve">{_escape(line)}</text>'
+        )
+        y += _LEGEND_LINE_HEIGHT
+
+    svg_parts.append("</svg>")
+    return "\n".join(svg_parts).encode("utf-8")

--- a/backend/app/tasks/image_translation.py
+++ b/backend/app/tasks/image_translation.py
@@ -30,8 +30,11 @@ from sqlalchemy.ext.asyncio import (
 from app.ai.translation import (
     classify_figure,
     extract_flowchart_structure,
+    extract_label_positions,
+    render_overlay_svg,
     render_svg,
     translate_figure_caption,
+    translate_labels,
     translate_structure,
 )
 from app.domain.models.source_image import SourceImage
@@ -613,3 +616,206 @@ def _svg_key_for(img: SourceImage) -> str:
     safe_label = figure_label.replace(" ", "_").replace(".", "_")
     prefix = img.rag_collection_id or img.source
     return f"source-images/{prefix}/{img.page_number}_{safe_label}.fr.svg"
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 slice 2.4 (#1883) — complex_diagram raster + numbered-badge overlay
+# ---------------------------------------------------------------------------
+
+
+class ComplexDiagramOverlayTask(Task):
+    """Celery base for the complex_diagram overlay backfill."""
+
+    def on_success(self, retval, task_id, args, kwargs):
+        logger.info("Complex-diagram overlay backfill completed", task_id=task_id, result=retval)
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        logger.error("Complex-diagram overlay backfill failed", task_id=task_id, exception=str(exc))
+
+
+@celery_app.task(
+    bind=True,
+    base=ComplexDiagramOverlayTask,
+    time_limit=3600,
+    soft_time_limit=3300,
+    ignore_result=True,
+    acks_late=False,
+)
+def backfill_complex_diagram_overlays(
+    self,
+    rag_collection_id: str | None = None,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """Render French-variant overlays for rows with ``figure_kind = 'complex_diagram'``.
+
+    Eligible: ``figure_kind = 'complex_diagram' AND storage_key_fr IS NULL AND
+    storage_url IS NOT NULL``. Fetches the English raster from MinIO,
+    extracts label positions, translates them, renders a numbered-badge
+    overlay SVG, uploads, writes back ``storage_key_fr`` + ``storage_url_fr``.
+    """
+    return asyncio.run(
+        _run_overlay_backfill(
+            task=self,
+            rag_collection_id=rag_collection_id,
+            limit=limit,
+            dry_run=dry_run,
+        )
+    )
+
+
+async def _run_overlay_backfill(
+    task: Task,
+    rag_collection_id: str | None,
+    limit: int | None,
+    dry_run: bool,
+) -> dict:
+    engine = create_async_engine(settings.database_url, pool_pre_ping=True)
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        return await _run_overlay_backfill_with_factory(
+            task=task,
+            rag_collection_id=rag_collection_id,
+            limit=limit,
+            dry_run=dry_run,
+            session_factory=session_factory,
+            storage=S3StorageService(),
+        )
+    finally:
+        await engine.dispose()
+
+
+async def _run_overlay_backfill_with_factory(
+    task: Task,
+    rag_collection_id: str | None,
+    limit: int | None,
+    dry_run: bool,
+    session_factory: async_sessionmaker[AsyncSession],
+    storage: S3StorageService,
+) -> dict:
+    async with session_factory() as session:
+        stmt = select(SourceImage).where(
+            SourceImage.figure_kind == "complex_diagram",
+            SourceImage.storage_key_fr.is_(None),
+            SourceImage.storage_url.is_not(None),
+        )
+        if rag_collection_id is not None:
+            stmt = stmt.where(SourceImage.rag_collection_id == rag_collection_id)
+        if limit is not None:
+            stmt = stmt.limit(limit)
+
+        rows = (await session.execute(stmt)).scalars().all()
+        total = len(rows)
+
+        logger.info(
+            "Complex-diagram overlay backfill: eligible rows",
+            total=total,
+            rag_collection_id=rag_collection_id,
+            dry_run=dry_run,
+        )
+
+        task.update_state(
+            state="OVERLAYING",
+            meta={
+                "step": "overlaying",
+                "total": total,
+                "processed": 0,
+                "rendered": 0,
+                "failed": 0,
+            },
+        )
+
+        if dry_run or total == 0:
+            return {
+                "status": "dry_run" if dry_run else "noop",
+                "eligible": total,
+                "rendered": 0,
+                "failed": 0,
+            }
+
+        rendered = 0
+        failed = 0
+        pending_commit = 0
+
+        async with httpx.AsyncClient(timeout=30.0) as http:
+            for idx, img in enumerate(rows):
+                try:
+                    upstream = await http.get(img.storage_url)
+                    upstream.raise_for_status()
+                    image_bytes = upstream.content
+                except Exception as exc:
+                    failed += 1
+                    logger.warning(
+                        "Failed to fetch image bytes for overlay backfill",
+                        source_image_id=str(img.id),
+                        storage_url=img.storage_url,
+                        error=str(exc),
+                    )
+                    continue
+
+                try:
+                    positions = await extract_label_positions(image_bytes=image_bytes)
+                    translated = await translate_labels(positions, target_lang="fr")
+                    svg_bytes = render_overlay_svg(
+                        image_bytes=image_bytes,
+                        width_px=img.width or 1024,
+                        height_px=img.height or 768,
+                        labels=translated,
+                    )
+                except Exception as exc:
+                    failed += 1
+                    logger.warning(
+                        "Overlay render failed",
+                        source_image_id=str(img.id),
+                        figure_number=img.figure_number,
+                        error=str(exc),
+                    )
+                    continue
+
+                try:
+                    key = _svg_key_for(img)
+                    url = await storage.upload_bytes(
+                        key=key,
+                        data=svg_bytes,
+                        content_type="image/svg+xml",
+                    )
+                except Exception as exc:
+                    failed += 1
+                    logger.warning(
+                        "Failed to upload FR overlay SVG to storage",
+                        source_image_id=str(img.id),
+                        error=str(exc),
+                    )
+                    continue
+
+                img.storage_key_fr = key
+                img.storage_url_fr = url
+                session.add(img)
+                rendered += 1
+                pending_commit += 1
+
+                if pending_commit >= _COMMIT_EVERY:
+                    await session.commit()
+                    pending_commit = 0
+
+                if (idx + 1) % 10 == 0 or idx + 1 == total:
+                    task.update_state(
+                        state="OVERLAYING",
+                        meta={
+                            "step": "overlaying",
+                            "total": total,
+                            "processed": idx + 1,
+                            "rendered": rendered,
+                            "failed": failed,
+                        },
+                    )
+
+        if pending_commit:
+            await session.commit()
+
+        return {
+            "status": "complete",
+            "eligible": total,
+            "rendered": rendered,
+            "failed": failed,
+        }

--- a/backend/tests/test_backfill_complex_diagram_overlays.py
+++ b/backend/tests/test_backfill_complex_diagram_overlays.py
@@ -1,0 +1,235 @@
+"""Unit tests for ``backfill_complex_diagram_overlays`` (issue #1883).
+
+Exercises ``_run_overlay_backfill_with_factory`` directly with a mocked
+session, httpx, Claude calls, and storage so the tests have no DB/MinIO/
+network dependency.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.ai.translation.complex_overlay import DiagramLabel, DiagramLabels
+from app.tasks import image_translation
+
+
+def _make_row(
+    storage_key_fr: str | None = None,
+    figure_kind: str = "complex_diagram",
+    storage_url: str | None = "https://minio/default.webp",
+    width: int | None = 800,
+    height: int | None = 600,
+) -> MagicMock:
+    row = MagicMock()
+    row.id = uuid.uuid4()
+    row.source = "biology"
+    row.rag_collection_id = "course-1"
+    row.figure_kind = figure_kind
+    row.storage_url = storage_url
+    row.storage_key_fr = storage_key_fr
+    row.storage_url_fr = None
+    row.figure_number = "1.1"
+    row.page_number = 1
+    row.width = width
+    row.height = height
+    return row
+
+
+class _FakeSession:
+    def __init__(self, rows):
+        self._rows = rows
+        self.added: list[MagicMock] = []
+        self.commits = 0
+
+    async def execute(self, stmt):
+        result = MagicMock()
+        scalars = MagicMock()
+        scalars.all = MagicMock(return_value=list(self._rows))
+        result.scalars = MagicMock(return_value=scalars)
+        return result
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def commit(self):
+        self.commits += 1
+
+
+class _FakeSessionFactory:
+    def __init__(self, session: _FakeSession):
+        self._session = session
+
+    def __call__(self):
+        session = self._session
+
+        class _Ctx:
+            async def __aenter__(self):
+                return session
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        return _Ctx()
+
+
+class _FakeStorage:
+    def __init__(self):
+        self.uploads: list[tuple[str, bytes, str]] = []
+
+    async def upload_bytes(self, key: str, data: bytes, content_type: str) -> str:
+        self.uploads.append((key, data, content_type))
+        return f"https://minio/{key}"
+
+
+def _patch_httpx(body: bytes = b"fake-webp"):
+    upstream = MagicMock()
+    upstream.content = body
+    upstream.raise_for_status = MagicMock()
+    http_client = MagicMock()
+    http_client.get = AsyncMock(return_value=upstream)
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=http_client)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return patch.object(image_translation.httpx, "AsyncClient", return_value=ctx)
+
+
+def _sample_labels() -> DiagramLabels:
+    return DiagramLabels(
+        labels=[
+            DiagramLabel(id="n1", text="Noyau", x_pct=30.0, y_pct=40.0),
+            DiagramLabel(id="n2", text="Membrane", x_pct=60.0, y_pct=50.0),
+        ]
+    )
+
+
+class TestRunOverlayBackfillWithFactory:
+    async def test_dry_run_counts_without_calling_claude(self):
+        rows = [_make_row(), _make_row()]
+        session = _FakeSession(rows)
+        task = MagicMock()
+        storage = _FakeStorage()
+
+        extract = AsyncMock(return_value=_sample_labels())
+        translate = AsyncMock(return_value=_sample_labels())
+
+        with (
+            _patch_httpx(),
+            patch.object(image_translation, "extract_label_positions", new=extract),
+            patch.object(image_translation, "translate_labels", new=translate),
+        ):
+            result = await image_translation._run_overlay_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=True,
+                session_factory=_FakeSessionFactory(session),
+                storage=storage,
+            )
+
+        assert result == {
+            "status": "dry_run",
+            "eligible": 2,
+            "rendered": 0,
+            "failed": 0,
+        }
+        extract.assert_not_awaited()
+        translate.assert_not_awaited()
+        assert storage.uploads == []
+        assert session.commits == 0
+
+    async def test_renders_and_uploads_all_eligible_rows(self):
+        rows = [_make_row(), _make_row()]
+        session = _FakeSession(rows)
+        task = MagicMock()
+        storage = _FakeStorage()
+
+        extract = AsyncMock(return_value=_sample_labels())
+        translate = AsyncMock(return_value=_sample_labels())
+
+        with (
+            _patch_httpx(),
+            patch.object(image_translation, "extract_label_positions", new=extract),
+            patch.object(image_translation, "translate_labels", new=translate),
+        ):
+            result = await image_translation._run_overlay_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=False,
+                session_factory=_FakeSessionFactory(session),
+                storage=storage,
+            )
+
+        assert result["status"] == "complete"
+        assert result["rendered"] == 2
+        assert result["failed"] == 0
+        assert len(storage.uploads) == 2
+        for key, data, content_type in storage.uploads:
+            assert key.endswith(".fr.svg")
+            assert content_type == "image/svg+xml"
+            assert data.startswith(b"<svg")
+        for row in rows:
+            assert row.storage_key_fr.endswith(".fr.svg")
+            assert row.storage_url_fr.startswith("https://minio/")
+
+    async def test_extract_failure_does_not_abort_batch(self):
+        rows = [_make_row(), _make_row(), _make_row()]
+        session = _FakeSession(rows)
+        task = MagicMock()
+        storage = _FakeStorage()
+
+        extract = AsyncMock(
+            side_effect=[
+                _sample_labels(),
+                ValueError("vision timed out"),
+                _sample_labels(),
+            ]
+        )
+        translate = AsyncMock(return_value=_sample_labels())
+
+        with (
+            _patch_httpx(),
+            patch.object(image_translation, "extract_label_positions", new=extract),
+            patch.object(image_translation, "translate_labels", new=translate),
+        ):
+            result = await image_translation._run_overlay_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=False,
+                session_factory=_FakeSessionFactory(session),
+                storage=storage,
+            )
+
+        assert result["rendered"] == 2
+        assert result["failed"] == 1
+        assert rows[0].storage_key_fr is not None
+        assert rows[1].storage_key_fr is None
+        assert rows[2].storage_key_fr is not None
+
+    async def test_empty_eligible_set_returns_noop(self):
+        session = _FakeSession([])
+        task = MagicMock()
+        storage = _FakeStorage()
+
+        extract = AsyncMock(return_value=_sample_labels())
+        translate = AsyncMock(return_value=_sample_labels())
+
+        with (
+            _patch_httpx(),
+            patch.object(image_translation, "extract_label_positions", new=extract),
+            patch.object(image_translation, "translate_labels", new=translate),
+        ):
+            result = await image_translation._run_overlay_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=False,
+                session_factory=_FakeSessionFactory(session),
+                storage=storage,
+            )
+
+        assert result["status"] == "noop"
+        assert result["eligible"] == 0
+        extract.assert_not_awaited()

--- a/backend/tests/test_complex_overlay.py
+++ b/backend/tests/test_complex_overlay.py
@@ -1,0 +1,225 @@
+"""Unit tests for the complex_diagram overlay renderer (issue #1883)."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from app.ai.translation.complex_overlay import (
+    DiagramLabel,
+    DiagramLabels,
+    _escape,
+    _parse_labels,
+    _wrap_legend_line,
+    extract_label_positions,
+    render_overlay_svg,
+    translate_labels,
+)
+
+
+def _mock_anthropic_response(text: str) -> MagicMock:
+    msg = MagicMock()
+    msg.content = [SimpleNamespace(text=text)]
+    return msg
+
+
+def _mock_client(text: str) -> MagicMock:
+    client = MagicMock()
+    client.messages = MagicMock()
+    client.messages.create = AsyncMock(return_value=_mock_anthropic_response(text))
+    return client
+
+
+class TestDiagramLabelCoercion:
+    def test_accepts_percentage_0_100(self):
+        label = DiagramLabel(id="n1", text="A", x_pct=42.0, y_pct=17.5)
+        assert label.x_pct == 42.0 and label.y_pct == 17.5
+
+    def test_coerces_fraction_0_1_to_percent(self):
+        label = DiagramLabel(id="n1", text="A", x_pct=0.42, y_pct=0.175)
+        assert label.x_pct == pytest.approx(42.0)
+        assert label.y_pct == pytest.approx(17.5)
+
+    def test_rejects_out_of_range(self):
+        with pytest.raises(ValidationError):
+            DiagramLabel(id="n1", text="A", x_pct=150.0, y_pct=0.0)
+
+
+class TestWrapLegendLine:
+    def test_short_fits_on_one_line(self):
+        out = _wrap_legend_line(1, "Noyau", max_chars=40)
+        assert out == ["1 — Noyau"]
+
+    def test_long_wraps_at_words_with_indent(self):
+        out = _wrap_legend_line(2, "Membrane plasmique très très longue label", max_chars=20)
+        assert out[0].startswith("2 — ")
+        # continuation lines are indented so the text column stays aligned
+        indent = " " * len("2 — ")
+        for line in out[1:]:
+            assert line.startswith(indent)
+
+
+class TestEscape:
+    def test_escapes_xml_metachars(self):
+        assert _escape("A & <B> \"c'") == "A &amp; &lt;B&gt; &quot;c&#39;"
+
+
+class TestParseLabels:
+    def test_strips_markdown_fences(self):
+        payload = {"labels": [{"id": "n1", "text": "X", "x_pct": 10, "y_pct": 20}]}
+        fenced = f"```json\n{json.dumps(payload)}\n```"
+        result = _parse_labels(fenced)
+        assert result.labels[0].text == "X"
+
+    def test_rejects_empty_labels_list(self):
+        with pytest.raises(ValidationError):
+            _parse_labels(json.dumps({"labels": []}))
+
+
+class TestExtractLabelPositions:
+    async def test_happy_path(self):
+        payload = {
+            "labels": [
+                {"id": "n1", "text": "Nucleus", "x_pct": 42.5, "y_pct": 17.0},
+                {"id": "n2", "text": "Membrane", "x_pct": 60.0, "y_pct": 50.0},
+            ]
+        }
+        client = _mock_client(json.dumps(payload))
+        result = await extract_label_positions(b"fake-webp", client=client)
+        assert isinstance(result, DiagramLabels)
+        assert [label.id for label in result.labels] == ["n1", "n2"]
+        assert result.labels[0].x_pct == 42.5
+
+    async def test_empty_bytes_rejected(self):
+        client = _mock_client("{}")
+        with pytest.raises(ValueError, match="non-empty"):
+            await extract_label_positions(b"", client=client)
+        client.messages.create.assert_not_awaited()
+
+    async def test_invalid_json_raises(self):
+        client = _mock_client("not json")
+        with pytest.raises(ValueError):
+            await extract_label_positions(b"fake-webp", client=client)
+
+    async def test_missing_labels_fails_validation(self):
+        client = _mock_client(json.dumps({}))
+        with pytest.raises(ValidationError):
+            await extract_label_positions(b"fake-webp", client=client)
+
+
+class TestTranslateLabels:
+    async def test_preserves_ids_and_coordinates(self):
+        source = DiagramLabels(
+            labels=[
+                DiagramLabel(id="n1", text="Nucleus", x_pct=42.5, y_pct=17.0),
+                DiagramLabel(id="n2", text="Membrane", x_pct=60.0, y_pct=50.0),
+            ]
+        )
+        translated = {
+            "labels": [
+                {"id": "n1", "text": "Noyau", "x_pct": 42.5, "y_pct": 17.0},
+                {"id": "n2", "text": "Membrane plasmique", "x_pct": 60.0, "y_pct": 50.0},
+            ]
+        }
+        client = _mock_client(json.dumps(translated))
+        out = await translate_labels(source, target_lang="fr", client=client)
+        assert out.labels[0].text == "Noyau"
+        assert out.labels[1].text == "Membrane plasmique"
+
+    async def test_rejects_unsupported_target_lang(self):
+        source = DiagramLabels(labels=[DiagramLabel(id="n1", text="x", x_pct=10, y_pct=10)])
+        with pytest.raises(ValueError, match="unsupported target_lang"):
+            await translate_labels(source, target_lang="de")
+
+    async def test_raises_when_translator_changes_ids(self):
+        source = DiagramLabels(labels=[DiagramLabel(id="n1", text="x", x_pct=10, y_pct=10)])
+        rogue = {"labels": [{"id": "different", "text": "y", "x_pct": 10, "y_pct": 10}]}
+        client = _mock_client(json.dumps(rogue))
+        with pytest.raises(ValueError, match="changed label ids"):
+            await translate_labels(source, target_lang="fr", client=client)
+
+
+class TestRenderOverlaySvg:
+    # We deliberately use string-based assertions instead of an XML parser
+    # here — SVG 1.1 with xlink:href needs namespace awareness in ET and it's
+    # more fragile than just grepping for the structural features we care
+    # about.
+
+    def test_renders_valid_svg_with_image_and_badges_and_legend(self):
+        labels = DiagramLabels(
+            labels=[
+                DiagramLabel(id="n1", text="Noyau", x_pct=25.0, y_pct=30.0),
+                DiagramLabel(id="n2", text="Membrane", x_pct=75.0, y_pct=60.0),
+            ]
+        )
+        svg = render_overlay_svg(
+            image_bytes=b"fake-webp-bytes",
+            width_px=800,
+            height_px=600,
+            labels=labels,
+        )
+        body = svg.decode("utf-8")
+        assert body.startswith("<svg")
+        assert 'xmlns="http://www.w3.org/2000/svg"' in body
+        # One embedded raster
+        assert body.count("<image ") == 1
+        assert 'xlink:href="data:image/webp;base64,' in body
+        # One badge circle per label
+        assert body.count("<circle ") == 2
+        # Legend contains the translated terms
+        assert "Noyau" in body
+        assert "Membrane" in body
+
+    def test_badge_positions_map_pct_to_pixels(self):
+        labels = DiagramLabels(labels=[DiagramLabel(id="n1", text="X", x_pct=50.0, y_pct=25.0)])
+        svg = render_overlay_svg(
+            image_bytes=b"bytes",
+            width_px=1000,
+            height_px=400,
+            labels=labels,
+        ).decode("utf-8")
+        # Renderer emits cx / cy rounded to 2 dp → 500.0 / 100.0.
+        # Look for the exact attribute tokens.
+        assert 'cx="500.0"' in svg or 'cx="500"' in svg
+        assert 'cy="100.0"' in svg or 'cy="100"' in svg
+
+    def test_xml_metachars_in_labels_escaped(self):
+        labels = DiagramLabels(labels=[DiagramLabel(id="n1", text="A & <B>", x_pct=10, y_pct=10)])
+        svg = render_overlay_svg(
+            image_bytes=b"bytes", width_px=400, height_px=300, labels=labels
+        ).decode("utf-8")
+        # Raw metachars in body text would break XML; check they are escaped
+        # within legend text (legend lines wrap "1 — A & <B>").
+        assert "A &amp; &lt;B&gt;" in svg
+        assert "A & <B>" not in svg.split("xlink:href=")[1]  # not in the svg body post-href
+
+    def test_rejects_empty_inputs(self):
+        good = DiagramLabels(labels=[DiagramLabel(id="n1", text="X", x_pct=10, y_pct=10)])
+        with pytest.raises(ValueError, match="image_bytes"):
+            render_overlay_svg(b"", 400, 300, good)
+        with pytest.raises(ValueError, match="width_px"):
+            render_overlay_svg(b"x", 0, 300, good)
+        with pytest.raises(ValueError, match="labels"):
+            render_overlay_svg(b"x", 400, 300, DiagramLabels.model_construct(labels=[]))
+
+    def test_viewbox_extends_below_image_for_legend(self):
+        labels = DiagramLabels(
+            labels=[DiagramLabel(id=f"n{i}", text=f"L{i}", x_pct=50, y_pct=50) for i in range(5)]
+        )
+        svg = render_overlay_svg(
+            image_bytes=b"x", width_px=600, height_px=400, labels=labels
+        ).decode("utf-8")
+        # Extract the viewBox value via simple string indexing.
+        vb_token = 'viewBox="'
+        idx = svg.index(vb_token) + len(vb_token)
+        viewbox = svg[idx : svg.index('"', idx)]
+        parts = viewbox.split()
+        assert len(parts) == 4
+        total_height = float(parts[3])
+        # Image is 400 tall; 5 legend lines × 20 px line-height + padding pad
+        # must push total over 400 + 5*20.
+        assert total_height > 400 + 5 * 20


### PR DESCRIPTION
Fixes #1883. Fourth slice of Phase 2 (epic #1819). Builds on #1834 plumbing, #1844 classifier, #1853/#1876 flowchart renderer.

**Branch base: dev** (per workflow rule). Had to sync main→dev first (PR #1884) to pick up slices 2.2/2.3 deps.

## Closes the biggest remaining gap

Classifier distribution from a staging sample (200 rows):

```
decorative          59    caption-only — done (#1820)
table               56    GAP
complex_diagram     50    ← this PR (~25% of figures)
clean_flowchart     21    SVG re-derived — done (#1853)
photo               12    caption-only — done
photo_with_callouts  1    GAP
chart                1    GAP
```

## Strategy

For anatomy plates / multi-panel figures / dense labelled diagrams, a full re-derive is visually wrong — Claude Vision can't reproduce the source illustration faithfully. Instead: **keep the raster, overlay numbered badges on each label, print a French legend below**. Every label is translated while the learner still sees the exact imagery from the source textbook.

## Summary

- New `app.ai.translation.complex_overlay`:
  - `extract_label_positions(image_bytes)` — Claude Vision returns `[{id, text, x_pct, y_pct}]`. Tolerant of 0..1 or 0..100 inputs via pydantic `field_validator`.
  - `translate_labels(labels, target_lang='fr')` — Claude Haiku translates each label text; preserves ids + coords; raises on id drift.
  - `render_overlay_svg(image_bytes, width_px, height_px, labels)` — self-contained SVG with base64-embedded raster, numbered \`<circle>\` badges, wrapped legend strip.
- `RAGPipeline._process_images` routes `figure_kind == 'complex_diagram'` through this pipeline (parallel to the `clean_flowchart` branch from #1853). Failures leave the FR variant NULL → endpoint falls back to English raster.
- New Celery task `backfill_complex_diagram_overlays` (task-scoped async engine, same pattern as #1829). Idempotent on `storage_key_fr IS NULL`.

## Test plan

- [x] `uv run ruff check && ruff format --check` — clean
- [x] `uv run pytest tests/test_complex_overlay.py tests/test_backfill_complex_diagram_overlays.py ...` — 132 pass (24 new)
- [ ] Staging after deploy:
  - [ ] `backfill_complex_diagram_overlays --kwargs='{\"dry_run\": true}'` reports eligible count
  - [ ] Bounded run on 5 rows; manually inspect 2-3 SVGs in a browser to judge badge placement + legend readability
  - [ ] `/fr/...` lesson with a `complex_diagram` figure shows the overlay variant; `/en/...` unchanged

## Out of scope (remaining slices)

- Slice 2.5: `chart` re-render (axes/legend extraction + matplotlib render)
- Slice 2.6: `table` → semantic HTML `<table>`
- Slice 2.7: `photo_with_callouts` overlay

## Risks

- **Coordinate accuracy** — Claude Vision gives approximate positions (usually within 5-10% of true). A badge that lands a few pixels from its label is still intelligible; the legend gives the exact meaning. If quality disappoints in practice, next iteration could snap badges to nearest detected text region.
- **Cost** — 2 Haiku calls per figure × ~1,300 complex_diagram rows on staging = ~2,600 calls total. Well under rate limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)