### PR TITLE
fix(tutor): split user/assistant commit so dropped streams don't lose user message (#1975)

### DIFF
--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -457,6 +457,11 @@ class TutorService:
                 "has_files": bool(file_content_blocks),
             }
 
+            # Persist the user's message before the LLM loop runs (#1975).
+            # Stream interruptions between here and end-of-stream then lose
+            # only the assistant reply — recoverable — instead of both sides.
+            await self._persist_user_message(conversation, user_msg_stored, session)
+
             if file_content_blocks:
                 user_content: list[Any] = [*file_content_blocks, {"type": "text", "text": message}]
                 conversation_history.append({"role": "user", "content": user_content})
@@ -666,7 +671,9 @@ class TutorService:
                 "tool_calls_count": tool_call_count,
             }
 
-            updated_messages = conversation.messages + [user_msg_stored, assistant_msg_stored]
+            # User message was already committed before the LLM loop (#1975);
+            # this commit only adds the assistant reply on top of it.
+            updated_messages = conversation.messages + [assistant_msg_stored]
             conversation.messages = updated_messages
             conversation.message_count = len(updated_messages)
             # Index of the just-persisted assistant reply — the frontend needs
@@ -1109,6 +1116,26 @@ class TutorService:
                 )
 
         return claude_messages
