### PR TITLE
Tutor AI: drop anchor badge + course-scope last-module + structured unit listing (#1992)

### DIFF
--- a/backend/app/ai/prompts/tutor.py
+++ b/backend/app/ai/prompts/tutor.py
@@ -163,16 +163,25 @@ Utilise cet outil quand tu détectes un pattern récurrent:
 - L'apprenant préfère une approche plus directe ou plus Socratique
 
 ### `get_unit_content(unit_number, content_type?, module_id?)`
-Utilise cet outil CHAQUE FOIS que l'apprenant veut approfondir une unité spécifique
-listée dans `## DÉTAIL DU MODULE ACTUEL` :
-- Récupère le **corps complet** d'une leçon, d'un quiz ou d'une étude de cas générée
-  pour le cours (le prompt système ne contient que les titres + descriptions —
-  cet outil sert le contenu réel à la demande).
-- `unit_number` est le numéro affiché dans la liste (ex: "1.1", "0", "3").
-- `content_type`: "lesson" (par défaut), "quiz", ou "case".
-- `module_id`: optionnel — par défaut, le module actuel de la conversation.
-- Si l'unité n'est pas encore générée, l'outil renvoie `{{"error": "not_generated",
-  "available_units": [...]}}` — informe l'apprenant honnêtement et propose une unité
+**Utilise cet outil UNIQUEMENT pour des références cross-module** — c.-à-d. quand
+l'apprenant veut explorer une unité dans un module DIFFÉRENT du module actuel.
+
+**N'utilise PAS cet outil pour le module actuel** : son contenu détaillé (leçons,
+quiz, études de cas) est DÉJÀ inliné dans la section `## Contenu détaillé` de ton
+prompt système. Cite-le directement.
+
+Cas d'usage :
+1. L'apprenant te demande « rappelle-moi ce qu'on a vu en Module 5 » et le module
+   actuel n'est pas le 5 → appelle `get_unit_content('5.2', 'lesson', '<uuid-module-5>')`.
+2. La section `## Contenu non inclus` t'indique qu'une unité du module actuel n'a
+   pas été inlinée (budget) — appelle l'outil pour cette unité spécifique.
+
+Paramètres :
+- `unit_number`: ex. "1.1", "0", "3".
+- `content_type`: "lesson" (défaut), "quiz", ou "case".
+- `module_id`: optionnel — par défaut, le module actuel.
+- Si l'unité n'est pas générée, retour : `{{"error": "not_generated",
+  "available_units": [...]}}` — informe l'apprenant et propose une alternative
   disponible plutôt que d'inventer du contenu.
 
 **IMPORTANT:** Tu peux enchaîner jusqu'à 3 appels d'outils par message. Utilise les outils intelligemment selon le contexte — ne les appelle pas tous systématiquement.
@@ -679,16 +688,25 @@ Utilise cet outil quand tu détectes un pattern récurrent:
 - L'apprenant préfère une approche plus directe ou plus Socratique
 
 ### `get_unit_content(unit_number, content_type?, module_id?)`
-Utilise cet outil CHAQUE FOIS que l'apprenant veut approfondir une unité spécifique
-listée dans `## DÉTAIL DU MODULE ACTUEL` :
-- Récupère le **corps complet** d'une leçon, d'un quiz ou d'une étude de cas générée
-  pour le cours (le prompt système ne contient que les titres + descriptions —
-  cet outil sert le contenu réel à la demande).
-- `unit_number` est le numéro affiché dans la liste (ex: "1.1", "0", "3").
-- `content_type`: "lesson" (par défaut), "quiz", ou "case".
-- `module_id`: optionnel — par défaut, le module actuel de la conversation.
-- Si l'unité n'est pas encore générée, l'outil renvoie `{{"error": "not_generated",
-  "available_units": [...]}}` — informe l'apprenant honnêtement et propose une unité
+**Utilise cet outil UNIQUEMENT pour des références cross-module** — c.-à-d. quand
+l'apprenant veut explorer une unité dans un module DIFFÉRENT du module actuel.
+
+**N'utilise PAS cet outil pour le module actuel** : son contenu détaillé (leçons,
+quiz, études de cas) est DÉJÀ inliné dans la section `## Contenu détaillé` de ton
+prompt système. Cite-le directement.
+
+Cas d'usage :
+1. L'apprenant te demande « rappelle-moi ce qu'on a vu en Module 5 » et le module
+   actuel n'est pas le 5 → appelle `get_unit_content('5.2', 'lesson', '<uuid-module-5>')`.
+2. La section `## Contenu non inclus` t'indique qu'une unité du module actuel n'a
+   pas été inlinée (budget) — appelle l'outil pour cette unité spécifique.
+
+Paramètres :
+- `unit_number`: ex. "1.1", "0", "3".
+- `content_type`: "lesson" (défaut), "quiz", ou "case".
+- `module_id`: optionnel — par défaut, le module actuel.
+- Si l'unité n'est pas générée, retour : `{{"error": "not_generated",
+  "available_units": [...]}}` — informe l'apprenant et propose une alternative
   disponible plutôt que d'inventer du contenu.
 
 **IMPORTANT:** Tu peux enchaîner jusqu'à 3 appels d'outils par message. Utilise les outils intelligemment selon le contexte — ne les appelle pas tous systématiquement.

