### PR TITLE
fix(wizard): make Réessayer button actually retry the failed upload (#2026)

### DIFF
--- a/frontend/components/admin/course-resource-upload-step.tsx
+++ b/frontend/components/admin/course-resource-upload-step.tsx
@@ -210,27 +210,20 @@ export function useCourseResourceUpload(
     ): Promise<{ ok: boolean; failed: string[] }> => {
       setUploadError(null);
       const queue = [...pendingFiles];
-      // Also retry anything currently in error state so a single button can
-      // both flush queued files AND retry failed ones.
-      const erroredNames = new Set(
-        files.filter((f) => f.status === "error").map((f) => f.name),
-      );
-      const erroredFiles = queue.filter(() => false); // placeholder — errored
-      // The actual File handles for errored entries are still in `pendingFiles`
-      // if they originated from a queued state. If a file was already uploaded
-      // once and failed, we don't have the original File handle to retry — the
-      // user must remove + reattach. That's surfaced via removeFile above.
-      void erroredNames;
-      void erroredFiles;
-
       if (queue.length === 0) return { ok: true, failed: [] };
 
+      // Per-file: try the upload, track which succeeded vs failed. Only
+      // successful files are pulled out of pendingFiles — failed ones stay
+      // queued so the next click of Réessayer actually re-uploads them
+      // instead of short-circuiting on an empty queue (#2026).
+      const succeeded: string[] = [];
       const failed: string[] = [];
       for (const file of queue) {
         const ok = await uploadOne(targetCourseId, file);
-        if (!ok) failed.push(file.name);
+        if (ok) succeeded.push(file.name);
+        else failed.push(file.name);
       }
-      setPendingFiles((prev) => prev.filter((f) => !queue.some((q) => q.name === f.name)));
+      setPendingFiles((prev) => prev.filter((f) => !succeeded.includes(f.name)));
 
       if (failed.length > 0) {
         setUploadError(
@@ -240,7 +233,7 @@ export function useCourseResourceUpload(
       }
       return { ok: true, failed: [] };
     },
-    [files, pendingFiles, t, uploadOne],
+    [pendingFiles, t, uploadOne],
   );
 
   const canAdvance =


### PR DESCRIPTION
## Summary

- Fixes #2026 — regression introduced by #2024.
- After an upload failure, clicking **Réessayer** would clear the banner momentarily but fire **no** new `POST /resources` and leave the file stuck in `error` state with Suivant disabled. The button looked dead.

## Root cause

`uploadAllPending` was draining every queued File from `pendingFiles` after the loop, including failed ones. The early guard `if (queue.length === 0) return { ok: true, failed: [] };` then short-circuited every subsequent retry call.

## Fix

Track successful filenames separately and only filter those out of `pendingFiles`. Failed files stay queued so the next call actually re-tries them. Also removed the dead `erroredNames` / `erroredFiles` / `void` placeholder block from the original commit.

`+9 / −16` in one file.

## Test plan

- [ ] After deploy, attach a PDF that 502s in the browser (any file given #2018), click Suivant → wizard stays on upload, banner appears, Suivant disabled (already verified for #2024).
- [ ] **Click Réessayer** → DevTools network panel shows a fresh `POST /admin/courses/{id}/resources` for the failed file; row goes `error` → `uploading` → `error`.
- [ ] Click Réessayer multiple times → fresh request each time.
- [ ] Remove the failed file via × → banner clears, Suivant remains correctly gated by remaining files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)