### PR TITLE
fix(figures): accept empty DiagramLabels + clamp pct; reclassify as photo

### DIFF
--- a/backend/app/ai/rag/pipeline.py
+++ b/backend/app/ai/rag/pipeline.py
@@ -298,23 +298,29 @@ class RAGPipeline:
             elif figure_kind == "complex_diagram":
                 try:
                     positions = await extract_label_positions(image_bytes=img.image_bytes)
-                    translated_positions = await translate_labels(positions, target_lang="fr")
-                    svg_bytes = render_overlay_svg(
-                        image_bytes=img.image_bytes,
-                        width_px=img.width or 1024,
-                        height_px=img.height or 768,
-                        labels=translated_positions,
-                    )
-                    svg_key = (
-                        f"source-images/{prefix}/{readable_name}/"
-                        f"{img.page_number}_{safe_label}.fr.svg"
-                    )
-                    storage_url_fr = await storage.upload_bytes(
-                        key=svg_key,
-                        data=svg_bytes,
-                        content_type="image/svg+xml",
-                    )
-                    storage_key_fr = svg_key
+                    if not positions.labels:
+                        # Vision found no text labels — treat as a photo so
+                        # Phase 1 caption translation covers it and the
+                        # overlay backfill doesn't re-process this row.
+                        figure_kind = "photo"
+                    else:
+                        translated_positions = await translate_labels(positions, target_lang="fr")
+                        svg_bytes = render_overlay_svg(
+                            image_bytes=img.image_bytes,
+                            width_px=img.width or 1024,
+                            height_px=img.height or 768,
+                            labels=translated_positions,
+                        )
+                        svg_key = (
+                            f"source-images/{prefix}/{readable_name}/"
+                            f"{img.page_number}_{safe_label}.fr.svg"
+                        )
+                        storage_url_fr = await storage.upload_bytes(
+                            key=svg_key,
+                            data=svg_bytes,
+                            content_type="image/svg+xml",
+                        )
+                        storage_key_fr = svg_key
                 except Exception as exc:
                     logger.warning(
                         "Failed to build FR overlay for complex_diagram, leaving fr variant NULL",

--- a/backend/app/ai/translation/complex_overlay.py
+++ b/backend/app/ai/translation/complex_overlay.py
@@ -43,25 +43,37 @@ logger = structlog.get_logger(__name__)
 class DiagramLabel(BaseModel):
     id: str = Field(..., min_length=1)
     text: str = Field(..., min_length=1)
-    # Percentage of image width/height (0.0-100.0). Claude Vision isn't
-    # pixel-accurate, so we don't pretend — percentages keep the renderer
-    # independent of the source image's resolution.
-    x_pct: float = Field(..., ge=0.0, le=100.0)
-    y_pct: float = Field(..., ge=0.0, le=100.0)
+    # Percentage of image width/height. Claude Vision isn't pixel-accurate,
+    # so we don't pretend — percentages keep the renderer independent of
+    # the source image's resolution.
+    x_pct: float
+    y_pct: float
 
     @field_validator("x_pct", "y_pct", mode="before")
     @classmethod
     def _coerce_percentage(cls, value: Any) -> Any:
         # Tolerate integer literals ("45") and 0-1 fractions ("0.45") from
-        # the model. Convert fractions to percentages so downstream code has
-        # one invariant.
-        if isinstance(value, int | float) and 0.0 < value <= 1.0:
-            return float(value) * 100.0
+        # the model. Convert fractions to percentages so downstream code
+        # has one invariant, then clamp near-edge overflows (Vision
+        # occasionally returns 104.0 for a label touching the bottom
+        # border) to the valid [0, 100] range instead of rejecting the
+        # whole response.
+        if isinstance(value, int | float):
+            if 0.0 < value <= 1.0:
+                value = float(value) * 100.0
+            if value < 0.0:
+                return 0.0
+            if value > 100.0:
+                return 100.0
         return value
 
 
 class DiagramLabels(BaseModel):
-    labels: list[DiagramLabel] = Field(..., min_length=1)
+    # Accept an empty list — Claude Vision legitimately returns zero labels
+    # for diagrams that have no visible text (dense illustrations, photos
+    # misclassified as complex_diagram). Callers handle the empty case by
+    # reclassifying the source image to 'photo' (caption-only path).
+    labels: list[DiagramLabel] = Field(default_factory=list)
 
 
 _EXTRACT_MODEL = "claude-haiku-4-5"

--- a/backend/app/tasks/image_translation.py
+++ b/backend/app/tasks/image_translation.py
@@ -732,6 +732,7 @@ async def _run_overlay_backfill_with_factory(
             }
 
         rendered = 0
+        reclassified = 0
         failed = 0
         sem = asyncio.Semaphore(_CONCURRENCY)
 
@@ -747,6 +748,11 @@ async def _run_overlay_backfill_with_factory(
                         return img, None, None, ("fetch", exc)
                     try:
                         positions = await extract_label_positions(image_bytes=image_bytes)
+                        if not positions.labels:
+                            # No text found — caller will reclassify as photo
+                            # and skip. Avoids an infinite re-process loop
+                            # over diagrams Vision can't label.
+                            return img, None, None, ("reclassify_photo", None)
                         translated = await translate_labels(positions, target_lang="fr")
                         svg_bytes = render_overlay_svg(
                             image_bytes=image_bytes,
@@ -774,6 +780,16 @@ async def _run_overlay_backfill_with_factory(
                 for img, key, url, err in outcomes:
                     if err is not None:
                         stage, exc = err
+                        if stage == "reclassify_photo":
+                            img.figure_kind = "photo"
+                            session.add(img)
+                            reclassified += 1
+                            logger.info(
+                                "complex_diagram has no extractable labels; reclassifying as photo",
+                                source_image_id=str(img.id),
+                                figure_number=img.figure_number,
+                            )
+                            continue
                         failed += 1
                         logger.warning(
                             "Overlay %s failed for source image, skipping",
@@ -796,6 +812,7 @@ async def _run_overlay_backfill_with_factory(
                         "total": total,
                         "processed": processed,
                         "rendered": rendered,
+                        "reclassified": reclassified,
                         "failed": failed,
                     },
                 )
@@ -804,5 +821,6 @@ async def _run_overlay_backfill_with_factory(
             "status": "complete",
             "eligible": total,
             "rendered": rendered,
+            "reclassified": reclassified,
             "failed": failed,
         }

--- a/backend/tests/test_backfill_complex_diagram_overlays.py
+++ b/backend/tests/test_backfill_complex_diagram_overlays.py
@@ -133,6 +133,9 @@ class TestRunOverlayBackfillWithFactory:
             "rendered": 0,
             "failed": 0,
         }
+        # Dry-run doesn't track reclassified either — only the post-loop
+        # complete result carries that counter.
+        assert "reclassified" not in result
         extract.assert_not_awaited()
         translate.assert_not_awaited()
         assert storage.uploads == []
@@ -209,6 +212,47 @@ class TestRunOverlayBackfillWithFactory:
         assert result["rendered"] == 2
         assert result["failed"] == 1
         assert sum(1 for r in rows if r.storage_key_fr is None) == 1
+        assert sum(1 for r in rows if r.storage_key_fr is not None) == 2
+
+    async def test_empty_labels_reclassifies_as_photo(self):
+        # Vision returns zero labels for diagrams it cannot read — the task
+        # must flip those rows to ``figure_kind = 'photo'`` so the overlay
+        # backfill stops re-processing them indefinitely (#1925).
+        rows = [_make_row(), _make_row(), _make_row()]
+        session = _FakeSession(rows)
+        task = MagicMock()
+        storage = _FakeStorage()
+
+        call_count = {"n": 0}
+
+        async def _extract(*, image_bytes):
+            call_count["n"] += 1
+            # Second call returns empty labels; others return real labels.
+            if call_count["n"] == 2:
+                return DiagramLabels(labels=[])
+            return _sample_labels()
+
+        extract = AsyncMock(side_effect=_extract)
+        translate = AsyncMock(return_value=_sample_labels())
+
+        with (
+            _patch_httpx(),
+            patch.object(image_translation, "extract_label_positions", new=extract),
+            patch.object(image_translation, "translate_labels", new=translate),
+        ):
+            result = await image_translation._run_overlay_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=False,
+                session_factory=_FakeSessionFactory(session),
+                storage=storage,
+            )
+
+        assert result["rendered"] == 2
+        assert result["reclassified"] == 1
+        assert result["failed"] == 0
+        assert sum(1 for r in rows if r.figure_kind == "photo") == 1
         assert sum(1 for r in rows if r.storage_key_fr is not None) == 2
 
     async def test_empty_eligible_set_returns_noop(self):

--- a/backend/tests/test_complex_overlay.py
+++ b/backend/tests/test_complex_overlay.py
@@ -7,7 +7,6 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from pydantic import ValidationError
 
 from app.ai.translation.complex_overlay import (
     DiagramLabel,
@@ -44,9 +43,17 @@ class TestDiagramLabelCoercion:
         assert label.x_pct == pytest.approx(42.0)
         assert label.y_pct == pytest.approx(17.5)
 
-    def test_rejects_out_of_range(self):
-        with pytest.raises(ValidationError):
-            DiagramLabel(id="n1", text="A", x_pct=150.0, y_pct=0.0)
+    def test_clamps_above_100_to_100(self):
+        # Vision occasionally returns y_pct=104.0 for near-edge labels;
+        # clamp rather than reject the whole response (#1925).
+        label = DiagramLabel(id="n1", text="A", x_pct=104.0, y_pct=150.0)
+        assert label.x_pct == 100.0
+        assert label.y_pct == 100.0
+
+    def test_clamps_below_0_to_0(self):
+        label = DiagramLabel(id="n1", text="A", x_pct=-3.0, y_pct=0.0)
+        assert label.x_pct == 0.0
+        assert label.y_pct == 0.0
 
 
 class TestWrapLegendLine:
@@ -75,9 +82,12 @@ class TestParseLabels:
         result = _parse_labels(fenced)
         assert result.labels[0].text == "X"
 
-    def test_rejects_empty_labels_list(self):
-        with pytest.raises(ValidationError):
-            _parse_labels(json.dumps({"labels": []}))
+    def test_accepts_empty_labels_list(self):
+        # Vision legitimately returns no labels for figures with no
+        # extractable text; callers reclassify those rows to 'photo'
+        # (#1925) — parsing shouldn't reject the response outright.
+        result = _parse_labels(json.dumps({"labels": []}))
+        assert result.labels == []
 
 
 class TestExtractLabelPositions:
@@ -105,10 +115,13 @@ class TestExtractLabelPositions:
         with pytest.raises(ValueError):
             await extract_label_positions(b"fake-webp", client=client)
 
-    async def test_missing_labels_fails_validation(self):
+    async def test_missing_labels_key_defaults_to_empty(self):
+        # ``labels`` defaults to an empty list, so a response that omits
+        # the key is treated as "no labels found" (handled by callers
+        # via reclassification-to-photo).
         client = _mock_client(json.dumps({}))
-        with pytest.raises(ValidationError):
-            await extract_label_positions(b"fake-webp", client=client)
+        result = await extract_label_positions(b"fake-webp", client=client)
+        assert result.labels == []
 
 
 class TestTranslateLabels:


### PR DESCRIPTION
Fixes #1925.

## Summary

Staging overlay backfill was stalling with ~2200 un-translated `complex_diagram` rows because `DiagramLabels` validation rejected two legitimate Claude Vision response shapes:

1. `{"labels": []}` — Vision found no text in the image
2. `y_pct=104.0` — near-edge label slightly out of the 0-100 range

Both paths now accept these responses and either render the overlay (clamped coordinates) or reclassify the row so it stops being eligible for overlay backfill.

## Changes

- **`DiagramLabel`** — drop `ge=0.0, le=100.0` Field bounds. The existing `mode="before"` coercer now clamps overflow/underflow to `[0, 100]` in addition to the 0-1-fraction normalisation it already did.
- **`DiagramLabels.labels`** — `min_length=0` (accept empty list) via `default_factory=list`. Empty is a valid "no labels found" signal.
- **`_overlay_one` (backfill task)** — if extract returns empty labels, flip `figure_kind` to `'photo'` and return a new `("reclassify_photo", None)` outcome. Task result dict gains a `reclassified` counter.
- **`_process_images` (ingest pipeline)** — symmetric change: on empty labels at ingest, set `figure_kind = 'photo'` locally before persisting so the row never becomes eligible for overlay backfill.

## Why reclassify-to-photo

Simpler than adding a new "attempted-no-labels" column. `figure_kind='photo'` semantically says "no embedded text to translate" — which is exactly what an empty Vision response means. Phase 1 caption translation still covers the row, and the overlay backfill's `WHERE figure_kind = 'complex_diagram'` eligibility filter automatically excludes reclassified rows.

## Test plan

- [x] `uv run pytest tests/test_complex_overlay.py tests/test_backfill_*.py tests/test_svg_rederiver.py tests/test_figure_classifier.py tests/test_figure_translator.py` — **96 pass**
- [x] `uv run ruff check` + `ruff format --check` — clean
- [ ] Staging after deploy: dispatch `backfill_complex_diagram_overlays`; expect bulk of 2200 stuck rows to render or reclassify in one run

## Test additions

- `test_clamps_above_100_to_100` + `test_clamps_below_0_to_0` — validate new clamp behaviour.
- `test_accepts_empty_labels_list` + `test_missing_labels_key_defaults_to_empty` — validate empty is accepted through parser and extractor.
- `test_empty_labels_reclassifies_as_photo` — integration test: second of three rows returns empty labels, assert that row ends up with `figure_kind='photo'`, `result["reclassified"] == 1`, others render normally.

## Out of scope

- New status column for terminal "vision returned empty" state — reclassify-to-photo is the simpler sufficient fix.
- Vision prompt tuning (separate issue if reclassify-to-photo ends up catching too many rows that should have had labels extracted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)