### PR TITLE
fix(auth): refresh access token before bouncing to /login

### DIFF
--- a/backend/app/api/v1/local_auth.py
+++ b/backend/app/api/v1/local_auth.py
@@ -79,7 +79,7 @@ class TokenResponse(BaseModel):
 class RefreshTokenRequest(BaseModel):
     """Refresh token request."""
 
-    refresh_token: str
+    refresh_token: str | None = None
 
 
 class RefreshTokenResponse(BaseModel):
@@ -332,7 +332,7 @@ async def verify_totp(
             value=result["refresh_token"],
             httponly=True,
             secure=True,
-            samesite="strict",
+            samesite="lax",
             max_age=auth_service.jwt_service.refresh_token_expire_days * 24 * 60 * 60,
         )
 
@@ -377,7 +377,7 @@ async def login(
             value=result["refresh_token"],
             httponly=True,
             secure=True,
-            samesite="strict",
+            samesite="lax",
             max_age=auth_service.jwt_service.refresh_token_expire_days * 24 * 60 * 60,
         )
 
@@ -396,12 +396,15 @@ async def login(
 
 @router.post("/refresh", response_model=RefreshTokenResponse)
 async def refresh_token(
-    request: RefreshTokenRequest, db=Depends(get_db_session)
+    http_request: Request,
+    payload: RefreshTokenRequest | None = None,
+    db=Depends(get_db_session),
 ) -> RefreshTokenResponse:
     """Refresh access token using refresh token.
 
-    Args:
-        request: Refresh token
+    Reads the token from the request body, falling back to the `refresh_token`
+    HttpOnly cookie. The cookie fallback lets the long-lived session survive
+    WebView localStorage eviction.
 
     Returns:
         New access token
@@ -410,9 +413,18 @@ async def refresh_token(
         401: Invalid or expired refresh token
         500: Refresh failed
     """
+    token = (payload.refresh_token if payload else None) or http_request.cookies.get(
+        "refresh_token"
+    )
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Refresh token required",
+        )
+
     try:
         auth_service = LocalAuthService(db)
-        result = await auth_service.refresh_access_token(request.refresh_token)
+        result = await auth_service.refresh_access_token(token)
 
         logger.info("Token refreshed successfully")
         return RefreshTokenResponse(**result)
