### PR TITLE
fix(tutor): show remaining messages in usage counter (#1971)

### DIFF
--- a/frontend/components/chat/usage-counter.tsx
+++ b/frontend/components/chat/usage-counter.tsx
@@ -17,6 +17,7 @@ export function UsageCounter({ currentUsage, maxUsage, className }: UsageCounter
   const usagePercentage = (currentUsage / maxUsage) * 100;
   const isWarning = usagePercentage >= 80;
   const isLimitReached = currentUsage >= maxUsage;
+  const remaining = Math.max(0, maxUsage - currentUsage);
 
   const getVariant = () => {
     if (isLimitReached) return 'destructive';
@@ -29,7 +30,7 @@ export function UsageCounter({ currentUsage, maxUsage, className }: UsageCounter
       {/* Counter Badge */}
       <div className="flex justify-center">
         <Badge variant={getVariant()} className="px-3 py-1">
-          {t('messageLimit', { count: currentUsage, max: maxUsage })}
+          {t('messageLimit', { remaining, max: maxUsage })}
         </Badge>
       </div>
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -341,7 +341,7 @@
     "send": "Send",
     "typing": "The tutor is typing...",
     "offline": "Tutor is offline",
-    "messageLimit": "{count}/{max} messages today",
+    "messageLimit": "{remaining}/{max} messages left today",
     "messageLimitWarning": "Daily message limit reached",
     "messageLimitWarningDescription": "You are approaching your daily message limit.",
     "messageLimitReached": "Daily message limit reached",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -341,7 +341,7 @@
     "send": "Envoyer",
     "typing": "Le tuteur écrit...",
     "offline": "Tuteur hors ligne",
-    "messageLimit": "{count}/{max} messages aujourd'hui",
+    "messageLimit": "{remaining}/{max} messages restants aujourd'hui",
     "messageLimitWarning": "Limite de messages quotidiens atteinte",
     "messageLimitWarningDescription": "Vous approchez de votre limite de messages quotidiens.",
     "messageLimitReached": "Limite de messages quotidiens atteinte",


### PR DESCRIPTION
## Summary

- Badge used to read `{count}/{max} messages today` where `count` was messages **used**. On a fresh day that shows `0/5` (free) or `0/1020` (paid), which users parse as *"0 messages left"* — looks like a lockout even though they can still send.
- Flip displayed value to **remaining** (`max - used`) and reword the i18n strings to be unambiguous.
- Thresholds (`isWarning`, `isLimitReached`, `getVariant`) keep using `currentUsage` so destructive badges + limit-reached alerts still fire at the right moment.

Fixes #1971

## Test plan

- [ ] `/fr/tutor` on a fresh day → `5/5 messages restants aujourd'hui` (free) or `1020/1020 …` (paid), not `0/5`.
- [ ] Send one message → badge ticks to `4/5` / `1019/1020`.
- [ ] Exhaust quota → `0/5 messages restants`, destructive badge + "limit reached" alert still render.
- [ ] `/en/tutor` mirrors with `"… messages left today"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)