### PR TITLE
fix(deploy): migration 082 — raw SQL with IF NOT EXISTS guards

### DIFF
--- a/backend/migrations/versions/082_tutor_voice_output.py
+++ b/backend/migrations/versions/082_tutor_voice_output.py
@@ -16,10 +16,13 @@ Adds two tables supporting issue #1932 (hybrid tutor voice output):
    ``tutor_voice_daily_minutes_cap`` across sessions. Holds OpenAI Realtime
    session ID, start/end timestamps, and reported duration.
 
-Forward-only: downgrade included for local dev reset.
+Uses raw SQL with ``IF NOT EXISTS`` guards mirroring the canonical 057
+pattern, because ``sa.Enum(..., create_type=False)`` isn't reliable in the
+Alembic context used by the deploy pipeline — staging blew up with
+``type "audio_status_enum" already exists`` under the SQLAlchemy-generated
+path (#1941). Forward-only; downgrade is kept for local dev reset.
 """
 
-import sqlalchemy as sa
 from alembic import op
 
 revision = "082"
@@ -29,93 +32,67 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.create_table(
-        "tutor_message_audio",
-        sa.Column(
-            "id",
-            sa.dialects.postgresql.UUID(as_uuid=True),
-            primary_key=True,
-            server_default=sa.text("gen_random_uuid()"),
-        ),
-        sa.Column(
-            "conversation_id",
-            sa.dialects.postgresql.UUID(as_uuid=True),
-            sa.ForeignKey("tutor_conversations.id", ondelete="CASCADE"),
-            nullable=False,
-        ),
-        sa.Column("message_index", sa.Integer(), nullable=False),
-        sa.Column("language", sa.String(length=5), nullable=False),
-        sa.Column(
-            "status",
-            sa.Enum(
-                "pending",
-                "generating",
-                "ready",
-                "failed",
-                name="audio_status_enum",
-                create_type=False,
-            ),
-            nullable=False,
-            server_default="pending",
-        ),
-        sa.Column("storage_key", sa.Text(), nullable=True),
-        sa.Column("storage_url", sa.Text(), nullable=True),
-        sa.Column("duration_seconds", sa.Integer(), nullable=True),
-        sa.Column("file_size_bytes", sa.Integer(), nullable=True),
-        sa.Column("error_message", sa.Text(), nullable=True),
-        sa.Column(
-            "created_at",
-            sa.DateTime(),
-            server_default=sa.func.now(),
-            nullable=False,
-        ),
-        sa.Column("generated_at", sa.DateTime(), nullable=True),
-        sa.UniqueConstraint(
-            "conversation_id",
-            "message_index",
-            "language",
-            name="uq_tutor_message_audio_conv_idx_lang",
-        ),
-    )
-    op.create_index(
-        "ix_tutor_message_audio_conversation_id",
-        "tutor_message_audio",
-        ["conversation_id"],
+    # Enum is created by migration 057; guard against re-create so repeated
+    # fresh-deploys or partial-retry flows don't blow up.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'audio_status_enum') THEN
+                CREATE TYPE audio_status_enum AS ENUM ('pending', 'generating', 'ready', 'failed');
+            END IF;
+        END$$;
+        """
     )
 
-    op.create_table(
-        "tutor_voice_sessions",
-        sa.Column(
-            "id",
-            sa.dialects.postgresql.UUID(as_uuid=True),
-            primary_key=True,
-            server_default=sa.text("gen_random_uuid()"),
-        ),
-        sa.Column(
-            "user_id",
-            sa.dialects.postgresql.UUID(as_uuid=True),
-            sa.ForeignKey("users.id", ondelete="CASCADE"),
-            nullable=False,
-        ),
-        sa.Column("openai_session_id", sa.String(length=100), nullable=True),
-        sa.Column(
-            "started_at",
-            sa.DateTime(),
-            server_default=sa.func.now(),
-            nullable=False,
-        ),
-        sa.Column("ended_at", sa.DateTime(), nullable=True),
-        sa.Column("duration_seconds", sa.Integer(), nullable=True),
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS tutor_message_audio (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            conversation_id UUID NOT NULL REFERENCES tutor_conversations(id) ON DELETE CASCADE,
+            message_index INTEGER NOT NULL,
+            language VARCHAR(5) NOT NULL,
+            status audio_status_enum NOT NULL DEFAULT 'pending',
+            storage_key TEXT,
+            storage_url TEXT,
+            duration_seconds INTEGER,
+            file_size_bytes INTEGER,
+            error_message TEXT,
+            created_at TIMESTAMP NOT NULL DEFAULT now(),
+            generated_at TIMESTAMP,
+            CONSTRAINT uq_tutor_message_audio_conv_idx_lang
+                UNIQUE (conversation_id, message_index, language)
+        );
+        """
     )
-    op.create_index(
-        "ix_tutor_voice_sessions_user_started",
-        "tutor_voice_sessions",
-        ["user_id", "started_at"],
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_tutor_message_audio_conversation_id
+        ON tutor_message_audio (conversation_id);
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS tutor_voice_sessions (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            openai_session_id VARCHAR(100),
+            started_at TIMESTAMP NOT NULL DEFAULT now(),
+            ended_at TIMESTAMP,
+            duration_seconds INTEGER
+        );
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_tutor_voice_sessions_user_started
+        ON tutor_voice_sessions (user_id, started_at);
+        """
     )
 
 
 def downgrade() -> None:
-    op.drop_index("ix_tutor_voice_sessions_user_started", "tutor_voice_sessions")
-    op.drop_table("tutor_voice_sessions")
-    op.drop_index("ix_tutor_message_audio_conversation_id", "tutor_message_audio")
-    op.drop_table("tutor_message_audio")
+    op.execute("DROP TABLE IF EXISTS tutor_voice_sessions")
+    op.execute("DROP TABLE IF EXISTS tutor_message_audio")
+    # Leave audio_status_enum in place — it's shared with generated_audio.


### PR DESCRIPTION
## Summary

Hotfix for broken staging deploy. Migration 082 (tutor voice tables) referenced the existing \`audio_status_enum\` via \`sa.Enum(..., create_type=False)\`. Despite the flag, SQLAlchemy's Alembic context dispatched \`CREATE TYPE\` anyway; since the enum was already created by migration 057, deploy blew up with \`DuplicateObjectError\`.

## Fix

Rewrite 082 to use raw \`op.execute()\` with \`CREATE TABLE IF NOT EXISTS\` / \`CREATE INDEX IF NOT EXISTS\` / \`DO \$\$ IF NOT EXISTS END\$\$\` for the enum — matches migration 057's canonical pattern that has been working in this codebase.

Reliable across:
- Fresh deploys (enum + tables both created)
- Re-runs after partial failure (everything guarded)
- Environments where the enum already exists (our case)

## Test plan

- [ ] CI passes
- [ ] Merge to dev, sync dev→main, observe staging deploy goes green
- [ ] Verify \`tutor_message_audio\` and \`tutor_voice_sessions\` tables exist on staging DB post-deploy

Fixes #1941

🤖 Generated with [Claude Code](https://claude.com/claude-code)