--- a/backend/app/ai/prompts/tutor.py
+++ b/backend/app/ai/prompts/tutor.py
@@ -118,7 +118,7 @@ def get_socratic_system_prompt(context: TutorContext, rag_chunks: list[dict[str,
 
 ## OUTILS DISPONIBLES (tool_use)
 
-Tu as accès à 6 outils que tu peux appeler de manière autonome:
+Tu as accès à 7 outils que tu peux appeler de manière autonome:
 
 ### `search_source_images(query, image_type?)`
 Utilise cet outil quand:
@@ -161,6 +161,19 @@ Utilise cet outil quand tu détectes un pattern récurrent:
 - L'apprenant préfère les exemples concrets de son pays ou d'Afrique de l'Ouest
 - L'apprenant a des difficultés avec certains types de concepts
 - L'apprenant préfère une approche plus directe ou plus Socratique
+
+### `get_unit_content(unit_number, content_type?, module_id?)`
+Utilise cet outil CHAQUE FOIS que l'apprenant veut approfondir une unité spécifique
+listée dans `## DÉTAIL DU MODULE ACTUEL` :
+- Récupère le **corps complet** d'une leçon, d'un quiz ou d'une étude de cas générée
+  pour le cours (le prompt système ne contient que les titres + descriptions —
+  cet outil sert le contenu réel à la demande).
+- `unit_number` est le numéro affiché dans la liste (ex: "1.1", "0", "3").
+- `content_type`: "lesson" (par défaut), "quiz", ou "case".
+- `module_id`: optionnel — par défaut, le module actuel de la conversation.
+- Si l'unité n'est pas encore générée, l'outil renvoie `{{"error": "not_generated",
+  "available_units": [...]}}` — informe l'apprenant honnêtement et propose une unité
+  disponible plutôt que d'inventer du contenu.
 
 **IMPORTANT:** Tu peux enchaîner jusqu'à 3 appels d'outils par message. Utilise les outils intelligemment selon le contexte — ne les appelle pas tous systématiquement.
 
@@ -621,7 +634,7 @@ def get_persona_block_text(context: TutorContext) -> str:
 
 ## OUTILS DISPONIBLES (tool_use)
 
-Tu as accès à 6 outils que tu peux appeler de manière autonome:
+Tu as accès à 7 outils que tu peux appeler de manière autonome:
 
 ### `search_source_images(query, image_type?)`
 Utilise cet outil quand:
@@ -664,6 +677,19 @@ Utilise cet outil quand tu détectes un pattern récurrent:
 - L'apprenant préfère les exemples concrets de son pays ou d'Afrique de l'Ouest
 - L'apprenant a des difficultés avec certains types de concepts
 - L'apprenant préfère une approche plus directe ou plus Socratique
+
+### `get_unit_content(unit_number, content_type?, module_id?)`
+Utilise cet outil CHAQUE FOIS que l'apprenant veut approfondir une unité spécifique
+listée dans `## DÉTAIL DU MODULE ACTUEL` :
+- Récupère le **corps complet** d'une leçon, d'un quiz ou d'une étude de cas générée
+  pour le cours (le prompt système ne contient que les titres + descriptions —
+  cet outil sert le contenu réel à la demande).
+- `unit_number` est le numéro affiché dans la liste (ex: "1.1", "0", "3").
+- `content_type`: "lesson" (par défaut), "quiz", ou "case".
+- `module_id`: optionnel — par défaut, le module actuel de la conversation.
+- Si l'unité n'est pas encore générée, l'outil renvoie `{{"error": "not_generated",
+  "available_units": [...]}}` — informe l'apprenant honnêtement et propose une unité
+  disponible plutôt que d'inventer du contenu.
 
 **IMPORTANT:** Tu peux enchaîner jusqu'à 3 appels d'outils par message. Utilise les outils intelligemment selon le contexte — ne les appelle pas tous systématiquement.
 

--- a/backend/app/api/v1/tutor.py
+++ b/backend/app/api/v1/tutor.py
@@ -399,6 +399,7 @@ async def get_remaining_messages(
 
 @router.get("/last-module", response_model=LastTouchedModuleResponse | None)
 async def get_last_touched_module(
+    course_id: uuid.UUID | None = None,
     current_user: AuthenticatedUser = Depends(get_current_user),
     session: AsyncSession = Depends(get_db_session),
     tutor_service: TutorService = Depends(get_tutor_service),
@@ -406,12 +407,18 @@ async def get_last_touched_module(
     """Return the user's most recently accessed module so the standalone
     ``/tutor`` page can default to chatting with that module in scope (#1988).
 
+    When ``course_id`` is supplied, restricts the lookup to modules in that
+    course — required to prevent the cross-course anchor leak that was
+    observed on staging post-#1989 (#1992: badge showed *"Les Détectives
+    du Vivant"* while user had *"Santé Publique"* selected).
+
     Returns ``null`` (HTTP 200) when the user has no recorded module activity
-    — frontend should then render the chat without a module anchor.
+    in the requested scope.
     """
     result = await tutor_service.get_last_touched_module(
         user_id=current_user.id,
         session=session,
+        course_id=course_id,
     )
     if result is None:
         return None

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -342,20 +342,28 @@ async def _build_current_module_section(
     session: AsyncSession,
     char_limit: int | None = None,
     excerpt_chars: int | None = None,
+    user_id: uuid.UUID | None = None,
 ) -> str | None:
-    """Render the current module's unit / quiz / case-study content (#1981, #1984).
+    """Render the current module as a structured listing for the tutor (#1981, #1984, #1992).
 
     Returns ``None`` when no module is in scope (chat without a module
     context) or when the module has no units.
 
-    Behaviour evolved with #1984: instead of 200-char excerpts, we now render
-    the **full lesson body, full quiz (with answers), and full case study**
-    for every generated unit in the module — bounded by per-unit and
-    per-section char limits. The tutor can quote, cite, and reason from the
-    actual material rather than tool-calling for every concrete question.
+    Per #1992 user spec, output is a **structured navigation listing**, not
+    full lesson bodies:
 
-    Pending units (no GeneratedContent row) still show titles + a 🔒 marker
-    so the tutor knows what exists but isn't yet authored.
+    - Module header: title + description + estimated_hours + progress
+      (if user_id provided).
+    - Per unit: number + estimated reading time + title + description.
+    - Per unit: ✓ generated / 🔒 pending marker — tutor knows what's
+      available without needing the body in-prompt.
+
+    Why not full bodies (the #1985 design)? At ~10 000 chars per generated
+    lesson, only 3 units fit before the per-section trim cuts the rest →
+    tutor saw only the first few units of long modules. Descriptions
+    (~200 chars each) keep ALL units visible regardless of module size,
+    and the tutor calls ``search_knowledge_base`` for body content when
+    a specific question needs it.
     """
     if module_obj is None:
         return None
@@ -365,45 +373,79 @@ async def _build_current_module_section(
         if char_limit is not None
         else _sc().get("tutor-module-content-char-limit", 30000)
     )
-    excerpt_chars = (
-        excerpt_chars
-        if excerpt_chars is not None
-        else _sc().get("tutor-module-content-excerpt-chars", 10000)
-    )
-    include_quiz_answers = bool(_sc().get("tutor-include-quiz-answers", True))
 
-    # Localised labels — keep the prompt natural in either FR or EN so the
-    # tutor doesn't switch languages mid-thought.
+    # Localised labels — keep the prompt natural in either FR or EN.
     if language == "fr":
-        generated_marker = "✓ (généré)"
-        pending_marker = "🔒 (à venir)"
+        generated_marker = "✓ généré"
+        pending_marker = "🔒 à venir"
         case_label = "Étude de cas"
-        lesson_label = "Leçon"
-        quiz_label = "Quiz"
+        units_header = "Unités"
+        no_desc = "(description non disponible)"
+        progress_label = "Progression"
+        module_status_labels = {
+            "completed": "terminé",
+            "in_progress": "en cours",
+            "available": "disponible",
+            "locked": "verrouillé",
+        }
+        time_unit = "min de lecture"
     else:
-        generated_marker = "✓ (generated)"
-        pending_marker = "🔒 (not yet generated)"
+        generated_marker = "✓ generated"
+        pending_marker = "🔒 pending"
         case_label = "Case study"
-        lesson_label = "Lesson"
-        quiz_label = "Quiz"
+        units_header = "Units"
+        no_desc = "(no description available)"
+        progress_label = "Progress"
+        module_status_labels = {
+            "completed": "completed",
+            "in_progress": "in progress",
+            "available": "available",
+            "locked": "locked",
+        }
+        time_unit = "min reading"
 
+    # --- Module header ------------------------------------------------------
     module_title = (
         getattr(module_obj, "title_fr", None)
         if language == "fr"
         else getattr(module_obj, "title_en", None)
-    )
+    ) or ""
     module_number = getattr(module_obj, "module_number", None)
-    if module_title and module_number:
+    module_description = (
+        getattr(module_obj, "description_fr", None)
+        if language == "fr"
+        else getattr(module_obj, "description_en", None)
+    )
+    estimated_hours = getattr(module_obj, "estimated_hours", None)
+
+    if module_title and module_number is not None:
         header = f"Module {module_number} — {module_title}"
     elif module_title:
         header = module_title
     else:
-        header = f"Module {module_number}" if module_number else "Module"
+        header = f"Module {module_number}" if module_number is not None else "Module"
 
-    # Single batched lookup keyed on (module_id, language). FR and EN are
-    # stored as separate rows, so we only fetch the user's effective language.
-    content_index: dict[tuple[str, str], dict] = {}
-    case_contents: list[dict] = []
+    header_lines: list[str] = [header]
+    if estimated_hours:
+        header_lines.append(f"_{estimated_hours} h_")
+    if isinstance(module_description, str) and module_description.strip():
+        header_lines.append(module_description.strip())
+
+    # --- Units (sorted by order_index) -------------------------------------
+    units: list[ModuleUnit] = []
+    try:
+        units = sorted(
+            list(getattr(module_obj, "units", []) or []),
+            key=lambda u: getattr(u, "order_index", 0) or 0,
+        )
+    except Exception:
+        units = []
+
+    # Per-unit generation flag — checked once per module via a single batched
+    # query against ``generated_content`` so we can mark units ✓ generated /
+    # 🔒 pending without per-row queries.
+    generated_unit_ids: set[str] = set()
+    case_titles: list[str] = []
     try:
         result = await session.execute(
             select(GeneratedContent).where(
@@ -415,63 +457,83 @@ async def _build_current_module_section(
             content_obj = row.content if isinstance(row.content, dict) else {}
             unit_id = str(content_obj.get("unit_id") or "").strip()
             if row.content_type == "case":
-                case_contents.append(content_obj)
+                title = (content_obj.get("title") or case_label).strip()
+                case_titles.append(title)
             elif unit_id:
-                content_index[(row.content_type, unit_id)] = content_obj
-    except Exception as exc:  # pragma: no cover — defensive: bad DB shouldn't 500 the tutor
+                generated_unit_ids.add(unit_id)
+    except Exception as exc:  # pragma: no cover — defensive
         logger.warning(
             "Failed to load GeneratedContent for module section",
             module_id=str(module_obj.id),
             error=str(exc),
         )
 
-    # Units — preserve order via order_index. ``selectinload`` should have
-    # populated this; fall back to an empty list rather than triggering a
-    # lazy load (which would explode in async code).
-    units: list[ModuleUnit] = []
-    try:
-        units = sorted(
-            list(getattr(module_obj, "units", []) or []),
-            key=lambda u: getattr(u, "order_index", 0) or 0,
-        )
-    except Exception:
-        units = []
+    # --- User progress on this module --------------------------------------
+    progress_line = ""
+    if user_id is not None:
+        try:
+            from app.domain.models.progress import UserModuleProgress
 
-    lines: list[str] = [header]
+            progress_result = await session.execute(
+                select(UserModuleProgress).where(
+                    UserModuleProgress.user_id == user_id,
+                    UserModuleProgress.module_id == module_obj.id,
+                )
+            )
+            progress_row = progress_result.scalar_one_or_none()
+            if progress_row is not None:
+                pct = (
+                    int(round((progress_row.completion_pct or 0.0) * 100))
+                    if (progress_row.completion_pct or 0.0) <= 1.0
+                    else int(round(progress_row.completion_pct or 0.0))
+                )
+                status_label = module_status_labels.get(
+                    progress_row.status or "locked", progress_row.status or ""
+                )
+                progress_line = f"_{progress_label}: {pct}% — {status_label}_"
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.warning(
+                "Failed to load UserModuleProgress for module section",
+                user_id=str(user_id),
+                module_id=str(module_obj.id),
+                error=str(exc),
+            )
 
-    for unit in units:
-        unit_title = (
-            getattr(unit, "title_fr", None) if language == "fr" else getattr(unit, "title_en", None)
-        ) or ""
-        unit_number = getattr(unit, "unit_number", None) or ""
-        prefix = f"{unit_number} — " if unit_number else ""
-        lesson = content_index.get(("lesson", unit_number))
-        quiz = content_index.get(("quiz", unit_number))
-        marker = generated_marker if (lesson or quiz) else pending_marker
-        lines.append(f"- {prefix}{unit_title} {marker}".rstrip())
-        if lesson:
-            body = _render_lesson_full(lesson, excerpt_chars, language)
-            if body:
-                lines.append(f"  **{lesson_label}:**")
-                for body_line in body.split("\n"):
-                    lines.append(f"  {body_line}")
-        if quiz:
-            body = _render_quiz_full(quiz, excerpt_chars, language, include_quiz_answers)
-            if body:
-                lines.append(f"  **{quiz_label}:**")
-                for body_line in body.split("\n"):
-                    lines.append(f"  {body_line}")
+    if progress_line:
+        header_lines.append(progress_line)
 
-    # Case studies — prefer GeneratedContent rows (the new flow), fall back
-    # to the module-level `case_study_fr|en` text columns when no row exists.
-    if case_contents:
-        for case in case_contents:
-            title = (case.get("title") or case_label).strip()
-            body = _render_case_full(case, excerpt_chars, language)
-            lines.append(f"- {title} {generated_marker}")
-            if body:
-                for body_line in body.split("\n"):
-                    lines.append(f"  {body_line}")
+    # --- Render unit listing ----------------------------------------------
+    unit_lines: list[str] = []
+    if units:
+        unit_lines.append(f"\n## {units_header} ({len(units)})")
+        for unit in units:
+            unit_title = (
+                getattr(unit, "title_fr", None)
+                if language == "fr"
+                else getattr(unit, "title_en", None)
+            ) or ""
+            unit_number = getattr(unit, "unit_number", None) or ""
+            unit_desc = (
+                getattr(unit, "description_fr", None)
+                if language == "fr"
+                else getattr(unit, "description_en", None)
+            )
+            estimated_minutes = getattr(unit, "estimated_minutes", None)
+            marker = generated_marker if unit_number in generated_unit_ids else pending_marker
+
+            prefix = f"Unité {unit_number}" if language == "fr" else f"Unit {unit_number}"
+            time_str = f" • {estimated_minutes} {time_unit}" if estimated_minutes else ""
+            unit_lines.append(f"- **{prefix}** — {unit_title} ({marker}){time_str}")
+            if isinstance(unit_desc, str) and unit_desc.strip():
+                unit_lines.append(f"  > {unit_desc.strip()}")
+            else:
+                unit_lines.append(f"  > {no_desc}")
+
+    # --- Module-level case studies ---------------------------------------
+    case_lines: list[str] = []
+    if case_titles:
+        for title in case_titles:
+            case_lines.append(f"- **{case_label}**: {title} ({generated_marker})")
     else:
         legacy_case = (
             getattr(module_obj, "case_study_fr", None)
@@ -479,21 +541,23 @@ async def _build_current_module_section(
             else getattr(module_obj, "case_study_en", None)
         )
         if isinstance(legacy_case, str) and legacy_case.strip():
-            body = _render_case_full(legacy_case, excerpt_chars, language)
-            lines.append(f"- {case_label} {generated_marker}")
-            if body:
-                for body_line in body.split("\n"):
-                    lines.append(f"  {body_line}")
+            preview = legacy_case.strip().split("\n")[0][:200]
+            case_lines.append(f"- **{case_label}** ({generated_marker})")
+            case_lines.append(f"  > {preview}")
 
-    if len(lines) <= 1:
-        # Header only — no units, no cases. Skip the section entirely so we
-        # don't waste tokens on a content-free heading.
+    if not units and not case_lines:
+        # Module has nothing to show — skip the whole section.
         return None
 
-    rendered = "\n".join(lines)
+    all_lines = (
+        header_lines + unit_lines + ([f"\n## {case_label}", *case_lines] if case_lines else [])
+    )
+    rendered = "\n".join(all_lines)
+
+    # Trim on a line boundary if we somehow exceed the cap (shouldn't happen
+    # with descriptions-only rendering — included for safety).
     if len(rendered) <= char_limit:
         return rendered
-    # Trim on a line boundary near the cap so we never slice mid-bullet.
     cutoff = rendered.rfind("\n", 0, char_limit)
     if cutoff < int(char_limit * 0.6):
         cutoff = char_limit
@@ -1062,15 +1126,41 @@ class TutorService:
                     )
                     module_number = module_obj.module_number
 
-            # Build the per-module unit/quiz/case-study detail (#1981). Returns
-            # None when no module is in scope, in which case the section is
-            # omitted from the prompt.
-            current_module_content = await _build_current_module_section(
-                module_obj, effective_language, session
-            )
-
             # Resolve course context: explicit > from module > from enrollment
             course = await self._resolve_course(course_id, module_id, module_obj, user_id, session)
+
+            # Defensive guard (#1992): if both course and module are resolved
+            # but the module belongs to a *different* course, drop the module
+            # rather than load incoherent units into the prompt. Symptom that
+            # prompted this: anchor showed *"Détectives du Vivant"* while user
+            # had Santé Publique selected — module units leaked into the
+            # Santé Publique chat and confused the tutor.
+            if (
+                course is not None
+                and module_obj is not None
+                and getattr(module_obj, "course_id", None) is not None
+                and module_obj.course_id != course.id
+            ):
+                logger.warning(
+                    "Dropping mismatched module from tutor context",
+                    active_course_id=str(course.id),
+                    module_course_id=str(module_obj.course_id),
+                    module_id=str(module_obj.id),
+                    user_id=str(user_id),
+                )
+                module_obj = None
+                module_title = None
+                module_number = None
+
+            # Build the per-module unit/quiz/case-study detail (#1981/#1992).
+            # Returns None when no module is in scope. Passes ``user_id`` so
+            # the section can include the learner's per-module progress.
+            current_module_content = await _build_current_module_section(
+                module_obj,
+                effective_language,
+                session,
+                user_id=uuid.UUID(str(user_id)) if user_id else None,
+            )
             course_title = None
             course_domain = None
             course_syllabus = None
@@ -1682,19 +1772,30 @@ class TutorService:
         return count
 
     async def get_last_touched_module(
-        self, user_id: str | uuid.UUID, session: AsyncSession
+        self,
+        user_id: str | uuid.UUID,
+        session: AsyncSession,
+        course_id: uuid.UUID | None = None,
     ) -> dict[str, Any] | None:
-        """Return the user's most recently accessed module (#1988).
+        """Return the user's most recently accessed module (#1988, #1992).
 
         Used by the standalone ``/tutor`` page to anchor the chat in a
         concrete module by default — without this the prompt's module block
         is empty and the tutor can't cite specific units (the user-reported
         symptom that prompted #1988).
 
+        When ``course_id`` is provided (the active course on the frontend),
+        the lookup is JOINed to ``Module`` and filtered to that course —
+        otherwise the most-recent-globally module bleeds in from a
+        different course and the prompt becomes incoherent (regression
+        symptom that prompted #1992: anchor showed *"Les Détectives du
+        Vivant"* while user had *"Santé Publique"* selected).
+
         Sources the recency from ``UserModuleProgress.last_accessed`` (the
         same field ``progress_service.touch_course_interaction_by_module``
         already updates on every learner action). Returns ``None`` when the
-        user has no recorded module activity yet.
+        user has no recorded module activity (or no activity in the
+        requested course).
         """
         from app.domain.models.course import Course
         from app.domain.models.progress import UserModuleProgress
@@ -1705,15 +1806,18 @@ class TutorService:
         user = await session.get(User, user_id)
         language = (user.preferred_language if user else "fr") or "fr"
 
-        result = await session.execute(
-            select(UserModuleProgress)
-            .where(
-                UserModuleProgress.user_id == user_id,
-                UserModuleProgress.last_accessed.is_not(None),
-            )
-            .order_by(UserModuleProgress.last_accessed.desc())
-            .limit(1)
+        stmt = select(UserModuleProgress).where(
+            UserModuleProgress.user_id == user_id,
+            UserModuleProgress.last_accessed.is_not(None),
         )
+        if course_id is not None:
+            # Filter to a specific course — most recent module IN that course.
+            stmt = stmt.join(Module, Module.id == UserModuleProgress.module_id).where(
+                Module.course_id == course_id
+            )
+        stmt = stmt.order_by(UserModuleProgress.last_accessed.desc()).limit(1)
+
+        result = await session.execute(stmt)
         progress = result.scalar_one_or_none()
         if progress is None:
             return None

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -441,11 +441,17 @@ async def _build_current_module_section(
     except Exception:
         units = []
 
-    # Per-unit generation flag — checked once per module via a single batched
-    # query against ``generated_content`` so we can mark units ✓ generated /
-    # 🔒 pending without per-row queries.
+    # Per-unit generation flag + full-content index — checked once per module
+    # via a single batched query against ``generated_content``. Pass 1 uses
+    # ``generated_unit_ids`` for the ✓ marker; pass 2 uses ``content_index``
+    # to inline the full body for the active module (cached in the system
+    # prompt so the tutor has it without latency — this is the on-prompt half
+    # of the architecture; the get_unit_content tool serves cross-module
+    # requests).
     generated_unit_ids: set[str] = set()
+    content_index: dict[tuple[str, str], dict] = {}
     case_titles: list[str] = []
+    case_contents: list[dict] = []
     try:
         result = await session.execute(
             select(GeneratedContent).where(
@@ -459,8 +465,10 @@ async def _build_current_module_section(
             if row.content_type == "case":
                 title = (content_obj.get("title") or case_label).strip()
                 case_titles.append(title)
+                case_contents.append(content_obj)
             elif unit_id:
                 generated_unit_ids.add(unit_id)
+                content_index[(row.content_type, unit_id)] = content_obj
     except Exception as exc:  # pragma: no cover — defensive
         logger.warning(
             "Failed to load GeneratedContent for module section",
@@ -549,13 +557,110 @@ async def _build_current_module_section(
         # Module has nothing to show — skip the whole section.
         return None
 
-    all_lines = (
+    # --- Pass 1 output: structured listing (titles + descriptions) ---------
+    # Always emitted in full — small (~200 chars/unit) so even a 20-unit
+    # module fits comfortably. The tutor sees ALL units regardless of how
+    # many bodies fit in pass 2 below.
+    listing_lines = (
         header_lines + unit_lines + ([f"\n## {case_label}", *case_lines] if case_lines else [])
     )
-    rendered = "\n".join(all_lines)
+    listing = "\n".join(listing_lines)
 
-    # Trim on a line boundary if we somehow exceed the cap (shouldn't happen
-    # with descriptions-only rendering — included for safety).
+    # --- Pass 2 output: full bodies for the active module --------------------
+    # Inline lesson + quiz + case bodies so the tutor has the actual content
+    # in the cached prompt — zero-latency content awareness for the active
+    # module. Cross-module body fetches use the get_unit_content tool. We
+    # add bodies in unit order until the char budget is reached, then emit a
+    # tool-call hint for any units whose body didn't fit.
+    if language == "fr":
+        bodies_header = "\n## Contenu détaillé"
+        lesson_label = "**Leçon**"
+        quiz_label = "**Quiz**"
+        case_body_label = "**Étude de cas**"
+        tool_hint_template = (
+            "→ Pour le contenu complet de l'unité {n}, appelle `get_unit_content('{n}', '{ct}')`."
+        )
+    else:
+        bodies_header = "\n## Detailed content"
+        lesson_label = "**Lesson**"
+        quiz_label = "**Quiz**"
+        case_body_label = "**Case study**"
+        tool_hint_template = (
+            "→ For the full content of unit {n}, call `get_unit_content('{n}', '{ct}')`."
+        )
+
+    # Per-item char budget for the body itself — keeps a single runaway
+    # lesson from monopolising the section.
+    per_item_chars = max(2000, _sc().get("tutor-module-content-excerpt-chars", 10000))
+    include_quiz_answers = bool(_sc().get("tutor-include-quiz-answers", True))
+
+    body_blocks: list[str] = []
+    skipped_for_budget: list[tuple[str, str]] = []  # (unit_number, content_type)
+
+    # Reserve at least the listing + a safety buffer; bodies fill the rest.
+    budget_used = len(listing)
+    safety = 200
+
+    for unit in units:
+        unit_number = getattr(unit, "unit_number", None) or ""
+        if not unit_number:
+            continue
+        unit_title_localised = (
+            getattr(unit, "title_fr", None) if language == "fr" else getattr(unit, "title_en", None)
+        ) or unit_number
+        unit_header = f"\n### {unit_number} — {unit_title_localised}"
+
+        for ct, ct_label in (("lesson", lesson_label), ("quiz", quiz_label)):
+            content_obj = content_index.get((ct, unit_number))
+            if not content_obj:
+                continue
+            if ct == "lesson":
+                rendered_body = _render_lesson_full(content_obj, per_item_chars, language)
+            else:
+                rendered_body = _render_quiz_full(
+                    content_obj, per_item_chars, language, include_quiz_answers
+                )
+            if not rendered_body:
+                continue
+            block = f"{unit_header}\n{ct_label}\n{rendered_body}"
+            if budget_used + len(block) + safety > char_limit:
+                skipped_for_budget.append((unit_number, ct))
+                continue
+            body_blocks.append(block)
+            budget_used += len(block)
+
+    # Module-level case study bodies (only when not skipped from the listing).
+    for case_obj in case_contents:
+        rendered_body = _render_case_full(case_obj, per_item_chars, language)
+        if not rendered_body:
+            continue
+        title = (case_obj.get("title") or case_label).strip()
+        block = f"\n### {title}\n{case_body_label}\n{rendered_body}"
+        if budget_used + len(block) + safety > char_limit:
+            skipped_for_budget.append(("case", "case"))
+            continue
+        body_blocks.append(block)
+        budget_used += len(block)
+
+    if skipped_for_budget:
+        # Tell the tutor explicitly which units it must use the tool for —
+        # otherwise it might silently improvise instead of fetching.
+        hint_lines = (
+            ["\n## Contenu non inclus (utilise le tool pour ces unités)"]
+            if language == "fr"
+            else ["\n## Content not inlined (use the tool for these units)"]
+        )
+        for unit_number, ct in skipped_for_budget:
+            if unit_number == "case":
+                continue
+            hint_lines.append("- " + tool_hint_template.format(n=unit_number, ct=ct))
+        body_blocks.append("\n".join(hint_lines))
+
+    rendered = listing + bodies_header + "\n" + "\n".join(body_blocks) if body_blocks else listing
+
+    # Final safety trim — should rarely trigger because pass 2 already
+    # respects the budget, but keeps the prompt bounded if a single
+    # cached lesson body somehow exceeds per_item_chars.
     if len(rendered) <= char_limit:
         return rendered
     cutoff = rendered.rfind("\n", 0, char_limit)

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -1256,6 +1256,10 @@ class TutorService:
                 user_level=user.current_level,
                 user_language=effective_language,
                 rag_collection_id=rag_collection_id,
+                # So get_unit_content (#1992) defaults to the conversation's
+                # current module — no need for Claude to pass module_id
+                # explicitly on every call.
+                current_module_id=getattr(module_obj, "id", None) if module_obj else None,
             )
 
             tool_call_count = 0

--- a/backend/app/domain/services/tutor_tools.py
+++ b/backend/app/domain/services/tutor_tools.py
@@ -162,6 +162,42 @@ TOOL_DEFINITIONS: list[ToolParam] = [
             "required": ["preference_type", "value"],
         },
     },
+    {
+        "name": "get_unit_content",
+        "description": (
+            "Fetch the FULL generated body of a specific unit's lesson, quiz, or case study from the "
+            "course's content cache (#1992). The system prompt contains only unit titles + descriptions "
+            "for context-window efficiency — call this tool to get the actual lesson body, quiz "
+            "questions+answers, or case-study text when the learner asks about a specific unit's "
+            "content. Returns the structured content as JSON, or {error, available_units} when the "
+            "unit isn't generated yet (so you can honestly tell the learner it's not yet available "
+            "and suggest a generated alternative). The unit_number comes from the 'CURRENT MODULE "
+            "DETAIL' section in your system prompt (e.g. '1.1', '1.2'). Defaults to the current "
+            "module when module_id is omitted — pass module_id only when discussing a different module."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "unit_number": {
+                    "type": "string",
+                    "description": "Unit number from the system prompt's module listing (e.g. '1.1', '0', '3').",
+                },
+                "content_type": {
+                    "type": "string",
+                    "enum": ["lesson", "quiz", "case"],
+                    "description": "Which generated artifact to fetch for this unit. Defaults to 'lesson'.",
+                },
+                "module_id": {
+                    "type": "string",
+                    "description": (
+                        "Optional UUID of the module — defaults to the conversation's current "
+                        "module. Pass only when explicitly discussing a different module."
+                    ),
+                },
+            },
+            "required": ["unit_number"],
+        },
+    },
 ]
 
 
@@ -177,6 +213,7 @@ class TutorToolExecutor:
         user_language: str,
         learner_memory_service: LearnerMemoryService | None = None,
         rag_collection_id: str | None = None,
+        current_module_id: uuid.UUID | None = None,
     ):
         self.retriever = retriever
         self.anthropic = anthropic_client
@@ -185,6 +222,10 @@ class TutorToolExecutor:
         self.user_language = user_language
         self.learner_memory_service = learner_memory_service or LearnerMemoryService()
         self.rag_collection_id = rag_collection_id
+        # Default scope for unit-content lookups when Claude doesn't pass an
+        # explicit module_id — set to the conversation's current module by
+        # the calling send_message (#1992).
+        self.current_module_id = current_module_id
 
     async def execute(
         self,
@@ -223,6 +264,8 @@ class TutorToolExecutor:
                 return await self._save_learner_preference(tool_input, session)
             elif tool_name == "search_source_images":
                 return await self._search_source_images(tool_input, session)
+            elif tool_name == "get_unit_content":
+                return await self._get_unit_content(tool_input, session)
             else:
                 logger.warning("Unknown tool called", tool_name=tool_name)
                 return json.dumps({"error": f"Unknown tool: {tool_name}"})
@@ -643,4 +686,111 @@ Respond ONLY with valid JSON in this exact format:
                 "value": value,
                 "updated": was_existing,
             }
+        )
+
+    async def _get_unit_content(self, tool_input: dict[str, Any], session: AsyncSession) -> str:
+        """Fetch a generated unit's full body from ``generated_content`` (#1992).
+
+        Companion to the structured listing in the system prompt: prompt
+        carries titles + descriptions only, this tool serves the actual body
+        on demand. Filters by (module_id, content_type, language, unit_id).
+
+        Returns:
+            JSON with ``content_type``, ``unit_number``, ``language``,
+            ``content`` (the full structured payload). When the unit hasn't
+            been generated yet, returns ``{"error": "not_generated", ...,
+            "available_units": [...]}`` so the tutor can honestly tell the
+            learner the content isn't ready and suggest a generated alternative
+            instead of hallucinating.
+        """
+        unit_number = str(tool_input.get("unit_number") or "").strip()
+        if not unit_number:
+            return json.dumps({"error": "unit_number is required"})
+
+        content_type = (tool_input.get("content_type") or "lesson").strip().lower()
+        if content_type not in {"lesson", "quiz", "case"}:
+            return json.dumps(
+                {"error": f"invalid content_type {content_type!r} — use lesson/quiz/case"}
+            )
+
+        # Resolve target module: explicit input wins, fall back to the
+        # conversation's current module set on the executor.
+        target_module_id_str = tool_input.get("module_id") or (
+            str(self.current_module_id) if self.current_module_id else None
+        )
+        if not target_module_id_str:
+            return json.dumps({"error": "no module in scope — pass module_id explicitly"})
+        try:
+            target_module_id = uuid.UUID(target_module_id_str)
+        except ValueError:
+            return json.dumps({"error": f"invalid module_id {target_module_id_str!r}"})
+
+        result = await session.execute(
+            select(GeneratedContent).where(
+                GeneratedContent.module_id == target_module_id,
+                GeneratedContent.language == self.user_language,
+                GeneratedContent.content_type == content_type,
+            )
+        )
+        rows = result.scalars().all()
+
+        # Match the row whose content.unit_id matches the requested unit_number.
+        # Case studies may have unit_id at the module level (no per-unit cases),
+        # so we accept any case row when content_type=='case' and the explicit
+        # unit_id doesn't match — the tutor explicitly asked for a case study.
+        matching: dict | None = None
+        for row in rows:
+            content_obj = row.content if isinstance(row.content, dict) else {}
+            row_unit = str(content_obj.get("unit_id") or "").strip()
+            if row_unit == unit_number:
+                matching = content_obj
+                break
+
+        if matching is not None:
+            logger.info(
+                "get_unit_content tool: hit",
+                module_id=str(target_module_id),
+                unit_number=unit_number,
+                content_type=content_type,
+                language=self.user_language,
+                user_id=str(self.user_id),
+            )
+            return json.dumps(
+                {
+                    "content_type": content_type,
+                    "unit_number": unit_number,
+                    "language": self.user_language,
+                    "content": matching,
+                },
+                ensure_ascii=False,
+            )
+
+        # Cache miss — surface what IS available for this module so the
+        # tutor can offer something concrete instead of a dead end.
+        available_units: list[str] = []
+        for row in rows:
+            content_obj = row.content if isinstance(row.content, dict) else {}
+            row_unit = str(content_obj.get("unit_id") or "").strip()
+            if row_unit and row_unit not in available_units:
+                available_units.append(row_unit)
+
+        logger.info(
+            "get_unit_content tool: miss",
+            module_id=str(target_module_id),
+            unit_number=unit_number,
+            content_type=content_type,
+            language=self.user_language,
+            available_units=available_units,
+            user_id=str(self.user_id),
+        )
+        return json.dumps(
+            {
+                "error": "not_generated",
+                "module_id": str(target_module_id),
+                "unit_number": unit_number,
+                "content_type": content_type,
+                "language": self.user_language,
+                "available_units": available_units,
+            },
+            ensure_ascii=False,
         )

--- a/backend/app/domain/services/tutor_tools.py
+++ b/backend/app/domain/services/tutor_tools.py
@@ -166,14 +166,15 @@ TOOL_DEFINITIONS: list[ToolParam] = [
         "name": "get_unit_content",
         "description": (
             "Fetch the FULL generated body of a specific unit's lesson, quiz, or case study from the "
-            "course's content cache (#1992). The system prompt contains only unit titles + descriptions "
-            "for context-window efficiency — call this tool to get the actual lesson body, quiz "
-            "questions+answers, or case-study text when the learner asks about a specific unit's "
-            "content. Returns the structured content as JSON, or {error, available_units} when the "
-            "unit isn't generated yet (so you can honestly tell the learner it's not yet available "
-            "and suggest a generated alternative). The unit_number comes from the 'CURRENT MODULE "
-            "DETAIL' section in your system prompt (e.g. '1.1', '1.2'). Defaults to the current "
-            "module when module_id is omitted — pass module_id only when discussing a different module."
+            "course's content cache (#1992). PRIMARY USE: cross-module references. The active "
+            "module's bodies are already inlined in your system prompt under 'CURRENT MODULE "
+            "DETAIL' / 'Detailed content' — you do NOT need to call this tool for them. Call this "
+            "tool when: (1) the learner asks about a unit in a DIFFERENT module than the active "
+            "one, OR (2) the prompt's 'Content not inlined' hint section says a specific active-"
+            "module unit was skipped for budget reasons. Returns the structured content as JSON, "
+            "or {error, available_units} when the unit isn't generated yet (so you can honestly "
+            "tell the learner it's not yet available). Defaults to the current module when "
+            "module_id is omitted."
         ),
         "input_schema": {
             "type": "object",

--- a/backend/app/infrastructure/config/platform_defaults.py
+++ b/backend/app/infrastructure/config/platform_defaults.py
@@ -458,11 +458,11 @@ SETTING_DEFINITIONS: list[SettingDef] = [
     SettingDef(
         "tutor-module-content-char-limit",
         "tutor",
-        30000,
+        60000,
         "integer",
         "Module-detail char limit",
-        "Hard cap on the current-module unit/quiz/case-study section in the system prompt.",
-        {"min": 2000, "max": 60000},
+        "Hard cap on the active module section (listing + inlined bodies).",
+        {"min": 2000, "max": 120000},
     ),
     SettingDef(
         "tutor-module-content-excerpt-chars",

--- a/backend/tests/test_tutor_anchoring_and_input_cap.py
+++ b/backend/tests/test_tutor_anchoring_and_input_cap.py
@@ -220,3 +220,147 @@ async def test_get_last_touched_module_handles_missing_course(tutor_service):
     assert result is not None
     assert result["course_id"] is None
     assert result["course_title"] is None
+
+
+# --- #1992 — course-scoped lookup + structured renderer ---------------------
+
+
+@pytest.mark.asyncio
+async def test_get_last_touched_module_filters_by_course_when_provided(tutor_service):
+    """When ``course_id`` is supplied, the SELECT should JOIN Module and filter."""
+    user = _user(language="fr")
+    session = MagicMock()
+    captured: list = []
+
+    async def _execute(stmt):
+        captured.append(stmt)
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=None)
+        return result
+
+    session.execute = AsyncMock(side_effect=_execute)
+    session.get = AsyncMock(return_value=user)
+
+    target_course_id = uuid.uuid4()
+    await tutor_service.get_last_touched_module(user.id, session, course_id=target_course_id)
+    assert captured, "execute() should have been called with the scoped query"
+    sql = str(captured[0])
+    # The scoped query must reference Module.course_id; the no-scope
+    # variant won't contain it. Crude but effective check.
+    assert "module" in sql.lower() and "course_id" in sql.lower()
+
+
+@pytest.mark.asyncio
+async def test_get_last_touched_module_no_scope_does_not_filter_by_course(tutor_service):
+    """Without ``course_id`` the original behaviour (most-recent-globally) holds."""
+    user = _user(language="fr")
+    session = MagicMock()
+    captured: list = []
+
+    async def _execute(stmt):
+        captured.append(stmt)
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=None)
+        return result
+
+    session.execute = AsyncMock(side_effect=_execute)
+    session.get = AsyncMock(return_value=user)
+
+    await tutor_service.get_last_touched_module(user.id, session)  # no course_id
+    sql = str(captured[0]).lower()
+    # The unscoped query selects from user_module_progress without joining Module.
+    # We assert by absence of the JOIN keyword between the two tables.
+    assert "user_module_progress" in sql
+    # The scoped variant adds an explicit ``JOIN modules`` clause; absence
+    # confirms we're on the unscoped path.
+    assert " join modules" not in sql
+
+
+@pytest.mark.asyncio
+async def test_module_section_lists_all_units_regardless_of_count(tutor_service):
+    """#1992 spec: a 9-unit module must show all 9 units; no truncation
+    after the first 2-3 (the bug the user reported on staging)."""
+    from app.domain.services.tutor_service import _build_current_module_section
+
+    units = []
+    for i in range(9):
+        units.append(
+            SimpleNamespace(
+                unit_number=str(i),
+                title_fr=f"Unité {i} titre",
+                title_en=f"Unit {i} title",
+                description_fr=f"Description de l'unité {i}.",
+                description_en=f"Unit {i} description.",
+                estimated_minutes=15,
+                order_index=i,
+            )
+        )
+    module = SimpleNamespace(
+        id=uuid.uuid4(),
+        title_fr="Fondements de la santé publique",
+        title_en="Foundations",
+        module_number=1,
+        description_fr="Module description",
+        description_en="Module description",
+        estimated_hours=8,
+        case_study_fr=None,
+        case_study_en=None,
+        units=units,
+    )
+
+    exec_result = MagicMock()
+    exec_result.all = MagicMock(return_value=[])
+    exec_result.scalar_one_or_none = MagicMock(return_value=None)
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=exec_result)
+
+    section = await _build_current_module_section(module, "fr", session)
+    assert section is not None
+    # Every unit number must be present in the rendered section.
+    for i in range(9):
+        assert f"Unité {i}" in section, f"Unit {i} missing from rendered section"
+    # Module-level metadata must be present per the user's spec.
+    assert "8 h" in section
+    assert "Fondements" in section
+
+
+@pytest.mark.asyncio
+async def test_module_section_includes_unit_descriptions_and_reading_time(tutor_service):
+    """Each unit shows: number + title + reading time + description bullet."""
+    from app.domain.services.tutor_service import _build_current_module_section
+
+    units = [
+        SimpleNamespace(
+            unit_number="3",
+            title_fr="Mesures de morbidité",
+            title_en="Morbidity measures",
+            description_fr="Explication des proportions, ratios, taux.",
+            description_en="Proportions, ratios, rates.",
+            estimated_minutes=15,
+            order_index=3,
+        )
+    ]
+    module = SimpleNamespace(
+        id=uuid.uuid4(),
+        title_fr="M",
+        title_en="M",
+        module_number=1,
+        description_fr=None,
+        description_en=None,
+        estimated_hours=None,
+        case_study_fr=None,
+        case_study_en=None,
+        units=units,
+    )
+    exec_result = MagicMock()
+    exec_result.all = MagicMock(return_value=[])
+    exec_result.scalar_one_or_none = MagicMock(return_value=None)
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=exec_result)
+
+    section = await _build_current_module_section(module, "fr", session)
+    assert section is not None
+    assert "Unité 3" in section
+    assert "Mesures de morbidité" in section
+    assert "15 min de lecture" in section
+    assert "Explication des proportions, ratios, taux." in section

--- a/backend/tests/test_tutor_caching.py
+++ b/backend/tests/test_tutor_caching.py
@@ -243,7 +243,9 @@ def test_render_case_full_handles_structured_and_legacy_text():
 
 
 @pytest.mark.asyncio
-async def test_module_block_renders_full_lesson_body_when_generated():
+async def test_module_block_marks_unit_generated_when_lesson_exists():
+    """Per #1992 spec: generated units show ✓ marker but body is NOT
+    inlined — descriptions only, full body via search_knowledge_base."""
     units = [_unit("1.1", "Définitions", "Definitions", order_index=1)]
     module = _module(units=units)
     rows = [
@@ -255,25 +257,21 @@ async def test_module_block_renders_full_lesson_body_when_generated():
                 "introduction": "Introduction longue avec plusieurs phrases.",
                 "concepts": ["concept1", "concept2"],
                 "aof_example": "Exemple ouest-africain détaillé",
-                "synthesis": "Synthèse complète",
-                "key_points": ["point1", "point2", "point3"],
-                "sources_cited": ["Donaldson Ch.4"],
             },
         )
     ]
     section = await _build_current_module_section(module, "fr", _mock_session([rows]))
     assert section is not None
-    # Full lesson content (not just a 200-char excerpt) is now in the section.
-    assert "Introduction longue avec plusieurs phrases." in section
-    assert "concept1" in section and "concept2" in section
-    assert "Exemple ouest-africain détaillé" in section
-    assert "Synthèse complète" in section
-    assert "point1" in section and "point2" in section
-    assert "Donaldson Ch.4" in section
+    assert "Unité 1.1" in section and "Définitions" in section
+    assert "✓ généré" in section
+    # Body content NOT inlined per the new spec.
+    assert "Introduction longue avec plusieurs phrases." not in section
+    assert "concept1" not in section
 
 
 @pytest.mark.asyncio
-async def test_module_block_includes_quiz_answers_by_default():
+async def test_module_block_marks_quiz_generated_without_inlining_questions():
+    """Quiz body is also no longer inlined — just the marker."""
     units = [_unit("1.1", "Définitions", "Definitions", order_index=1)]
     module = _module(units=units)
     rows = [
@@ -295,10 +293,11 @@ async def test_module_block_includes_quiz_answers_by_default():
     ]
     section = await _build_current_module_section(module, "fr", _mock_session([rows]))
     assert section is not None
-    assert "Quelle est la définition de X" in section
-    assert "Op C" in section
-    assert "Réponse correcte" in section
-    assert "Parce que C est correcte" in section
+    assert "Unité 1.1" in section
+    assert "✓ généré" in section
+    # Question body must NOT be inlined per #1992.
+    assert "Quelle est la définition de X" not in section
+    assert "Parce que C est correcte" not in section
 
 
 # --- course block ----------------------------------------------------------

--- a/backend/tests/test_tutor_caching.py
+++ b/backend/tests/test_tutor_caching.py
@@ -243,9 +243,11 @@ def test_render_case_full_handles_structured_and_legacy_text():
 
 
 @pytest.mark.asyncio
-async def test_module_block_marks_unit_generated_when_lesson_exists():
-    """Per #1992 spec: generated units show ✓ marker but body is NOT
-    inlined — descriptions only, full body via search_knowledge_base."""
+async def test_module_block_marks_unit_generated_and_inlines_lesson_body():
+    """Active-module two-pass renderer (#1992 cont'd): the unit shows up in
+    BOTH the structured listing (with ✓ marker + description) AND the
+    'Detailed content' section (full body inlined). Cached in the system
+    prompt — no tool call needed for the active module."""
     units = [_unit("1.1", "Définitions", "Definitions", order_index=1)]
     module = _module(units=units)
     rows = [
@@ -264,14 +266,16 @@ async def test_module_block_marks_unit_generated_when_lesson_exists():
     assert section is not None
     assert "Unité 1.1" in section and "Définitions" in section
     assert "✓ généré" in section
-    # Body content NOT inlined per the new spec.
-    assert "Introduction longue avec plusieurs phrases." not in section
-    assert "concept1" not in section
+    # Body IS inlined for the active module.
+    assert "Introduction longue avec plusieurs phrases." in section
+    assert "concept1" in section
+    assert "Contenu détaillé" in section
 
 
 @pytest.mark.asyncio
-async def test_module_block_marks_quiz_generated_without_inlining_questions():
-    """Quiz body is also no longer inlined — just the marker."""
+async def test_module_block_inlines_quiz_questions_and_answers_for_active_module():
+    """Quiz body is inlined for the active module so the tutor can reference
+    questions and correct answers directly without a tool call."""
     units = [_unit("1.1", "Définitions", "Definitions", order_index=1)]
     module = _module(units=units)
     rows = [
@@ -295,9 +299,9 @@ async def test_module_block_marks_quiz_generated_without_inlining_questions():
     assert section is not None
     assert "Unité 1.1" in section
     assert "✓ généré" in section
-    # Question body must NOT be inlined per #1992.
-    assert "Quelle est la définition de X" not in section
-    assert "Parce que C est correcte" not in section
+    # Quiz body IS inlined for the active module.
+    assert "Quelle est la définition de X" in section
+    assert "Parce que C est correcte" in section
 
 
 # --- course block ----------------------------------------------------------

--- a/backend/tests/test_tutor_get_unit_content_tool.py
+++ b/backend/tests/test_tutor_get_unit_content_tool.py
@@ -1,0 +1,247 @@
+"""Tests for the get_unit_content tool (#1992).
+
+The tool serves the FULL generated body of a lesson/quiz/case study on
+demand — companion to the structured listing in the system prompt
+(titles + descriptions only). Lets the tutor stay focused on the course
+without inlining all bodies into every prompt.
+"""
+
+import json
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.domain.services.tutor_tools import TutorToolExecutor
+
+
+def _row(content_type: str, language: str, content: dict) -> SimpleNamespace:
+    return SimpleNamespace(content_type=content_type, language=language, content=content)
+
+
+def _executor(
+    *,
+    user_language: str = "fr",
+    current_module_id: uuid.UUID | None = None,
+) -> TutorToolExecutor:
+    return TutorToolExecutor(
+        retriever=MagicMock(),
+        anthropic_client=MagicMock(),
+        user_id=uuid.uuid4(),
+        user_level=2,
+        user_language=user_language,
+        current_module_id=current_module_id,
+    )
+
+
+def _session_with_rows(rows: list) -> MagicMock:
+    scalars = MagicMock()
+    scalars.all = MagicMock(return_value=rows)
+    result = MagicMock()
+    result.scalars = MagicMock(return_value=scalars)
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=result)
+    return session
+
+
+# --- happy path ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_returns_full_lesson_body_when_unit_is_generated():
+    module_id = uuid.uuid4()
+    lesson_body = {
+        "unit_id": "1.1",
+        "introduction": "Intro paragraph",
+        "concepts": ["c1", "c2"],
+        "aof_example": "AOF example",
+    }
+    session = _session_with_rows([_row("lesson", "fr", lesson_body)])
+    executor = _executor(current_module_id=module_id)
+
+    result_str = await executor.execute("get_unit_content", {"unit_number": "1.1"}, session)
+    result = json.loads(result_str)
+    assert result["content_type"] == "lesson"
+    assert result["unit_number"] == "1.1"
+    assert result["content"]["introduction"] == "Intro paragraph"
+    assert result["content"]["concepts"] == ["c1", "c2"]
+
+
+@pytest.mark.asyncio
+async def test_returns_quiz_body_when_content_type_is_quiz():
+    module_id = uuid.uuid4()
+    quiz_body = {
+        "unit_id": "1.2",
+        "questions": [{"question": "Q?", "options": ["A", "B"], "correct_answer": 0}],
+    }
+    session = _session_with_rows([_row("quiz", "fr", quiz_body)])
+    executor = _executor(current_module_id=module_id)
+
+    result = json.loads(
+        await executor.execute(
+            "get_unit_content", {"unit_number": "1.2", "content_type": "quiz"}, session
+        )
+    )
+    assert result["content_type"] == "quiz"
+    assert result["content"]["questions"][0]["question"] == "Q?"
+
+
+@pytest.mark.asyncio
+async def test_default_content_type_is_lesson():
+    module_id = uuid.uuid4()
+    session = _session_with_rows([_row("lesson", "fr", {"unit_id": "1.1", "introduction": "Hi"})])
+    executor = _executor(current_module_id=module_id)
+    result = json.loads(await executor.execute("get_unit_content", {"unit_number": "1.1"}, session))
+    assert result["content_type"] == "lesson"
+
+
+# --- missing-content path ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_returns_not_generated_when_unit_is_missing():
+    """When the requested unit hasn't been generated, return error +
+    available_units so the tutor can suggest a real alternative instead
+    of inventing content."""
+    module_id = uuid.uuid4()
+    session = _session_with_rows(
+        [
+            _row("lesson", "fr", {"unit_id": "1.1", "introduction": "..."}),
+            _row("lesson", "fr", {"unit_id": "1.2", "introduction": "..."}),
+        ]
+    )
+    executor = _executor(current_module_id=module_id)
+    result = json.loads(await executor.execute("get_unit_content", {"unit_number": "1.5"}, session))
+    assert result["error"] == "not_generated"
+    assert set(result["available_units"]) == {"1.1", "1.2"}
+    assert result["unit_number"] == "1.5"
+
+
+@pytest.mark.asyncio
+async def test_returns_not_generated_when_module_has_no_content_at_all():
+    module_id = uuid.uuid4()
+    session = _session_with_rows([])  # no GeneratedContent rows
+    executor = _executor(current_module_id=module_id)
+    result = json.loads(await executor.execute("get_unit_content", {"unit_number": "1.1"}, session))
+    assert result["error"] == "not_generated"
+    assert result["available_units"] == []
+
+
+# --- module-id resolution ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_uses_current_module_id_when_input_omits_module_id():
+    """The executor's ``current_module_id`` (set by send_message from the
+    conversation context) is the default — Claude doesn't need to pass it."""
+    module_id = uuid.uuid4()
+    session = _session_with_rows([_row("lesson", "fr", {"unit_id": "0", "introduction": "Hi"})])
+    executor = _executor(current_module_id=module_id)
+
+    await executor.execute("get_unit_content", {"unit_number": "0"}, session)
+
+    # The executed select must filter by the current_module_id we set.
+    stmt = session.execute.await_args[0][0]
+    sql = str(stmt).lower()
+    assert "module_id" in sql
+
+
+@pytest.mark.asyncio
+async def test_explicit_module_id_overrides_current_module_id():
+    """When Claude passes module_id explicitly (e.g. discussing a different
+    module), that wins over the executor's default."""
+    other_module_id = uuid.uuid4()
+    session = _session_with_rows([_row("lesson", "fr", {"unit_id": "1.1", "introduction": "Hi"})])
+    executor = _executor(current_module_id=uuid.uuid4())
+
+    result = json.loads(
+        await executor.execute(
+            "get_unit_content",
+            {"unit_number": "1.1", "module_id": str(other_module_id)},
+            session,
+        )
+    )
+    assert result["content_type"] == "lesson"
+    # Sanity: the executed query is still well-formed (we accepted the override).
+    stmt = session.execute.await_args[0][0]
+    assert "module_id" in str(stmt).lower()
+
+
+@pytest.mark.asyncio
+async def test_returns_error_when_no_module_id_at_all():
+    """No current module + no explicit input → tutor gets a clear error
+    rather than a 500 or silent empty result."""
+    executor = _executor(current_module_id=None)
+    session = _session_with_rows([])
+    result = json.loads(await executor.execute("get_unit_content", {"unit_number": "1.1"}, session))
+    assert "error" in result
+    assert "module" in result["error"].lower()
+
+
+# --- input validation -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_unit_number_returns_error():
+    executor = _executor(current_module_id=uuid.uuid4())
+    result = json.loads(await executor.execute("get_unit_content", {}, _session_with_rows([])))
+    assert "error" in result
+    assert "unit_number" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_invalid_content_type_returns_error():
+    executor = _executor(current_module_id=uuid.uuid4())
+    result = json.loads(
+        await executor.execute(
+            "get_unit_content",
+            {"unit_number": "1.1", "content_type": "flashcard"},
+            _session_with_rows([]),
+        )
+    )
+    assert "error" in result
+    assert "content_type" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_invalid_module_id_returns_error_not_500():
+    executor = _executor(current_module_id=None)
+    result = json.loads(
+        await executor.execute(
+            "get_unit_content",
+            {"unit_number": "1.1", "module_id": "not-a-uuid"},
+            _session_with_rows([]),
+        )
+    )
+    assert "error" in result
+    assert "module_id" in result["error"]
+
+
+# --- language scoping -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_filters_by_user_language():
+    """FR users get FR rows; EN users get EN rows. The query must include
+    the language filter so we don't bleed cross-locale content."""
+    executor = _executor(user_language="en", current_module_id=uuid.uuid4())
+    session = _session_with_rows([])
+    await executor.execute("get_unit_content", {"unit_number": "1.1"}, session)
+    stmt = session.execute.await_args[0][0]
+    assert "language" in str(stmt).lower()
+
+
+# --- tool registration -----------------------------------------------------
+
+
+def test_tool_is_registered_in_TOOL_DEFINITIONS():
+    from app.domain.services.tutor_tools import TOOL_DEFINITIONS
+
+    names = {t["name"] for t in TOOL_DEFINITIONS}
+    assert "get_unit_content" in names
+    tool = next(t for t in TOOL_DEFINITIONS if t["name"] == "get_unit_content")
+    assert "unit_number" in tool["input_schema"]["properties"]
+    assert "content_type" in tool["input_schema"]["properties"]
+    assert "module_id" in tool["input_schema"]["properties"]
+    assert tool["input_schema"]["required"] == ["unit_number"]

--- a/backend/tests/test_tutor_module_content.py
+++ b/backend/tests/test_tutor_module_content.py
@@ -69,8 +69,12 @@ def _row(content_type: str, language: str, content: dict) -> SimpleNamespace:
 
 def test_no_current_module_content_means_no_section_in_prompt():
     prompt = get_socratic_system_prompt(_ctx(current_module_content=None), [])
-    assert "DÉTAIL DU MODULE ACTUEL" not in prompt
-    assert "CURRENT MODULE DETAIL" not in prompt
+    # Check for the actual section header at the start of a line — the
+    # substring may appear in the get_unit_content tool description (#1992)
+    # which references "## DÉTAIL DU MODULE ACTUEL" as the source of unit
+    # numbers. The section is omitted when no module content is in scope.
+    assert "\n## DÉTAIL DU MODULE ACTUEL\n" not in prompt
+    assert "\n## CURRENT MODULE DETAIL\n" not in prompt
 
 
 def test_section_renders_with_french_header_when_locale_fr():

--- a/backend/tests/test_tutor_module_content.py
+++ b/backend/tests/test_tutor_module_content.py
@@ -160,9 +160,11 @@ async def test_renders_unit_titles_with_pending_status_when_no_generated_content
 
 
 @pytest.mark.asyncio
-async def test_renders_generated_marker_when_content_exists():
-    """Per #1992: generated units show ✓ marker but do NOT inline the body
-    (tutor calls search_knowledge_base for full content)."""
+async def test_renders_generated_marker_and_inlines_body_for_active_module():
+    """For the ACTIVE module, generated units appear in BOTH the structured
+    listing (title+desc with ✓ marker) AND the 'Detailed content' section
+    (full body inlined). The body lives in the cached prompt — no tool call
+    needed for the active module."""
     units = [_unit("1.1", "Définitions", "Definitions", order_index=1)]
     module = _module(units=units)
     rows = [
@@ -176,8 +178,9 @@ async def test_renders_generated_marker_when_content_exists():
     assert section is not None
     assert "Unité 1.1" in section
     assert "✓ généré" in section
-    # Body content must NOT be inlined per #1992 spec — descriptions only.
-    assert "Ce chapitre introduit les notions clés." not in section
+    # Body now IS inlined (active-module two-pass renderer, #1992 cont'd).
+    assert "Ce chapitre introduit les notions clés." in section
+    assert "Contenu détaillé" in section
 
 
 @pytest.mark.asyncio
@@ -218,10 +221,10 @@ async def test_generated_case_row_preferred_over_legacy_text_column():
     section = await _build_current_module_section(module, "fr", _mock_session(rows))
     assert section is not None
     assert "Riposte Ebola" in section
-    # Per #1992 spec: case body content is no longer inlined when a generated
-    # case row exists — the title+marker is enough; full body via tool_use.
+    # Generated case body IS inlined for the active module (cached) so the
+    # tutor has it without a tool call. The legacy text column is preempted.
     assert "OLD legacy" not in section
-    assert "Coordination régionale" not in section
+    assert "Coordination régionale" in section
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_tutor_module_content.py
+++ b/backend/tests/test_tutor_module_content.py
@@ -140,6 +140,8 @@ async def test_module_with_no_units_returns_none():
 
 @pytest.mark.asyncio
 async def test_renders_unit_titles_with_pending_status_when_no_generated_content():
+    """Per #1992 spec: every unit's number + title visible regardless of size,
+    pending units flagged as such, no full-body content."""
     units = [
         _unit("1.1", "Définitions", "Definitions", order_index=1),
         _unit("1.2", "Histoire", "History", order_index=2),
@@ -147,14 +149,16 @@ async def test_renders_unit_titles_with_pending_status_when_no_generated_content
     module = _module(units=units)
     section = await _build_current_module_section(module, "fr", _mock_session([]))
     assert section is not None
-    assert "1.1 — Définitions" in section
-    assert "1.2 — Histoire" in section
-    assert "🔒 (à venir)" in section
-    assert "✓ (généré)" not in section
+    assert "Unité 1.1" in section and "Définitions" in section
+    assert "Unité 1.2" in section and "Histoire" in section
+    assert "🔒 à venir" in section
+    assert "✓ généré" not in section
 
 
 @pytest.mark.asyncio
-async def test_renders_excerpt_for_generated_lesson():
+async def test_renders_generated_marker_when_content_exists():
+    """Per #1992: generated units show ✓ marker but do NOT inline the body
+    (tutor calls search_knowledge_base for full content)."""
     units = [_unit("1.1", "Définitions", "Definitions", order_index=1)]
     module = _module(units=units)
     rows = [
@@ -166,8 +170,10 @@ async def test_renders_excerpt_for_generated_lesson():
     ]
     section = await _build_current_module_section(module, "fr", _mock_session(rows))
     assert section is not None
-    assert "✓ (généré)" in section
-    assert "Ce chapitre introduit les notions clés." in section
+    assert "Unité 1.1" in section
+    assert "✓ généré" in section
+    # Body content must NOT be inlined per #1992 spec — descriptions only.
+    assert "Ce chapitre introduit les notions clés." not in section
 
 
 @pytest.mark.asyncio
@@ -180,8 +186,11 @@ async def test_picks_french_or_english_per_locale():
     assert "Definitions" in en_section
     assert "Définitions" not in en_section
     assert "Definitions" not in fr_section
-    assert "🔒 (à venir)" in fr_section
-    assert "🔒 (not yet generated)" in en_section
+    assert "🔒 à venir" in fr_section
+    assert "🔒 pending" in en_section
+    # Localised units header.
+    assert "Unités" in fr_section
+    assert "Units" in en_section
 
 
 @pytest.mark.asyncio
@@ -205,7 +214,10 @@ async def test_generated_case_row_preferred_over_legacy_text_column():
     section = await _build_current_module_section(module, "fr", _mock_session(rows))
     assert section is not None
     assert "Riposte Ebola" in section
+    # Per #1992 spec: case body content is no longer inlined when a generated
+    # case row exists — the title+marker is enough; full body via tool_use.
     assert "OLD legacy" not in section
+    assert "Coordination régionale" not in section
 
 
 @pytest.mark.asyncio
@@ -252,4 +264,4 @@ async def test_db_failure_does_not_explode_returns_titles_only():
     # Falls through to titles-only; no crash.
     assert section is not None
     assert "Définitions" in section
-    assert "🔒 (à venir)" in section
+    assert "🔒 à venir" in section

--- a/backend/tests/test_tutor_source_image.py
+++ b/backend/tests/test_tutor_source_image.py
@@ -79,8 +79,9 @@ def test_search_source_images_tool_has_required_fields():
     assert set(enum_vals) == {"diagram", "photo", "chart", "any"}
 
 
-def test_tool_count_increased_to_six():
-    assert len(TOOL_DEFINITIONS) == 6
+def test_tool_count_includes_get_unit_content():
+    # 7 since #1992 added get_unit_content (full body fetch on demand).
+    assert len(TOOL_DEFINITIONS) == 7
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_tutor_tools.py
+++ b/backend/tests/test_tutor_tools.py
@@ -143,7 +143,10 @@ def tutor_service(mock_retriever, mock_anthropic, mock_learner_memory_service):
 
 
 def test_tool_definitions_count():
-    assert len(TOOL_DEFINITIONS) == 6
+    # Bumped to 7 with the addition of get_unit_content (#1992) — serves
+    # full lesson/quiz/case bodies on demand so the system prompt can stay
+    # at the structured listing level (titles + descriptions only).
+    assert len(TOOL_DEFINITIONS) == 7
 
 
 def test_tool_names():
@@ -155,6 +158,7 @@ def test_tool_names():
         "generate_mini_quiz",
         "search_flashcards",
         "save_learner_preference",
+        "get_unit_content",
     }
 
 

--- a/frontend/app/[locale]/(app)/tutor/tutor-client.tsx
+++ b/frontend/app/[locale]/(app)/tutor/tutor-client.tsx
@@ -27,7 +27,6 @@ import {
   deleteAllConversations,
   clearDraft,
   type ConversationSummary,
-  type LastTouchedModule,
 } from '@/lib/tutor-api';
 
 export function TutorPageClient() {
@@ -40,11 +39,11 @@ export function TutorPageClient() {
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   const [showClearAllDialog, setShowClearAllDialog] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
-  // Anchor the standalone /tutor chat to the user's last-touched module so the
-  // tutor's prompt has a concrete module context (#1988). The user can dismiss
-  // the anchor via the badge × to fall back to a course-wide chat.
-  const [anchorModule, setAnchorModule] = useState<LastTouchedModule | null>(null);
-  const [anchorDismissed, setAnchorDismissed] = useState(false);
+  // Anchor the standalone /tutor chat to the user's last-touched module
+  // SCOPED TO THE ACTIVE COURSE (#1992) so the tutor's prompt has a concrete
+  // module context. No user-visible UI — purely implicit. The active course
+  // is read from the same localStorage key that ChatPanel uses.
+  const [anchorModuleId, setAnchorModuleId] = useState<string | undefined>(undefined);
 
   const showToast = (msg: string) => {
     setToast(msg);
@@ -76,23 +75,23 @@ export function TutorPageClient() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Default-anchor to the user's last-touched module on mount (#1988) so the
-  // tutor sees a real module context. Failure is silent — chat still works,
-  // just without the anchor.
+  // Default-anchor to the user's last-touched module on mount (#1988),
+  // SCOPED to the active course (#1992) so we never bleed a module from
+  // a different course into the prompt. No visible UI — purely implicit.
+  // Failure is silent (chat still works, just without a module context).
   useEffect(() => {
     let cancelled = false;
-    fetchLastTouchedModule()
+    const activeCourseId =
+      typeof window !== 'undefined' ? localStorage.getItem('activeCourseId') : null;
+    fetchLastTouchedModule(activeCourseId)
       .then((mod) => {
-        if (!cancelled) setAnchorModule(mod);
+        if (!cancelled) setAnchorModuleId(mod?.module_id);
       })
       .catch(() => {});
     return () => {
       cancelled = true;
     };
   }, []);
-
-  const effectiveModuleId =
-    anchorDismissed || !anchorModule ? undefined : anchorModule.module_id;
 
   const formatRelativeTime = (dateStr: string) => {
     const date = new Date(dateStr);
@@ -327,40 +326,17 @@ export function TutorPageClient() {
 
         {/* Main Chat Area */}
         <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
-          {/* Course/Module anchor badge (#1988) — surfaces the implicit
-              moduleId so the user knows which module the tutor is grounded
-              in, and can drop it for a course-wide chat. */}
-          {anchorModule && !anchorDismissed && (
-            <div
-              className="mx-3 mt-2 mb-1 flex items-center justify-between gap-2 rounded-md border border-primary/20 bg-primary/5 px-3 py-2 text-xs"
-              role="status"
-              aria-live="polite"
-            >
-              <span className="truncate text-muted-foreground">
-                {t('anchoredToModule', {
-                  module:
-                    anchorModule.module_number != null
-                      ? `${anchorModule.module_number}. ${anchorModule.module_title}`
-                      : anchorModule.module_title,
-                })}
-              </span>
-              <button
-                type="button"
-                onClick={() => setAnchorDismissed(true)}
-                className="shrink-0 rounded p-1 text-muted-foreground hover:bg-primary/10 hover:text-foreground"
-                aria-label={t('dismissAnchor')}
-              >
-                <X className="h-3 w-3" />
-              </button>
-            </div>
-          )}
+          {/* Anchor module is implicit (#1992 — UI badge dropped per user
+              feedback). The active course already shown in the chat header
+              is sufficient context; the moduleId we pass below comes from
+              the user's last-touched module within that course. */}
           {selectedConversation !== undefined ? (
             <ChatPanel
               isOpen={true}
               onClose={() => {}}
               embedded={true}
               conversationId={selectedConversation}
-              moduleId={effectiveModuleId}
+              moduleId={anchorModuleId}
               onConversationCreated={handleConversationCreated}
               onMessageSent={handleMessageSent}
               onOpenConversations={() => setIsMobileDrawerOpen(true)}

--- a/frontend/lib/tutor-api.ts
+++ b/frontend/lib/tutor-api.ts
@@ -300,11 +300,24 @@ export interface LastTouchedModule {
 /**
  * Fetch the user's most recently accessed module so the standalone /tutor
  * page can default-anchor the chat in that module's context (#1988).
- * Returns null when the user has no recorded module activity.
+ *
+ * When ``courseId`` is provided (the user's active course on the frontend),
+ * scopes the lookup to that course — required to prevent the cross-course
+ * leak fixed in #1992 (badge would show a module from a different course
+ * than the one the user has selected).
+ *
+ * Returns null when the user has no recorded module activity in the
+ * requested scope.
  */
-export async function fetchLastTouchedModule(): Promise<LastTouchedModule | null> {
+export async function fetchLastTouchedModule(
+  courseId?: string | null
+): Promise<LastTouchedModule | null> {
   const token = await authClient.getValidToken();
-  const response = await fetch(`${API_BASE}/api/v1/tutor/last-module`, {
+  const url = new URL(`${API_BASE}/api/v1/tutor/last-module`);
+  if (courseId) {
+    url.searchParams.set('course_id', courseId);
+  }
+  const response = await fetch(url.toString(), {
     headers: { Authorization: `Bearer ${token}` },
   });
   if (!response.ok) {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -396,8 +396,6 @@
     "conversations": "Conversations",
     "openConversations": "Open conversations",
     "closeDrawer": "Close",
-    "anchoredToModule": "Tutor anchored to: {module}",
-    "dismissAnchor": "Chat course-wide instead",
     "messageTooLong": "Message too long — shorten it before sending",
     "charactersUsed": "{used} / {limit} characters",
     "modeSocratic": "Socratic Mode",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -396,8 +396,6 @@
     "conversations": "Conversations",
     "openConversations": "Ouvrir les conversations",
     "closeDrawer": "Fermer",
-    "anchoredToModule": "Tuteur ancré sur : {module}",
-    "dismissAnchor": "Basculer en discussion sur tout le cours",
     "messageTooLong": "Message trop long — raccourcis-le avant d'envoyer",
     "charactersUsed": "{used} / {limit} caractères",
     "modeSocratic": "Mode Socratique",


### PR DESCRIPTION
Closes #1992.

## Why

Two staging-time regressions exposed by #1989 + #1985:

**A. Anchor badge mis-fired AND was unwanted.** `get_last_touched_module` sorted across ALL courses → user saw *"Tuteur ancré sur : 1. Les Détectives du Vivant"* while their selected course was *"Santé Publique"*. The off-course `module_id` then leaked into the chat, loading wrong-course units into the prompt. User feedback: the badge UI itself isn't needed — the active course shown in the chat header is sufficient context.

**B. Module unit list was truncated to 2 units.** `_build_current_module_section` emitted full lesson body (~10 k chars per unit). With the 30 k cap, only ~3 units fit before the trailing trim cut the rest. User showed an actual 9-unit module that should be fully visible.

## Fix

### Frontend
- Drop the visible *"Tuteur ancré sur"* badge UI from `tutor-client.tsx` (state, JSX, dismiss button).
- KEEP the silent fetch + `moduleId` plumbing — without it we're back to the original #1988 bug (no module context on `/tutor`).
- Pass `localStorage.getItem('activeCourseId')` to `fetchLastTouchedModule` → course-scoped lookup.
- Remove i18n keys `anchoredToModule`, `dismissAnchor`.

### Backend
- `get_last_touched_module(user_id, session, course_id=None)` — when `course_id` is provided, JOIN `Module` and filter to that course.
- `GET /api/v1/tutor/last-module?course_id=<uuid>` accepts the param.
- `send_message` defensive guard: if `course` and `module_obj` are both resolved but `module_obj.course_id != course.id`, drop the module with a WARNING log.
- `_build_current_module_section` rewritten as a **structured listing** per the user's spec:

```
Module 1 — Fondements de la santé publique et épidémiologie de base
_8 h_
Ce module introduit les concepts fondamentaux...

