### PR TITLE
fix(tutor): resolve {{source_image:UUID}} markers on history GET

### DIFF
--- a/backend/app/api/v1/schemas/tutor.py
+++ b/backend/app/api/v1/schemas/tutor.py
@@ -27,6 +27,13 @@ class TutorMessage(BaseModel):
     activity_suggestions: list[dict[str, str]] = Field(
         default_factory=list, description="Suggested activities"
     )
+    # Resolved figure metadata for any {{source_image:UUID}} markers in content.
+    # Populated by get_conversation() so history-loaded messages render the
+    # same inline images as the live stream (#1937).
+    source_image_refs: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="Resolved source_image metadata for markers in content",
+    )
 
 
 class TutorChatRequest(BaseModel):

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -45,6 +45,98 @@ COMPACT_SUMMARIZE_UP_TO = _sc().get("tutor-compaction-summarize-up-to", 15)
 
 SESSION_CONTEXT_TOKEN_BUDGET = _sc().get("tutor-context-token-budget", 1500)
 
+# Shared between the live-stream resolver and the GET-conversation resolver (#1937).
+_SOURCE_IMAGE_MARKER_RE = re.compile(r"\{\{source_image:([0-9a-f-]{36})\}\}", re.IGNORECASE)
+
+
+async def _resolve_source_images_by_uuid(
+    uuids: set[str],
+    session: AsyncSession,
+) -> dict[str, dict[str, Any]]:
+    """Fetch ``SourceImage`` rows for the given UUID strings and return a map
+    keyed on UUID string whose values have the exact shape the frontend
+    expects in ``sourceImageRefs`` entries.
+
+    Silent on missing UUIDs (returns only what was found) and on DB errors
+    (returns an empty map after logging). Keeps the live stream and the
+    history GET path from diverging in shape. See #1937.
+    """
+    if not uuids:
+        return {}
+    try:
+        result = await session.execute(
+            select(SourceImage).where(SourceImage.id.in_([uuid.UUID(u) for u in uuids]))
+        )
+    except Exception as exc:
+        logger.warning("Failed to resolve source image UUIDs", error=str(exc))
+        return {}
+
+    resolved: dict[str, dict[str, Any]] = {}
+    for img in result.scalars().all():
+        meta = img.to_meta_dict()
+        resolved[str(img.id)] = {
+            "id": str(img.id),
+            "figure_number": meta.get("figure_number"),
+            "caption": meta.get("caption"),
+            "caption_fr": meta.get("caption_fr") or meta.get("caption"),
+            "caption_en": meta.get("caption_en") or meta.get("caption"),
+            "attribution": meta.get("attribution"),
+            "image_type": meta.get("image_type", "unknown"),
+            "storage_url": meta.get("storage_url"),
+            "storage_url_fr": meta.get("storage_url_fr"),
+            "alt_text_fr": meta.get("alt_text_fr"),
+            "alt_text_en": meta.get("alt_text_en"),
+        }
+    return resolved
+
+
+async def _attach_source_image_refs(
+    messages: list[dict[str, Any]],
+    session: AsyncSession,
+) -> list[dict[str, Any]]:
+    """Return ``messages`` with ``source_image_refs`` added to each assistant
+    entry that contains ``{{source_image:UUID}}`` markers.
+
+    User messages are left untouched (listen/image rendering is assistant-only).
+    Missing UUIDs are silently dropped — same contract as the live-stream
+    resolver. Markers in a message are returned in first-appearance order so
+    the frontend's ``splitWithSourceImageMarkers`` renders correctly.
+    """
+    # First pass — collect the union of UUIDs across all assistant messages.
+    all_uuids: set[str] = set()
+    per_message_uuids: list[list[str]] = []
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            per_message_uuids.append([])
+            continue
+        content = msg.get("content") or ""
+        uuids_in_order: list[str] = []
+        seen_local: set[str] = set()
+        for m in _SOURCE_IMAGE_MARKER_RE.finditer(content):
+            uid = m.group(1).lower()
+            if uid not in seen_local:
+                seen_local.add(uid)
+                uuids_in_order.append(uid)
+        per_message_uuids.append(uuids_in_order)
+        all_uuids.update(uuids_in_order)
+
+    resolved = await _resolve_source_images_by_uuid(all_uuids, session)
+
+    # Second pass — build each message's refs list without mutating input.
+    out: list[dict[str, Any]] = []
+    for msg, uuids_in_order in zip(messages, per_message_uuids, strict=False):
+        if not uuids_in_order:
+            out.append(msg)
+            continue
+        refs = [resolved[u] for u in uuids_in_order if u in resolved]
+        # Shallow-copy so existing callers that retain a reference to the
+        # conversation's stored messages (e.g. in-process tests) aren't
+        # surprised by a mutation.
+        enriched = dict(msg)
+        enriched["source_image_refs"] = refs
+        out.append(enriched)
+    return out
+
 
 @dataclass
 class SessionContext:
