### PR TITLE
fix(wizard): split indexation recap into Texte/Images rows + tighten publish gate (#2032)

### DIFF
--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -151,6 +151,135 @@ function ETALabel({ seconds, t }: { seconds: number | undefined; t: ReturnType<t
   return <span>{t("index.etaMinutes", { minutes: Math.ceil(seconds / 60) })}</span>;
 }
 
+// Stages where the celery task is still working on the TEXT phase. After
+// these, the task moves into image extraction/linking.
+const TEXT_STAGES = new Set([
+  "PENDING",
+  "STARTED",
+  "EXTRACTING",
+  "CHUNKING",
+  "EMBEDDING",
+  "STORING",
+]);
+
+// Stages where the IMAGE phase has begun (text is done by now).
+const IMAGE_STAGES = new Set(["EXTRACTING_IMAGES", "LINKING_IMAGES"]);
+
+function isIndexationFullyComplete(indexStatus: IndexStatus | null): boolean {
+  if (!indexStatus) return false;
+  const taskState = indexStatus.task?.state;
+  // Truthful signal: celery task hit COMPLETE/SUCCESS. We also accept the
+  // case where the task was cleaned from the result backend but the live
+  // chunk count + indexed flag say we're done, since those persist.
+  if (taskState === "COMPLETE" || taskState === "SUCCESS") return true;
+  if (
+    !taskState &&
+    indexStatus.indexed &&
+    (indexStatus.chunks_indexed ?? 0) > 0
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function IndexationRecap({
+  indexStatus,
+  isIndexing,
+  progressValue,
+  onCancel,
+  t,
+}: {
+  indexStatus: IndexStatus | null;
+  isIndexing: boolean;
+  progressValue: number;
+  onCancel?: () => void;
+  t: ReturnType<typeof useTranslations>;
+}) {
+  const taskState = indexStatus?.task?.state;
+  const stepLabel = indexStatus?.task?.step_label;
+  const eta = indexStatus?.task?.estimated_seconds_remaining;
+  const chunks = indexStatus?.chunks_indexed ?? 0;
+  const images = indexStatus?.images_indexed ?? 0;
+
+  // Phase derivations based on the celery task state machine.
+  const textRunning = !!taskState && TEXT_STAGES.has(taskState);
+  const imagesRunning = !!taskState && IMAGE_STAGES.has(taskState);
+  const fullyDone = isIndexationFullyComplete(indexStatus);
+  const textDone = fullyDone || imagesRunning || chunks > 0;
+  const imagesDone = fullyDone;
+
+  return (
+    <div className="rounded-lg border bg-card p-4 space-y-3">
+      {/* Texte row */}
+      <div className="flex items-center gap-2">
+        {textDone ? (
+          <CheckCircle2 className="h-4 w-4 shrink-0 text-green-600" />
+        ) : textRunning ? (
+          <div className="h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        ) : (
+          <div className="h-4 w-4 shrink-0 rounded-full border border-muted-foreground/40" />
+        )}
+        <p className="text-sm font-medium">{t("index.recap.textRow")}</p>
+        <span className="ml-auto text-xs text-muted-foreground">
+          {chunks > 0
+            ? t("index.recap.chunksCount", { count: chunks })
+            : "—"}
+        </span>
+      </div>
+
+      {/* Images row */}
+      <div className="flex items-center gap-2">
+        {imagesDone ? (
+          <CheckCircle2 className="h-4 w-4 shrink-0 text-green-600" />
+        ) : imagesRunning ? (
+          <div className="h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        ) : (
+          <div className="h-4 w-4 shrink-0 rounded-full border border-muted-foreground/40" />
+        )}
+        <p className="text-sm font-medium">{t("index.recap.imagesRow")}</p>
+        <span className="ml-auto text-xs text-muted-foreground">
+          {images > 0
+            ? t("index.recap.imagesCount", { count: images })
+            : imagesRunning
+            ? t("index.recap.imagesPending")
+            : imagesDone
+            ? t("index.recap.imagesNone")
+            : "—"}
+        </span>
+      </div>
+
+      {/* Live step label + ETA only while a phase is active */}
+      {isIndexing && (
+        <>
+          <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+            <span className="truncate">
+              {stepLabel || t("index.taskPending")}
+            </span>
+            {eta !== undefined && eta > 0 && (
+              <div className="flex items-center gap-1 shrink-0">
+                <Clock className="h-3 w-3" />
+                <ETALabel seconds={eta} t={t} />
+              </div>
+            )}
+          </div>
+          <Progress value={progressValue} className="h-2" />
+          {onCancel && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onCancel}
+              className="w-full min-h-[44px] border-destructive/50 text-destructive hover:bg-destructive/5 hover:text-destructive"
+            >
+              <StopCircle className="mr-2 h-4 w-4" />
+              {t("index.cancelIndexation")}
+            </Button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
 // ── Props ─────────────────────────────────────────────────────────────
 
 interface AICourseWizardProps {
@@ -1232,49 +1361,19 @@ export function AICourseWizard({
                   </div>
                 )}
 
-                {/* Indexation progress (inline, not a separate step) */}
-                {isIndexing && (
-                  <div className="rounded-lg border bg-card p-4 space-y-3">
-                    <div className="flex items-center justify-between gap-2">
-                      <div className="flex items-center gap-2">
-                        <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent shrink-0" />
-                        <p className="text-sm font-medium">
-                          {taskProg ? (taskProg.state === "EXTRACTING_IMAGES" ? t("index.stepExtractingImages") : getStepLabel(taskProg.step)) : t("index.taskPending")}
-                        </p>
-                      </div>
-                      {taskProg?.estimated_seconds_remaining !== undefined && taskProg.estimated_seconds_remaining > 0 && (
-                        <div className="flex items-center gap-1 text-xs text-muted-foreground shrink-0">
-                          <Clock className="h-3 w-3" />
-                          <ETALabel seconds={taskProg.estimated_seconds_remaining} t={t} />
-                        </div>
-                      )}
-                    </div>
-                    <Progress value={progressValue} className="h-2" />
-                    <div className="flex items-center justify-between text-xs text-muted-foreground">
-                      <span>{progressValue}%</span>
-                      {taskProg && taskProg.files_total > 0 && (
-                        <span>{t("index.filesProgress", { current: taskProg.files_processed, total: taskProg.files_total })}</span>
-                      )}
-                    </div>
-                    <Button variant="outline" size="sm" onClick={cancelIndexation} className="w-full min-h-[44px] border-destructive/50 text-destructive hover:bg-destructive/5 hover:text-destructive">
-                      <StopCircle className="mr-2 h-4 w-4" />
-                      {t("index.cancelIndexation")}
-                    </Button>
-                  </div>
-                )}
-
-                {indexStatus?.indexed && !isIndexing && (
-                  <div className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-3 dark:border-green-900 dark:bg-green-950">
-                    <CheckCircle2 className="h-5 w-5 text-green-600" />
-                    <div>
-                      <p className="text-sm font-medium text-green-700 dark:text-green-400">{t("index.indexed")}</p>
-                      <p className="text-xs text-green-600 dark:text-green-500">
-                        {indexStatus.images_indexed && indexStatus.images_indexed > 0
-                          ? t("index.chunksAndImagesIndexed", { chunks: indexStatus.chunks_indexed, images: indexStatus.images_indexed })
-                          : t("index.chunksIndexed", { count: indexStatus.chunks_indexed })}
-                      </p>
-                    </div>
-                  </div>
+                {/* Indexation recap: text + images on separate rows. The
+                    backend pipeline is one celery task with two phases
+                    (text → images), so a single combined progress bar hid
+                    the second phase. Surfacing both phases makes "0 images
+                    while published" visible (#2032). */}
+                {(isIndexing || indexStatus?.indexed) && (
+                  <IndexationRecap
+                    indexStatus={indexStatus}
+                    isIndexing={isIndexing}
+                    progressValue={progressValue}
+                    onCancel={cancelIndexation}
+                    t={t}
+                  />
                 )}
 
                 {indexError && !isIndexing && (
@@ -1423,7 +1522,10 @@ export function AICourseWizard({
                       disabled={
                         isPublishing ||
                         isIndexing ||
-                        (publishSummaryIndexStatus?.chunks_indexed ?? 0) === 0
+                        // Require the celery task to have hit COMPLETE — not
+                        // just chunks_indexed > 0 — so we don't publish while
+                        // image extraction is still in flight (#2032).
+                        !isIndexationFullyComplete(publishSummaryIndexStatus)
                       }
                     >
                       {isPublishing ? (

--- a/frontend/components/admin/course-wizard-client.tsx
+++ b/frontend/components/admin/course-wizard-client.tsx
@@ -1542,7 +1542,21 @@ export function CourseWizardClient({
                     <Button
                       onClick={publishCourse}
                       className="w-full min-h-11"
-                      disabled={isPublishing}
+                      disabled={
+                        isPublishing ||
+                        isIndexing ||
+                        // Match the AI wizard's gate: require the celery
+                        // task to be fully complete (text + image phases),
+                        // not just chunks_indexed > 0. Avoids publishing
+                        // while image extraction is mid-flight (#2032).
+                        !(
+                          indexStatus?.task?.state === "COMPLETE" ||
+                          indexStatus?.task?.state === "SUCCESS" ||
+                          (!indexStatus?.task?.state &&
+                            indexStatus?.indexed === true &&
+                            (indexStatus?.chunks_indexed ?? 0) > 0)
+                        )
+                      }
                     >
                       {isPublishing ? (
                         <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent mr-2" />

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1475,6 +1475,14 @@
         "imagesProgress": "{count} images extracted",
         "stepExtractingImages": "Extracting images from PDFs",
         "chunksAndImagesIndexed": "{chunks} chunks and {images} images indexed",
+        "recap": {
+          "textRow": "Text",
+          "imagesRow": "Images",
+          "chunksCount": "{count, plural, one {# chunk} other {# chunks}}",
+          "imagesCount": "{count, plural, one {# image} other {# images}}",
+          "imagesPending": "pending",
+          "imagesNone": "no images"
+        },
         "resumeHint": "You can close and come back later. The task continues in the background.",
         "inProgress": "Indexation in progress",
         "noImagesIndexed": "No images were indexed. You can re-index images separately without re-running the full pipeline (no extra OpenAI cost).",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1475,6 +1475,14 @@
         "imagesProgress": "{count} images extraites",
         "stepExtractingImages": "Extraction des images des PDFs",
         "chunksAndImagesIndexed": "{chunks} fragments et {images} images indexés",
+        "recap": {
+          "textRow": "Texte",
+          "imagesRow": "Images",
+          "chunksCount": "{count, plural, one {# fragment} other {# fragments}}",
+          "imagesCount": "{count, plural, one {# image} other {# images}}",
+          "imagesPending": "en attente",
+          "imagesNone": "aucune image"
+        },
         "resumeHint": "Vous pouvez fermer et revenir plus tard. La tâche continue en arrière-plan.",
         "inProgress": "Indexation en cours",
         "noImagesIndexed": "Aucune image indexée. Vous pouvez ré-indexer les images séparément sans relancer le pipeline complet (sans coût OpenAI supplémentaire).",


### PR DESCRIPTION
## Summary

Fixes #2032 — closes the loop on the indexation chain (#2018 → #2023 → #2026 → #2029) by surfacing both phases of the celery task in the wizard and gating publish on the truthful task-completion signal.

## Changes (frontend-only)

### A) Indexation step now shows a two-row recap

**Before:** single combined progress bar; image phase invisible.
**After:** dedicated `IndexationRecap` component renders:
- **Texte** row — spinner during text phases, checkmark + chunk count once text is done
- **Images** row — dash before extraction starts, spinner during EXTRACTING_IMAGES, checkmark + image count once COMPLETE
- live step label + ETA + cancel button stay below while the task is active

State derived from `task.state` (TEXT_STAGES vs IMAGE_STAGES vs terminal).

### B) Publish gate uses the truthful task-completion signal

**AI wizard** — was `chunks_indexed === 0`. Now requires `task.state === COMPLETE` / `SUCCESS`, with a fallback to `indexed=true && chunks>0` when the task result has been evicted from Celery's result backend.

**Manual wizard** — had **no** indexation gate at all (only `isPublishing`). Now matches the AI wizard's logic.

This makes "publish while images still extracting" impossible — the staging incident (`a8b62017-...` published with `image_count: 0` while task was still EXTRACTING_IMAGES) cannot recur.

## Files

- `frontend/components/admin/ai-course-wizard.tsx` — adds `IndexationRecap` sub-component, replaces inline indexation UI, tightens publish gate via `isIndexationFullyComplete()` helper
- `frontend/components/admin/course-wizard-client.tsx` — same gate logic on the manual wizard's publish button
- `frontend/messages/{fr,en}.json` — adds `index.recap.{textRow,imagesRow,chunksCount,imagesCount,imagesPending,imagesNone}` keys

`+177 / -45` total.

## Backend

No backend change. `backend/app/tasks/rag_indexation.py:439` already only writes `creation_step = "indexed"` after the full pipeline (text + images + linking) reaches COMPLETE — the wizard was just not consuming that signal.

## Test plan (staging, after deploy)

- [ ] Trigger indexation on a course with figures (use `triola.pdf`).
- [ ] Index step shows two rows: Texte (spinner → ✓ + N fragments) and Images (dash → spinner → ✓ + N images), each transitioning independently.
- [ ] Publier button stays **disabled** the entire time the task is running, including the EXTRACTING_IMAGES phase, regardless of `chunks_indexed`.
- [ ] Once task hits COMPLETE: both rows green-checked, Publier becomes clickable.
- [ ] Manual wizard (CourseWizardClient): same Publier gate — no longer publishable while indexation is in flight.
- [ ] PDFs with no figures: Images row shows "aucune image" / "no images" with a checkmark when the task completes — Publier still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)