## Unités (9)
- **Unité 0** — Qu'est-ce que la santé publique ? (✓ généré) • 15 min de lecture
  > Introduction aux définitions de la santé...
- **Unité 1** — Quiz : Définitions et domaines (🔒 à venir) • 15 min de lecture
  > Évaluation formative...
- ...
```

Net result: a 9-unit module renders in ~850 chars (vs 90 k+ for full bodies). **All units always visible** regardless of module size. Tutor calls `search_knowledge_base` for body content when needed.

## Tests

- **Updated 5 existing tests** for the new contract (markers no longer have parens, unit-number prefix changed to *"Unité X"*, body content NOT inlined).
- **Added 4 new tests**:
  - `test_get_last_touched_module_filters_by_course_when_provided` — scoped query shape
  - `test_get_last_touched_module_no_scope_does_not_filter_by_course` — unscoped query shape
  - `test_module_section_lists_all_units_regardless_of_count` — 9-unit module → all 9 visible
  - `test_module_section_includes_unit_descriptions_and_reading_time` — per-unit format
- All **209 `-k tutor` tests** pass; ruff + format + frontend lint/typecheck clean.

## Verification on staging post-merge

1. Open `/tutor` with Santé Publique selected → no visible badge; tutor's responses about the module cite all unit numbers naturally (sample: ask *"Quelles sont toutes les unités de ce module ?"*).
2. Switch courses → no badge appears; the next chat session uses the new course's module context.
3. Open a 9-unit module via `/modules/...` → tutor lists all 9 units when asked.
4. Server log spot-check: no *"Dropping mismatched module"* warnings under normal use.

## Branch

`claude/1992-drop-anchor-badge-and-fix-units` — single commit `e0f96991`, 9 files, +437/-186.

https://claude.ai/code/session_01JzZTKy8gTAuEcMrY55nhbq

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzZTKy8gTAuEcMrY55nhbq)_