@@ -518,7 +530,7 @@ async def logout(
         success = await auth_service.logout(request.refresh_token)
 
         # Clear refresh token cookie
-        response.delete_cookie(key="refresh_token", httponly=True, secure=True, samesite="strict")
+        response.delete_cookie(key="refresh_token", httponly=True, secure=True, samesite="lax")
 
         if success:
             logger.info("User logged out successfully")
@@ -530,7 +542,7 @@ async def logout(
     except Exception as e:
         logger.error("Logout error", error=str(e))
         # Don't raise error for logout, just clear cookie
-        response.delete_cookie(key="refresh_token", httponly=True, secure=True, samesite="strict")
+        response.delete_cookie(key="refresh_token", httponly=True, secure=True, samesite="lax")
         return {"message": "Logged out"}
 
 
@@ -613,7 +625,7 @@ async def login_with_password(
             value=result["refresh_token"],
             httponly=True,
             secure=True,
-            samesite="strict",
+            samesite="lax",
             max_age=auth_service.jwt_service.refresh_token_expire_days * 24 * 60 * 60,
         )
 
@@ -773,7 +785,7 @@ async def verify_email_otp(
             value=result["refresh_token"],
             httponly=True,
             secure=True,
-            samesite="strict",
+            samesite="lax",
             max_age=auth_service.jwt_service.refresh_token_expire_days * 24 * 60 * 60,
         )
 
@@ -858,7 +870,7 @@ async def verify_login_otp(
             value=result["refresh_token"],
             httponly=True,
             secure=True,
-            samesite="strict",
+            samesite="lax",
             max_age=auth_service.jwt_service.refresh_token_expire_days * 24 * 60 * 60,
         )
 
@@ -941,7 +953,7 @@ async def verify_phone_otp(
             value=result["refresh_token"],
             httponly=True,
             secure=True,
-            samesite="strict",
+            samesite="lax",
             max_age=auth_service.jwt_service.refresh_token_expire_days * 24 * 60 * 60,
         )
 
@@ -1007,7 +1019,7 @@ async def verify_login_phone_otp(
             value=result["refresh_token"],
             httponly=True,
             secure=True,
-            samesite="strict",
+            samesite="lax",
             max_age=auth_service.jwt_service.refresh_token_expire_days * 24 * 60 * 60,
         )
 

--- a/frontend/components/shared/auth-guard.tsx
+++ b/frontend/components/shared/auth-guard.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "@/i18n/routing";
 import { useLocale } from "next-intl";
 import { usePathname } from "next/navigation";
 import { identifyUser } from "@/lib/analytics";
+import { authClient } from "@/lib/auth";
 
 function getStoredToken(): string | null {
   if (typeof window === "undefined") return null;
@@ -33,6 +34,28 @@ function isPublicAppPath(pathname: string): boolean {
   return PUBLIC_APP_PATHS.some((p) => p.test(pathname));
 }
 
+function identifyFromStorage(): void {
+  const storedUser = localStorage.getItem("user");
+  if (!storedUser) return;
+  try {
+    const user = JSON.parse(storedUser) as {
+      id?: string;
+      country?: string;
+      current_level?: number;
+      preferred_language?: string;
+    };
+    if (user.id) {
+      identifyUser(user.id, {
+        country: user.country,
+        level: user.current_level,
+        preferred_language: user.preferred_language,
+      });
+    }
+  } catch {
+    // ignore malformed user data
+  }
+}
+
 export function AuthGuard({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const locale = useLocale();
@@ -40,6 +63,22 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
   const [authorized, setAuthorized] = useState(false);
 
   useEffect(() => {
+    let cancelled = false;
+
+    const authorize = () => {
+      if (cancelled) return;
+      identifyFromStorage();
+      startTransition(() => setAuthorized(true));
+    };
+
+    const redirectToLogin = () => {
+      if (cancelled) return;
+      localStorage.removeItem("access_token");
+      localStorage.removeItem("refresh_token");
+      localStorage.removeItem("user");
+      router.replace("/login");
+    };
+
     // Allow public routes through without authentication
     if (isPublicAppPath(pathname)) {
       startTransition(() => setAuthorized(true));
@@ -47,34 +86,21 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
     }
 
     const token = getStoredToken();
-    if (!token || isTokenExpired(token)) {
-      localStorage.removeItem("access_token");
-      localStorage.removeItem("refresh_token");
-      localStorage.removeItem("user");
-      router.replace("/login");
+    if (token && !isTokenExpired(token)) {
+      authorize();
       return;
     }
-    const storedUser = localStorage.getItem("user");
-    if (storedUser) {
-      try {
-        const user = JSON.parse(storedUser) as {
-          id?: string;
-          country?: string;
-          current_level?: number;
-          preferred_language?: string;
-        };
-        if (user.id) {
-          identifyUser(user.id, {
-            country: user.country,
-            level: user.current_level,
-            preferred_language: user.preferred_language,
-          });
-        }
-      } catch {
-        // ignore malformed user data
-      }
-    }
-    startTransition(() => setAuthorized(true));
+
+    // Try to refresh before bouncing to login: middleware accepts the 90-day
+    // refresh_token cookie, so a missing/expired access_token is recoverable.
+    authClient
+      .refreshAccessToken()
+      .then(authorize)
+      .catch(redirectToLogin);
+
+    return () => {
+      cancelled = true;
+    };
   }, [locale, pathname, router]);
 
   if (!authorized) {

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -185,7 +185,7 @@ class AuthClient {
       localStorage.setItem('user', JSON.stringify(authResponse.user));
       // Set cookie for server-side middleware auth check
       const maxAge = authResponse.expires_in || 900;
-      document.cookie = `access_token=${authResponse.access_token}; path=/; max-age=${maxAge}; SameSite=Strict; Secure`;
+      document.cookie = `access_token=${authResponse.access_token}; path=/; max-age=${maxAge}; SameSite=Lax; Secure`;
     }
   }
 
@@ -198,7 +198,7 @@ class AuthClient {
       localStorage.removeItem('refresh_token');
       localStorage.removeItem('user');
       // Clear middleware auth cookie
-      document.cookie = 'access_token=; path=/; max-age=0; SameSite=Strict; Secure';
+      document.cookie = 'access_token=; path=/; max-age=0; SameSite=Lax; Secure';
     }
   }
 
@@ -262,18 +262,18 @@ class AuthClient {
   }
 
   /**
-   * Refresh access token using refresh token
+   * Refresh access token using refresh token.
+   * Sends the localStorage token if present; otherwise relies on the
+   * HttpOnly refresh_token cookie (backend reads cookie when body omitted).
    */
   async refreshAccessToken(): Promise<void> {
-    if (!this.refreshToken) {
-      throw new AuthError('No refresh token available');
-    }
+    const body = this.refreshToken
+      ? JSON.stringify({ refresh_token: this.refreshToken })
+      : JSON.stringify({});
 
     const response = await this.apiCall<RefreshTokenResponse>('/refresh', {
       method: 'POST',
-      body: JSON.stringify({
-        refresh_token: this.refreshToken,
-      }),
+      body,
     });
 
     this.accessToken = response.access_token;
@@ -281,7 +281,7 @@ class AuthClient {
       localStorage.setItem('access_token', response.access_token);
       // Update middleware auth cookie
       const maxAge = response.expires_in || 900;
-      document.cookie = `access_token=${response.access_token}; path=/; max-age=${maxAge}; SameSite=Strict; Secure`;
+      document.cookie = `access_token=${response.access_token}; path=/; max-age=${maxAge}; SameSite=Lax; Secure`;
     }
   }
 

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -155,8 +155,9 @@ class AuthClient {
         headers,
       });
     } catch (error) {
-      // If we get a 401 and have a refresh token, try to refresh
-      if (error instanceof AuthError && error.status === 401 && this.refreshToken) {
+      // On 401, always attempt refresh — the HttpOnly refresh_token cookie may
+      // be valid even when localStorage was evicted (Android WebView).
+      if (error instanceof AuthError && error.status === 401) {
         try {
           await this.refreshAccessToken();
           // Retry with new token
@@ -402,11 +403,20 @@ class AuthClient {
       });
 
       if (!response.ok) {
-        if (response.status === 401 && this.refreshToken) {
-          // Try to refresh token
-          await this.refreshAccessToken();
+        if (response.status === 401) {
+          // Always retry via refresh — cookie may carry a valid session even
+          // when localStorage was evicted. refreshAccessToken throws on 401.
+          try {
+            await this.refreshAccessToken();
+          } catch {
+            const errorData = await response.json().catch(() => ({}));
+            throw new AuthError(
+              errorData.detail || `Request failed with status ${response.status}`,
+              response.status
+            );
+          }
           headers['Authorization'] = `Bearer ${this.accessToken}`;
-          
+
           const retryResponse = await fetch(url, {
             ...options,
             headers,


### PR DESCRIPTION
## Summary

- AuthGuard now attempts `authClient.refreshAccessToken()` when the stored access_token is missing/expired and only redirects to `/login` if refresh itself fails. Without this, every hard-refresh past the 15-min access_token expiry was undoing the session restore that `middleware.ts` (#1936) put in place.
- Backend `/auth/refresh` reads the refresh token from the request body **or** the HttpOnly `refresh_token` cookie (defense-in-depth: works even when WebView evicts localStorage).
- All `samesite="strict"` → `"lax"` on refresh_token cookies (9 sites — set + delete) and the JS-set access_token cookie (3 sites). Strict cookies are dropped by Android WebView on certain same-origin reload paths; Lax is safe because the cookie is HttpOnly.

## Why

Users on the Sira Android wrapper were getting bounced to `/login` on hard refresh — most reliably reproducible by reloading the tutor AI page after the access_token expired. The 90-day session work in #1936 fixed the middleware and the backend `max_age`, but never updated the client-side AuthGuard, so AuthGuard kept overriding the middleware's decision.

## Test plan

- [ ] Log in via the Android app, navigate to `/tutor`, wait past the 15-min access_token expiry (or temporarily shorten `auth-access-token-expiry-minutes` to 1), pull-to-refresh → page reloads cleanly, no redirect to `/login`.
- [ ] Kill the Android app from recents, reopen, navigate around → stays logged in.
- [ ] Explicit logout still works (redirects to login, subsequent navigation requires re-auth).
- [ ] DB-revoke the refresh token, refresh page → clean redirect to `/login` (no infinite spinner / console errors).
- [ ] Public paths like `/fr/courses` still render without auth.
- [ ] Frontend lint / `tsc --noEmit` / backend ruff / mypy: no new errors introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)