### PR TITLE
fix(migration): 081 must work on json column (#1903)

### DIFF
--- a/backend/migrations/versions/081_canonical_unit_id_in_generated_content.py
+++ b/backend/migrations/versions/081_canonical_unit_id_in_generated_content.py
@@ -43,7 +43,7 @@ def upgrade() -> None:
             """
             SELECT id, content->>'unit_id' AS uid
             FROM generated_content
-            WHERE content ? 'unit_id' AND content->>'unit_id' <> ''
+            WHERE content->>'unit_id' IS NOT NULL AND content->>'unit_id' <> ''
             """
         )
     ).fetchall()
@@ -75,8 +75,8 @@ def upgrade() -> None:
                 """
                 UPDATE generated_content
                 SET content = jsonb_set(
-                    content, '{unit_id}', to_jsonb(:val::text)
-                )
+                    content::jsonb, '{unit_id}', to_jsonb(:val::text)
+                )::json
                 WHERE id = :id
                 """
             ),


### PR DESCRIPTION
## Summary
- \`generated_content.content\` is PostgreSQL \`json\` (sa.JSON()), not \`jsonb\`.
- Migration 081 used \`content ? 'unit_id'\` and \`jsonb_set(content, ...)\`, both of which require \`jsonb\` — staging deploy of the #1897 refactor sync errored with \`operator does not exist: json ? unknown\`.
- Swap both to \`json\`/\`jsonb\`-agnostic forms.

### Changes
- WHERE clause: \`content ? 'unit_id'\` → \`content->>'unit_id' IS NOT NULL\` (uses the \`->>\` operator which works on both json and jsonb; nonexistent keys return NULL so it behaves identically to the existence check).
- UPDATE: \`jsonb_set(content, ...)\` → \`jsonb_set(content::jsonb, ...)::json\` (cast in, cast back out so the column type is preserved).

### Failure reference
Staging deploy [run 24879087741](https://github.com/Benidrissa/etutor-digital-ph/actions/runs/24879087741) — \`Deploy to Server\` job, Alembic upgrade.

Fixes #1903

## Test plan
- [ ] CI \`alembic upgrade head\` passes (already did — it only failed against staging's actual data)
- [ ] Re-deploy: \`Deploy to Server\` step clears migration 081 and the app starts
- [ ] Smoke check: after deploy, \`SELECT DISTINCT content->>'unit_id' FROM generated_content WHERE content->>'unit_id' IS NOT NULL\` on staging returns only canonical \`N.M\` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)