### PR TITLE
fix(lesson UI): tab strip scrollbar arrows from h-8 clipping 44px triggers

### DIFF
--- a/frontend/components/learning/lesson-media-tabs.tsx
+++ b/frontend/components/learning/lesson-media-tabs.tsx
@@ -55,7 +55,7 @@ export function LessonMediaTabs({
       onValueChange={handleValueChange}
       className="mb-6 gap-3"
     >
-      <TabsList className="h-auto w-full justify-start gap-1 rounded-lg bg-muted p-1 overflow-x-auto">
+      <TabsList className="group-data-horizontal/tabs:h-auto min-h-12 w-full justify-start gap-1 rounded-lg bg-muted p-1 overflow-x-auto overflow-y-hidden">
         <TabsTrigger
           value="read"
           className="min-h-11 flex-none gap-2 px-4 data-active:bg-background"


### PR DESCRIPTION
## Summary
- The shadcn TabsList primitive forces \`group-data-horizontal/tabs:h-8\` (32 px) on the list container; our triggers use \`min-h-11\` (44 px) for tap targets, so content overflows and the browser shows tiny up/down scroll arrows on the right edge.
- Override the variant directly (\`group-data-horizontal/tabs:h-auto\`), set \`min-h-12\` for visual containment, add \`overflow-y-hidden\` to defend against future trigger-height drift.

Fixes #1888

## Test plan
- [ ] Open any lesson on staging; confirm no scrollbar arrows on the right edge of the tab strip
- [ ] All three triggers (Lire / Écouter / Vidéo) still tappable at ≥44×44 px
- [ ] Mobile (320 px width): horizontal overflow still scrolls if needed; vertical never does

🤖 Generated with [Claude Code](https://claude.com/claude-code)