### PR TITLE
fix(tutor): move toggleSuggestions into ChatTutor.suggestions namespace

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -350,7 +350,8 @@
       "quiz": "Create a quiz on this topic",
       "flashcards": "Generate flashcards",
       "explain": "Explain this concept",
-      "example": "Give me an example"
+      "example": "Give me an example",
+      "toggleSuggestions": "Quick actions"
     },
     "sources": {
       "title": "Sources",
@@ -395,7 +396,6 @@
     "conversations": "Conversations",
     "openConversations": "Open conversations",
     "closeDrawer": "Close",
-    "toggleSuggestions": "Quick actions",
     "modeSocratic": "Socratic Mode",
     "modeExplanatory": "Explanatory Mode",
     "modeSocraticTooltip": "Guided questions",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -350,7 +350,8 @@
       "quiz": "Créer un quiz sur ce sujet",
       "flashcards": "Générer des flashcards",
       "explain": "Expliquer ce concept",
-      "example": "Donnez-moi un exemple"
+      "example": "Donnez-moi un exemple",
+      "toggleSuggestions": "Actions rapides"
     },
     "sources": {
       "title": "Sources",
@@ -395,7 +396,6 @@
     "conversations": "Conversations",
     "openConversations": "Ouvrir les conversations",
     "closeDrawer": "Fermer",
-    "toggleSuggestions": "Actions rapides",
     "modeSocratic": "Mode Socratique",
     "modeExplanatory": "Mode Explicatif",
     "modeSocraticTooltip": "Guidage par questions",


### PR DESCRIPTION
## Summary
- `ChatSuggestions` binds `useTranslations('ChatTutor.suggestions')` and calls `t('toggleSuggestions')`, so next-intl looks for `ChatTutor.suggestions.toggleSuggestions`. The key lived at `ChatTutor.toggleSuggestions` (one level up), throwing `MISSING_MESSAGE` on `/tutor` in both locales.
- Move the key into the `suggestions` sub-object in `en.json` and `fr.json` so it matches the component's existing namespace. No component change.

## Test plan
- [ ] Load `/fr/tutor` — console shows no `MISSING_MESSAGE`.
- [ ] Load `/en/tutor` — same.
- [ ] Mobile suggestions toggle button `aria-label` reads "Actions rapides" / "Quick actions".

Fixes #1913