### PR TITLE
fix(profile): update saves but UI shows no change (#1908)

### DIFF
--- a/frontend/app/[locale]/(app)/profile/profile-client.tsx
+++ b/frontend/app/[locale]/(app)/profile/profile-client.tsx
@@ -114,6 +114,7 @@ export function ProfileClient() {
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
   const [showRecontextAlert, setShowRecontextAlert] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const [updateError, setUpdateError] = useState<string | null>(null);
   const queryClient = useQueryClient();
   const router = useRouter();
   const locale = useLocale();
@@ -137,11 +138,15 @@ export function ProfileClient() {
   const updateMutation = useMutation({
     mutationFn: updateProfile,
     onSuccess: (data) => {
+      setUpdateError(null);
       queryClient.setQueryData(["profile"], data.profile || data);
       setIsEditing(false);
       if (data.content_recontextualization_required) {
         setShowRecontextAlert(true);
       }
+    },
+    onError: (err: Error) => {
+      setUpdateError(err.message || t("updateError"));
     },
   });
 
@@ -421,6 +426,13 @@ export function ProfileClient() {
 
               <Separator />
 
+              {updateError && (
+                <Alert variant="destructive">
+                  <AlertTriangle className="h-4 w-4" />
+                  <AlertDescription>{updateError}</AlertDescription>
+                </Alert>
+              )}
+
               <div className="flex justify-between">
                 {!isEditing ? (
                   <Button onClick={() => setIsEditing(true)} variant="outline">
@@ -433,6 +445,7 @@ export function ProfileClient() {
                       variant="outline"
                       onClick={() => {
                         setIsEditing(false);
+                        setUpdateError(null);
                         form.reset();
                       }}
                     >
@@ -508,15 +521,18 @@ export function ProfileClient() {
               onClick={async () => {
                 const newValue = !(profile?.analytics_opt_out ?? false);
                 try {
-                  await updateProfile({ analytics_opt_out: newValue });
-                  queryClient.invalidateQueries({ queryKey: ["userProfile"] });
+                  const data = await updateProfile({ analytics_opt_out: newValue });
+                  setUpdateError(null);
+                  queryClient.setQueryData(["profile"], data.profile || data);
                   if (newValue) {
                     localStorage.setItem("analytics_opt_out", "1");
                   } else {
                     localStorage.removeItem("analytics_opt_out");
                   }
-                } catch {
-                  // ignore
+                } catch (err) {
+                  setUpdateError(
+                    (err as Error).message || t("updateError"),
+                  );
                 }
               }}
               className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -869,6 +869,7 @@
     "edit": "Edit",
     "cancel": "Cancel",
     "save": "Save Changes",
+    "updateError": "Could not save your changes. Please try again.",
     "logout": "Log out",
     "logoutDescription": "Sign out of your account",
     "loggingOut": "Logging out...",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -869,6 +869,7 @@
     "edit": "Modifier",
     "cancel": "Annuler",
     "save": "Sauvegarder",
+    "updateError": "Impossible d'enregistrer vos modifications. Veuillez réessayer.",
     "logout": "Déconnexion",
     "logoutDescription": "Se déconnecter de votre compte",
     "loggingOut": "Déconnexion en cours...",

--- a/frontend/sw.ts
+++ b/frontend/sw.ts
@@ -86,6 +86,11 @@ const serwist = new Serwist({
       matcher: ({ url, request }: { url: URL; request: Request }) => {
         if (request.method !== "GET") return false;
         if (url.pathname.startsWith("/api/generate")) return false;
+        // Don't cache user-mutable profile/auth state — SWR would serve
+        // stale bodies after PATCH and the form re-syncs to old values
+        // (#1908).
+        if (url.pathname.startsWith("/api/v1/users/")) return false;
+        if (url.pathname.startsWith("/api/v1/auth/")) return false;
         if (url.pathname.startsWith("/api/")) return true;
         return false;
       },


### PR DESCRIPTION
## Summary

Fixes three related bugs in the profile save path that all surface as "click Save, no error, but no visible change" — issue #1908.

- **SW cache** — `frontend/sw.ts` was caching all `GET /api/*` with `StaleWhileRevalidate`. After `PATCH /users/me`, the next GET served the pre-update body and React Query's `values`-driven form re-synced to old values. Excluded `/api/v1/users/` and `/api/v1/auth/` from the SW matcher.
- **Silent mutation failure** — `updateMutation` had no `onError`; backend wraps everything in `except Exception` → generic 500. Users saw spinner end and assumed success. Added `onError` that surfaces the message through a destructive `<Alert>` near the Save button.
- **Privacy toggle wrong key** — `invalidateQueries({ queryKey: ["userProfile"] })` but the actual key is `["profile"]` (introduced in #663). Backend persisted the change but the UI never refetched. Switched the toggle to the same `setQueryData(["profile"], ...)` path the form's `onSuccess` uses, and routed its errors through the same `updateError` state.

Closes #1908.

## Test plan

- [ ] Sign in, edit Name, Save → UI updates immediately
- [ ] Hard-refresh (Ctrl+Shift+R) → updated name persists (SW fix)
- [ ] Soft refresh and re-focus tab → updated name still shown
- [ ] Force a backend error (e.g. send `preferred_language: "de"` via devtools) → red Alert shows, form stays in edit mode
- [ ] Toggle analytics opt-out → visual state matches DB immediately, no refresh needed
- [ ] `npx tsc --noEmit` & `npx eslint` clean on the two changed source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)