### PR TITLE
fix(migration): swap :: casts in 081 to CAST syntax (#1907)

### DIFF
--- a/backend/migrations/versions/081_canonical_unit_id_in_generated_content.py
+++ b/backend/migrations/versions/081_canonical_unit_id_in_generated_content.py
@@ -74,9 +74,13 @@ def upgrade() -> None:
             sa.text(
                 """
                 UPDATE generated_content
-                SET content = jsonb_set(
-                    content::jsonb, '{unit_id}', to_jsonb(:val::text)
-                )::json
+                SET content = CAST(
+                    jsonb_set(
+                        CAST(content AS jsonb),
+                        '{unit_id}',
+                        to_jsonb(CAST(:val AS text))
+                    ) AS json
+                )
                 WHERE id = :id
                 """
             ),


### PR DESCRIPTION
## Summary
Follow-up to #1903/#1904. The previous fix replaced \`?\` with \`IS NOT NULL\` (good) but added \`::\` casts that collide with SQLAlchemy's bind-param parser, producing \`syntax error at or near \":\"\` on redeploy.

Swap both casts to \`CAST(... AS type)\`, matching the convention used in [\`031_add_course_preassessment.py\`](backend/migrations/versions/031_add_course_preassessment.py).

### Before
\`\`\`sql
SET content = jsonb_set(
    content::jsonb, '{unit_id}', to_jsonb(:val::text)
)::json
\`\`\`

### After
\`\`\`sql
SET content = CAST(
    jsonb_set(
        CAST(content AS jsonb),
        '{unit_id}',
        to_jsonb(CAST(:val AS text))
    ) AS json
)
\`\`\`

### Failure reference
[run 24880126644](https://github.com/Benidrissa/etutor-digital-ph/actions/runs/24880126644) — \`Deploy to Server\` job.

Fixes #1907

## Test plan
- [ ] CI passes
- [ ] Staging redeploy: migration 081 applies and the app starts
- [ ] Post-migration: \`SELECT DISTINCT content->>'unit_id' FROM generated_content WHERE content->>'unit_id' IS NOT NULL\` returns canonical \`N.M\` values only

🤖 Generated with [Claude Code](https://claude.com/claude-code)