### PR TITLE
fix(lessons): redirect legacy /lessons/{unit} URLs for non-lesson units

### DIFF
--- a/frontend/app/[locale]/(app)/modules/[moduleId]/case-study/page.tsx
+++ b/frontend/app/[locale]/(app)/modules/[moduleId]/case-study/page.tsx
@@ -2,6 +2,7 @@ import { getTranslations, getLocale } from 'next-intl/server';
 import { Link } from '@/i18n/routing';
 import { ChevronLeft } from 'lucide-react';
 import { getModuleUnits } from '@/lib/api';
+import { matchUnit } from '@/lib/unit-id';
 import { CaseStudyViewer } from '@/components/learning/case-study-viewer';
 import { EnrollmentGuard } from '@/components/shared/enrollment-guard';
 interface CaseStudyPageProps {
@@ -25,13 +26,7 @@ export default async function CaseStudyPage({ params, searchParams }: CaseStudyP
     : moduleData?.learning_objectives_en;
   const bloomLevel = moduleData?.bloom_level;
 
-  // unitId is "M01-U09" format; API units use UUID id and "1.9" unit_number
-  // Match by unit_number: extract module & unit numbers from "MXX-UYY" → "X.Y"
-  const unitNumMatch = unitId.match(/^M0*(\d+)-U0*(\d+)$/);
-  const unitNumber = unitNumMatch ? `${unitNumMatch[1]}.${unitNumMatch[2]}` : null;
-  const matchedUnit = moduleData?.units?.find(
-    (u) => u.id === unitId || (unitNumber && u.unit_number === unitNumber)
-  );
+  const matchedUnit = matchUnit(moduleData?.units, unitId);
   const unitTitle = matchedUnit
     ? (language === 'fr' ? matchedUnit.title_fr : matchedUnit.title_en)
     : undefined;

--- a/frontend/app/[locale]/(app)/modules/[moduleId]/lessons/[unitId]/page.tsx
+++ b/frontend/app/[locale]/(app)/modules/[moduleId]/lessons/[unitId]/page.tsx
@@ -1,9 +1,10 @@
 import { getTranslations } from 'next-intl/server';
 import { getLocale } from 'next-intl/server';
-import { Link } from '@/i18n/routing';
+import { Link, redirect } from '@/i18n/routing';
 import { ChevronLeft } from 'lucide-react';
 
 import { API_BASE, ModuleUnitsResponse } from '@/lib/api';
+import { matchUnit } from '@/lib/unit-id';
 import { LessonViewer } from '@/components/learning/lesson-viewer';
 import { EnrollmentGuard } from '@/components/shared/enrollment-guard';
 
@@ -31,7 +32,15 @@ export default async function LessonPage({ params }: LessonPageProps) {
 
   const language = locale as 'fr' | 'en';
   const moduleData = await fetchModuleData(moduleId);
-  const unit = moduleData?.units?.find(u => u.unit_number === unitId || u.id === unitId);
+  const unit = matchUnit(moduleData?.units, unitId);
+
+  if (unit?.unit_type === 'scenario' || unit?.unit_type === 'case-study') {
+    redirect({ href: `/modules/${moduleId}/case-study?unit=${unit.unit_number}`, locale });
+  }
+  if (unit?.unit_type === 'quiz') {
+    redirect({ href: `/modules/${moduleId}/quiz?unit=${unit.unit_number}`, locale });
+  }
+
   const moduleTitle = language === 'fr' ? (moduleData?.title_fr || moduleId) : (moduleData?.title_en || moduleId);
   const unitTitle = language === 'fr' ? (unit?.title_fr || unitId) : (unit?.title_en || unitId);
   const moduleLevel = moduleData?.level || 1;
@@ -97,7 +106,7 @@ export async function generateMetadata({ params }: LessonPageProps) {
 
   const language = locale as 'fr' | 'en';
   const moduleData = await fetchModuleData(moduleId);
-  const unit = moduleData?.units?.find(u => u.unit_number === unitId || u.id === unitId);
+  const unit = matchUnit(moduleData?.units, unitId);
   const unitTitle = language === 'fr' ? (unit?.title_fr || unitId) : (unit?.title_en || unitId);
   const modTitle = language === 'fr' ? (moduleData?.title_fr || moduleId) : (moduleData?.title_en || moduleId);
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -201,7 +201,7 @@ export interface UnitProgressDetail {
   description_en?: string;
   estimated_minutes: number;
   order_index: number;
-  unit_type?: "lesson" | "quiz" | "case-study";
+  unit_type?: "lesson" | "quiz" | "case-study" | "scenario";
   status: "pending" | "in_progress" | "completed";
 }
 
@@ -268,7 +268,7 @@ export interface PublicUnitDetail {
   description_en?: string;
   estimated_minutes: number;
   order_index: number;
-  unit_type?: "lesson" | "quiz" | "case-study";
+  unit_type?: "lesson" | "quiz" | "case-study" | "scenario";
 }
 
 export interface ModuleUnitsResponse {

--- a/frontend/lib/offline/content-loader.ts
+++ b/frontend/lib/offline/content-loader.ts
@@ -8,6 +8,7 @@
 
 import { getOfflineContent, upsertOfflineContent, type ContentType } from './db';
 import { apiFetch } from '@/lib/api';
+import { legacyUnitIdToUnitNumber } from '@/lib/unit-id';
 
 export interface ContentLoadResult<T> {
   data: T;
@@ -198,20 +199,8 @@ export class OfflineContentNotAvailable extends Error {
 // --- Helpers ---
 
 /**
- * Convert URL-format unitId ("M01-U05") to API-format ("1.5").
- * Returns null if the input doesn't match the MXX-UYY pattern.
- *
- * The download manager stores content under the API format (unit.unit_number),
- * but quiz/case-study pages pass the URL format from route params.
- */
-function normalizeUnitId(unitId: string): string | null {
-  const match = unitId.match(/^M0*(\d+)-U0*(\d+)$/);
-  return match ? `${match[1]}.${match[2]}` : null;
-}
-
-/**
  * Look up offline content trying both the original unitId and the normalized
- * format (M01-U05 → 1.5) to handle the URL vs API format mismatch.
+ * legacy format (M01-U05 → 1.5) to handle the URL vs API format mismatch.
  */
 async function getOfflineContentWithFallback(
   moduleId: string,
@@ -222,7 +211,7 @@ async function getOfflineContentWithFallback(
   const cached = await getOfflineContent(moduleId, unitId, contentType, locale);
   if (cached) return cached;
 
-  const normalized = normalizeUnitId(unitId);
+  const normalized = legacyUnitIdToUnitNumber(unitId);
   if (normalized && normalized !== unitId) {
     return getOfflineContent(moduleId, normalized, contentType, locale);
   }

--- a/frontend/lib/unit-id.ts
+++ b/frontend/lib/unit-id.ts
@@ -1,0 +1,18 @@
+export function legacyUnitIdToUnitNumber(unitId: string): string | null {
+  const m = unitId.match(/^M0*(\d+)-U0*(\d+)$/);
+  return m ? `${m[1]}.${m[2]}` : null;
+}
+
+export function matchUnit<T extends { id: string; unit_number: string }>(
+  units: T[] | undefined,
+  unitId: string,
+): T | undefined {
+  if (!units) return undefined;
+  const legacy = legacyUnitIdToUnitNumber(unitId);
+  return units.find(
+    (u) =>
+      u.id === unitId ||
+      u.unit_number === unitId ||
+      (legacy !== null && u.unit_number === legacy),
+  );
+}


### PR DESCRIPTION
## Summary

- The lessons page mounted `LessonViewer` unconditionally; scenario/case-study/quiz units routed to `/lessons/{unit}` (still legal via the backend's `M0X-U0Y` → `X.Y` compat shim) rendered dead pages.
- Detect `unit_type` from the public `/api/v1/content/modules/{id}/units` response and server-side redirect to the canonical route (`/case-study?unit=...` or `/quiz?unit=...`) preserving locale.
- Collapsed three copies of the `M0X-U0Y` → `X.Y` matcher into a shared `frontend/lib/unit-id.ts` helper used by the lessons page, case-study page, and offline content-loader.
- Widened the `unit_type` union in `frontend/lib/api.ts` to include `"scenario"` (backend already returns it).

## Regression timeline (for the record)

- **2026-04-09 · 684b44b4** introduced the dedicated `/case-study` route and removed `isCaseStudy` branching from the lessons page. Overlay was updated to emit `/case-study` links; legacy `/lessons/{unit}` links for case-study units silently broke.
- **2026-04-11 · b141b3f4** added `scenario` unit_type. Both `scenario` and `case-study` now return `CaseStudyResponse` from the lesson endpoint, but the lessons page still only renders `LessonViewer`.

Fixes #1894

## Test plan

- [ ] `/fr/modules/aab749f1-fba3-45d3-bcff-e0f4f925475a/lessons/M01-U04` → 307/308 → `/fr/modules/.../case-study?unit=1.4` renders the scenario.
- [ ] `/fr/modules/.../lessons/1.4` (numeric form) → same redirect.
- [ ] `/fr/modules/.../lessons/M01-U05` (quiz) → redirects to `/fr/modules/.../quiz?unit=1.5`.
- [ ] `/fr/modules/.../lessons/1.1` still renders `LessonViewer`. Regression guard.
- [ ] `/en/...` variants preserve the `/en` locale prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)