### PR TITLE
Sync dev to main: ENABLE_FIGURE_VISION kill-switch (#1929)

### DIFF
--- a/backend/app/ai/translation/complex_overlay.py
+++ b/backend/app/ai/translation/complex_overlay.py
@@ -164,8 +164,11 @@ async def extract_label_positions(
     """Claude Vision call: return every visible label + its approximate position."""
     if not image_bytes:
         raise ValueError("image_bytes must be non-empty")
+    settings = get_settings()
+    if not settings.enable_figure_vision:
+        # Cost kill-switch (#1928). Caller catches and treats as a skip.
+        raise RuntimeError("figure vision is disabled (ENABLE_FIGURE_VISION=false)")
     if client is None:
-        settings = get_settings()
         if not settings.anthropic_api_key:
             raise ValueError("ANTHROPIC_API_KEY is required to extract labels")
         client = anthropic.AsyncAnthropic(

--- a/backend/app/ai/translation/figure_classifier.py
+++ b/backend/app/ai/translation/figure_classifier.py
@@ -143,8 +143,12 @@ async def classify_figure(
     if not image_bytes:
         raise ValueError("image_bytes must be non-empty")
 
+    settings = get_settings()
+    if not settings.enable_figure_vision:
+        # Cost kill-switch (#1928). Caller catches and treats as a skip.
+        raise RuntimeError("figure vision is disabled (ENABLE_FIGURE_VISION=false)")
+
     if client is None:
-        settings = get_settings()
         if not settings.anthropic_api_key:
             raise ValueError("ANTHROPIC_API_KEY is required to classify figures")
         client = anthropic.AsyncAnthropic(

--- a/backend/app/ai/translation/svg_rederiver.py
+++ b/backend/app/ai/translation/svg_rederiver.py
@@ -139,8 +139,12 @@ async def extract_flowchart_structure(
     if not image_bytes:
         raise ValueError("image_bytes must be non-empty")
 
+    settings = get_settings()
+    if not settings.enable_figure_vision:
+        # Cost kill-switch (#1928). Caller catches and treats as a skip.
+        raise RuntimeError("figure vision is disabled (ENABLE_FIGURE_VISION=false)")
+
     if client is None:
-        settings = get_settings()
         if not settings.anthropic_api_key:
             raise ValueError("ANTHROPIC_API_KEY is required to extract flowcharts")
         client = anthropic.AsyncAnthropic(

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -30,6 +30,14 @@ class Settings(BaseSettings):
     # Anthropic Claude API
     anthropic_api_key: str = ""
 
+    # Cost kill-switch for Vision-backed figure tasks (classifier, flowchart
+    # SVG re-deriver, complex_diagram overlay extractor). Set to False in an
+    # environment that shouldn't spend on Claude Vision — backfills and the
+    # Vision-gated ingest branches short-circuit cleanly. Text-only Haiku
+    # features (caption translation, tutor, lessons) are unaffected.
+    # Issue #1928 — staging burned ~$30 in 4 hours of repeated backfills.
+    enable_figure_vision: bool = True
+
     # Google AI (Gemini TTS)
     google_api_key: str = ""
 

--- a/backend/app/tasks/image_translation.py
+++ b/backend/app/tasks/image_translation.py
@@ -316,6 +316,10 @@ async def _run_kind_backfill_with_factory(
     dry_run: bool,
     session_factory: async_sessionmaker[AsyncSession],
 ) -> dict:
+    if not settings.enable_figure_vision:
+        # Cost kill-switch (#1928) — every row does a Claude Vision call.
+        logger.info("figure-kind backfill short-circuit: vision disabled")
+        return {"status": "disabled", "eligible": 0, "classified": 0, "failed": 0}
     async with session_factory() as session:
         stmt = select(SourceImage).where(
             SourceImage.figure_kind.is_(None),
@@ -490,6 +494,10 @@ async def _run_svg_backfill_with_factory(
     session_factory: async_sessionmaker[AsyncSession],
     storage: S3StorageService,
 ) -> dict:
+    if not settings.enable_figure_vision:
+        # Cost kill-switch (#1928) — every row does 1-2 Claude Vision calls.
+        logger.info("flowchart SVG backfill short-circuit: vision disabled")
+        return {"status": "disabled", "eligible": 0, "rendered": 0, "failed": 0}
     async with session_factory() as session:
         stmt = select(SourceImage).where(
             SourceImage.figure_kind == "clean_flowchart",
@@ -691,6 +699,16 @@ async def _run_overlay_backfill_with_factory(
     session_factory: async_sessionmaker[AsyncSession],
     storage: S3StorageService,
 ) -> dict:
+    if not settings.enable_figure_vision:
+        # Cost kill-switch (#1928) — every row does 2 Claude Vision calls.
+        logger.info("complex_diagram overlay backfill short-circuit: vision disabled")
+        return {
+            "status": "disabled",
+            "eligible": 0,
+            "rendered": 0,
+            "reclassified": 0,
+            "failed": 0,
+        }
     async with session_factory() as session:
         stmt = select(SourceImage).where(
             SourceImage.figure_kind == "complex_diagram",

--- a/backend/tests/test_backfill_clean_flowchart_svgs.py
+++ b/backend/tests/test_backfill_clean_flowchart_svgs.py
@@ -280,3 +280,34 @@ class TestRunSvgBackfillWithFactory:
         assert result["eligible"] == 0
         extract.assert_not_awaited()
         translate.assert_not_awaited()
+
+    async def test_short_circuits_when_vision_disabled(self):
+        # Cost kill-switch (#1928) — flag=False should return immediately,
+        # skipping any DB query and any Claude call.
+        rows = [_make_row(), _make_row()]
+        session = _FakeSession(rows)
+        task = MagicMock()
+        storage = _FakeStorage()
+
+        extract = AsyncMock(return_value=_sample_structure())
+        translate = AsyncMock(return_value=_sample_structure())
+
+        with (
+            patch.object(image_translation.settings, "enable_figure_vision", False),
+            patch.object(image_translation, "extract_flowchart_structure", new=extract),
+            patch.object(image_translation, "translate_structure", new=translate),
+        ):
+            result = await image_translation._run_svg_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=False,
+                session_factory=_FakeSessionFactory(session),
+                storage=storage,
+            )
+
+        assert result["status"] == "disabled"
+        assert result["rendered"] == 0
+        extract.assert_not_awaited()
+        translate.assert_not_awaited()
+        assert storage.uploads == []

--- a/backend/tests/test_backfill_complex_diagram_overlays.py
+++ b/backend/tests/test_backfill_complex_diagram_overlays.py
@@ -280,3 +280,35 @@ class TestRunOverlayBackfillWithFactory:
         assert result["status"] == "noop"
         assert result["eligible"] == 0
         extract.assert_not_awaited()
+
+    async def test_short_circuits_when_vision_disabled(self):
+        # Cost kill-switch (#1928) — flag=False should return immediately,
+        # skipping any DB query and any Claude call.
+        rows = [_make_row(), _make_row()]
+        session = _FakeSession(rows)
+        task = MagicMock()
+        storage = _FakeStorage()
+
+        extract = AsyncMock(return_value=_sample_labels())
+        translate = AsyncMock(return_value=_sample_labels())
+
+        with (
+            patch.object(image_translation.settings, "enable_figure_vision", False),
+            patch.object(image_translation, "extract_label_positions", new=extract),
+            patch.object(image_translation, "translate_labels", new=translate),
+        ):
+            result = await image_translation._run_overlay_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=False,
+                session_factory=_FakeSessionFactory(session),
+                storage=storage,
+            )
+
+        assert result["status"] == "disabled"
+        assert result["rendered"] == 0
+        assert result["reclassified"] == 0
+        extract.assert_not_awaited()
+        translate.assert_not_awaited()
+        assert storage.uploads == []

--- a/backend/tests/test_backfill_figure_kinds.py
+++ b/backend/tests/test_backfill_figure_kinds.py
@@ -262,3 +262,28 @@ class TestRunKindBackfillWithFactory:
         assert result["status"] == "noop"
         assert result["eligible"] == 0
         classifier.assert_not_awaited()
+
+    async def test_short_circuits_when_vision_disabled(self):
+        # Cost kill-switch (#1928) — flag=False should return immediately,
+        # skipping any DB query and any Claude call.
+        rows = [_make_row(), _make_row()]
+        session = _FakeSession(rows)
+        task = MagicMock()
+        classifier = AsyncMock(return_value=FigureClassification(kind="photo"))
+
+        with (
+            patch.object(image_translation.settings, "enable_figure_vision", False),
+            patch.object(image_translation, "classify_figure", new=classifier),
+        ):
+            result = await image_translation._run_kind_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=False,
+                session_factory=_FakeSessionFactory(session),
+            )
+
+        assert result["status"] == "disabled"
+        assert result["classified"] == 0
+        classifier.assert_not_awaited()
+        assert session.commits == 0

--- a/backend/tests/test_complex_overlay.py
+++ b/backend/tests/test_complex_overlay.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import json
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.ai.translation import complex_overlay
 from app.ai.translation.complex_overlay import (
     DiagramLabel,
     DiagramLabels,
@@ -108,6 +109,17 @@ class TestExtractLabelPositions:
         client = _mock_client("{}")
         with pytest.raises(ValueError, match="non-empty"):
             await extract_label_positions(b"", client=client)
+        client.messages.create.assert_not_awaited()
+
+    async def test_raises_when_vision_disabled(self):
+        # Cost kill-switch (#1928).
+        client = _mock_client(json.dumps({"labels": []}))
+        fake_settings = MagicMock(enable_figure_vision=False, anthropic_api_key="key")
+        with (
+            patch.object(complex_overlay, "get_settings", return_value=fake_settings),
+            pytest.raises(RuntimeError, match="vision is disabled"),
+        ):
+            await extract_label_positions(b"fake-webp", client=client)
         client.messages.create.assert_not_awaited()
 
     async def test_invalid_json_raises(self):

--- a/backend/tests/test_figure_classifier.py
+++ b/backend/tests/test_figure_classifier.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import json
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
 
+from app.ai.translation import figure_classifier
 from app.ai.translation.figure_classifier import (
     FigureClassification,
     _extract_json_object,
@@ -49,6 +50,18 @@ class TestClassifyFigure:
         result = await classify_figure(image_bytes=b"fake-webp", client=client)
         assert isinstance(result, FigureClassification)
         assert result.kind == "clean_flowchart"
+
+    async def test_raises_when_vision_disabled(self):
+        # Cost kill-switch (#1928) — even with a mock client supplied, the
+        # function must refuse to make the Vision call when the flag is off.
+        client = _mock_client(json.dumps({"kind": "photo"}))
+        fake_settings = MagicMock(enable_figure_vision=False, anthropic_api_key="key")
+        with (
+            patch.object(figure_classifier, "get_settings", return_value=fake_settings),
+            pytest.raises(RuntimeError, match="vision is disabled"),
+        ):
+            await classify_figure(image_bytes=b"fake-webp", client=client)
+        client.messages.create.assert_not_awaited()
 
     @pytest.mark.parametrize(
         "kind",

--- a/backend/tests/test_svg_rederiver.py
+++ b/backend/tests/test_svg_rederiver.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import json
 import xml.etree.ElementTree as ET
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
 
+from app.ai.translation import svg_rederiver
 from app.ai.translation.svg_rederiver import (
     FlowchartEdge,
     FlowchartNode,
@@ -127,6 +128,17 @@ class TestExtractFlowchartStructure:
         assert result.nodes[0].text == "Make an observation"
         assert result.edges[0].from_id == "n1"
         assert result.edges[0].label is None
+
+    async def test_raises_when_vision_disabled(self):
+        # Cost kill-switch (#1928).
+        client = _mock_client('{"nodes": [], "edges": []}')
+        fake_settings = MagicMock(enable_figure_vision=False, anthropic_api_key="key")
+        with (
+            patch.object(svg_rederiver, "get_settings", return_value=fake_settings),
+            pytest.raises(RuntimeError, match="vision is disabled"),
+        ):
+            await extract_flowchart_structure(b"fake-webp", client=client)
+        client.messages.create.assert_not_awaited()
 
     async def test_strips_markdown_fences(self):
         payload = {


### PR DESCRIPTION
## Summary

Promotes **#1929 / #1928** from dev to main — env-driven kill-switch for Vision-backed figure tasks (cost control after ~\$30/4h staging burn).

## Content

- **#1929**: \`enable_figure_vision: bool = True\` setting, gated at function-level (3 Vision entry points) and task-level (3 backfill tasks short-circuit at entry). Default True preserves prod behaviour; staging flips via env.

## Test plan

- [x] CI inherits from #1929 green runs (102 tests pass)
- [ ] Staging deploy + env flip: \`echo 'ENABLE_FIGURE_VISION=false' >> .env && docker compose up -d --force-recreate celery-worker\` → verify backfills short-circuit with \`{status: 'disabled'}\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)