### PR TITLE
fix(admin-courses): unbreak stuck-draft pipeline (#2015 #2016 #2017)

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -145,6 +145,55 @@ async def _fetch_image_count(db, rag_collection_id: str | None) -> int:
     return result.scalar_one()
 
 
+def _safe_task_meta(task_result: AsyncResult) -> tuple[str, dict]:
+    """Read Celery task state + meta without 500ing on malformed payloads.
+
+    `AsyncResult.info` is a property that calls `exception_to_python()` for
+    FAILURE-state tasks; if the stored payload is missing `exc_type`, that
+    raises before any caller-side guard runs. Degrade to `("FAILURE", {})`
+    instead of letting the polling endpoint 500. See #2015.
+    """
+    state = task_result.state
+    meta: dict = {}
+    try:
+        info = task_result.info
+        if isinstance(info, dict):
+            meta = info
+    except (ValueError, KeyError):
+        state = "FAILURE"
+    return state, meta
+
+
+async def _require_indexed_sources(course: Course, db) -> None:
+    """Refuse AI generation when no indexed source content exists for the course.
+
+    See #2017: title/description/objectives/syllabus/modules must be grounded in
+    indexed RAG content. Falling through to a prompt-only generation produces
+    fabricated, citation-less material.
+    """
+    if not course.rag_collection_id:
+        chunk_count = 0
+    else:
+        chunk_result = await db.execute(
+            select(func.count())
+            .select_from(DocumentChunk)
+            .where(DocumentChunk.source == course.rag_collection_id)
+        )
+        chunk_count = chunk_result.scalar_one()
+    if chunk_count == 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "no_source_summary",
+                "message_key": "course.generate.no_source_summary",
+                "message": (
+                    "Upload at least one source document and wait for indexation "
+                    "to complete before generating course content."
+                ),
+            },
+        )
+
+
 def _slugify(text: str) -> str:
     slug = text.lower().strip()
     slug = re.sub(r"[^\w\s-]", "", slug)
