### PR TITLE
fix(indexation): commit source_images per image + stream live progress (#2029)

### DIFF
--- a/backend/app/ai/rag/pipeline.py
+++ b/backend/app/ai/rag/pipeline.py
@@ -1,5 +1,6 @@
 """RAG pipeline for processing documents into searchable chunks with embeddings."""
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -160,6 +161,7 @@ class RAGPipeline:
         source: str,
         rag_collection_id: str | None = None,
         session: AsyncSession | None = None,
+        progress_callback: "Callable[[int, int, str | None], None] | None" = None,
     ) -> int:
         """Extract images from a PDF, upload to MinIO, store metadata, and link to chunks.
 
@@ -168,6 +170,11 @@ class RAGPipeline:
             source: Source identifier (e.g., "donaldson").
             rag_collection_id: Optional RAG collection identifier.
             session: Database session (will create one if not provided).
+            progress_callback: Optional `(images_done, images_total, current_figure_label)`
+                callback invoked after each image is committed. Used by the celery
+                task wrapper to update task.meta so the UI can show live progress
+                instead of freezing at the start of the image-extraction phase
+                (#2029).
 
         Returns:
             Number of images processed and stored.
@@ -179,9 +186,13 @@ class RAGPipeline:
         session_provided = session is not None
         if not session_provided:
             async with async_session_factory() as session:
-                return await self._process_images(pdf_path, source, rag_collection_id, session)
+                return await self._process_images(
+                    pdf_path, source, rag_collection_id, session, progress_callback
+                )
         else:
-            return await self._process_images(pdf_path, source, rag_collection_id, session)
+            return await self._process_images(
+                pdf_path, source, rag_collection_id, session, progress_callback
+            )
 
     async def _process_images(
         self,
@@ -189,6 +200,7 @@ class RAGPipeline:
         source: str,
         rag_collection_id: str | None,
         session: AsyncSession,
+        progress_callback: "Callable[[int, int, str | None], None] | None" = None,
     ) -> int:
         """Internal: extract, upload, store, and link images."""
         extractor = PDFImageExtractor(pdf_path.parent)
@@ -359,9 +371,21 @@ class RAGPipeline:
             )
 
             session.add(db_image)
+            # Commit per image so /index-status reflects progress live and
+            # so a hang on a later image doesn't lose previously-extracted
+            # work. Was a single batch commit at end-of-PDF (#2029).
+            await session.commit()
             stored_count += 1
 
-        await session.commit()
+            if progress_callback is not None:
+                try:
+                    progress_callback(stored_count, len(images), figure_label)
+                except Exception as cb_exc:  # never let callbacks break extraction
+                    logger.debug(
+                        "image progress_callback raised, ignoring",
+                        error=str(cb_exc),
+                    )
+
         logger.info("Stored source images", source=source, count=stored_count)
 
         links = await linker.link_images_to_chunks(source, session)

--- a/backend/app/tasks/rag_indexation.py
+++ b/backend/app/tasks/rag_indexation.py
@@ -324,9 +324,7 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
             # instead of freezing at img_progress for the whole pass (#2029).
             # Loop locals are bound via default args so the closure captures
             # this iteration's values, not the moving loop bindings.
-            _link_progress_for_pdf = (
-                img_progress + int((1 / len(pdf_files)) * 7)
-            )
+            _link_progress_for_pdf = img_progress + int((1 / len(pdf_files)) * 7)
 
             def _image_progress_cb(
                 done: int,
@@ -344,16 +342,13 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
                 if total <= 0:
                     return
                 ratio = min(done / total, 1.0)
-                live_progress = _img_progress + int(
-                    (_link_progress - _img_progress) * ratio
-                )
+                live_progress = _img_progress + int((_link_progress - _img_progress) * ratio)
                 self.update_state(
                     state="EXTRACTING_IMAGES",
                     meta={
                         "step": "extracting_images",
                         "step_label": (
-                            f"Extraction des illustrations: {_pdf_name} "
-                            f"({done}/{total})"
+                            f"Extraction des illustrations: {_pdf_name} ({done}/{total})"
                         ),
                         "progress": live_progress,
                         "files_total": _files_total,

--- a/backend/app/tasks/rag_indexation.py
+++ b/backend/app/tasks/rag_indexation.py
@@ -319,12 +319,59 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
                 },
             )
 
+            # Per-image progress callback: lets the celery task stream live
+            # progress to /index-status while images are being processed,
+            # instead of freezing at img_progress for the whole pass (#2029).
+            # Loop locals are bound via default args so the closure captures
+            # this iteration's values, not the moving loop bindings.
+            _link_progress_for_pdf = (
+                img_progress + int((1 / len(pdf_files)) * 7)
+            )
+
+            def _image_progress_cb(
+                done: int,
+                total: int,
+                figure_label: str | None,
+                *,
+                _img_progress: int = img_progress,
+                _link_progress: int = _link_progress_for_pdf,
+                _running_total: int = total_images,
+                _pdf_name: str = pdf_path.name,
+                _files_processed: int = i + 1,
+                _total_chunks: int = total_chunks,
+                _files_total: int = len(pdf_files),
+            ) -> None:
+                if total <= 0:
+                    return
+                ratio = min(done / total, 1.0)
+                live_progress = _img_progress + int(
+                    (_link_progress - _img_progress) * ratio
+                )
+                self.update_state(
+                    state="EXTRACTING_IMAGES",
+                    meta={
+                        "step": "extracting_images",
+                        "step_label": (
+                            f"Extraction des illustrations: {_pdf_name} "
+                            f"({done}/{total})"
+                        ),
+                        "progress": live_progress,
+                        "files_total": _files_total,
+                        "files_processed": _files_processed,
+                        "current_file": _pdf_name,
+                        "chunks_processed": _total_chunks,
+                        "images_processed": _running_total + done,
+                        "estimated_seconds_remaining": _remaining(live_progress),
+                    },
+                )
+
             image_count = 0
             try:
                 image_count = await pipeline.process_pdf_images(
                     pdf_path=str(pdf_path),
                     source=rag_collection_id,
                     rag_collection_id=rag_collection_id,
+                    progress_callback=_image_progress_cb,
                 )
                 total_images += image_count
             except Exception as img_exc:


### PR DESCRIPTION
## Summary

- Fixes #2029 — for PDFs with many figures (real repro on staging today: triola.pdf, ~600 pages of biostatistics), the wizard's indexation step shows `images_indexed: 0` and `progress: 88%` frozen for 10–20 minutes even though images are actively uploading to MinIO.
- The fix moves `source_images` commits from one-batch-per-PDF to one-per-image, and threads a callback so the celery task's `update_state` fires after each image is committed.

## Files

- [backend/app/ai/rag/pipeline.py](backend/app/ai/rag/pipeline.py) — `process_pdf_images` / `_process_images` accept an optional `progress_callback`; commit moved inside the loop.
- [backend/app/tasks/rag_indexation.py](backend/app/tasks/rag_indexation.py) — image-extraction loop passes a callback that updates task meta with `(done/total, current figure label, smoothed progress)` per image. Loop locals bound via default args to avoid B023 late-binding.

`+74 / −3` total.

## Test plan (staging, after deploy)

- [ ] Trigger indexation on a course with a multi-figure PDF (use `triola.pdf`).
- [ ] Poll `/admin/courses/{id}/index-status` every 5s — `images_indexed` should rise monotonically (e.g. 0 → 5 → 12 → 23 → …) instead of staying 0 until the end.
- [ ] `task.progress` should advance smoothly through the EXTRACTING_IMAGES phase, not freeze at one value.
- [ ] `task.step_label` should include `(N/M)` reflecting the current image.
- [ ] Kill `etutor-celery-worker` mid-extraction and re-trigger: previously-extracted images remain in the DB (resilience).

## Out of scope

- Per-image timeout on Vision API calls (root-cause #3 in the issue) is left for a follow-up. The bigger UX win is in this PR; the timeout hardening can ship separately.
- Wizard publish gating while images are still extracting is a separate UX question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)