### PR TITLE
feat(tutor): voice call is now course + module + locale aware

### DIFF
--- a/backend/app/api/v1/schemas/tutor_voice.py
+++ b/backend/app/api/v1/schemas/tutor_voice.py
@@ -24,6 +24,14 @@ class VoiceSessionRequest(BaseModel):
     """Request body for minting an OpenAI Realtime session token."""
 
     locale: Literal["fr", "en"] = Field("en", description="Voice call locale")
+    course_id: UUID | None = Field(
+        None,
+        description="Active course ID for context-aware voice tutoring (#1956)",
+    )
+    module_id: UUID | None = Field(
+        None,
+        description="Active module ID (optional, falls back to course's default)",
+    )
 
 
 class VoiceSessionResponse(BaseModel):

--- a/backend/app/api/v1/tutor_voice.py
+++ b/backend/app/api/v1/tutor_voice.py
@@ -21,6 +21,7 @@ from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.ai.prompts.tutor import get_socratic_system_prompt
 from app.api.deps import get_db_session
 from app.api.deps_local_auth import AuthenticatedUser, get_current_user
 from app.api.v1.schemas.tutor_voice import (
@@ -32,7 +33,9 @@ from app.api.v1.schemas.tutor_voice import (
 )
 from app.domain.models.conversation import TutorConversation
 from app.domain.models.tutor_voice import TutorMessageAudio, TutorVoiceSession
+from app.domain.models.user import User
 from app.domain.services.tutor_audio_service import TutorAudioService
+from app.domain.services.tutor_context_builder import build_tutor_context
 from app.infrastructure.config.settings import get_settings
 from app.infrastructure.storage.s3 import S3StorageService
 
@@ -189,6 +192,18 @@ async def _minutes_used_today(user_id: uuid.UUID, db: AsyncSession) -> int:
     return (int(seconds) + 59) // 60
 
 
+_VOICE_MODE_SUFFIX = """
+
+## Voice-call mode (spoken output)
+
+You are now in a **live voice call** with the learner. Adapt your responses:
+- Keep replies short — 1-3 spoken sentences by default. The learner can always ask for more.
+- Use natural spoken phrasing. Do not use markdown, bullet points, or source_image markers.
+- Still follow the Socratic pedagogy above: ask probing questions, guide rather than lecture.
+- If you'd normally cite a source, say it briefly in speech ("as covered in Chapter 4") rather than a formal citation.
+- If the learner asks you to speak louder / slower / in a different language, acknowledge and comply."""
+
+
 @router.post("/voice-session", response_model=VoiceSessionResponse)
 async def create_voice_session(
     body: VoiceSessionRequest,
@@ -199,6 +214,9 @@ async def create_voice_session(
 
     403 when cap is reached, 503 when OpenAI is not configured, 402 reserved for
     the future credit-balance gate (not applied in v1).
+
+    The session is started with a course/module-aware system prompt (#1956)
+    so the voice tutor is context-aware like the text tutor.
     """
     settings = get_settings()
     if not settings.openai_api_key:
@@ -215,7 +233,33 @@ async def create_voice_session(
             detail=f"Daily voice-call cap reached ({cap} min). Try again tomorrow.",
         )
 
+    # Build the context-aware system prompt, mirroring what the text tutor
+    # injects on every message. Voice mode tacks on a short suffix reminding
+    # the model to keep output spoken-style and drop text-only constructs.
+    user = await db.get(User, current_user.id)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
+    context = await build_tutor_context(
+        user=user,
+        course_id=body.course_id,
+        module_id=body.module_id,
+        locale=body.locale,
+        session=db,
+    )
+    instructions = get_socratic_system_prompt(context, []) + _VOICE_MODE_SUFFIX
+
     voice = "alloy" if body.locale == "en" else "shimmer"
+    openai_payload: dict[str, object] = {
+        "model": settings.openai_realtime_model,
+        "voice": voice,
+        "instructions": instructions,
+        # Server-side transcription of user speech — useful for debug logs and
+        # future cross-session continuity.
+        "input_audio_transcription": {"model": "whisper-1"},
+    }
 
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
@@ -226,10 +270,7 @@ async def create_voice_session(
                     "Content-Type": "application/json",
                     "OpenAI-Beta": "realtime=v1",
                 },
-                json={
-                    "model": settings.openai_realtime_model,
-                    "voice": voice,
-                },
+                json=openai_payload,
             )
             response.raise_for_status()
             payload = response.json()
@@ -243,6 +284,16 @@ async def create_voice_session(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="Could not start voice session. Please try again.",
         ) from exc
+
+    logger.info(
+        "Voice session created",
+        user_id=str(current_user.id),
+        course_id=str(body.course_id) if body.course_id else None,
+        module_id=str(body.module_id) if body.module_id else None,
+        language=body.locale,
+        course_title=context.course_title,
+        module_title=context.module_title,
+    )
 
     client_secret_obj = payload.get("client_secret") or {}
     client_secret = client_secret_obj.get("value")

--- a/backend/app/domain/services/tutor_context_builder.py
+++ b/backend/app/domain/services/tutor_context_builder.py
@@ -1,0 +1,152 @@
+"""Shared builder for ``TutorContext``, used by both the text tutor and the
+voice-call session endpoint (#1956).
+
+Keeps the two tutor surfaces from drifting — both resolve the same course /
+module / audience / learner memory and produce the same system-prompt input.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.ai.prompts.audience import detect_audience
+from app.ai.prompts.tutor import TutorContext
+from app.domain.models.course import Course, UserCourseEnrollment
+from app.domain.models.module import Module
+from app.domain.models.user import User
+from app.domain.services.learner_memory_service import LearnerMemoryService
+
+logger = structlog.get_logger(__name__)
+
+
+async def resolve_course(
+    course_id: uuid.UUID | None,
+    module_id: uuid.UUID | None,
+    module_obj: Module | None,
+    user_id: uuid.UUID,
+    session: AsyncSession,
+) -> Course | None:
+    """Resolve course: explicit course_id > module's course > active enrollment.
+
+    When course_id is explicit, verifies the user is enrolled (active) to
+    prevent access to paid content. Falls back to enrollment if not.
+
+    Moved from ``TutorService._resolve_course`` so the voice-session endpoint
+    can reuse it without instantiating the full TutorService.
+    """
+    # 1. Explicit course_id — verify enrollment
+    if course_id:
+        enrolled = await session.execute(
+            select(UserCourseEnrollment).where(
+                UserCourseEnrollment.user_id == user_id,
+                UserCourseEnrollment.course_id == course_id,
+                UserCourseEnrollment.status == "active",
+            )
+        )
+        if enrolled.scalar_one_or_none():
+            course = await session.get(Course, course_id)
+            if course:
+                return course
+        else:
+            logger.warning(
+                "Tutor course_id not enrolled, falling back",
+                user_id=str(user_id),
+                course_id=str(course_id),
+            )
+
+    # 2. From module's course_id
+    if module_obj and module_obj.course_id:
+        course = await session.get(Course, module_obj.course_id)
+        if course:
+            return course
+
+    # 3. Fallback: most recent active enrollment
+    result = await session.execute(
+        select(UserCourseEnrollment)
+        .where(
+            UserCourseEnrollment.user_id == user_id,
+            UserCourseEnrollment.status == "active",
+        )
+        .order_by(UserCourseEnrollment.enrolled_at.desc())
+        .limit(1)
+    )
+    enrollment = result.scalar_one_or_none()
+    if enrollment:
+        return await session.get(Course, enrollment.course_id)
+
+    return None
+
+
+async def build_tutor_context(
+    user: User,
+    course_id: uuid.UUID | None,
+    module_id: uuid.UUID | None,
+    locale: str | None,
+    session: AsyncSession,
+    learner_memory_service: LearnerMemoryService | None = None,
+    tutor_mode: str = "socratic",
+    context_type: str | None = None,
+    context_id: uuid.UUID | None = None,
+) -> TutorContext:
+    """Build a :class:`TutorContext` from user + optional course/module.
+
+    * Effective language comes from the ``locale`` param when it's fr/en, else
+      the user's saved preferred_language.
+    * Module is loaded once to extract title and number.
+    * Course is resolved via :func:`resolve_course`.
+    * Audience (is_kids, age range) is derived from the course.
+    * Learner memory (≤200 tokens) is loaded via LearnerMemoryService.
+
+    ``previous_session_context`` and ``progress_snapshot`` are intentionally
+    not populated here — those are text-tutor specific (compaction + per-
+    conversation progress bleed across sessions). The caller can augment if
+    needed.
+    """
+    effective_language = locale if locale in ("fr", "en") else user.preferred_language
+    lm_service = learner_memory_service or LearnerMemoryService()
+
+    module_title: str | None = None
+    module_number: int | None = None
+    module_obj: Module | None = None
+    if module_id:
+        module_obj = await session.get(Module, module_id)
+        if module_obj:
+            module_title = (
+                module_obj.title_fr if effective_language == "fr" else module_obj.title_en
+            )
+            module_number = module_obj.module_number
+
+    course = await resolve_course(course_id, module_id, module_obj, user.id, session)
+
+    course_title: str | None = None
+    course_domain: str | None = None
+    if course:
+        course_title = course.title_fr if effective_language == "fr" else course.title_en
+        course_domain = course_title
+
+    audience = detect_audience(course)
+    learner_memory = await lm_service.format_for_prompt(user.id, session)
+
+    return TutorContext(
+        user_level=user.current_level,
+        user_language=effective_language,
+        user_country=user.country or "CI",
+        module_id=str(module_id) if module_id else None,
+        module_title=module_title,
+        module_number=module_number,
+        context_type=context_type,
+        tutor_mode=tutor_mode,
+        context_id=str(context_id) if context_id else None,
+        course_title=course_title,
+        course_domain=course_domain,
+        learner_memory=learner_memory,
+        previous_session_context="",
+        progress_snapshot="",
+        is_kids=audience.is_kids,
+        age_min=audience.age_min,
+        age_max=audience.age_max,
+    )

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -14,9 +14,7 @@ from anthropic.types import MessageParam, ToolResultBlockParam, ToolUseBlock
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from app.ai.prompts.audience import detect_audience
 from app.ai.prompts.tutor import (
-    TutorContext,
     get_activity_suggestions,
     get_compaction_prompt,
     get_socratic_system_prompt,
@@ -24,7 +22,6 @@ from app.ai.prompts.tutor import (
 from app.ai.rag.embeddings import EmbeddingService
 from app.ai.rag.retriever import SemanticRetriever
 from app.domain.models.conversation import TutorConversation
-from app.domain.models.course import Course, UserCourseEnrollment
 from app.domain.models.module import Module
 from app.domain.models.source_image import SourceImage
 from app.domain.models.user import User
@@ -32,6 +29,7 @@ from app.domain.services.analytics_service import AnalyticsService
 from app.domain.services.learner_memory_service import LearnerMemoryService
 from app.domain.services.platform_settings_service import SettingsCache
 from app.domain.services.subscription_service import SubscriptionService
+from app.domain.services.tutor_context_builder import build_tutor_context, resolve_course
 from app.domain.services.tutor_tools import TOOL_DEFINITIONS, TutorToolExecutor
 from app.infrastructure.config.settings import get_settings
 
@@ -394,57 +392,41 @@ class TutorService:
                 user.preferred_language = locale
                 session.add(user)
 
-            # Resolve module title for human-readable system prompt
-            module_title = None
-            module_number = None
-            module_obj = None
+            # Build context via the shared helper so text and voice tutors can't
+            # drift (#1956). Pass the already-loaded learner_memory_service to
+            # avoid a redundant instantiation.
+            context = await build_tutor_context(
+                user=user,
+                course_id=course_id,
+                module_id=module_id,
+                locale=locale,
+                session=session,
+                learner_memory_service=self.learner_memory_service,
+                tutor_mode=tutor_mode,
+                context_type=context_type,
+                context_id=context_id,
+            )
+            # Text tutor augments the shared context with session-scoped fields
+            # that voice doesn't use.
+            context.learner_memory = session_ctx.learner_memory
+            context.previous_session_context = session_ctx.previous_compact
+            context.progress_snapshot = session_ctx.progress_snapshot
+
+            # Re-resolve the course so we can pull rag_collection_id and touch
+            # the interaction row. The helper already did the auth check +
+            # fallback logic; this second call is cheap (primary-key GET).
+            module_obj: Module | None = None
             if module_id:
                 module_obj = await session.get(Module, module_id)
-                if module_obj:
-                    module_title = (
-                        module_obj.title_fr if effective_language == "fr" else module_obj.title_en
-                    )
-                    module_number = module_obj.module_number
-
-            # Resolve course context: explicit > from module > from enrollment
-            course = await self._resolve_course(course_id, module_id, module_obj, user_id, session)
-            course_title = None
-            course_domain = None
-            rag_collection_id = None
+            course = await resolve_course(course_id, module_id, module_obj, user_id, session)
+            rag_collection_id = course.rag_collection_id if course else None
             if course:
-                course_title = course.title_fr if effective_language == "fr" else course.title_en
-                course_domain = course_domain or course_title
-                rag_collection_id = course.rag_collection_id
-
-                # Touch course interaction for recent-courses ranking
                 try:
                     from app.domain.services.progress_service import touch_course_interaction
 
                     await touch_course_interaction(session, uuid.UUID(str(user_id)), course.id)
                 except Exception:
                     pass  # non-fatal
-
-            audience = detect_audience(course)
-
-            context = TutorContext(
-                user_level=user.current_level,
-                user_language=effective_language,
-                user_country=user.country or "CI",
-                module_id=str(module_id) if module_id else None,
-                module_title=module_title,
-                module_number=module_number,
-                context_type=context_type,
-                tutor_mode=tutor_mode,
-                context_id=str(context_id) if context_id else None,
-                course_title=course_title,
-                course_domain=course_domain,
-                learner_memory=session_ctx.learner_memory,
-                previous_session_context=session_ctx.previous_compact,
-                progress_snapshot=session_ctx.progress_snapshot,
-                is_kids=audience.is_kids,
-                age_min=audience.age_min,
-                age_max=audience.age_max,
-            )
 
             system_prompt = get_socratic_system_prompt(context, [])
 
@@ -1016,61 +998,6 @@ class TutorService:
         await session.commit()
 
         return conversation
-
-    async def _resolve_course(
-        self,
-        course_id: uuid.UUID | None,
-        module_id: uuid.UUID | None,
-        module_obj: Module | None,
-        user_id: uuid.UUID,
-        session: AsyncSession,
-    ) -> Course | None:
-        """Resolve course: explicit course_id > module's course > active enrollment.
-
-        When course_id is explicit, verifies the user is enrolled (active)
-        to prevent access to paid content. Falls back to enrollment if not.
-        """
-        # 1. Explicit course_id — verify enrollment
-        if course_id:
-            enrolled = await session.execute(
-                select(UserCourseEnrollment).where(
-                    UserCourseEnrollment.user_id == user_id,
-                    UserCourseEnrollment.course_id == course_id,
-                    UserCourseEnrollment.status == "active",
-                )
-            )
-            if enrolled.scalar_one_or_none():
-                course = await session.get(Course, course_id)
-                if course:
-                    return course
-            else:
-                logger.warning(
-                    "Tutor course_id not enrolled, falling back",
-                    user_id=str(user_id),
-                    course_id=str(course_id),
-                )
-
-        # 2. From module's course_id
-        if module_obj and module_obj.course_id:
-            course = await session.get(Course, module_obj.course_id)
-            if course:
-                return course
-
-        # 3. Fallback: most recent active enrollment
-        result = await session.execute(
-            select(UserCourseEnrollment)
-            .where(
-                UserCourseEnrollment.user_id == user_id,
-                UserCourseEnrollment.status == "active",
-            )
-            .order_by(UserCourseEnrollment.enrolled_at.desc())
-            .limit(1)
-        )
-        enrollment = result.scalar_one_or_none()
-        if enrollment:
-            return await session.get(Course, enrollment.course_id)
-
-        return None
 
     async def _retrieve_relevant_context(
         self, query: str, user: User, module_id: uuid.UUID | None, session: AsyncSession

--- a/backend/tests/test_tutor_context_builder.py
+++ b/backend/tests/test_tutor_context_builder.py
@@ -1,0 +1,243 @@
+"""Unit tests for the shared tutor context builder (#1956).
+
+Uses a mocked async session because the integration db_session fixture is
+blocked on #554. The helpers are pure: they call ``session.execute`` for
+enrollment lookups and ``session.get`` for Course / Module / User.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.domain.services.tutor_context_builder import (
+    build_tutor_context,
+    resolve_course,
+)
+
+
+def _fake_course(
+    course_id: uuid.UUID,
+    title_fr: str = "Santé publique",
+    title_en: str = "Public health",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=course_id,
+        title_fr=title_fr,
+        title_en=title_en,
+        rag_collection_id=None,
+    )
+
+
+def _fake_module(
+    module_id: uuid.UUID,
+    course_id: uuid.UUID | None,
+    title_fr: str = "Épidémiologie",
+    title_en: str = "Epidemiology",
+    module_number: int = 1,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=module_id,
+        course_id=course_id,
+        title_fr=title_fr,
+        title_en=title_en,
+        module_number=module_number,
+    )
+
+
+def _fake_user() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        current_level=2,
+        preferred_language="fr",
+        country="BF",
+    )
+
+
+def _session_with(
+    *,
+    enrollment_result=None,
+    get_map: dict | None = None,
+    execute_results: list | None = None,
+) -> MagicMock:
+    """Build an AsyncSession mock.
+
+    * ``enrollment_result``: what scalar_one_or_none() returns for enrollment
+      lookups (default None = not enrolled).
+    * ``get_map``: {id: obj} for ``session.get(Type, id)``.
+    * ``execute_results``: a queue of Result objects if a test needs multiple
+      execute() calls with different return values.
+    """
+
+    def _result(scalar_one_or_none=None, scalar=None):
+        r = MagicMock()
+        r.scalar_one_or_none = MagicMock(return_value=scalar_one_or_none)
+        r.scalar = MagicMock(return_value=scalar)
+        return r
+
+    session = MagicMock()
+    if execute_results is not None:
+        session.execute = AsyncMock(side_effect=execute_results)
+    else:
+        session.execute = AsyncMock(return_value=_result(scalar_one_or_none=enrollment_result))
+
+    if get_map is not None:
+
+        async def _get(cls, obj_id):
+            return (get_map or {}).get(obj_id)
+
+        session.get = AsyncMock(side_effect=_get)
+    else:
+        session.get = AsyncMock(return_value=None)
+
+    return session
+
+
+class TestResolveCourse:
+    async def test_explicit_id_enrolled_returns_course(self):
+        course_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+        course = _fake_course(course_id)
+        session = _session_with(
+            enrollment_result=SimpleNamespace(course_id=course_id),
+            get_map={course_id: course},
+        )
+        out = await resolve_course(course_id, None, None, user_id, session)
+        assert out is course
+
+    async def test_explicit_id_not_enrolled_falls_back_to_module(self):
+        course_id = uuid.uuid4()
+        mod_course_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+        mod = _fake_module(uuid.uuid4(), mod_course_id)
+        mod_course = _fake_course(mod_course_id, title_fr="Module course")
+        # First execute (explicit enrollment check) returns no row;
+        # resolve_course falls through and gets the module's course.
+        session = _session_with(
+            enrollment_result=None,
+            get_map={mod_course_id: mod_course},
+        )
+        out = await resolve_course(course_id, mod.id, mod, user_id, session)
+        assert out is mod_course
+
+    async def test_module_only_returns_module_course(self):
+        mod_course_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+        mod = _fake_module(uuid.uuid4(), mod_course_id)
+        mod_course = _fake_course(mod_course_id)
+        session = _session_with(get_map={mod_course_id: mod_course})
+        # No explicit course_id; first query path is the enrollment-fallback.
+        session.execute = AsyncMock(
+            return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None))
+        )
+        out = await resolve_course(None, mod.id, mod, user_id, session)
+        assert out is mod_course
+
+    async def test_no_course_no_module_no_enrollments_returns_none(self):
+        session = _session_with()
+        out = await resolve_course(None, None, None, uuid.uuid4(), session)
+        assert out is None
+
+    async def test_recent_enrollment_fallback(self):
+        course_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+        course = _fake_course(course_id)
+        enrollment = SimpleNamespace(course_id=course_id)
+        session = _session_with(
+            enrollment_result=enrollment,
+            get_map={course_id: course},
+        )
+        out = await resolve_course(None, None, None, user_id, session)
+        assert out is course
+
+
+class TestBuildTutorContext:
+    @pytest.fixture
+    def mock_memory(self):
+        m = MagicMock()
+        m.format_for_prompt = AsyncMock(return_value="(learner memory snippet)")
+        return m
+
+    async def test_populates_course_and_module_in_user_language(self, mock_memory):
+        course_id = uuid.uuid4()
+        module_id = uuid.uuid4()
+        user = _fake_user()
+        course = _fake_course(course_id, title_fr="Santé publique", title_en="Public health")
+        module = _fake_module(
+            module_id, course_id, title_fr="Épidémiologie", title_en="Epidemiology", module_number=3
+        )
+        session = _session_with(
+            enrollment_result=SimpleNamespace(course_id=course_id),
+            get_map={course_id: course, module_id: module},
+        )
+
+        ctx = await build_tutor_context(
+            user=user,
+            course_id=course_id,
+            module_id=module_id,
+            locale="fr",
+            session=session,
+            learner_memory_service=mock_memory,
+        )
+
+        assert ctx.user_language == "fr"
+        assert ctx.course_title == "Santé publique"
+        assert ctx.module_title == "Épidémiologie"
+        assert ctx.module_number == 3
+        assert ctx.module_id == str(module_id)
+        assert ctx.learner_memory == "(learner memory snippet)"
+        # Text-tutor-only fields stay empty — voice call doesn't use them.
+        assert ctx.previous_session_context == ""
+        assert ctx.progress_snapshot == ""
+
+    async def test_english_locale_picks_english_titles(self, mock_memory):
+        course_id = uuid.uuid4()
+        user = _fake_user()
+        course = _fake_course(course_id, title_fr="Santé publique", title_en="Public health")
+        session = _session_with(
+            enrollment_result=SimpleNamespace(course_id=course_id),
+            get_map={course_id: course},
+        )
+        ctx = await build_tutor_context(
+            user=user,
+            course_id=course_id,
+            module_id=None,
+            locale="en",
+            session=session,
+            learner_memory_service=mock_memory,
+        )
+        assert ctx.user_language == "en"
+        assert ctx.course_title == "Public health"
+
+    async def test_no_course_no_module_yields_minimal_context(self, mock_memory):
+        user = _fake_user()
+        session = _session_with()
+        ctx = await build_tutor_context(
+            user=user,
+            course_id=None,
+            module_id=None,
+            locale="fr",
+            session=session,
+            learner_memory_service=mock_memory,
+        )
+        assert ctx.course_title is None
+        assert ctx.module_title is None
+        assert ctx.user_level == 2
+        assert ctx.user_country == "BF"
+
+    async def test_invalid_locale_falls_back_to_user_preferred(self, mock_memory):
+        user = _fake_user()
+        user.preferred_language = "en"
+        session = _session_with()
+        ctx = await build_tutor_context(
+            user=user,
+            course_id=None,
+            module_id=None,
+            locale=None,
+            session=session,
+            learner_memory_service=mock_memory,
+        )
+        assert ctx.user_language == "en"

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -654,7 +654,12 @@ export function ChatPanel({
       </div>
 
       {/* Voice Call Modal */}
-      <VoiceCallModal open={showVoiceCall} onOpenChange={setShowVoiceCall} />
+      <VoiceCallModal
+        open={showVoiceCall}
+        onOpenChange={setShowVoiceCall}
+        courseId={activeCourseId}
+        moduleId={moduleId ?? null}
+      />
 
       {/* Clear History Dialog */}
       <AlertDialog open={showClearDialog} onOpenChange={setShowClearDialog}>

--- a/frontend/components/chat/voice-call-modal.tsx
+++ b/frontend/components/chat/voice-call-modal.tsx
@@ -17,6 +17,10 @@ import { cn } from '@/lib/utils';
 interface VoiceCallModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** Active course for context-aware voice tutoring (#1956). */
+  courseId?: string | null;
+  /** Active module, if the user is on a module page. */
+  moduleId?: string | null;
 }
 
 type CallState =
@@ -36,7 +40,12 @@ function formatDuration(seconds: number): string {
   return `${m}:${s.toString().padStart(2, '0')}`;
 }
 
-export function VoiceCallModal({ open, onOpenChange }: VoiceCallModalProps) {
+export function VoiceCallModal({
+  open,
+  onOpenChange,
+  courseId,
+  moduleId,
+}: VoiceCallModalProps) {
   const t = useTranslations('ChatTutor');
   const locale = useLocale();
   const language = (locale === 'fr' ? 'fr' : 'en') as 'fr' | 'en';
@@ -75,7 +84,11 @@ export function VoiceCallModal({ open, onOpenChange }: VoiceCallModalProps) {
 
   const startCall = useCallback(async () => {
     setState('requesting_token');
-    const { data, status } = await startVoiceSession(language);
+    const { data, status } = await startVoiceSession({
+      locale: language,
+      courseId,
+      moduleId,
+    });
     if (!data) {
       setState(status === 403 ? 'cap_reached' : 'failed');
       return;
@@ -104,7 +117,7 @@ export function VoiceCallModal({ open, onOpenChange }: VoiceCallModalProps) {
         setState('failed');
       }
     }
-  }, [language, hangUp]);
+  }, [language, courseId, moduleId, hangUp]);
 
   const toggleMute = useCallback(() => {
     const conn = connectionRef.current;

--- a/frontend/lib/tutor-voice-api.ts
+++ b/frontend/lib/tutor-voice-api.ts
@@ -61,12 +61,21 @@ export async function fetchTutorMessageAudio(
   );
 }
 
+export interface StartVoiceSessionParams {
+  locale: 'fr' | 'en';
+  courseId?: string | null;
+  moduleId?: string | null;
+}
+
 export async function startVoiceSession(
-  locale: 'fr' | 'en',
+  params: StartVoiceSessionParams,
 ): Promise<{ data: VoiceSessionResponse | null; status: number }> {
+  const body: Record<string, string> = { locale: params.locale };
+  if (params.courseId) body.course_id = params.courseId;
+  if (params.moduleId) body.module_id = params.moduleId;
   return authedJson<VoiceSessionResponse>('/api/v1/tutor/voice-session', {
     method: 'POST',
-    body: JSON.stringify({ locale }),
+    body: JSON.stringify(body),
   });
 }
 


### PR DESCRIPTION
## Summary

Voice-call mode now knows the user's active course, module, level, and language. Injects the same Socratic system prompt the text tutor uses (with a short voice-mode suffix) via OpenAI Realtime's \`instructions\` field.

## Changes

**Backend**
- New \`tutor_context_builder.py\` with \`resolve_course()\` + \`build_tutor_context()\` — shared by text + voice tutors.
- \`VoiceSessionRequest\` accepts \`course_id\` + \`module_id\`.
- \`create_voice_session\` loads User, builds context, posts \`instructions\` + \`input_audio_transcription\` to OpenAI Realtime.
- \`tutor_service.send_message\` delegates to the new helper.
- Voice-mode suffix appended to the system prompt tells the model to use spoken-style short replies, no markdown, no \`{{source_image}}\` markers.

**Frontend**
- \`startVoiceSession({ locale, courseId, moduleId })\`.
- \`VoiceCallModal\` accepts \`courseId\` + \`moduleId\` props.
- \`ChatPanel\` passes its \`activeCourseId\` + \`moduleId\`.

**Tests**
- 9 pure-mock tests for \`resolve_course\` + \`build_tutor_context\` (course resolution, locale pick, empty fallbacks).

## Test plan

- [ ] On staging, while enrolled in a course: click phone icon, say "What module am I studying?" — tutor names the current module.
- [ ] Voice tutor asks Socratic questions grounded in the course domain.
- [ ] Switch to EN, start a new call — tutor replies in English.

## Out of scope

- RAG tool-use mid-call (deferred; injected system prompt should cover most sessions).
- Cross-session continuity via compacted context / progress snapshot.

Fixes #1956

🤖 Generated with [Claude Code](https://claude.com/claude-code)