### PR TITLE
chore(pwa): bump SW CACHE_VERSION to evict stale pre-fix bundles on mobile

### DIFF
--- a/frontend/sw.ts
+++ b/frontend/sw.ts
@@ -18,7 +18,7 @@ declare const self: ServiceWorkerGlobalScope;
 const DAY_IN_SECONDS = 24 * 60 * 60;
 
 // Bump when storage shape or routing changes so clients drop stale caches.
-const CACHE_VERSION = "v3-tutor-no-cache";
+const CACHE_VERSION = "v4-quiz-hydration-race-fix";
 
 const OFFLINE_FALLBACK_URL = "/offline.html";
 


### PR DESCRIPTION
## Summary

- Bumps `CACHE_VERSION` in `frontend/sw.ts` from `v3-tutor-no-cache` to `v4-quiz-hydration-race-fix`.

## Why

After the quiz hydration-race fix shipped (PR #2003 → 0dd9347 on `main`), the user reports the broken quiz now loads correctly on **desktop** but still fails on **mobile**. Root cause: `frontend/sw.ts` caches `*.js` / `*.css` under `CacheFirst` (lines 74–84) with `maxAgeSeconds = 30 * DAY` and a cache namespace name keyed on `CACHE_VERSION`. Until that constant changes, even a freshly-activated SW (we already set `skipWaiting: true` + `clientsClaim: true`) reuses the same `static-assets-v3-tutor-no-cache` namespace, so the old pre-fix JS bundle keeps being served.

The file's own line-20 comment is explicit: *"Bump when storage shape or routing changes so clients drop stale caches."*

## What this does

Bumping the version string rewrites every cache namespace name (`google-fonts-*`, `static-images-*`, `static-assets-*`, `api-responses-*`, `pages-*`). The new SW finds zero entries under the new names → re-fetches every asset class from network on next visit. Old `*-v3-tutor-no-cache` caches become orphans and get evicted by `ExpirationPlugin` / browser quota over time. Mobile users get the post-fix bundle on their next page load — no manual cache-clear or PWA reinstall required.

## Test plan

- [x] Desktop already serves the fixed bundle (no SW or fresher cache) — no regression expected.
- [ ] After deploy, reload `https://etutor.elearning.portfolio2.kimbetien.com/fr/modules/2263b50e-677c-4dbc-9612-842ad282476a/units/1.2` on the affected phone. Expect: single "generating" cycle (≤ 60s on cold cache), quiz loads.
- [ ] DevTools → Application → Cache Storage on the phone shows new namespaces with the `v4-quiz-hydration-race-fix` suffix; old `v3-*` entries are absent or orphaned.

https://claude.ai/code/session_015VUoMAFu8raFtdWbXWKLK2

---
_Generated by [Claude Code](https://claude.ai/code/session_015VUoMAFu8raFtdWbXWKLK2)_