### PR TITLE
fix(tutor): surface delete failures instead of silently swallowing them

### DIFF
--- a/frontend/app/[locale]/(app)/tutor/tutor-client.tsx
+++ b/frontend/app/[locale]/(app)/tutor/tutor-client.tsx
@@ -37,6 +37,12 @@ export function TutorPageClient() {
   const [isMobileDrawerOpen, setIsMobileDrawerOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   const [showClearAllDialog, setShowClearAllDialog] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
+
+  const showToast = (msg: string) => {
+    setToast(msg);
+    setTimeout(() => setToast(null), 3000);
+  };
 
   const loadConversations = useCallback(async () => {
     try {
@@ -99,25 +105,31 @@ export function TutorPageClient() {
   );
 
   const handleDeleteConversation = async (id: string) => {
+    setDeleteTarget(null);
     try {
       await deleteConversation(id);
-    } catch { /* proxy may block response */ }
-    clearDraft(id);
-    if (selectedConversation === id) {
-      setSelectedConversation(null);
+      clearDraft(id);
+      if (selectedConversation === id) {
+        setSelectedConversation(null);
+      }
+    } catch (err) {
+      console.error('Failed to delete conversation', err);
+      showToast(t('error'));
     }
-    setDeleteTarget(null);
     await loadConversations();
   };
 
   const handleClearAll = async () => {
+    setShowClearAllDialog(false);
     try {
       await deleteAllConversations();
-    } catch { /* proxy may block response */ }
-    conversations.forEach((c) => clearDraft(c.id));
-    clearDraft(null);
-    setSelectedConversation(null);
-    setShowClearAllDialog(false);
+      conversations.forEach((c) => clearDraft(c.id));
+      clearDraft(null);
+      setSelectedConversation(null);
+    } catch (err) {
+      console.error('Failed to clear conversations', err);
+      showToast(t('error'));
+    }
     await loadConversations();
   };
 
@@ -230,6 +242,15 @@ export function TutorPageClient() {
 
   return (
     <ChatProvider>
+      {toast && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="fixed top-4 right-4 z-50 rounded-lg bg-destructive px-4 py-2 text-sm text-destructive-foreground shadow-lg"
+        >
+          {toast}
+        </div>
+      )}
       <div className="flex flex-1 min-h-0 overflow-hidden">
         {/* Conversations Sidebar — hidden on mobile, visible on desktop */}
         <div className="w-80 border-r bg-card hidden md:flex flex-col shrink-0">


### PR DESCRIPTION
## Summary
- `handleDeleteConversation` and `handleClearAll` wrapped their API call in `try { … } catch { /* proxy may block response */ }` and then cleared drafts, reset selection, and refetched as if the delete had succeeded — so genuine failures looked identical to success ("nothing happens").
- Stop faking success: keep the draft-clear / selection-reset / refetch only on the success path; on failure, log the error and show a toast. Always refetch so the list reflects server truth. Dialog closes up front regardless for UI responsiveness.
- Uses the existing `ChatTutor.error` i18n key and the same inline-toast pattern already used in `admin/settings-client.tsx`. No new deps.

This is the **unmask** step (2a in the plan). With the real HTTP failure now visible on staging, the underlying cause will be identified from DevTools Network + backend logs and fixed in a follow-up.

## Test plan
- [ ] On staging, delete a single conversation that currently does nothing — confirm a toast surfaces with the real error, and the list matches server state after refetch.
- [ ] Same for "Clear all".
- [ ] When the underlying issue is fixed (separate commit), delete single → list updates immediately; refresh → stays gone.
- [ ] When fixed, "Clear all" with ≥2 conversations → list empties; `GET /conversations` returns `{conversations: [], total: 0}`.
- [ ] No visible change in success-path behaviour: successful deletes still clear drafts and reset selection.

Refs #1915