### PR TITLE
fix(migration 086): repoint generated_images/audio.lesson_id before orphan DELETE

### DIFF
--- a/backend/migrations/versions/086_add_module_unit_id_to_generated_content.py
+++ b/backend/migrations/versions/086_add_module_unit_id_to_generated_content.py
@@ -97,6 +97,40 @@ def upgrade() -> None:
     # 3. Delete orphan rows: had a non-summative JSON unit_id but no
     # matching module_units row. These are the stale-cache rows
     # producing observable topic mismatches.
+    #
+    # Repoint media tables (generated_images, generated_audio) that
+    # reference generated_content via lesson_id. The model declares
+    # ondelete="SET NULL" but the actual FK shape on prod can predate
+    # that declaration, so we explicitly NULL them out before the DELETE.
+    # Idempotent and safe regardless of the live FK definition.
+    bind.execute(
+        sa.text(
+            """
+            UPDATE generated_images
+            SET lesson_id = NULL
+            WHERE lesson_id IN (
+                SELECT id FROM generated_content
+                WHERE content->>'unit_id' IS NOT NULL
+                  AND content->>'unit_id' NOT IN ('', 'summative')
+                  AND module_unit_id IS NULL
+            )
+            """
+        )
+    )
+    bind.execute(
+        sa.text(
+            """
+            UPDATE generated_audio
+            SET lesson_id = NULL
+            WHERE lesson_id IN (
+                SELECT id FROM generated_content
+                WHERE content->>'unit_id' IS NOT NULL
+                  AND content->>'unit_id' NOT IN ('', 'summative')
+                  AND module_unit_id IS NULL
+            )
+            """
+        )
+    )
     orphans = bind.execute(
         sa.text(
             """
@@ -107,7 +141,7 @@ def upgrade() -> None:
             """
         )
     )
-    print(f"[084] Deleted {orphans.rowcount} orphan generated_content row(s)")
+    print(f"[086] Deleted {orphans.rowcount} orphan generated_content row(s)")
 
     # 4. Swap the unique indexes.
     op.execute("DROP INDEX IF EXISTS idx_unique_lesson_per_unit")


### PR DESCRIPTION
## Summary

Migration 086 (#2007) failed deploying to staging with:

\`\`\`
sqlalchemy.exc.IntegrityError: ... ForeignKeyViolationError: update or delete on table \"generated_content\" violates foreign key constraint \"generated_images_lesson_id_fkey\" on table \"generated_images\"
\`\`\`

The model declares \`generated_images.lesson_id\` and \`generated_audio.lesson_id\` with \`ondelete=\"SET NULL\"\`, but the live FK constraints on staging predate that declaration, so the cascade-set-null doesn't fire — the DELETE just blocks.

## Fix

Before the orphan-DELETE in 086, explicitly NULL out \`lesson_id\` on \`generated_images\` and \`generated_audio\` rows pointing at any row about to be deleted. Idempotent + safe regardless of live FK shape.

Other FKs to \`generated_content\` are \`ondelete=CASCADE\` (lesson_reading, flashcard, quiz_attempts, summative_attempts) — those handle themselves.

The previous failed deploy rolled back cleanly via Alembic's transactional DDL — staging schema is unchanged, so 086 is re-runnable on next deploy.

## Test plan
- [x] ruff + format pass
- [ ] CI green
- [ ] Migration applies cleanly on staging on next deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)