@@ -627,38 +719,18 @@ class TutorService:
             }
 
             # Resolve any {{source_image:UUID}} markers in the response that
-            # weren't captured via tool calls (e.g. from conversation history)
-            _IMG_RE = re.compile(r"\{\{source_image:([0-9a-f-]{36})\}\}", re.IGNORECASE)
-            seen_ids = {r["id"] for r in source_image_refs}
-            extra_ids = [
-                m.group(1) for m in _IMG_RE.finditer(full_response) if m.group(1) not in seen_ids
-            ]
+            # weren't captured via tool calls (e.g. from conversation history).
+            # Shares the resolver with get_conversation() so the shape stays
+            # identical between live stream and history GET (#1937).
+            seen_ids = {r["id"].lower() for r in source_image_refs}
+            extra_ids = {
+                m.group(1).lower()
+                for m in _SOURCE_IMAGE_MARKER_RE.finditer(full_response)
+                if m.group(1).lower() not in seen_ids
+            }
             if extra_ids:
-                try:
-                    db_imgs = await session.execute(
-                        select(SourceImage).where(
-                            SourceImage.id.in_([uuid.UUID(i) for i in extra_ids])
-                        )
-                    )
-                    for img in db_imgs.scalars().all():
-                        meta = img.to_meta_dict()
-                        source_image_refs.append(
-                            {
-                                "id": str(img.id),
-                                "figure_number": meta.get("figure_number"),
-                                "caption": meta.get("caption"),
-                                "caption_fr": meta.get("caption_fr") or meta.get("caption"),
-                                "caption_en": meta.get("caption_en") or meta.get("caption"),
-                                "attribution": meta.get("attribution"),
-                                "image_type": meta.get("image_type", "unknown"),
-                                "storage_url": meta.get("storage_url"),
-                                "storage_url_fr": meta.get("storage_url_fr"),
-                                "alt_text_fr": meta.get("alt_text_fr"),
-                                "alt_text_en": meta.get("alt_text_en"),
-                            }
-                        )
-                except Exception as exc:
-                    logger.warning("Failed to resolve extra image markers", error=str(exc))
+                resolved = await _resolve_source_images_by_uuid(extra_ids, session)
+                source_image_refs.extend(resolved.values())
 
             if source_image_refs:
                 yield {
@@ -695,7 +767,12 @@ class TutorService:
     async def get_conversation(
         self, user_id: str | uuid.UUID, conversation_id: uuid.UUID, session: AsyncSession
     ) -> dict[str, Any] | None:
-        """Get a specific conversation."""
+        """Get a specific conversation.
+
+        Assistant messages containing ``{{source_image:UUID}}`` markers have
+        ``source_image_refs`` attached with resolved figure metadata, so the
+        frontend can render images identically to the live-stream path (#1937).
+        """
         if isinstance(user_id, str):
             user_id = uuid.UUID(user_id)
 
@@ -708,10 +785,12 @@ class TutorService:
         if not conversation:
             return None
 
+        messages_out = await _attach_source_image_refs(conversation.messages or [], session)
+
         return {
             "id": conversation.id,
             "module_id": conversation.module_id,
-            "messages": conversation.messages,
+            "messages": messages_out,
             "created_at": conversation.created_at,
         }
 

--- a/backend/tests/test_tutor_conversation_image_resolution.py
+++ b/backend/tests/test_tutor_conversation_image_resolution.py
@@ -1,0 +1,208 @@
+"""Unit tests for the source_image-marker resolution used by get_conversation (#1937).
+
+Uses a mocked async session because the integration db_session fixture is
+blocked on #554 (create_all vs Alembic enum types). The helpers under test
+are pure: they only call ``session.execute`` with a SELECT and shape results.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.domain.services.tutor_service import (
+    _attach_source_image_refs,
+    _resolve_source_images_by_uuid,
+)
+
+
+def _fake_source_image(
+    image_id: uuid.UUID,
+    figure_number: int = 1,
+    caption: str = "A figure",
+) -> SimpleNamespace:
+    """Minimal stand-in for ``SourceImage`` with a ``.to_meta_dict()`` method."""
+    return SimpleNamespace(
+        id=image_id,
+        to_meta_dict=lambda: {
+            "figure_number": figure_number,
+            "caption": caption,
+            "caption_fr": caption,
+            "caption_en": caption,
+            "attribution": "Donaldson Ch. 10",
+            "image_type": "photo",
+            "storage_url": "https://minio/bucket/x.png",
+            "storage_url_fr": None,
+            "alt_text_fr": caption,
+            "alt_text_en": caption,
+        },
+    )
+
+
+def _mock_session_returning(images: list) -> MagicMock:
+    """Build an AsyncSession mock whose .execute returns a Result containing images."""
+    scalars = MagicMock()
+    scalars.all = MagicMock(return_value=images)
+    result = MagicMock()
+    result.scalars = MagicMock(return_value=scalars)
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=result)
+    return session
+
+
+class TestResolveByUuid:
+    async def test_empty_uuids_skips_db(self):
+        session = MagicMock()
+        session.execute = AsyncMock()
+        out = await _resolve_source_images_by_uuid(set(), session)
+        assert out == {}
+        session.execute.assert_not_awaited()
+
+    async def test_returns_map_keyed_on_uuid_string(self):
+        img_id = uuid.UUID("7a49d4fd-cbf6-4adb-b5eb-b770b2a00a88")
+        session = _mock_session_returning([_fake_source_image(img_id, figure_number=7)])
+
+        out = await _resolve_source_images_by_uuid({str(img_id)}, session)
+
+        assert set(out.keys()) == {str(img_id)}
+        entry = out[str(img_id)]
+        assert entry["id"] == str(img_id)
+        assert entry["figure_number"] == 7
+        assert entry["storage_url"] == "https://minio/bucket/x.png"
+
+    async def test_missing_uuids_are_silently_dropped(self):
+        found = uuid.UUID("7a49d4fd-cbf6-4adb-b5eb-b770b2a00a88")
+        missing = "00000000-0000-0000-0000-000000000000"
+        session = _mock_session_returning([_fake_source_image(found)])
+
+        out = await _resolve_source_images_by_uuid({str(found), missing}, session)
+
+        assert str(found) in out
+        assert missing not in out
+
+    async def test_db_error_returns_empty_map(self):
+        session = MagicMock()
+        session.execute = AsyncMock(side_effect=RuntimeError("connection lost"))
+
+        out = await _resolve_source_images_by_uuid(
+            {"7a49d4fd-cbf6-4adb-b5eb-b770b2a00a88"}, session
+        )
+
+        assert out == {}
+
+
+class TestAttachRefs:
+    async def test_user_messages_untouched(self):
+        session = _mock_session_returning([])
+        messages = [
+            {
+                "role": "user",
+                "content": "Please show a figure.",
+                "timestamp": "2026-04-24T00:00:00",
+            },
+        ]
+        out = await _attach_source_image_refs(messages, session)
+        assert "source_image_refs" not in out[0]
+        # No marker anywhere → no DB query at all.
+        session.execute.assert_not_awaited()
+
+    async def test_assistant_without_markers_untouched(self):
+        session = _mock_session_returning([])
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Just text, no markers here.",
+                "timestamp": "2026-04-24T00:00:00",
+            }
+        ]
+        out = await _attach_source_image_refs(messages, session)
+        assert "source_image_refs" not in out[0]
+
+    async def test_single_marker_attaches_ref(self):
+        img_id = uuid.UUID("7a49d4fd-cbf6-4adb-b5eb-b770b2a00a88")
+        session = _mock_session_returning([_fake_source_image(img_id)])
+        messages = [
+            {
+                "role": "assistant",
+                "content": f"See figure: {{{{source_image:{img_id}}}}}",
+                "timestamp": "2026-04-24T00:00:00",
+            }
+        ]
+        out = await _attach_source_image_refs(messages, session)
+        refs = out[0]["source_image_refs"]
+        assert len(refs) == 1
+        assert refs[0]["id"] == str(img_id)
+
+    async def test_duplicate_uuid_in_same_message_deduplicated(self):
+        img_id = uuid.UUID("7a49d4fd-cbf6-4adb-b5eb-b770b2a00a88")
+        session = _mock_session_returning([_fake_source_image(img_id)])
+        marker = f"{{{{source_image:{img_id}}}}}"
+        messages = [
+            {
+                "role": "assistant",
+                "content": f"Look: {marker}. Compare to: {marker}",
+                "timestamp": "2026-04-24T00:00:00",
+            }
+        ]
+        out = await _attach_source_image_refs(messages, session)
+        assert len(out[0]["source_image_refs"]) == 1
+
+    async def test_multiple_messages_share_one_batched_query(self):
+        a_id = uuid.UUID("7a49d4fd-cbf6-4adb-b5eb-b770b2a00a88")
+        b_id = uuid.UUID("11111111-2222-3333-4444-555555555555")
+        session = _mock_session_returning(
+            [_fake_source_image(a_id, figure_number=1), _fake_source_image(b_id, figure_number=2)]
+        )
+        messages = [
+            {
+                "role": "assistant",
+                "content": f"First: {{{{source_image:{a_id}}}}}",
+                "timestamp": "2026-04-24T00:00:00",
+            },
+            {"role": "user", "content": "cool", "timestamp": "2026-04-24T00:00:01"},
+            {
+                "role": "assistant",
+                "content": f"And also both: {{{{source_image:{a_id}}}}} and {{{{source_image:{b_id}}}}}",
+                "timestamp": "2026-04-24T00:00:02",
+            },
+        ]
+        out = await _attach_source_image_refs(messages, session)
+        # One DB round-trip for the union of UUIDs.
+        assert session.execute.await_count == 1
+        assert [r["id"] for r in out[0]["source_image_refs"]] == [str(a_id)]
+        assert "source_image_refs" not in out[1]
+        assert [r["id"] for r in out[2]["source_image_refs"]] == [str(a_id), str(b_id)]
+
+    async def test_does_not_mutate_input(self):
+        img_id = uuid.UUID("7a49d4fd-cbf6-4adb-b5eb-b770b2a00a88")
+        session = _mock_session_returning([_fake_source_image(img_id)])
+        original = {
+            "role": "assistant",
+            "content": f"See: {{{{source_image:{img_id}}}}}",
+            "timestamp": "2026-04-24T00:00:00",
+        }
+        await _attach_source_image_refs([original], session)
+        assert "source_image_refs" not in original
+
+    @pytest.mark.parametrize(
+        "marker",
+        [
+            "{{source_image:7A49D4FD-CBF6-4ADB-B5EB-B770B2A00A88}}",  # upper-case
+            "{{Source_Image:7a49d4fd-cbf6-4adb-b5eb-b770b2a00a88}}",  # mixed case label
+        ],
+    )
+    async def test_case_insensitive_matching(self, marker: str):
+        img_id = uuid.UUID("7a49d4fd-cbf6-4adb-b5eb-b770b2a00a88")
+        session = _mock_session_returning([_fake_source_image(img_id)])
+        messages = [
+            {
+                "role": "assistant",
+                "content": f"Figure: {marker}",
+                "timestamp": "2026-04-24T00:00:00",
+            }
+        ]
+        out = await _attach_source_image_refs(messages, session)
+        assert out[0]["source_image_refs"][0]["id"] == str(img_id)

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -207,6 +207,9 @@ export function ChatPanel({
             chapter: s.chapter ?? j + 1,
             page: s.page ?? 0,
           })),
+          // Backend resolves {{source_image:UUID}} markers on GET so history
+          // messages render images identically to the live stream (#1937).
+          sourceImageRefs: m.source_image_refs,
         }));
         setMessages(loaded.length > 0 ? loaded : [welcomeMessage]);
       })
@@ -223,6 +226,7 @@ export function ChatPanel({
               chapter: s.chapter ?? j + 1,
               page: s.page ?? 0,
             })),
+            sourceImageRefs: m.source_image_refs,
           }));
           setMessages(loaded.length > 0 ? loaded : [welcomeMessage]);
         } else {

--- a/frontend/lib/tutor-api.ts
+++ b/frontend/lib/tutor-api.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { authClient } from '@/lib/auth';
-import { API_BASE } from '@/lib/api';
+import { API_BASE, type SourceImageMeta } from '@/lib/api';
 
 export interface UploadedFile {
   file_id: string;
@@ -109,6 +109,10 @@ export interface ConversationMessage {
   sources: Array<{ source: string; chapter?: number; page?: number }>;
   timestamp: string;
   activity_suggestions: Array<{ type: string; label: string; url?: string }>;
+  // Resolved by backend on GET so history-loaded messages render images
+  // identically to live-stream messages (#1937). Optional for backward-compat
+  // with cached responses from before the field existed.
+  source_image_refs?: SourceImageMeta[];
 }
 
 export interface ConversationDetail {


### PR DESCRIPTION
## Summary

Long-standing latent bug: `{{source_image:UUID}}` markers in tutor replies only render during live SSE streaming. After a page reload, markers appear as raw text because `get_conversation()` never resolved them.

Fix is server-side resolution on GET — works retroactively for every historical conversation, no schema migration, no backfill.

## Root cause

- `tutor_service.get_conversation()` returned `messages` verbatim with no image-ref hydration.
- Frontend `chat-message.tsx` only renders images when `sourceImageRefs` is populated, which only happened via the live SSE `source_image_refs` event.

## Changes

**Backend**
- New `_resolve_source_images_by_uuid(uuids, session)` helper — batched SELECT + shape in the exact form the frontend expects. Silent on missing UUIDs and DB errors.
- New `_attach_source_image_refs(messages, session)` — collects the union of marker UUIDs across assistant messages, runs one DB round-trip, attaches `source_image_refs` in first-appearance order. No input mutation.
- `get_conversation()` routes messages through the helper.
- `TutorMessage` schema gains `source_image_refs: list[dict] = []` (backward-compatible default).
- Streaming sweep deduped onto the shared helper — two inline copies collapsed into one.

**Frontend**
- `ConversationMessage` type gets `source_image_refs?: SourceImageMeta[]`.
- `chat-panel.tsx` history loader and offline fallback hydrate `ChatMessage.sourceImageRefs`.
- `chat-message.tsx` untouched — existing marker-splitting logic works once refs are populated.

**Tests** (pure-mock async session — db_session fixture is blocked on #554)
- Empty UUIDs skip DB entirely.
- Missing UUIDs silently dropped.
- DB errors return empty map (no 500 on GET).
- User messages never get `source_image_refs`.
- Assistant messages without markers untouched.
- Single + duplicate marker.
- Multiple messages → one batched query.
- No input mutation.
- Case-insensitive matching.

## Test plan

- [ ] Merge to `dev`, push dev→main sync, staging auto-deploys
- [ ] On staging, reload the conversation containing `7a49d4fd-cbf6-4adb-b5eb-b770b2a00a88` — image renders inline with caption instead of raw text
- [ ] Send a new message referencing an image via RAG — both live stream AND reload render correctly
- [ ] GET /api/v1/tutor/conversations/{id} response includes `source_image_refs` on assistant messages with markers, empty `[]` elsewhere
- [ ] No regression to the live streaming path

Fixes #1937

🤖 Generated with [Claude Code](https://claude.com/claude-code)