### PR TITLE
feat(tutor): playback speed chip on listen button

### DIFF
--- a/frontend/components/chat/listen-button.tsx
+++ b/frontend/components/chat/listen-button.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
-import { Play, Pause, Loader2, Volume2 } from 'lucide-react';
+import { Play, Pause, Loader2, Volume2, Gauge } from 'lucide-react';
 import { API_BASE } from '@/lib/api';
 import { fetchTutorMessageAudio } from '@/lib/tutor-voice-api';
 import { cn } from '@/lib/utils';
@@ -15,6 +15,21 @@ interface ListenButtonProps {
 
 type State = 'idle' | 'loading' | 'playing' | 'paused' | 'failed';
 
+const PLAYBACK_RATES = [1, 1.25, 1.5, 1.75, 2] as const;
+const PLAYBACK_RATE_STORAGE_KEY = 'tutorListenRate';
+
+function formatRate(rate: number): string {
+  // Drop trailing zeros (1 → "1", 1.5 → "1.5", 1.25 → "1.25").
+  return `${rate}×`;
+}
+
+function loadInitialRate(): number {
+  if (typeof window === 'undefined') return 1;
+  const raw = window.localStorage.getItem(PLAYBACK_RATE_STORAGE_KEY);
+  const parsed = raw ? Number(raw) : NaN;
+  return (PLAYBACK_RATES as readonly number[]).includes(parsed) ? parsed : 1;
+}
+
 export function ListenButton({
   conversationId,
   messageIndex,
@@ -24,6 +39,8 @@ export function ListenButton({
   const locale = useLocale();
   const language = (locale === 'fr' ? 'fr' : 'en') as 'fr' | 'en';
   const [state, setState] = useState<State>('idle');
+  const [playbackRate, setPlaybackRate] = useState<number>(() => loadInitialRate());
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
   useEffect(() => {
@@ -41,6 +58,13 @@ export function ListenButton({
       audio.removeEventListener('play', onPlay);
     };
   }, []);
+
+  // Apply rate live to the <audio> element whenever it changes.
+  useEffect(() => {
+    if (audioRef.current) {
+      audioRef.current.playbackRate = playbackRate;
+    }
+  }, [playbackRate]);
 
   const handleClick = useCallback(async () => {
     const audio = audioRef.current;
@@ -70,12 +94,26 @@ export function ListenButton({
     // to avoid leaking internal MinIO hostnames (#1949). Resolve to absolute
     // same-origin URL, matching the lesson-audio pattern.
     audio.src = data.url.startsWith('/') ? `${API_BASE}${data.url}` : data.url;
+    // Re-apply the current rate after src change (some browsers reset it).
+    audio.playbackRate = playbackRate;
+    setHasLoadedOnce(true);
     try {
       await audio.play();
     } catch {
       setState('failed');
     }
-  }, [state, conversationId, messageIndex, language]);
+  }, [state, conversationId, messageIndex, language, playbackRate]);
+
+  const cycleRate = useCallback(() => {
+    setPlaybackRate((current) => {
+      const idx = PLAYBACK_RATES.indexOf(current as (typeof PLAYBACK_RATES)[number]);
+      const next = PLAYBACK_RATES[(idx + 1) % PLAYBACK_RATES.length];
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(PLAYBACK_RATE_STORAGE_KEY, String(next));
+      }
+      return next;
+    });
+  }, []);
 
   const label =
     state === 'playing'
@@ -95,20 +133,21 @@ export function ListenButton({
           ? Volume2
           : Play;
 
+  const rateLabel = t('voice.playbackRate');
+
   return (
-    <>
+    <div className={cn('mt-2 inline-flex items-center gap-1.5', className)}>
       <button
         type="button"
         onClick={handleClick}
         disabled={state === 'failed'}
         aria-label={label}
         className={cn(
-          'mt-2 inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium',
+          'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium',
           'bg-current/10 hover:bg-current/20 transition-colors',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
           'min-h-8',
           state === 'failed' && 'opacity-60 cursor-not-allowed',
-          className,
         )}
       >
         <Icon
@@ -116,8 +155,27 @@ export function ListenButton({
         />
         <span>{label}</span>
       </button>
+
+      {hasLoadedOnce && state !== 'failed' && (
+        <button
+          type="button"
+          onClick={cycleRate}
+          aria-label={rateLabel}
+          title={rateLabel}
+          className={cn(
+            'inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs font-medium tabular-nums',
+            'bg-current/5 hover:bg-current/15 transition-colors',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+            'min-h-8',
+          )}
+        >
+          <Gauge className="w-3.5 h-3.5" />
+          <span>{formatRate(playbackRate)}</span>
+        </button>
+      )}
+
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <audio ref={audioRef} preload="none" />
-    </>
+    </div>
   );
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -431,6 +431,7 @@
       "pause": "Pause",
       "loading": "Generating…",
       "audioUnavailable": "Audio unavailable",
+      "playbackRate": "Playback speed",
       "callTitle": "Voice call with tutor",
       "callReady": "Start a voice conversation. You can interrupt the tutor anytime.",
       "connecting": "Connecting…",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -431,6 +431,7 @@
       "pause": "Pause",
       "loading": "Génération…",
       "audioUnavailable": "Audio indisponible",
+      "playbackRate": "Vitesse de lecture",
       "callTitle": "Appel vocal avec le tuteur",
       "callReady": "Démarrez une conversation vocale. Vous pouvez interrompre le tuteur à tout moment.",
       "connecting": "Connexion en cours…",


### PR DESCRIPTION
## Summary

Rate chip next to the Écouter/Pause button. Cycles \`[1×, 1.25×, 1.5×, 1.75×, 2×]\`. Persists via localStorage. Mid-playback rate changes apply live.

## Why

Learners on 3G with tight time budgets want to accelerate the tutor TTS playback. HTML5 \`<audio>\` supports \`playbackRate\` natively — no backend work.

## Changes

**Frontend only**
- \`listen-button.tsx\` — add \`playbackRate\` state, \`cycleRate\` handler, \`<Gauge>\` chip
- \`messages/{en,fr}.json\` — new \`voice.playbackRate\` key (aria-label/title only; visible text is numeric)

## Test plan

- [ ] Staging: click Écouter → audio plays at 1×
- [ ] Rate chip appears after first load
- [ ] Click 1× → 1.25× → 1.5× → 1.75× → 2× → 1×; audio speed updates live
- [ ] Reload page, click Écouter again → starts at last-selected rate
- [ ] No regression to play/pause/cache flow

Fixes #1953

🤖 Generated with [Claude Code](https://claude.com/claude-code)