### PR TITLE
fix(tutor): roll back usage count when response container is suppressed

### DIFF
--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -88,6 +88,8 @@ export function ChatPanel({
     return 'socratic';
   });
   const scrollAreaRef = useRef<HTMLDivElement>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const isMountedRef = useRef(true);
   const [enrolledCourses, setEnrolledCourses] = useState<CourseWithEnrollment[]>([]);
   const [activeCourseId, setActiveCourseId] = useState<string | null>(() => {
     if (courseId) return courseId;
@@ -142,17 +144,41 @@ export function ChatPanel({
     refreshEnrolledCourses();
   }, [refreshEnrolledCourses]);
 
-  useEffect(() => {
-    // Same reasoning as the enrollments fetch above — anonymous visitors
-    // shouldn't see a 401 in console for a tutor stats call they can't use.
+  // Server-truth refresh for daily message quota. Re-called on any failure
+  // path in handleSendMessage so the optimistic +1 increment is reconciled
+  // against `/tutor/remaining` when the assistant container is suppressed.
+  const refetchRemaining = useCallback(async () => {
     if (!authClient.isAuthenticated()) return;
-    fetchTutorStats()
-      .then((stats) => {
-        setMaxDailyUsage(stats.daily_messages_limit);
-        setCurrentUsage(stats.daily_messages_used);
-      })
-      .catch(() => {});
+    try {
+      const stats = await fetchTutorStats();
+      if (!isMountedRef.current) return;
+      setMaxDailyUsage(stats.daily_messages_limit);
+      setCurrentUsage(stats.daily_messages_used);
+    } catch {
+      // silent — anonymous visitors and transient failures are handled upstream
+    }
   }, []);
+
+  useEffect(() => {
+    refetchRemaining();
+  }, [refetchRemaining]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      abortControllerRef.current?.abort();
+    };
+  }, []);
+
+  // Abort any in-flight stream when the user switches conversations so the
+  // optimistic usage increment from the abandoned send gets rolled back via
+  // the catch/finally path instead of hanging until unmount.
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, [activeConversationId]);
 
   useEffect(() => {
     clearStaleDrafts();
@@ -234,6 +260,11 @@ export function ChatPanel({
       language: locale,
     });
 
+    abortControllerRef.current?.abort();
+    const abortController = new AbortController();
+    abortControllerRef.current = abortController;
+    let usageReconciled = false;
+
     try {
       let token: string;
       try {
@@ -260,6 +291,7 @@ export function ChatPanel({
           file_ids: attachedFiles.map((f) => f.fileId),
           locale: locale,
         }),
+        signal: abortController.signal,
       });
 
       if (!response.ok) {
@@ -344,6 +376,7 @@ export function ChatPanel({
                 if (typeof chunk.data?.remaining_messages === 'number') {
                   const remaining = chunk.data.remaining_messages as number;
                   setCurrentUsage(maxDailyUsage - remaining);
+                  usageReconciled = true;
                 }
               } else if (chunk.type === 'error') {
                 const errorCode = chunk.data?.code;
@@ -365,19 +398,37 @@ export function ChatPanel({
         }
       }
     } catch (error) {
-      console.error('Failed to send message:', error);
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: (Date.now() + 1).toString(),
-          content: t('error'),
-          isUser: false,
-          timestamp: new Date(),
-        },
-      ]);
+      if ((error as Error | undefined)?.name !== 'AbortError') {
+        console.error('Failed to send message:', error);
+        if (isMountedRef.current) {
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: (Date.now() + 1).toString(),
+              content: t('error'),
+              isUser: false,
+              timestamp: new Date(),
+            },
+          ]);
+        }
+      }
     } finally {
-      setIsLoading(false);
-      setIsTyping(false);
+      if (abortControllerRef.current === abortController) {
+        abortControllerRef.current = null;
+      }
+      // Reconcile the optimistic +1 from line 229 whenever the response
+      // container was suppressed (error chunk, non-ok response, thrown
+      // fetch, or user-initiated abort via conversation switch / unmount).
+      // Backend only persists the user message together with a successful
+      // assistant reply, so without this the counter drifts high.
+      if (!usageReconciled && isMountedRef.current) {
+        setCurrentUsage((prev) => Math.max(0, prev - 1));
+        void refetchRemaining();
+      }
+      if (isMountedRef.current) {
+        setIsLoading(false);
+        setIsTyping(false);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- The tutor `UsageCounter` was drifting down every time the assistant response container was suppressed (error chunk, non-ok fetch, network failure, aborted stream on conversation switch). The backend only persists the user message together with a successful assistant reply — so those paths never actually consume a message.
- `chat-panel.tsx` now tracks a `usageReconciled` flag per send; if the `finished` chunk never applies the server-authoritative `remaining_messages`, a `finally` block rolls back the optimistic +1 and re-reads `/tutor/remaining` via the existing `fetchTutorStats()`.
- Added an `AbortController` so unmount and conversation switch abort the in-flight stream and flow through the rollback path, and the user-initiated `AbortError` no longer paints a spurious error bubble.

No backend changes, no new endpoints.

Fixes #1910

## Test plan
- [ ] Send a message at `effective_limit = 0` → backend yields `limit_reached`; header counter stays put (previously decreased).
- [ ] DevTools → offline, press send → fetch rejects; counter stays put (previously off-by-one for the session).
- [ ] Send a long-running question, switch conversation mid-stream → stream aborts cleanly; counter re-syncs; no error bubble painted.
- [ ] Happy path: send a normal message → `finished` chunk sets counter; no double refetch fires.
- [ ] `GET /api/v1/tutor/remaining` response and on-screen counter match after each of the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)