@@ -389,6 +438,8 @@ async def suggest_course_metadata(
     if not course:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
 
+    await _require_indexed_sources(course, db)
+
     # Gather context from uploaded resources
     res_result = await db.execute(
         select(CourseResource.raw_text).where(CourseResource.course_id == course_id).limit(5)
@@ -590,6 +641,7 @@ async def save_syllabus(
             id=uuid.uuid4(),
             course_id=course_id,
             module_number=m.module_number,
+            level=1,
             title_fr=m.title_fr,
             title_en=m.title_en,
             description_fr=m.description_fr,
@@ -782,6 +834,8 @@ async def generate_course_structure(
             detail=f"A task is already in progress (step: {course.creation_step})",
         )
 
+    await _require_indexed_sources(course, db)
+
     from app.domain.services.platform_settings_service import SettingsCache
 
     cache = SettingsCache.instance()
@@ -846,6 +900,8 @@ async def regenerate_course_syllabus(
             status_code=status.HTTP_409_CONFLICT,
             detail="A generation task is already in progress",
         )
+
+    await _require_indexed_sources(course, db)
 
     from app.domain.services.platform_settings_service import SettingsCache
 
@@ -927,10 +983,11 @@ async def get_generate_status(
 
     if resolved_task_id:
         task_result = AsyncResult(resolved_task_id)
+        state, meta = _safe_task_meta(task_result)
         response["task"] = {
             "id": resolved_task_id,
-            "state": task_result.state,
-            "meta": task_result.info if isinstance(task_result.info, dict) else {},
+            "state": state,
+            "meta": meta,
         }
 
     return response
@@ -1109,10 +1166,10 @@ async def get_rag_index_status(
     effective_task_id = task_id or course.indexation_task_id
     if effective_task_id:
         task_result = AsyncResult(effective_task_id)
-        meta = task_result.info if isinstance(task_result.info, dict) else {}
+        state, meta = _safe_task_meta(task_result)
         response["task"] = {
             "id": effective_task_id,
-            "state": task_result.state,
+            "state": state,
             "step": meta.get("step"),
             "step_label": meta.get("step_label"),
             "progress": meta.get("progress", 0),
@@ -1414,6 +1471,8 @@ async def admin_generate_module_content(
     if not course:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
 
+    await _require_indexed_sources(course, db)
+
     module_result = await db.execute(
         select(Module).where(Module.id == module_id, Module.course_id == course_id)
     )
@@ -1630,10 +1689,10 @@ async def get_preassessment_status(
 
     if task_id:
         task_result = AsyncResult(task_id)
-        meta = task_result.info if isinstance(task_result.info, dict) else {}
+        state, meta = _safe_task_meta(task_result)
         response["task"] = {
             "id": task_id,
-            "state": task_result.state,
+            "state": state,
             "step": meta.get("step"),
             "progress": meta.get("progress", 0),
             "question_count": meta.get("question_count", 0),

--- a/backend/tests/test_admin_courses_helpers.py
+++ b/backend/tests/test_admin_courses_helpers.py
@@ -1,0 +1,167 @@
+"""Unit tests for admin_courses helpers introduced by #2015 / #2016 / #2017.
+
+These exercise pure helpers with no DB or HTTP dependencies, sidestepping the
+pytest-asyncio event-loop conflict that keeps the integration suite skipped
+(see test_courses.py).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.v1.admin_courses import _require_indexed_sources, _safe_task_meta
+
+
+class _RaisingInfoAsyncResult:
+    """Stub mimicking celery.result.AsyncResult with a malformed payload.
+
+    Reading `.info` raises the same ValueError that real Celery raises when
+    `exception_to_python()` hits a payload missing `exc_type`. See #2015.
+    """
+
+    state = "FAILURE"
+
+    @property
+    def info(self):
+        raise ValueError("Exception information must include the exception type")
+
+
+class _DictInfoAsyncResult:
+    state = "PROGRESS"
+
+    def __init__(self, meta: dict) -> None:
+        self._meta = meta
+
+    @property
+    def info(self):
+        return self._meta
+
+
+class _NonDictInfoAsyncResult:
+    state = "SUCCESS"
+
+    @property
+    def info(self):
+        return "not a dict"
+
+
+# ---------------------------------------------------------------------------
+# #2015 — _safe_task_meta degrades malformed payloads instead of raising
+# ---------------------------------------------------------------------------
+
+
+def test_safe_task_meta_returns_state_and_meta_on_dict_info():
+    state, meta = _safe_task_meta(_DictInfoAsyncResult({"progress": 42, "step": "embedding"}))
+    assert state == "PROGRESS"
+    assert meta == {"progress": 42, "step": "embedding"}
+
+
+def test_safe_task_meta_falls_back_to_empty_meta_for_non_dict_info():
+    state, meta = _safe_task_meta(_NonDictInfoAsyncResult())
+    assert state == "SUCCESS"
+    assert meta == {}
+
+
+def test_safe_task_meta_degrades_to_failure_when_info_raises():
+    """The bug from #2015: AsyncResult.info raises on malformed Celery payload.
+
+    The helper must swallow ValueError/KeyError and return ("FAILURE", {})
+    instead of letting the polling endpoint 500.
+    """
+    state, meta = _safe_task_meta(_RaisingInfoAsyncResult())
+    assert state == "FAILURE"
+    assert meta == {}
+
+
+def test_safe_task_meta_degrades_to_failure_when_info_raises_keyerror():
+    class _KeyErrorInfo:
+        state = "FAILURE"
+
+        @property
+        def info(self):
+            raise KeyError("exc_type")
+
+    state, meta = _safe_task_meta(_KeyErrorInfo())
+    assert state == "FAILURE"
+    assert meta == {}
+
+
+# ---------------------------------------------------------------------------
+# #2017 — _require_indexed_sources gate
+# ---------------------------------------------------------------------------
+
+
+def _make_db_with_chunk_count(count: int):
+    """Build a minimal mock db.execute that mimics SQLAlchemy's count() result."""
+
+    class _Result:
+        def scalar_one(self):
+            return count
+
+    db = SimpleNamespace()
+    db.execute = AsyncMock(return_value=_Result())
+    return db
+
+
+@pytest.mark.asyncio
+async def test_require_indexed_sources_passes_when_chunks_present():
+    course = SimpleNamespace(rag_collection_id="col-1")
+    db = _make_db_with_chunk_count(3)
+    await _require_indexed_sources(course, db)  # no exception
+
+
+@pytest.mark.asyncio
+async def test_require_indexed_sources_blocks_when_no_rag_collection():
+    course = SimpleNamespace(rag_collection_id=None)
+    db = _make_db_with_chunk_count(0)  # not actually called, but harmless
+    with pytest.raises(HTTPException) as exc_info:
+        await _require_indexed_sources(course, db)
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail["code"] == "no_source_summary"
+    assert exc_info.value.detail["message_key"] == "course.generate.no_source_summary"
+
+
+@pytest.mark.asyncio
+async def test_require_indexed_sources_blocks_when_zero_chunks():
+    course = SimpleNamespace(rag_collection_id="col-1")
+    db = _make_db_with_chunk_count(0)
+    with pytest.raises(HTTPException) as exc_info:
+        await _require_indexed_sources(course, db)
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail["code"] == "no_source_summary"
+
+
+# ---------------------------------------------------------------------------
+# #2016 — save_syllabus must populate Module.level (NOT NULL on the column)
+# ---------------------------------------------------------------------------
+
+
+def test_module_model_construction_with_level_succeeds():
+    """Sanity check: the Module ORM class accepts a `level` kwarg and persists it.
+
+    Regression for #2016 — the save_syllabus handler was instantiating Module
+    without `level`, which is `nullable=False` with no server_default.
+    """
+    from app.domain.models.module import Module
+
+    m = Module(level=1, module_number=1, title_fr="t", title_en="t")
+    assert m.level == 1
+
+
+def test_save_syllabus_handler_sets_level_in_module_constructor():
+    """The handler source must include `level=1` in its Module(...) call.
+
+    A source-level guard is enough here: the integration path is exercised
+    by the wizard end-to-end on staging, but the unit-level assertion catches
+    accidental regressions if someone reformats the kwargs block.
+    """
+    import inspect
+
+    from app.api.v1.admin_courses import save_syllabus
+
+    src = inspect.getsource(save_syllabus)
+    assert "level=1" in src, "save_syllabus must set Module.level — see #2016"

--- a/frontend/components/admin/course-wizard-client.tsx
+++ b/frontend/components/admin/course-wizard-client.tsx
@@ -34,7 +34,7 @@ import {
   AlertDialogTitle,
   AlertDialogDescription,
 } from "@/components/ui/alert-dialog";
-import { apiFetch, API_BASE, getCourseTaxonomy, type TaxonomyItem } from "@/lib/api";
+import { apiFetch, ApiError, API_BASE, getCourseTaxonomy, type TaxonomyItem } from "@/lib/api";
 import { authClient } from "@/lib/auth";
 
 type WizardStep = "upload" | "info" | "generate" | "index" | "publish";
@@ -404,6 +404,30 @@ export function CourseWizardClient({
   }, [resumeCourseId, resumeCreationStep]);
 
   useEffect(() => {
+    // When the user reaches the "generate" step we need to know whether
+    // sources have already been indexed; the syllabus generator is gated on
+    // chunks_indexed > 0 by the backend (#2017). Skip if already indexing
+    // (the polling effect keeps indexStatus fresh in that case).
+    if (step !== "generate" || !courseId || isIndexing) return;
+    if (indexStatus?.indexed) return;
+
+    apiFetch<{
+      indexed: boolean;
+      chunks_indexed: number;
+      images_indexed?: number;
+    }>(`/api/v1/admin/courses/${courseId}/index-status`)
+      .then((data) => {
+        setIndexStatus((prev) => ({
+          ...(prev ?? {}),
+          indexed: data.indexed,
+          chunks_indexed: data.chunks_indexed,
+          images_indexed: data.images_indexed,
+        }));
+      })
+      .catch(() => {});
+  }, [step, courseId, isIndexing, indexStatus?.indexed]);
+
+  useEffect(() => {
     if (step !== "upload" || !courseId) return;
 
     const fetchExistingFiles = async () => {
@@ -651,8 +675,12 @@ export function CourseWizardClient({
       );
       setGenerateTaskId(result.task_id);
       setIsGenerating(true);
-    } catch {
-      setRegenerateError(t("generate.regenerateError"));
+    } catch (err) {
+      if (err instanceof ApiError && err.code === "no_source_summary") {
+        setRegenerateError(t("generate.no_source_summary"));
+      } else {
+        setRegenerateError(t("generate.regenerateError"));
+      }
     } finally {
       setIsRegenerating(false);
     }
@@ -686,8 +714,12 @@ export function CourseWizardClient({
         }
       );
       setGenerateTaskId(result.task_id);
-    } catch {
-      setGenerateError(t("generate.error"));
+    } catch (err) {
+      if (err instanceof ApiError && err.code === "no_source_summary") {
+        setGenerateError(t("generate.no_source_summary"));
+      } else {
+        setGenerateError(t("generate.error"));
+      }
       setIsGenerating(false);
     }
   }, [courseId, courseInfo, isGenerating, shouldForceGenerate, t]);
@@ -1293,11 +1325,44 @@ export function CourseWizardClient({
                   </div>
                 )}
 
+                {generatedModules.length === 0 &&
+                  !isGenerating &&
+                  !isCheckingGenerateStatus &&
+                  !indexStatus?.indexed &&
+                  !isIndexing && (
+                    <div className="flex flex-col gap-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-300">
+                      <div className="flex items-start gap-2">
+                        <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                        <p>{t("generate.no_source_summary")}</p>
+                      </div>
+                      <Button
+                        onClick={startIndexation}
+                        size="sm"
+                        className="self-start min-h-[44px]"
+                      >
+                        <Database className="mr-2 h-4 w-4" />
+                        {t("generate.no_source_summaryRunIndex")}
+                      </Button>
+                    </div>
+                  )}
+
+                {generatedModules.length === 0 &&
+                  !isGenerating &&
+                  !isCheckingGenerateStatus &&
+                  !indexStatus?.indexed &&
+                  isIndexing && (
+                    <div className="flex items-center gap-2 rounded-lg border bg-card p-3 text-sm">
+                      <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent shrink-0" />
+                      <p>{t("index.taskRunning")}</p>
+                    </div>
+                  )}
+
                 {generatedModules.length === 0 && !isGenerating && !isCheckingGenerateStatus && (
                   <Button
                     onClick={() => generateSyllabus()}
                     className="w-full min-h-11"
-                    disabled={isGenerating}
+                    disabled={isGenerating || !indexStatus?.indexed}
+                    title={!indexStatus?.indexed ? t("generate.no_source_summary") : undefined}
                   >
                     <Sparkles className="mr-2 h-4 w-4" />
                     {t("generate.button")}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1444,7 +1444,9 @@
         "regenerateFreshConfirmDescription": "This will re-analyze all PDFs from scratch. The current module structure will be replaced.",
         "regenerateFreshConfirmAction": "Discard & regenerate",
         "regenerateFreshConfirmCancel": "Cancel",
-        "regenerateError": "Failed to regenerate syllabus."
+        "regenerateError": "Failed to regenerate syllabus.",
+        "no_source_summary": "Upload at least one source document and complete indexation before generating course content.",
+        "no_source_summaryRunIndex": "Run indexation now"
       },
       "index": {
         "title": "RAG Indexation",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1444,7 +1444,9 @@
         "regenerateFreshConfirmDescription": "Cela va ré-analyser tous les PDFs depuis le début. La structure des modules actuels sera remplacée.",
         "regenerateFreshConfirmAction": "Vider et regénérer",
         "regenerateFreshConfirmCancel": "Annuler",
-        "regenerateError": "Erreur lors de la regénération du syllabus."
+        "regenerateError": "Erreur lors de la regénération du syllabus.",
+        "no_source_summary": "Téléversez au moins un document source et terminez l'indexation avant de générer le contenu du cours.",
+        "no_source_summaryRunIndex": "Lancer l'indexation maintenant"
       },
       "index": {
         "title": "Indexation RAG",


### PR DESCRIPTION
## Summary

Three related defects that combined to leave admin draft courses stuck on "Indexation en cours" with no recovery path. All surfaced together on staging on 2026-04-26 with course `c1e197d5-...`.

- **#2015** — `GET /index-status` (plus sibling `/generate-status`, `/preassessment-status`) 500'd forever when Celery's failure payload was missing `exc_type`. `AsyncResult.info` is a property that raises `ValueError` before the `isinstance(...)` guard runs. Extracted `_safe_task_meta()` that catches and degrades to `("FAILURE", {})` so the UI can advance to a cancellable state.
- **#2016** — `PATCH /syllabus` 500'd with a NOT NULL violation on `modules.level`. The handler never set `level`, but the column is `nullable=False` with no `server_default`. Set `level=1` to match the existing convention in `syllabus_generation.py` and `syllabus_agent_service.py`.
- **#2017** — Generation endpoints (`suggest-metadata`, `generate-structure`, `regenerate-syllabus`, `modules/.../generate-content`) fell through to "generate from prompt only" when no source materials were indexed, producing ungrounded, citation-less content. Added `_require_indexed_sources()` returning 400 with structured `{code: "no_source_summary", message_key, message}` when `DocumentChunk` count is zero. Frontend wizard now fetches index status on entry to the generate step, disables the Generate button, and offers an inline **Run indexation now** button + FR/EN i18n keys.

Fixes #2015
Fixes #2016
Fixes #2017

## Test plan

- [x] New unit tests in [backend/tests/test_admin_courses_helpers.py](backend/tests/test_admin_courses_helpers.py) — 9/9 passing locally:
  - `_safe_task_meta` returns degraded `FAILURE` when `AsyncResult.info` raises (`ValueError` and `KeyError`)
  - `_require_indexed_sources` raises 400 with `code=no_source_summary` for both no-collection and zero-chunks cases
  - `Module(level=1, ...)` constructs and `save_syllabus` source contains `level=1`
- [ ] Staging smoke: create draft course, no files → click Generate → expect 400 toast with localized message + Generate button disabled
- [ ] Staging smoke: upload PDF, complete indexation, generate → 200, syllabus persists via `PATCH /syllabus` → 200 (verify `SELECT level FROM modules WHERE course_id = '...'` returns `level = 1` for every row)
- [ ] Staging smoke: trigger indexation against a course with zero files, then poll `GET /index-status?task_id=...` → expect 200 with `task.state == "FAILURE"` (no more 500 loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)