### PR TITLE
chore(migration): align dev's 081 text to main's form (#1921)

### DIFF
--- a/backend/migrations/versions/081_canonical_unit_id_in_generated_content.py
+++ b/backend/migrations/versions/081_canonical_unit_id_in_generated_content.py
@@ -74,13 +74,9 @@ def upgrade() -> None:
             sa.text(
                 """
                 UPDATE generated_content
-                SET content = CAST(
-                    jsonb_set(
-                        CAST(content AS jsonb),
-                        '{unit_id}',
-                        to_jsonb(CAST(:val AS text))
-                    ) AS json
-                )
+                SET content = jsonb_set(
+                    content::jsonb, '{unit_id}', to_jsonb(CAST(:val AS text))
+                )::json
                 WHERE id = :id
                 """
             ),


### PR DESCRIPTION
## Summary
Pure textual alignment — no behavior change. Dev's migration 081 currently uses the three-cast rewrite from #1909; main's (from #1912) uses the minimal form — \`content::jsonb\` / \`)::json\` kept, only \`:val::text\` swapped to \`CAST(:val AS text)\`. Both are behaviorally identical.

The textual divergence caused an add/add conflict on the superseded #1918. Aligning dev to match main byte-for-byte in the UPDATE block so the next dev→main sync opens \`CLEAN\`.

Fixes #1921

## Test plan
- [ ] CI green (migration applies against the test DB)
- [ ] Next dev→main sync PR shows \`mergeStateStatus: CLEAN\` with zero conflict on migration 081

🤖 Generated with [Claude Code](https://claude.com/claude-code)