### PR TITLE
fix(migration): 081 json/jsonb — cherry-pick #1904 to main (unblocks deploy)

### DIFF
--- a/backend/migrations/versions/081_canonical_unit_id_in_generated_content.py
+++ b/backend/migrations/versions/081_canonical_unit_id_in_generated_content.py
@@ -43,7 +43,7 @@ def upgrade() -> None:
             """
             SELECT id, content->>'unit_id' AS uid
             FROM generated_content
-            WHERE content ? 'unit_id' AND content->>'unit_id' <> ''
+            WHERE content->>'unit_id' IS NOT NULL AND content->>'unit_id' <> ''
             """
         )
     ).fetchall()
@@ -75,8 +75,8 @@ def upgrade() -> None:
                 """
                 UPDATE generated_content
                 SET content = jsonb_set(
-                    content, '{unit_id}', to_jsonb(:val::text)
-                )
+                    content::jsonb, '{unit_id}', to_jsonb(:val::text)
+                )::json
                 WHERE id = :id
                 """
             ),


### PR DESCRIPTION
Cherry-picks #1904 (merged to \`dev\` after #1901 squashed, so missed main).

Staging deploy of #1901 (a8470e92) failed:
\`\`\`
asyncpg.exceptions.UndefinedFunctionError: operator does not exist: json ? unknown
  File "/app/migrations/versions/081_canonical_unit_id_in_generated_content.py", line 41, in upgrade
\`\`\`

Cause: \`generated_content.content\` is \`sa.JSON()\` (postgres \`json\`), not \`jsonb\`. The \`?\` existence operator and \`jsonb_set(content, ...)\` both require \`jsonb\`.

Fix (identical to #1904):
- \`content ? 'unit_id'\` → \`content->>'unit_id' IS NOT NULL\`
- \`jsonb_set(content, ...)\` → \`jsonb_set(content::jsonb, ...)::json\`

Single commit, single file, 3-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)