+
+    async def _persist_user_message(
+        self,
+        conversation: TutorConversation,
+        user_msg: dict[str, Any],
+        session: AsyncSession,
+    ) -> None:
+        """Append the user's message to the conversation and commit immediately.
+
+        Splitting this from the assistant-reply commit is the durability fix for
+        #1975: a stream interruption (mobile dropout, AbortController, container
+        restart) between message receipt and end-of-stream used to lose both
+        sides of the exchange because they shared a single commit. With this
+        helper called before the LLM loop, only the assistant reply is at risk
+        — and the user can see their message persisted on reload and retry.
+        """
+        conversation.messages = conversation.messages + [user_msg]
+        conversation.message_count = len(conversation.messages)
+        session.add(conversation)
+        await session.commit()
 
     async def _compact_conversation_async(
         self,

--- a/backend/tests/test_tutor_service.py
+++ b/backend/tests/test_tutor_service.py
@@ -460,3 +460,66 @@ async def test_get_conversation_returns_messages(tutor_service, sample_user, sam
     assert result["id"] == sample_conversation.id
     assert result["messages"] == sample_conversation.messages
     assert "created_at" in result
+
+
+# Regression tests for #1975 — split user/assistant commits so a stream
+# interruption between message receipt and end-of-stream doesn't lose both
+# sides of the exchange.
+
+
+async def test_persist_user_message_appends_and_commits(tutor_service, sample_conversation):
+    """User message must be appended to conversation.messages and committed."""
+    sample_conversation.messages = []
+    sample_conversation.message_count = 0
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    user_msg = {
+        "role": "user",
+        "content": "What is hypertension?",
+        "timestamp": datetime.now(UTC).isoformat(),
+        "has_files": False,
+    }
+
+    await tutor_service._persist_user_message(sample_conversation, user_msg, mock_session)
+
+    assert sample_conversation.messages == [user_msg]
+    assert sample_conversation.message_count == 1
+    mock_session.add.assert_called_once_with(sample_conversation)
+    assert mock_session.commit.await_count == 1
+
+
+async def test_persist_user_message_preserves_existing_messages(tutor_service, sample_conversation):
+    """Helper must not clobber prior turns — appending only."""
+    prior_user = {"role": "user", "content": "earlier", "timestamp": "t0"}
+    prior_assistant = {"role": "assistant", "content": "earlier reply", "timestamp": "t1"}
+    sample_conversation.messages = [prior_user, prior_assistant]
+    sample_conversation.message_count = 2
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    new_user = {"role": "user", "content": "follow-up", "timestamp": "t2"}
+    await tutor_service._persist_user_message(sample_conversation, new_user, mock_session)
+
+    assert sample_conversation.messages == [prior_user, prior_assistant, new_user]
+    assert sample_conversation.message_count == 3
+    assert mock_session.commit.await_count == 1
+
+
+async def test_persist_user_message_commit_durability_invariant(tutor_service, sample_conversation):
+    """The contract is: when this returns, the new message is durable.
+
+    A bare flush() would have left the row visible only inside the request's
+    session — a follow-up GET on a different connection would 404 (#1625
+    pattern). This test guards against accidentally regressing to flush.
+    """
+    sample_conversation.messages = []
+    sample_conversation.message_count = 0
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    await tutor_service._persist_user_message(
+        sample_conversation,
+        {"role": "user", "content": "x", "timestamp": "t"},
+        mock_session,
+    )
+
+    # commit() — not just flush() — is required for cross-session visibility.
+    assert mock_session.commit.await_count >= 1

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -273,6 +273,15 @@ export function ChatPanel({
       language: locale,
     });
 
+    // Pre-empt the localStorage cache as soon as the user sends, not just on
+    // the 'finished' SSE chunk. A dropped stream used to leave the cache
+    // serving the pre-message snapshot — and once the backend persists the
+    // user message early (#1975), that stale cache would re-hide it on next
+    // mount. Invalidate now so any later refetch goes to network.
+    if (activeConversationId) {
+      invalidateConversationCache(activeConversationId);
+    }
+
     abortControllerRef.current?.abort();
     const abortController = new AbortController();
     abortControllerRef.current = abortController;


### PR DESCRIPTION
Closes #1975.

## Problem

User reported: "some messages in my last tutor AI session disappeared from the discussion thread." Verified on inspection — both the user message and the assistant reply were appended to `conversation.messages` in a single commit at end-of-stream. Any failure between message receipt and end-of-stream (mobile dropout, `AbortController`, container restart, exception in a tool call) lost **both sides** of the exchange even though they had been optimistically rendered.

`backend/app/domain/services/tutor_service.py:669-687` (before this PR):
```python
updated_messages = conversation.messages + [user_msg_stored, assistant_msg_stored]
conversation.messages = updated_messages
…
await session.commit()
```

`frontend/components/chat/chat-panel.tsx:398-401` compounded the symptom: the per-conversation localStorage cache (5-min TTL) was invalidated only on the `'finished'` SSE chunk, so a dropped stream kept serving the pre-message snapshot.

## Fix

- **Backend** — extract `_persist_user_message()` and call it right after the `user_msg_stored` dict is built, before the LLM loop runs. The existing end-of-stream commit is changed to append only the assistant reply on top of the already-persisted user message. A dropped stream now loses only the assistant reply (recoverable: the user can see they sent it and retry), instead of erasing both sides.
- **Frontend** — invalidate the per-conversation localStorage cache as soon as the user clicks send. With the backend persisting the user message early, this is required: a dropped stream would otherwise leave the cache hiding the just-persisted user message on next mount.

## Tests

Three new unit tests for `_persist_user_message`:
- appends to an empty `messages` and commits
- preserves prior turns (append, not replace)
- guards the `commit()`-not-`flush()` durability invariant (same #1625 pattern)

All 91 existing tutor-area tests still pass; ruff clean.

## Out of scope (issue #1975 captures these for follow-up)

- `send_message` ↔ `_compact_conversation_async` race — fire-and-forget compaction reads without a row lock.
- Optimistic UI never reconciles against backend state on `message_complete`.
- `messages` is `JSON` not `JSONB`; every write is a full-column overwrite.
- localStorage TTL of 5 min is too long for user-mutable data.

## Test plan

- [ ] Unit tests pass in CI
- [ ] Manual: throttle DevTools to "Offline" mid-stream, then "Online" again. The user message must remain in the thread on reload (before the fix it disappears).
- [ ] Manual: refresh the browser mid-stream. The user message must remain (assistant reply may be missing — that's expected and recoverable).
- [ ] Manual: complete a normal send/receive cycle. Both messages persist and appear after reload.
- [ ] Regression: existing tutor send/receive, history GET, voice listen-button, and compaction flows continue to work.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JSwaVV6cVz6PULnK1Gcjz4)_