### PR TITLE
fix(frontend): raise rewrite-proxy body limit so >10MB PDF uploads reach the backend (#2018)

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -70,6 +70,11 @@ const nextConfig: NextConfig = {
       "remark-gfm",
       "remark-math",
     ],
+    // Course-resource PDFs (tens of MB) are uploaded through the /api/* rewrite
+    // to the FastAPI backend. Next.js's default proxy body buffer is 10MB,
+    // which silently truncates larger uploads and makes the upstream return 502.
+    // Match the wizard's advertised "max 100 Mo par fichier". See #2018.
+    middlewareClientMaxBodySize: "100mb",
   },
 
   async rewrites() {


### PR DESCRIPTION
## Summary

- Fixes #2018 — the admin AI-assisted course wizard advertises **"max 100 Mo par fichier"** but Next.js's default `/api/*` rewrite-proxy body buffer is **10 MB**, so larger PDFs were silently truncated and the upstream multipart parse failed → browser saw **502 Bad Gateway** and no file reached FastAPI.
- One-line config change in `frontend/next.config.ts`: add `experimental.middlewareClientMaxBodySize: "100mb"` so the proxy buffer matches the advertised UI limit.

## Why this is the minimal fix

- All other admin API calls already work fine — the 10 MB cap only affected uploads (multipart bodies) routed through the `/api/*` rewrite.
- Bumping the limit is reversible and additive; bypassing the FE proxy entirely (calling `api.elearning…` directly from the upload component) would be cleaner but is a larger change with CORS implications — left as a follow-up note in the issue.

## Test plan

- [ ] After staging deploy: in the admin AI-assisted wizard, attach `resources/triola.pdf` (28.2 MB) and click "Suivant".
- [ ] Verify `POST /admin/courses/{id}/resources` returns 201 (not 502).
- [ ] Verify `GET /admin/courses/{id}/resources` then lists `triola.pdf`.
- [ ] Verify smaller PDFs (<10 MB) still upload normally.
- [ ] Verify `docker logs etutor-frontend` no longer emits the "Request body exceeded 10MB" warning for normal uploads.
- [ ] Sanity-check that the rest of the wizard (objectives → AI proposition → generate → syllabus) advances past the upload step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)