### PR TITLE
fix(lesson_service): add _resolve_unit method to LessonGenerationService

### DIFF
--- a/backend/app/domain/services/lesson_service.py
+++ b/backend/app/domain/services/lesson_service.py
@@ -665,6 +665,25 @@ class LessonGenerationService:
             return module.books_sources
         return None
 
+    async def _resolve_unit(
+        self, module: Module, unit_id: str, session: AsyncSession
+    ) -> ModuleUnit | None:
+        """Resolve a ModuleUnit row from `(module, unit_id)` for prompt grounding.
+
+        Same logic as the helper on CaseStudyGenerationService — duplicated here
+        because the prompt-grounding paths in this class call `self._resolve_unit`
+        and the two services don't share a base class. Issue #2007.
+        """
+        unit_result = await session.execute(
+            select(ModuleUnit).where(
+                and_(
+                    ModuleUnit.module_id == module.id,
+                    ModuleUnit.unit_number == unit_id,
+                )
+            )
+        )
+        return unit_result.scalar_one_or_none()
+
     async def _build_lesson_query(
         self, module: Module, unit_id: str, language: str, session: AsyncSession
     ) -> str:


### PR DESCRIPTION
## Summary

Hotfix for staging error after #2008 / #2011 deployed:

\`\`\`
AttributeError: 'LessonGenerationService' object has no attribute '_resolve_unit'
\`\`\`

#2008 added two \`self._resolve_unit(...)\` call sites in \`LessonGenerationService\` (streaming variant + non-streaming \`_generate_lesson_content\`) to thread \`unit.title_fr/en\` into the prompt grounding. But the helper was only defined on \`CaseStudyGenerationService\` — the two services don't share a base class. Tests masked it because the lesson-service tests use \`AsyncMock(spec=ClaudeService)\`, which shadows the missing method.

The bug is hidden by the cache: it only fires when \`generated_content\` doesn't already have a row for the requested unit. Surfaced now because we just bulk-purged 107 stale lesson rows on staging to clear the legacy weak-prompt content.

## Fix

Add \`_resolve_unit\` to \`LessonGenerationService\` — same body as the case-study one. A shared base class / module-level helper is the right long-term refactor but out of scope here.

## Test plan
- [x] All 12 \`test_lesson_query_builder\` tests pass
- [ ] CI green
- [ ] Re-deploy staging → browse a unit page → confirm new on-topic content generates without 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)