### PR TITLE
fix(lesson UI): tab strip scrollbar arrows from h-8 clipping 44px triggers

### DIFF
--- a/frontend/components/learning/lesson-media-tabs.tsx
+++ b/frontend/components/learning/lesson-media-tabs.tsx
@@ -55,7 +55,7 @@ export function LessonMediaTabs({
       onValueChange={handleValueChange}
       className="mb-6 gap-3"
     >
-      <TabsList className="h-auto w-full justify-start gap-1 rounded-lg bg-muted p-1 overflow-x-auto">
+      <TabsList className="group-data-horizontal/tabs:h-auto min-h-12 w-full justify-start gap-1 rounded-lg bg-muted p-1 overflow-x-auto overflow-y-hidden">
         <TabsTrigger
           value="read"
           className="min-h-11 flex-none gap-2 px-4 data-active:bg-background"


### PR DESCRIPTION
Cherry-pick of #1889 (already merged to dev as 009938a6) — scoped to ship just this one-line CSS fix to staging.

## Summary
- The shadcn TabsList primitive forces \`group-data-horizontal/tabs:h-8\` (32 px) on the list container; our triggers use \`min-h-11\` (44 px). Content overflows and the browser shows tiny scroll arrows on the right edge of the tab strip.
- Override the variant directly (\`group-data-horizontal/tabs:h-auto\`), set \`min-h-12\` for visual containment, add \`overflow-y-hidden\` as defense.

Fixes #1888

## Test plan
- [ ] No scrollbar arrows on the tab strip
- [ ] Triggers still ≥44×44 px tap targets
- [ ] Mobile (320 px): horizontal overflow if needed; vertical never

🤖 Generated with [Claude Code](https://claude.com/claude-code)