### PR TITLE
fix(migration): 081 `:val::text` bind/cast collision (unblocks deploy) — fixes #1911

### DIFF
--- a/backend/migrations/versions/081_canonical_unit_id_in_generated_content.py
+++ b/backend/migrations/versions/081_canonical_unit_id_in_generated_content.py
@@ -75,7 +75,7 @@ def upgrade() -> None:
                 """
                 UPDATE generated_content
                 SET content = jsonb_set(
-                    content::jsonb, '{unit_id}', to_jsonb(:val::text)
+                    content::jsonb, '{unit_id}', to_jsonb(CAST(:val AS text))
                 )::json
                 WHERE id = :id
                 """


### PR DESCRIPTION
Follow-up to #1904/#1906.

After \`content ? 'unit_id'\` and \`jsonb_set(content, ...)\` were fixed, staging deploy hit a new migration error:

\`\`\`
asyncpg.exceptions.PostgresSyntaxError: syntax error at or near ":"
  File "/app/migrations/versions/081_canonical_unit_id_in_generated_content.py", line 73, in upgrade
    conn.execute(
\`\`\`

SQLAlchemy's \`text()\` bind-parameter prefix \`:\` collides with PostgreSQL's cast operator \`::\`. \`to_jsonb(:val::text)\` → asyncpg trips on adjacent colons.

Fix: rewrite cast as \`to_jsonb(CAST(:val AS text))\` — same semantics, SQL-standard syntax, no \`:\`-adjacent \`::\`.

Single-line change in one migration file.

Fixes #1911

🤖 Generated with [Claude Code](https://claude.com/claude-code)