### PR TITLE
fix(compose): wire ENABLE_FIGURE_VISION through to containers

### DIFF
--- a/docker-compose.prod.sira-donnia.yml
+++ b/docker-compose.prod.sira-donnia.yml
@@ -81,6 +81,10 @@ services:
       APP_ENV: production
       CORS_ORIGINS: https://app.sira-donnia.org
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      # Cost kill-switch for Vision-backed figure tasks (#1928). Default
+      # true preserves behaviour; flip to false in .env + recreate the
+      # worker to stop Claude Vision spend on backfills + ingest.
+      ENABLE_FIGURE_VISION: ${ENABLE_FIGURE_VISION:-true}
       HEYGEN_API_KEY: ${HEYGEN_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}
@@ -171,6 +175,10 @@ services:
       APP_ENV: production
       CORS_ORIGINS: https://app.sira-donnia.org
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      # Cost kill-switch for Vision-backed figure tasks (#1928). Default
+      # true preserves behaviour; flip to false in .env + recreate the
+      # worker to stop Claude Vision spend on backfills + ingest.
+      ENABLE_FIGURE_VISION: ${ENABLE_FIGURE_VISION:-true}
       HEYGEN_API_KEY: ${HEYGEN_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -81,6 +81,10 @@ services:
       APP_ENV: production
       CORS_ORIGINS: https://etutor.elearning.portfolio2.kimbetien.com
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      # Cost kill-switch for Vision-backed figure tasks (#1928). Default
+      # true preserves behaviour; flip to false in .env + recreate the
+      # worker to stop Claude Vision spend on backfills + ingest.
+      ENABLE_FIGURE_VISION: ${ENABLE_FIGURE_VISION:-true}
       HEYGEN_API_KEY: ${HEYGEN_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}
@@ -171,6 +175,10 @@ services:
       APP_ENV: production
       CORS_ORIGINS: https://etutor.elearning.portfolio2.kimbetien.com
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      # Cost kill-switch for Vision-backed figure tasks (#1928). Default
+      # true preserves behaviour; flip to false in .env + recreate the
+      # worker to stop Claude Vision spend on backfills + ingest.
+      ENABLE_FIGURE_VISION: ${ENABLE_FIGURE_VISION:-true}
       HEYGEN_API_KEY: ${HEYGEN_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}


### PR DESCRIPTION
Follow-up to #1929 — the code-level kill-switch was live but the env var never made it into the running container because docker-compose.prod.yml + docker-compose.prod.sira-donnia.yml enumerate each env var explicitly.

## Evidence

Staging 2026-04-24 16:15 UTC: added \`ENABLE_FIGURE_VISION=false\` to host \`.env\`, ran \`docker compose up -d --force-recreate celery-worker\`, dispatched \`backfill_figure_kinds\`. Task ran and made 82 failing Vision calls instead of short-circuiting with \`status=disabled\`. Inside-container \`env\` confirmed the var was absent.

## Change

Adds \`ENABLE_FIGURE_VISION: \${ENABLE_FIGURE_VISION:-true}\` to the \`environment:\` block of both \`backend\` and \`celery-worker\` services, in both staging (\`docker-compose.prod.yml\`) and prod (\`docker-compose.prod.sira-donnia.yml\`) compose files. Default true → no behaviour change unless an operator opts out.

## Test plan

- [x] Compose files parse (YAML syntax verified via diff).
- [ ] After merge + deploy: host \`.env\` with \`ENABLE_FIGURE_VISION=false\` takes effect; dispatched backfill short-circuits with \`{status: 'disabled'}\`; log line \"short-circuit: vision disabled\" appears.

Related: #1928, #1929.

🤖 Generated with [Claude Code](https://claude.com/claude-code)