### PR TITLE
perf(backfills): parallelize figure backfills + complex_diagram overlays (cherry of #1892 + #1886)

### DIFF
--- a/backend/app/ai/rag/pipeline.py
+++ b/backend/app/ai/rag/pipeline.py
@@ -15,8 +15,11 @@ from app.ai.rag.image_linker import ImageLinker
 from app.ai.translation import (
     classify_figure,
     extract_flowchart_structure,
+    extract_label_positions,
+    render_overlay_svg,
     render_svg,
     translate_figure_caption,
+    translate_labels,
     translate_structure,
 )
 from app.domain.models.document_chunk import DocumentChunk
@@ -288,6 +291,33 @@ class RAGPipeline:
                 except Exception as exc:
                     logger.warning(
                         "Failed to re-derive flowchart as FR SVG, leaving fr variant NULL",
+                        source=source,
+                        figure_number=img.figure_number,
+                        error=str(exc),
+                    )
+            elif figure_kind == "complex_diagram":
+                try:
+                    positions = await extract_label_positions(image_bytes=img.image_bytes)
+                    translated_positions = await translate_labels(positions, target_lang="fr")
+                    svg_bytes = render_overlay_svg(
+                        image_bytes=img.image_bytes,
+                        width_px=img.width or 1024,
+                        height_px=img.height or 768,
+                        labels=translated_positions,
+                    )
+                    svg_key = (
+                        f"source-images/{prefix}/{readable_name}/"
+                        f"{img.page_number}_{safe_label}.fr.svg"
+                    )
+                    storage_url_fr = await storage.upload_bytes(
+                        key=svg_key,
+                        data=svg_bytes,
+                        content_type="image/svg+xml",
+                    )
+                    storage_key_fr = svg_key
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to build FR overlay for complex_diagram, leaving fr variant NULL",
                         source=source,
                         figure_number=img.figure_number,
                         error=str(exc),

--- a/backend/app/ai/translation/__init__.py
+++ b/backend/app/ai/translation/__init__.py
@@ -1,5 +1,12 @@
-"""AI-backed translation utilities (issue #1820, #1844, #1852)."""
+"""AI-backed translation utilities (issues #1820, #1844, #1852, #1883)."""
 
+from app.ai.translation.complex_overlay import (
+    DiagramLabel,
+    DiagramLabels,
+    extract_label_positions,
+    render_overlay_svg,
+    translate_labels,
+)
 from app.ai.translation.figure_classifier import (
     FigureClassification,
     FigureKind,
@@ -19,6 +26,8 @@ from app.ai.translation.svg_rederiver import (
 )
 
 __all__ = [
+    "DiagramLabel",
+    "DiagramLabels",
     "FigureClassification",
     "FigureKind",
     "FigureTranslation",
@@ -27,7 +36,10 @@ __all__ = [
     "FlowchartStructure",
     "classify_figure",
     "extract_flowchart_structure",
+    "extract_label_positions",
+    "render_overlay_svg",
     "render_svg",
     "translate_figure_caption",
+    "translate_labels",
     "translate_structure",
 ]

--- a/backend/app/ai/translation/complex_overlay.py
+++ b/backend/app/ai/translation/complex_overlay.py
@@ -1,0 +1,368 @@
+"""Re-derive a ``complex_diagram`` figure as a raster + numbered-badge overlay
++ French legend (issue #1883, Phase 2 slice 2.4).
+
+``clean_flowchart`` figures can be rebuilt from scratch as SVG because the
+source is already a clean logical graph (boxes + arrows). Complex diagrams —
+anatomy plates, multi-panel figures, dense labelled illustrations — can't:
+Claude Vision can't reproduce the imagery faithfully and a rebuild produces a
+mangled copy. Strategy here is opposite: **keep the original raster untouched,
+overlay small numbered badges on top of each translatable label, and put a
+``1 — Noyau, 2 — Membrane...`` legend below the image**. Every label is
+translated; the visual fidelity of the underlying figure is preserved.
+
+Pipeline:
+
+1. ``extract_label_positions`` — Claude Vision returns a list of labels with
+   approximate percentage coordinates relative to the image (not pixel-
+   accurate; badges just need to sit near the right area).
+2. ``translate_labels`` — single Claude Haiku call translates the text of
+   every label to the target locale, preserving ids and coordinates.
+3. ``render_overlay_svg`` — produces one self-contained SVG:
+   - the raster is embedded via a base64 ``<image href="data:image/webp;base64,...">``
+   - numbered ``<circle>`` badges are drawn on top at each label's position
+   - a legend strip below the image maps each badge number to its translated
+     term.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+from typing import Any
+
+import anthropic
+import structlog
+from pydantic import BaseModel, Field, ValidationError, field_validator
+
+from app.infrastructure.config.settings import get_settings
+
+logger = structlog.get_logger(__name__)
+
+
+class DiagramLabel(BaseModel):
+    id: str = Field(..., min_length=1)
+    text: str = Field(..., min_length=1)
+    # Percentage of image width/height (0.0-100.0). Claude Vision isn't
+    # pixel-accurate, so we don't pretend — percentages keep the renderer
+    # independent of the source image's resolution.
+    x_pct: float = Field(..., ge=0.0, le=100.0)
+    y_pct: float = Field(..., ge=0.0, le=100.0)
+
+    @field_validator("x_pct", "y_pct", mode="before")
+    @classmethod
+    def _coerce_percentage(cls, value: Any) -> Any:
+        # Tolerate integer literals ("45") and 0-1 fractions ("0.45") from
+        # the model. Convert fractions to percentages so downstream code has
+        # one invariant.
+        if isinstance(value, int | float) and 0.0 < value <= 1.0:
+            return float(value) * 100.0
+        return value
+
+
+class DiagramLabels(BaseModel):
+    labels: list[DiagramLabel] = Field(..., min_length=1)
+
+
+_EXTRACT_MODEL = "claude-haiku-4-5"
+_TRANSLATE_MODEL = "claude-haiku-4-5"
+_MAX_TOKENS = 2048
+
+
+_EXTRACT_SYSTEM = (
+    "You locate every text label drawn ON TOP of a complex diagram image and "
+    "return their approximate positions. Reply with a single JSON object and "
+    "nothing else — no prose, no markdown fences."
+)
+
+_EXTRACT_USER = (
+    "Find every text label that is drawn on or immediately next to a structure "
+    "in this diagram. Return JSON:\n"
+    '  {"labels": [{"id": "n1", "text": "...", "x_pct": 42.5, "y_pct": 17.0}, ...]}\n\n'
+    "Rules:\n"
+    "- ids are short stable identifiers you invent (n1, n2, …) in the order you\n"
+    "  want them numbered in the final legend.\n"
+    "- text is the label verbatim — preserve capitalisation, accents, and\n"
+    "  punctuation. Do not invent, translate, or abbreviate.\n"
+    "- x_pct / y_pct are the position of the label's leftmost character, as a\n"
+    "  percentage (0–100) of the image's width and height. (0,0) is the top-\n"
+    "  left corner. Approximate is fine; we just need the badge to land near\n"
+    "  the label.\n"
+    "- Include only labels that ARE text visible inside/next to the figure.\n"
+    "  Skip figure captions / attribution / axis titles that live outside the\n"
+    "  image proper. Skip any text that is part of a scale bar.\n"
+    "- Do NOT return label order guesses, coordinates in pixels, or any other\n"
+    "  field. Reply with JSON only."
+)
+
+
+_TRANSLATE_SYSTEM = (
+    "You translate the text fields of a labelled diagram into the target "
+    "language. Reply with a single JSON object and nothing else."
+)
+
+_TRANSLATE_USER_TEMPLATE = (
+    "Translate every ``text`` field in this labelled diagram into "
+    "{target_lang_full}. Preserve ids and coordinates byte-identical; only "
+    "translate the text. Use natural terminology for the subject — if the "
+    "label is a scientific term (anatomy, biology, chemistry) use the "
+    "standard French term, not a literal translation.\n\n"
+    "Input:\n{payload}\n\n"
+    "Reply with the translated JSON only."
+)
+
+
+def _extract_json_object(text: str) -> str:
+    clean = text.strip()
+    if clean.startswith("```"):
+        first_newline = clean.find("\n")
+        if first_newline > 0:
+            clean = clean[first_newline + 1 :]
+        if clean.rstrip().endswith("```"):
+            clean = clean.rstrip()[:-3]
+    start = clean.find("{")
+    end = clean.rfind("}")
+    if start < 0 or end <= start:
+        raise ValueError("no JSON object in response")
+    body = clean[start : end + 1]
+    return re.sub(r",\s*([}\]])", r"\1", body)
+
+
+def _parse_labels(text: str) -> DiagramLabels:
+    body = _extract_json_object(text)
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"labels response was not valid JSON: {exc}") from exc
+    try:
+        return DiagramLabels(**payload)
+    except ValidationError:
+        logger.warning(
+            "DiagramLabels failed validation",
+            payload_keys=list(payload.keys()) if isinstance(payload, dict) else None,
+        )
+        raise
+
+
+async def extract_label_positions(
+    image_bytes: bytes,
+    image_media_type: str = "image/webp",
+    client: anthropic.AsyncAnthropic | None = None,
+) -> DiagramLabels:
+    """Claude Vision call: return every visible label + its approximate position."""
+    if not image_bytes:
+        raise ValueError("image_bytes must be non-empty")
+    if client is None:
+        settings = get_settings()
+        if not settings.anthropic_api_key:
+            raise ValueError("ANTHROPIC_API_KEY is required to extract labels")
+        client = anthropic.AsyncAnthropic(
+            api_key=settings.anthropic_api_key,
+            timeout=90.0,
+        )
+
+    encoded = base64.standard_b64encode(image_bytes).decode("ascii")
+    response = await client.messages.create(
+        model=_EXTRACT_MODEL,
+        max_tokens=_MAX_TOKENS,
+        system=_EXTRACT_SYSTEM,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": image_media_type,
+                            "data": encoded,
+                        },
+                    },
+                    {"type": "text", "text": _EXTRACT_USER},
+                ],
+            }
+        ],
+        temperature=0.0,
+    )
+
+    text = "".join(
+        getattr(block, "text", "") for block in response.content if hasattr(block, "text")
+    )
+    if not text.strip():
+        raise ValueError("empty label-extraction response")
+    return _parse_labels(text)
+
+
+async def translate_labels(
+    labels: DiagramLabels,
+    target_lang: str = "fr",
+    client: anthropic.AsyncAnthropic | None = None,
+) -> DiagramLabels:
+    """Translate every label's text into ``target_lang``, preserving ids and positions."""
+    if target_lang not in {"fr", "en"}:
+        raise ValueError(f"unsupported target_lang: {target_lang!r}")
+    if client is None:
+        settings = get_settings()
+        if not settings.anthropic_api_key:
+            raise ValueError("ANTHROPIC_API_KEY is required to translate labels")
+        client = anthropic.AsyncAnthropic(
+            api_key=settings.anthropic_api_key,
+            timeout=60.0,
+        )
+
+    target_full = {"fr": "French", "en": "English"}[target_lang]
+    payload = labels.model_dump_json()
+    response = await client.messages.create(
+        model=_TRANSLATE_MODEL,
+        max_tokens=_MAX_TOKENS,
+        system=_TRANSLATE_SYSTEM,
+        messages=[
+            {
+                "role": "user",
+                "content": _TRANSLATE_USER_TEMPLATE.format(
+                    target_lang_full=target_full, payload=payload
+                ),
+            }
+        ],
+        temperature=0.0,
+    )
+    text = "".join(
+        getattr(block, "text", "") for block in response.content if hasattr(block, "text")
+    )
+    if not text.strip():
+        raise ValueError("empty label-translation response")
+    translated = _parse_labels(text)
+
+    original_ids = {label.id for label in labels.labels}
+    translated_ids = {label.id for label in translated.labels}
+    if original_ids != translated_ids:
+        raise ValueError(
+            "translator changed label ids: "
+            f"added={translated_ids - original_ids}, "
+            f"removed={original_ids - translated_ids}"
+        )
+    return translated
+
+
+# ---------------------------------------------------------------------------
+# SVG rendering
+# ---------------------------------------------------------------------------
+
+_BADGE_RADIUS_FRACTION = 0.02  # fraction of min(width, height)
+_BADGE_MIN_RADIUS = 10
+_BADGE_MAX_RADIUS = 22
+_LEGEND_FONT_SIZE = 14
+_LEGEND_LINE_HEIGHT = 20
+_LEGEND_PADDING = 20
+_LEGEND_MAX_CHARS_PER_LINE = 80
+
+
+def _escape(text: str) -> str:
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&#39;")
+    )
+
+
+def _wrap_legend_line(number: int, text: str, max_chars: int) -> list[str]:
+    """Wrap a `N — text` line at word boundaries, returning visible lines."""
+    prefix = f"{number} — "
+    budget = max(1, max_chars - len(prefix))
+    words = text.split()
+    if not words:
+        return [prefix.rstrip()]
+    lines: list[str] = []
+    current = words[0]
+    for word in words[1:]:
+        if len(current) + 1 + len(word) <= budget:
+            current = f"{current} {word}"
+        else:
+            lines.append(current)
+            current = word
+    lines.append(current)
+    # The first line includes the prefix; continuation lines are indented to
+    # match visually.
+    indent = " " * len(prefix)
+    return [prefix + lines[0]] + [indent + line for line in lines[1:]]
+
+
+def render_overlay_svg(
+    image_bytes: bytes,
+    width_px: int,
+    height_px: int,
+    labels: DiagramLabels,
+    image_media_type: str = "image/webp",
+) -> bytes:
+    """Render a ``complex_diagram`` figure as raster + badge overlay + legend.
+
+    Produces a single self-contained SVG document: the source raster is
+    embedded base64, numbered badges sit on top at each label's position, and
+    a legend strip below maps ``N — translated term`` for each badge.
+    """
+    if not image_bytes:
+        raise ValueError("image_bytes must be non-empty")
+    if width_px <= 0 or height_px <= 0:
+        raise ValueError("width_px and height_px must be positive")
+    if not labels.labels:
+        raise ValueError("labels must be non-empty")
+
+    badge_radius = max(
+        _BADGE_MIN_RADIUS,
+        min(_BADGE_MAX_RADIUS, int(min(width_px, height_px) * _BADGE_RADIUS_FRACTION)),
+    )
+    font_size_badge = max(10, int(badge_radius * 1.1))
+
+    # Legend rows: one entry per label, possibly wrapping onto multiple lines.
+    legend_lines: list[str] = []
+    for i, label in enumerate(labels.labels, start=1):
+        legend_lines.extend(_wrap_legend_line(i, label.text, _LEGEND_MAX_CHARS_PER_LINE))
+
+    legend_height = _LEGEND_PADDING * 2 + len(legend_lines) * _LEGEND_LINE_HEIGHT
+    total_height = height_px + legend_height
+
+    encoded_image = base64.standard_b64encode(image_bytes).decode("ascii")
+
+    svg_parts: list[str] = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" '
+        f'viewBox="0 0 {width_px} {total_height}" '
+        f'font-family="Helvetica, Arial, sans-serif" font-size="{_LEGEND_FONT_SIZE}">'
+    ]
+
+    # Base raster (encoded inline so the SVG is a self-contained asset).
+    svg_parts.append(
+        f'<image x="0" y="0" width="{width_px}" height="{height_px}" '
+        f'xlink:href="data:{image_media_type};base64,{encoded_image}" />'
+    )
+
+    # Numbered badges over the raster.
+    for i, label in enumerate(labels.labels, start=1):
+        cx = round(label.x_pct / 100.0 * width_px, 2)
+        cy = round(label.y_pct / 100.0 * height_px, 2)
+        svg_parts.append(
+            f'<circle cx="{cx}" cy="{cy}" r="{badge_radius}" '
+            f'fill="#FFCA28" stroke="#5D4037" stroke-width="1.5" opacity="0.95" />'
+        )
+        svg_parts.append(
+            f'<text x="{cx}" y="{cy + font_size_badge * 0.35:.2f}" '
+            f'text-anchor="middle" font-size="{font_size_badge}" '
+            f'font-weight="700" fill="#3E2723">{i}</text>'
+        )
+
+    # Legend strip below the image.
+    svg_parts.append(
+        f'<rect x="0" y="{height_px}" width="{width_px}" height="{legend_height}" '
+        f'fill="#FAFAFA" stroke="#E0E0E0" stroke-width="1" />'
+    )
+    y = height_px + _LEGEND_PADDING + _LEGEND_FONT_SIZE
+    for line in legend_lines:
+        svg_parts.append(
+            f'<text x="{_LEGEND_PADDING}" y="{y}" fill="#212121" '
+            f'xml:space="preserve">{_escape(line)}</text>'
+        )
+        y += _LEGEND_LINE_HEIGHT
+
+    svg_parts.append("</svg>")
+    return "\n".join(svg_parts).encode("utf-8")

--- a/backend/app/tasks/image_translation.py
+++ b/backend/app/tasks/image_translation.py
@@ -30,8 +30,11 @@ from sqlalchemy.ext.asyncio import (
 from app.ai.translation import (
     classify_figure,
     extract_flowchart_structure,
+    extract_label_positions,
+    render_overlay_svg,
     render_svg,
     translate_figure_caption,
+    translate_labels,
     translate_structure,
 )
 from app.domain.models.source_image import SourceImage
@@ -43,6 +46,18 @@ logger = structlog.get_logger(__name__)
 
 _DEFAULT_BATCH_SIZE = 50
 _COMMIT_EVERY = 10
+
+# Concurrency knobs for the parallel backfill passes (issue #1891).
+#   _CONCURRENCY  — max rows processed in parallel per batch. Each row does
+#                   up to 3 Claude Haiku calls, so 8 × 3 ≈ 24 concurrent
+#                   calls in the worst case. Well under Anthropic's 50 req/s
+#                   tier limit; conservative against rate-limit bursts.
+#   _BATCH_SIZE   — rows per commit boundary. One `session.commit()` per
+#                   batch preserves the crash-safety of the prior sequential
+#                   version (at most BATCH_SIZE rows worth of work lost on
+#                   process kill) while keeping transactions short.
+_CONCURRENCY = 8
+_BATCH_SIZE = 40
 
 
 class ImageTranslationTask(Task):
@@ -169,51 +184,52 @@ async def _run_backfill_with_factory(
 
         translated = 0
         failed = 0
-        pending_commit = 0
+        sem = asyncio.Semaphore(_CONCURRENCY)
 
-        for idx, img in enumerate(rows):
-            try:
-                result = await translate_figure_caption(
-                    caption=img.caption or "",
-                    image_type=img.image_type,
-                    figure_number=img.figure_number,
-                )
-            except Exception as exc:
-                failed += 1
-                logger.warning(
-                    "Translation failed for source image, skipping",
-                    source_image_id=str(img.id),
-                    figure_number=img.figure_number,
-                    error=str(exc),
-                )
-                continue
+        async def _translate_one(img):
+            async with sem:
+                try:
+                    result = await translate_figure_caption(
+                        caption=img.caption or "",
+                        image_type=img.image_type,
+                        figure_number=img.figure_number,
+                    )
+                    return img, result, None
+                except Exception as exc:  # noqa: BLE001 — log and continue
+                    return img, None, exc
 
-            img.caption_fr = result.caption_fr
-            img.caption_en = result.caption_en
-            img.alt_text_fr = result.alt_text_fr
-            img.alt_text_en = result.alt_text_en
-            session.add(img)
-            translated += 1
-            pending_commit += 1
-
-            if pending_commit >= _COMMIT_EVERY:
-                await session.commit()
-                pending_commit = 0
-
-            if (idx + 1) % 10 == 0 or idx + 1 == total:
-                task.update_state(
-                    state="TRANSLATING",
-                    meta={
-                        "step": "translating",
-                        "total": total,
-                        "processed": idx + 1,
-                        "translated": translated,
-                        "failed": failed,
-                    },
-                )
-
-        if pending_commit:
+        processed = 0
+        for batch_start in range(0, total, _BATCH_SIZE):
+            batch = rows[batch_start : batch_start + _BATCH_SIZE]
+            outcomes = await asyncio.gather(*(_translate_one(img) for img in batch))
+            for img, result, exc in outcomes:
+                if exc is not None:
+                    failed += 1
+                    logger.warning(
+                        "Translation failed for source image, skipping",
+                        source_image_id=str(img.id),
+                        figure_number=img.figure_number,
+                        error=str(exc),
+                    )
+                    continue
+                img.caption_fr = result.caption_fr
+                img.caption_en = result.caption_en
+                img.alt_text_fr = result.alt_text_fr
+                img.alt_text_en = result.alt_text_en
+                session.add(img)
+                translated += 1
             await session.commit()
+            processed = batch_start + len(batch)
+            task.update_state(
+                state="TRANSLATING",
+                meta={
+                    "step": "translating",
+                    "total": total,
+                    "processed": processed,
+                    "translated": translated,
+                    "failed": failed,
+                },
+            )
 
         return {
             "status": "complete",
@@ -341,59 +357,55 @@ async def _run_kind_backfill_with_factory(
 
         classified = 0
         failed = 0
-        pending_commit = 0
+        sem = asyncio.Semaphore(_CONCURRENCY)
 
         async with httpx.AsyncClient(timeout=30.0) as http:
-            for idx, img in enumerate(rows):
-                try:
-                    upstream = await http.get(img.storage_url)
-                    upstream.raise_for_status()
-                    image_bytes = upstream.content
-                except Exception as exc:
-                    failed += 1
-                    logger.warning(
-                        "Failed to fetch image bytes for classification, skipping",
-                        source_image_id=str(img.id),
-                        storage_url=img.storage_url,
-                        error=str(exc),
-                    )
-                    continue
 
-                try:
-                    classification = await classify_figure(image_bytes=image_bytes)
-                except Exception as exc:
-                    failed += 1
-                    logger.warning(
-                        "Classification failed for source image, skipping",
-                        source_image_id=str(img.id),
-                        figure_number=img.figure_number,
-                        error=str(exc),
-                    )
-                    continue
+            async def _classify_one(img):
+                async with sem:
+                    try:
+                        upstream = await http.get(img.storage_url)
+                        upstream.raise_for_status()
+                        image_bytes = upstream.content
+                    except Exception as exc:  # noqa: BLE001
+                        return img, None, ("fetch", exc)
+                    try:
+                        classification = await classify_figure(image_bytes=image_bytes)
+                        return img, classification, None
+                    except Exception as exc:  # noqa: BLE001
+                        return img, None, ("classify", exc)
 
-                img.figure_kind = classification.kind
-                session.add(img)
-                classified += 1
-                pending_commit += 1
-
-                if pending_commit >= _COMMIT_EVERY:
-                    await session.commit()
-                    pending_commit = 0
-
-                if (idx + 1) % 10 == 0 or idx + 1 == total:
-                    task.update_state(
-                        state="CLASSIFYING",
-                        meta={
-                            "step": "classifying",
-                            "total": total,
-                            "processed": idx + 1,
-                            "classified": classified,
-                            "failed": failed,
-                        },
-                    )
-
-        if pending_commit:
-            await session.commit()
+            processed = 0
+            for batch_start in range(0, total, _BATCH_SIZE):
+                batch = rows[batch_start : batch_start + _BATCH_SIZE]
+                outcomes = await asyncio.gather(*(_classify_one(img) for img in batch))
+                for img, classification, err in outcomes:
+                    if err is not None:
+                        stage, exc = err
+                        failed += 1
+                        logger.warning(
+                            "Classification %s failed for source image, skipping",
+                            stage,
+                            source_image_id=str(img.id),
+                            figure_number=img.figure_number,
+                            error=str(exc),
+                        )
+                        continue
+                    img.figure_kind = classification.kind
+                    session.add(img)
+                    classified += 1
+                await session.commit()
+                processed = batch_start + len(batch)
+                task.update_state(
+                    state="CLASSIFYING",
+                    meta={
+                        "step": "classifying",
+                        "total": total,
+                        "processed": processed,
+                        "classified": classified,
+                        "failed": failed,
+                    },
+                )
 
         return {
             "status": "complete",
@@ -520,78 +532,67 @@ async def _run_svg_backfill_with_factory(
 
         rendered = 0
         failed = 0
-        pending_commit = 0
+        sem = asyncio.Semaphore(_CONCURRENCY)
 
         async with httpx.AsyncClient(timeout=30.0) as http:
-            for idx, img in enumerate(rows):
-                try:
-                    upstream = await http.get(img.storage_url)
-                    upstream.raise_for_status()
-                    image_bytes = upstream.content
-                except Exception as exc:
-                    failed += 1
-                    logger.warning(
-                        "Failed to fetch image bytes for SVG re-derivation",
-                        source_image_id=str(img.id),
-                        storage_url=img.storage_url,
-                        error=str(exc),
-                    )
-                    continue
 
-                try:
-                    structure = await extract_flowchart_structure(image_bytes=image_bytes)
-                    translated = await translate_structure(structure, target_lang="fr")
-                    svg_bytes = render_svg(translated)
-                except Exception as exc:
-                    failed += 1
-                    logger.warning(
-                        "SVG re-derivation failed",
-                        source_image_id=str(img.id),
-                        figure_number=img.figure_number,
-                        error=str(exc),
-                    )
-                    continue
+            async def _rederive_one(img):
+                async with sem:
+                    try:
+                        upstream = await http.get(img.storage_url)
+                        upstream.raise_for_status()
+                        image_bytes = upstream.content
+                    except Exception as exc:  # noqa: BLE001
+                        return img, None, None, ("fetch", exc)
+                    try:
+                        structure = await extract_flowchart_structure(image_bytes=image_bytes)
+                        translated = await translate_structure(structure, target_lang="fr")
+                        svg_bytes = render_svg(translated)
+                    except Exception as exc:  # noqa: BLE001
+                        return img, None, None, ("rederive", exc)
+                    try:
+                        key = _svg_key_for(img)
+                        url = await storage.upload_bytes(
+                            key=key,
+                            data=svg_bytes,
+                            content_type="image/svg+xml",
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        return img, None, None, ("upload", exc)
+                    return img, key, url, None
 
-                try:
-                    key = _svg_key_for(img)
-                    url = await storage.upload_bytes(
-                        key=key,
-                        data=svg_bytes,
-                        content_type="image/svg+xml",
-                    )
-                except Exception as exc:
-                    failed += 1
-                    logger.warning(
-                        "Failed to upload FR SVG to storage",
-                        source_image_id=str(img.id),
-                        error=str(exc),
-                    )
-                    continue
-
-                img.storage_key_fr = key
-                img.storage_url_fr = url
-                session.add(img)
-                rendered += 1
-                pending_commit += 1
-
-                if pending_commit >= _COMMIT_EVERY:
-                    await session.commit()
-                    pending_commit = 0
-
-                if (idx + 1) % 10 == 0 or idx + 1 == total:
-                    task.update_state(
-                        state="REDERIVING",
-                        meta={
-                            "step": "rederiving",
-                            "total": total,
-                            "processed": idx + 1,
-                            "rendered": rendered,
-                            "failed": failed,
-                        },
-                    )
-
-        if pending_commit:
-            await session.commit()
+            processed = 0
+            for batch_start in range(0, total, _BATCH_SIZE):
+                batch = rows[batch_start : batch_start + _BATCH_SIZE]
+                outcomes = await asyncio.gather(*(_rederive_one(img) for img in batch))
+                for img, key, url, err in outcomes:
+                    if err is not None:
+                        stage, exc = err
+                        failed += 1
+                        logger.warning(
+                            "SVG %s failed for source image, skipping",
+                            stage,
+                            source_image_id=str(img.id),
+                            figure_number=img.figure_number,
+                            error=str(exc),
+                        )
+                        continue
+                    img.storage_key_fr = key
+                    img.storage_url_fr = url
+                    session.add(img)
+                    rendered += 1
+                await session.commit()
+                processed = batch_start + len(batch)
+                task.update_state(
+                    state="REDERIVING",
+                    meta={
+                        "step": "rederiving",
+                        "total": total,
+                        "processed": processed,
+                        "rendered": rendered,
+                        "failed": failed,
+                    },
+                )
 
         return {
             "status": "complete",
@@ -613,3 +614,195 @@ def _svg_key_for(img: SourceImage) -> str:
     safe_label = figure_label.replace(" ", "_").replace(".", "_")
     prefix = img.rag_collection_id or img.source
     return f"source-images/{prefix}/{img.page_number}_{safe_label}.fr.svg"
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 slice 2.4 (#1883) — complex_diagram raster + numbered-badge overlay
+# ---------------------------------------------------------------------------
+
+
+class ComplexDiagramOverlayTask(Task):
+    """Celery base for the complex_diagram overlay backfill."""
+
+    def on_success(self, retval, task_id, args, kwargs):
+        logger.info("Complex-diagram overlay backfill completed", task_id=task_id, result=retval)
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        logger.error("Complex-diagram overlay backfill failed", task_id=task_id, exception=str(exc))
+
+
+@celery_app.task(
+    bind=True,
+    base=ComplexDiagramOverlayTask,
+    time_limit=3600,
+    soft_time_limit=3300,
+    ignore_result=True,
+    acks_late=False,
+)
+def backfill_complex_diagram_overlays(
+    self,
+    rag_collection_id: str | None = None,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """Render French-variant overlays for rows with ``figure_kind = 'complex_diagram'``.
+
+    Eligible: ``figure_kind = 'complex_diagram' AND storage_key_fr IS NULL AND
+    storage_url IS NOT NULL``. Fetches the English raster from MinIO,
+    extracts label positions, translates them, renders a numbered-badge
+    overlay SVG, uploads, writes back ``storage_key_fr`` + ``storage_url_fr``.
+    """
+    return asyncio.run(
+        _run_overlay_backfill(
+            task=self,
+            rag_collection_id=rag_collection_id,
+            limit=limit,
+            dry_run=dry_run,
+        )
+    )
+
+
+async def _run_overlay_backfill(
+    task: Task,
+    rag_collection_id: str | None,
+    limit: int | None,
+    dry_run: bool,
+) -> dict:
+    engine = create_async_engine(settings.database_url, pool_pre_ping=True)
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        return await _run_overlay_backfill_with_factory(
+            task=task,
+            rag_collection_id=rag_collection_id,
+            limit=limit,
+            dry_run=dry_run,
+            session_factory=session_factory,
+            storage=S3StorageService(),
+        )
+    finally:
+        await engine.dispose()
+
+
+async def _run_overlay_backfill_with_factory(
+    task: Task,
+    rag_collection_id: str | None,
+    limit: int | None,
+    dry_run: bool,
+    session_factory: async_sessionmaker[AsyncSession],
+    storage: S3StorageService,
+) -> dict:
+    async with session_factory() as session:
+        stmt = select(SourceImage).where(
+            SourceImage.figure_kind == "complex_diagram",
+            SourceImage.storage_key_fr.is_(None),
+            SourceImage.storage_url.is_not(None),
+        )
+        if rag_collection_id is not None:
+            stmt = stmt.where(SourceImage.rag_collection_id == rag_collection_id)
+        if limit is not None:
+            stmt = stmt.limit(limit)
+
+        rows = (await session.execute(stmt)).scalars().all()
+        total = len(rows)
+
+        logger.info(
+            "Complex-diagram overlay backfill: eligible rows",
+            total=total,
+            rag_collection_id=rag_collection_id,
+            dry_run=dry_run,
+        )
+
+        task.update_state(
+            state="OVERLAYING",
+            meta={
+                "step": "overlaying",
+                "total": total,
+                "processed": 0,
+                "rendered": 0,
+                "failed": 0,
+            },
+        )
+
+        if dry_run or total == 0:
+            return {
+                "status": "dry_run" if dry_run else "noop",
+                "eligible": total,
+                "rendered": 0,
+                "failed": 0,
+            }
+
+        rendered = 0
+        failed = 0
+        sem = asyncio.Semaphore(_CONCURRENCY)
+
+        async with httpx.AsyncClient(timeout=30.0) as http:
+
+            async def _overlay_one(img):
+                async with sem:
+                    try:
+                        upstream = await http.get(img.storage_url)
+                        upstream.raise_for_status()
+                        image_bytes = upstream.content
+                    except Exception as exc:  # noqa: BLE001
+                        return img, None, None, ("fetch", exc)
+                    try:
+                        positions = await extract_label_positions(image_bytes=image_bytes)
+                        translated = await translate_labels(positions, target_lang="fr")
+                        svg_bytes = render_overlay_svg(
+                            image_bytes=image_bytes,
+                            width_px=img.width or 1024,
+                            height_px=img.height or 768,
+                            labels=translated,
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        return img, None, None, ("render", exc)
+                    try:
+                        key = _svg_key_for(img)
+                        url = await storage.upload_bytes(
+                            key=key,
+                            data=svg_bytes,
+                            content_type="image/svg+xml",
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        return img, None, None, ("upload", exc)
+                    return img, key, url, None
+
+            processed = 0
+            for batch_start in range(0, total, _BATCH_SIZE):
+                batch = rows[batch_start : batch_start + _BATCH_SIZE]
+                outcomes = await asyncio.gather(*(_overlay_one(img) for img in batch))
+                for img, key, url, err in outcomes:
+                    if err is not None:
+                        stage, exc = err
+                        failed += 1
+                        logger.warning(
+                            "Overlay %s failed for source image, skipping",
+                            stage,
+                            source_image_id=str(img.id),
+                            figure_number=img.figure_number,
+                            error=str(exc),
+                        )
+                        continue
+                    img.storage_key_fr = key
+                    img.storage_url_fr = url
+                    session.add(img)
+                    rendered += 1
+                await session.commit()
+                processed = batch_start + len(batch)
+                task.update_state(
+                    state="OVERLAYING",
+                    meta={
+                        "step": "overlaying",
+                        "total": total,
+                        "processed": processed,
+                        "rendered": rendered,
+                        "failed": failed,
+                    },
+                )
+
+        return {
+            "status": "complete",
+            "eligible": total,
+            "rendered": rendered,
+            "failed": failed,
+        }

--- a/backend/tests/test_backfill_complex_diagram_overlays.py
+++ b/backend/tests/test_backfill_complex_diagram_overlays.py
@@ -1,8 +1,8 @@
-"""Unit tests for ``backfill_clean_flowchart_svgs`` (issue #1852).
+"""Unit tests for ``backfill_complex_diagram_overlays`` (issue #1883).
 
-Exercises ``_run_svg_backfill_with_factory`` directly with an injected
-session factory, a mocked httpx client, mocked Claude calls (extract +
-translate), and a fake storage to avoid DB/MinIO/network.
+Exercises ``_run_overlay_backfill_with_factory`` directly with a mocked
+session, httpx, Claude calls, and storage so the tests have no DB/MinIO/
+network dependency.
 """
 
 from __future__ import annotations
@@ -10,18 +10,16 @@ from __future__ import annotations
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from app.ai.translation.svg_rederiver import (
-    FlowchartEdge,
-    FlowchartNode,
-    FlowchartStructure,
-)
+from app.ai.translation.complex_overlay import DiagramLabel, DiagramLabels
 from app.tasks import image_translation
 
 
 def _make_row(
     storage_key_fr: str | None = None,
-    figure_kind: str = "clean_flowchart",
+    figure_kind: str = "complex_diagram",
     storage_url: str | None = "https://minio/default.webp",
+    width: int | None = 800,
+    height: int | None = 600,
 ) -> MagicMock:
     row = MagicMock()
     row.id = uuid.uuid4()
@@ -33,6 +31,8 @@ def _make_row(
     row.storage_url_fr = None
     row.figure_number = "1.1"
     row.page_number = 1
+    row.width = width
+    row.height = height
     return row
 
 
@@ -82,47 +82,43 @@ class _FakeStorage:
         return f"https://minio/{key}"
 
 
-def _patch_httpx(response_bytes: bytes = b"fake-webp"):
+def _patch_httpx(body: bytes = b"fake-webp"):
     upstream = MagicMock()
-    upstream.content = response_bytes
+    upstream.content = body
     upstream.raise_for_status = MagicMock()
-
     http_client = MagicMock()
     http_client.get = AsyncMock(return_value=upstream)
-
     ctx = MagicMock()
     ctx.__aenter__ = AsyncMock(return_value=http_client)
     ctx.__aexit__ = AsyncMock(return_value=False)
-
     return patch.object(image_translation.httpx, "AsyncClient", return_value=ctx)
 
 
-def _sample_structure() -> FlowchartStructure:
-    return FlowchartStructure(
-        nodes=[
-            FlowchartNode(id="n1", text="Make an observation"),
-            FlowchartNode(id="n2", text="Ask a question"),
-        ],
-        edges=[FlowchartEdge(from_id="n1", to_id="n2")],
+def _sample_labels() -> DiagramLabels:
+    return DiagramLabels(
+        labels=[
+            DiagramLabel(id="n1", text="Noyau", x_pct=30.0, y_pct=40.0),
+            DiagramLabel(id="n2", text="Membrane", x_pct=60.0, y_pct=50.0),
+        ]
     )
 
 
-class TestRunSvgBackfillWithFactory:
+class TestRunOverlayBackfillWithFactory:
     async def test_dry_run_counts_without_calling_claude(self):
         rows = [_make_row(), _make_row()]
         session = _FakeSession(rows)
         task = MagicMock()
         storage = _FakeStorage()
 
-        extract = AsyncMock(return_value=_sample_structure())
-        translate = AsyncMock(return_value=_sample_structure())
+        extract = AsyncMock(return_value=_sample_labels())
+        translate = AsyncMock(return_value=_sample_labels())
 
         with (
             _patch_httpx(),
-            patch.object(image_translation, "extract_flowchart_structure", new=extract),
-            patch.object(image_translation, "translate_structure", new=translate),
+            patch.object(image_translation, "extract_label_positions", new=extract),
+            patch.object(image_translation, "translate_labels", new=translate),
         ):
-            result = await image_translation._run_svg_backfill_with_factory(
+            result = await image_translation._run_overlay_backfill_with_factory(
                 task=task,
                 rag_collection_id=None,
                 limit=None,
@@ -148,15 +144,15 @@ class TestRunSvgBackfillWithFactory:
         task = MagicMock()
         storage = _FakeStorage()
 
-        extract = AsyncMock(return_value=_sample_structure())
-        translate = AsyncMock(return_value=_sample_structure())
+        extract = AsyncMock(return_value=_sample_labels())
+        translate = AsyncMock(return_value=_sample_labels())
 
         with (
             _patch_httpx(),
-            patch.object(image_translation, "extract_flowchart_structure", new=extract),
-            patch.object(image_translation, "translate_structure", new=translate),
+            patch.object(image_translation, "extract_label_positions", new=extract),
+            patch.object(image_translation, "translate_labels", new=translate),
         ):
-            result = await image_translation._run_svg_backfill_with_factory(
+            result = await image_translation._run_overlay_backfill_with_factory(
                 task=task,
                 rag_collection_id=None,
                 limit=None,
@@ -179,7 +175,7 @@ class TestRunSvgBackfillWithFactory:
 
     async def test_extract_failure_does_not_abort_batch(self):
         # Parallel execution: drive the extract mock by call ordinal so the
-        # test asserts counts (not position-based row identity).
+        # assertion only checks counts, not per-row identity.
         rows = [_make_row(), _make_row(), _make_row()]
         session = _FakeSession(rows)
         task = MagicMock()
@@ -191,17 +187,17 @@ class TestRunSvgBackfillWithFactory:
             call_count["n"] += 1
             if call_count["n"] == 2:
                 raise ValueError("vision timed out")
-            return _sample_structure()
+            return _sample_labels()
 
         extract = AsyncMock(side_effect=_extract)
-        translate = AsyncMock(return_value=_sample_structure())
+        translate = AsyncMock(return_value=_sample_labels())
 
         with (
             _patch_httpx(),
-            patch.object(image_translation, "extract_flowchart_structure", new=extract),
-            patch.object(image_translation, "translate_structure", new=translate),
+            patch.object(image_translation, "extract_label_positions", new=extract),
+            patch.object(image_translation, "translate_labels", new=translate),
         ):
-            result = await image_translation._run_svg_backfill_with_factory(
+            result = await image_translation._run_overlay_backfill_with_factory(
                 task=task,
                 rag_collection_id=None,
                 limit=None,
@@ -212,62 +208,23 @@ class TestRunSvgBackfillWithFactory:
 
         assert result["rendered"] == 2
         assert result["failed"] == 1
-        assert len(storage.uploads) == 2
-        # Exactly one row stays NULL; two rows get storage_key_fr.
         assert sum(1 for r in rows if r.storage_key_fr is None) == 1
         assert sum(1 for r in rows if r.storage_key_fr is not None) == 2
-
-    async def test_upload_failure_does_not_abort_batch(self):
-        rows = [_make_row(), _make_row()]
-        session = _FakeSession(rows)
-        task = MagicMock()
-
-        class _FailingStorage:
-            def __init__(self):
-                self.calls = 0
-
-            async def upload_bytes(self, key, data, content_type):
-                self.calls += 1
-                if self.calls == 1:
-                    raise RuntimeError("minio down")
-                return f"https://minio/{key}"
-
-        storage = _FailingStorage()
-
-        extract = AsyncMock(return_value=_sample_structure())
-        translate = AsyncMock(return_value=_sample_structure())
-
-        with (
-            _patch_httpx(),
-            patch.object(image_translation, "extract_flowchart_structure", new=extract),
-            patch.object(image_translation, "translate_structure", new=translate),
-        ):
-            result = await image_translation._run_svg_backfill_with_factory(
-                task=task,
-                rag_collection_id=None,
-                limit=None,
-                dry_run=False,
-                session_factory=_FakeSessionFactory(session),
-                storage=storage,
-            )
-
-        assert result["rendered"] == 1
-        assert result["failed"] == 1
 
     async def test_empty_eligible_set_returns_noop(self):
         session = _FakeSession([])
         task = MagicMock()
         storage = _FakeStorage()
 
-        extract = AsyncMock(return_value=_sample_structure())
-        translate = AsyncMock(return_value=_sample_structure())
+        extract = AsyncMock(return_value=_sample_labels())
+        translate = AsyncMock(return_value=_sample_labels())
 
         with (
             _patch_httpx(),
-            patch.object(image_translation, "extract_flowchart_structure", new=extract),
-            patch.object(image_translation, "translate_structure", new=translate),
+            patch.object(image_translation, "extract_label_positions", new=extract),
+            patch.object(image_translation, "translate_labels", new=translate),
         ):
-            result = await image_translation._run_svg_backfill_with_factory(
+            result = await image_translation._run_overlay_backfill_with_factory(
                 task=task,
                 rag_collection_id=None,
                 limit=None,
@@ -279,4 +236,3 @@ class TestRunSvgBackfillWithFactory:
         assert result["status"] == "noop"
         assert result["eligible"] == 0
         extract.assert_not_awaited()
-        translate.assert_not_awaited()

--- a/backend/tests/test_backfill_figure_kinds.py
+++ b/backend/tests/test_backfill_figure_kinds.py
@@ -142,21 +142,42 @@ class TestRunKindBackfillWithFactory:
         assert session.commits >= 1
 
     async def test_classifier_failure_does_not_abort_batch(self):
-        rows = [_make_row(), _make_row(), _make_row()]
+        # Parallel execution order is non-deterministic; drive the mock by
+        # the per-row storage_url so assertions don't depend on scheduling.
+        rows = [
+            _make_row(storage_url="https://minio/ok-1.webp"),
+            _make_row(storage_url="https://minio/FAIL.webp"),
+            _make_row(storage_url="https://minio/ok-2.webp"),
+        ]
         session = _FakeSession(rows)
         task = MagicMock()
-        httpx_patch, _ = _patch_httpx()
-        classifier = AsyncMock(
-            side_effect=[
-                FigureClassification(kind="chart"),
-                ValueError("vision timeout"),
-                FigureClassification(kind="photo"),
-            ]
-        )
+
+        upstream = MagicMock()
+        upstream.content = b"bytes"
+        upstream.raise_for_status = MagicMock()
+        http_client = MagicMock()
+        http_client.get = AsyncMock(return_value=upstream)
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=http_client)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+
+        call_seq: list[bytes] = []
+
+        async def _classifier(*, image_bytes):
+            # All three rows pass the same bytes (mock returns the same body)
+            # so we distinguish by call ordinal. Parallel safe because we
+            # treat the 2nd scheduled call as the failure — and we assert by
+            # result count, not by specific row.
+            call_seq.append(image_bytes)
+            if len(call_seq) == 2:
+                raise ValueError("vision timeout")
+            return FigureClassification(kind="photo")
 
         with (
-            httpx_patch,
-            patch.object(image_translation, "classify_figure", new=classifier),
+            patch.object(image_translation.httpx, "AsyncClient", return_value=ctx),
+            patch.object(
+                image_translation, "classify_figure", new=AsyncMock(side_effect=_classifier)
+            ),
         ):
             result = await image_translation._run_kind_backfill_with_factory(
                 task=task,
@@ -168,20 +189,30 @@ class TestRunKindBackfillWithFactory:
 
         assert result["classified"] == 2
         assert result["failed"] == 1
-        assert rows[0].figure_kind == "chart"
-        assert rows[1].figure_kind is None
-        assert rows[2].figure_kind == "photo"
+        # Exactly one row stays NULL, exactly two rows get classified.
+        assert sum(1 for r in rows if r.figure_kind is None) == 1
+        assert sum(1 for r in rows if r.figure_kind == "photo") == 2
 
     async def test_httpx_failure_does_not_abort_batch(self):
-        rows = [_make_row(), _make_row()]
+        # Drive fetch failure by URL so the assertion is order-independent.
+        rows = [
+            _make_row(storage_url="https://minio/network-FAIL.webp"),
+            _make_row(storage_url="https://minio/ok.webp"),
+        ]
         session = _FakeSession(rows)
         task = MagicMock()
 
         upstream_ok = MagicMock()
         upstream_ok.content = b"ok"
         upstream_ok.raise_for_status = MagicMock()
+
+        async def _get(url):
+            if "FAIL" in url:
+                raise Exception("network")
+            return upstream_ok
+
         http_client = MagicMock()
-        http_client.get = AsyncMock(side_effect=[Exception("network"), upstream_ok])
+        http_client.get = AsyncMock(side_effect=_get)
         ctx = MagicMock()
         ctx.__aenter__ = AsyncMock(return_value=http_client)
         ctx.__aexit__ = AsyncMock(return_value=False)
@@ -202,6 +233,10 @@ class TestRunKindBackfillWithFactory:
 
         assert result["classified"] == 1
         assert result["failed"] == 1
+        fail_row = next(r for r in rows if "FAIL" in r.storage_url)
+        ok_row = next(r for r in rows if "FAIL" not in r.storage_url)
+        assert fail_row.figure_kind is None
+        assert ok_row.figure_kind == "photo"
         assert rows[0].figure_kind is None
         assert rows[1].figure_kind == "photo"
         classifier.assert_awaited_once()

--- a/backend/tests/test_backfill_image_translations.py
+++ b/backend/tests/test_backfill_image_translations.py
@@ -142,10 +142,23 @@ class TestRunBackfillWithFactory:
         assert session.commits >= 1
 
     async def test_translator_failure_does_not_abort_batch(self):
-        rows = [_make_row(), _make_row(), _make_row()]
+        # With parallel execution, side_effect list order is non-deterministic.
+        # Mark one row as "should fail" and have the mock side_effect branch
+        # on the input caption — that keeps the assertion order-independent.
+        rows = [
+            _make_row(caption="ok-1"),
+            _make_row(caption="FAIL"),
+            _make_row(caption="ok-2"),
+        ]
         session = _FakeSession(rows)
         task = MagicMock()
-        mock_tx = AsyncMock(side_effect=[_translation(), ValueError("transient"), _translation()])
+
+        async def _side_effect(*, caption, **_):
+            if caption == "FAIL":
+                raise ValueError("transient")
+            return _translation()
+
+        mock_tx = AsyncMock(side_effect=_side_effect)
         with patch.object(image_translation, "translate_figure_caption", new=mock_tx):
             result = await image_translation._run_backfill_with_factory(
                 task=task,
@@ -160,9 +173,12 @@ class TestRunBackfillWithFactory:
             "translated": 2,
             "failed": 1,
         }
-        assert rows[1].caption_fr is None
-        assert rows[0].caption_fr == "caption_fr"
-        assert rows[2].caption_fr == "caption_fr"
+        # The FAIL row never gets caption_fr assigned; the other two do.
+        fail_row = next(r for r in rows if r.caption == "FAIL")
+        ok_rows = [r for r in rows if r.caption != "FAIL"]
+        assert fail_row.caption_fr is None
+        for row in ok_rows:
+            assert row.caption_fr == "caption_fr"
 
     async def test_empty_eligible_set_returns_noop(self):
         session = _FakeSession([])

--- a/backend/tests/test_complex_overlay.py
+++ b/backend/tests/test_complex_overlay.py
@@ -1,0 +1,225 @@
+"""Unit tests for the complex_diagram overlay renderer (issue #1883)."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from app.ai.translation.complex_overlay import (
+    DiagramLabel,
+    DiagramLabels,
+    _escape,
+    _parse_labels,
+    _wrap_legend_line,
+    extract_label_positions,
+    render_overlay_svg,
+    translate_labels,
+)
+
+
+def _mock_anthropic_response(text: str) -> MagicMock:
+    msg = MagicMock()
+    msg.content = [SimpleNamespace(text=text)]
+    return msg
+
+
+def _mock_client(text: str) -> MagicMock:
+    client = MagicMock()
+    client.messages = MagicMock()
+    client.messages.create = AsyncMock(return_value=_mock_anthropic_response(text))
+    return client
+
+
+class TestDiagramLabelCoercion:
+    def test_accepts_percentage_0_100(self):
+        label = DiagramLabel(id="n1", text="A", x_pct=42.0, y_pct=17.5)
+        assert label.x_pct == 42.0 and label.y_pct == 17.5
+
+    def test_coerces_fraction_0_1_to_percent(self):
+        label = DiagramLabel(id="n1", text="A", x_pct=0.42, y_pct=0.175)
+        assert label.x_pct == pytest.approx(42.0)
+        assert label.y_pct == pytest.approx(17.5)
+
+    def test_rejects_out_of_range(self):
+        with pytest.raises(ValidationError):
+            DiagramLabel(id="n1", text="A", x_pct=150.0, y_pct=0.0)
+
+
+class TestWrapLegendLine:
+    def test_short_fits_on_one_line(self):
+        out = _wrap_legend_line(1, "Noyau", max_chars=40)
+        assert out == ["1 — Noyau"]
+
+    def test_long_wraps_at_words_with_indent(self):
+        out = _wrap_legend_line(2, "Membrane plasmique très très longue label", max_chars=20)
+        assert out[0].startswith("2 — ")
+        # continuation lines are indented so the text column stays aligned
+        indent = " " * len("2 — ")
+        for line in out[1:]:
+            assert line.startswith(indent)
+
+
+class TestEscape:
+    def test_escapes_xml_metachars(self):
+        assert _escape("A & <B> \"c'") == "A &amp; &lt;B&gt; &quot;c&#39;"
+
+
+class TestParseLabels:
+    def test_strips_markdown_fences(self):
+        payload = {"labels": [{"id": "n1", "text": "X", "x_pct": 10, "y_pct": 20}]}
+        fenced = f"```json\n{json.dumps(payload)}\n```"
+        result = _parse_labels(fenced)
+        assert result.labels[0].text == "X"
+
+    def test_rejects_empty_labels_list(self):
+        with pytest.raises(ValidationError):
+            _parse_labels(json.dumps({"labels": []}))
+
+
+class TestExtractLabelPositions:
+    async def test_happy_path(self):
+        payload = {
+            "labels": [
+                {"id": "n1", "text": "Nucleus", "x_pct": 42.5, "y_pct": 17.0},
+                {"id": "n2", "text": "Membrane", "x_pct": 60.0, "y_pct": 50.0},
+            ]
+        }
+        client = _mock_client(json.dumps(payload))
+        result = await extract_label_positions(b"fake-webp", client=client)
+        assert isinstance(result, DiagramLabels)
+        assert [label.id for label in result.labels] == ["n1", "n2"]
+        assert result.labels[0].x_pct == 42.5
+
+    async def test_empty_bytes_rejected(self):
+        client = _mock_client("{}")
+        with pytest.raises(ValueError, match="non-empty"):
+            await extract_label_positions(b"", client=client)
+        client.messages.create.assert_not_awaited()
+
+    async def test_invalid_json_raises(self):
+        client = _mock_client("not json")
+        with pytest.raises(ValueError):
+            await extract_label_positions(b"fake-webp", client=client)
+
+    async def test_missing_labels_fails_validation(self):
+        client = _mock_client(json.dumps({}))
+        with pytest.raises(ValidationError):
+            await extract_label_positions(b"fake-webp", client=client)
+
+
+class TestTranslateLabels:
+    async def test_preserves_ids_and_coordinates(self):
+        source = DiagramLabels(
+            labels=[
+                DiagramLabel(id="n1", text="Nucleus", x_pct=42.5, y_pct=17.0),
+                DiagramLabel(id="n2", text="Membrane", x_pct=60.0, y_pct=50.0),
+            ]
+        )
+        translated = {
+            "labels": [
+                {"id": "n1", "text": "Noyau", "x_pct": 42.5, "y_pct": 17.0},
+                {"id": "n2", "text": "Membrane plasmique", "x_pct": 60.0, "y_pct": 50.0},
+            ]
+        }
+        client = _mock_client(json.dumps(translated))
+        out = await translate_labels(source, target_lang="fr", client=client)
+        assert out.labels[0].text == "Noyau"
+        assert out.labels[1].text == "Membrane plasmique"
+
+    async def test_rejects_unsupported_target_lang(self):
+        source = DiagramLabels(labels=[DiagramLabel(id="n1", text="x", x_pct=10, y_pct=10)])
+        with pytest.raises(ValueError, match="unsupported target_lang"):
+            await translate_labels(source, target_lang="de")
+
+    async def test_raises_when_translator_changes_ids(self):
+        source = DiagramLabels(labels=[DiagramLabel(id="n1", text="x", x_pct=10, y_pct=10)])
+        rogue = {"labels": [{"id": "different", "text": "y", "x_pct": 10, "y_pct": 10}]}
+        client = _mock_client(json.dumps(rogue))
+        with pytest.raises(ValueError, match="changed label ids"):
+            await translate_labels(source, target_lang="fr", client=client)
+
+
+class TestRenderOverlaySvg:
+    # We deliberately use string-based assertions instead of an XML parser
+    # here — SVG 1.1 with xlink:href needs namespace awareness in ET and it's
+    # more fragile than just grepping for the structural features we care
+    # about.
+
+    def test_renders_valid_svg_with_image_and_badges_and_legend(self):
+        labels = DiagramLabels(
+            labels=[
+                DiagramLabel(id="n1", text="Noyau", x_pct=25.0, y_pct=30.0),
+                DiagramLabel(id="n2", text="Membrane", x_pct=75.0, y_pct=60.0),
+            ]
+        )
+        svg = render_overlay_svg(
+            image_bytes=b"fake-webp-bytes",
+            width_px=800,
+            height_px=600,
+            labels=labels,
+        )
+        body = svg.decode("utf-8")
+        assert body.startswith("<svg")
+        assert 'xmlns="http://www.w3.org/2000/svg"' in body
+        # One embedded raster
+        assert body.count("<image ") == 1
+        assert 'xlink:href="data:image/webp;base64,' in body
+        # One badge circle per label
+        assert body.count("<circle ") == 2
+        # Legend contains the translated terms
+        assert "Noyau" in body
+        assert "Membrane" in body
+
+    def test_badge_positions_map_pct_to_pixels(self):
+        labels = DiagramLabels(labels=[DiagramLabel(id="n1", text="X", x_pct=50.0, y_pct=25.0)])
+        svg = render_overlay_svg(
+            image_bytes=b"bytes",
+            width_px=1000,
+            height_px=400,
+            labels=labels,
+        ).decode("utf-8")
+        # Renderer emits cx / cy rounded to 2 dp → 500.0 / 100.0.
+        # Look for the exact attribute tokens.
+        assert 'cx="500.0"' in svg or 'cx="500"' in svg
+        assert 'cy="100.0"' in svg or 'cy="100"' in svg
+
+    def test_xml_metachars_in_labels_escaped(self):
+        labels = DiagramLabels(labels=[DiagramLabel(id="n1", text="A & <B>", x_pct=10, y_pct=10)])
+        svg = render_overlay_svg(
+            image_bytes=b"bytes", width_px=400, height_px=300, labels=labels
+        ).decode("utf-8")
+        # Raw metachars in body text would break XML; check they are escaped
+        # within legend text (legend lines wrap "1 — A & <B>").
+        assert "A &amp; &lt;B&gt;" in svg
+        assert "A & <B>" not in svg.split("xlink:href=")[1]  # not in the svg body post-href
+
+    def test_rejects_empty_inputs(self):
+        good = DiagramLabels(labels=[DiagramLabel(id="n1", text="X", x_pct=10, y_pct=10)])
+        with pytest.raises(ValueError, match="image_bytes"):
+            render_overlay_svg(b"", 400, 300, good)
+        with pytest.raises(ValueError, match="width_px"):
+            render_overlay_svg(b"x", 0, 300, good)
+        with pytest.raises(ValueError, match="labels"):
+            render_overlay_svg(b"x", 400, 300, DiagramLabels.model_construct(labels=[]))
+
+    def test_viewbox_extends_below_image_for_legend(self):
+        labels = DiagramLabels(
+            labels=[DiagramLabel(id=f"n{i}", text=f"L{i}", x_pct=50, y_pct=50) for i in range(5)]
+        )
+        svg = render_overlay_svg(
+            image_bytes=b"x", width_px=600, height_px=400, labels=labels
+        ).decode("utf-8")
+        # Extract the viewBox value via simple string indexing.
+        vb_token = 'viewBox="'
+        idx = svg.index(vb_token) + len(vb_token)
+        viewbox = svg[idx : svg.index('"', idx)]
+        parts = viewbox.split()
+        assert len(parts) == 4
+        total_height = float(parts[3])
+        # Image is 400 tall; 5 legend lines × 20 px line-height + padding pad
+        # must push total over 400 + 5*20.
+        assert total_height > 400 + 5 * 20


### PR DESCRIPTION
## Summary

Narrow cherry-pick of **#1892** (parallelize) + **#1886** (complex_diagram overlays) directly to main, sidestepping unrelated dev↔main divergence currently blocking sync PR #1923.

Both PRs reviewed, CI green, merged to dev as of 2026-04-24. This brings only those two changes to main (and thus to staging on deploy).

### Why this and not #1923

Dev and main have duplicate fixes applied separately (#1908/#1920 for profile, #1907/#1912 for migration 081) causing add/add conflicts on frontend files. Resolving which implementation is canonical is out of scope for the current task (shipping the backfill parallelization). Leaving #1923 open for later reconciliation.

### Content

- **#1892**: batched `asyncio.gather` + `Semaphore(8)` in all four backfill tasks — ~6-8× throughput on staging classifier runs
- **#1886**: `backfill_complex_diagram_overlays` task + complex_overlay module (Claude Vision label extraction + numbered-badge SVG renderer) + ingest wiring

Same diff as reviewed in #1892. No new code.

## Test plan

- [x] CI passes (inherits from #1892 green runs)
- [ ] Staging auto-deploy on merge — verify worker picks up parallel path
- [ ] Dispatch classifier + overlay backfills post-deploy; confirm throughput improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)