### PR TITLE
fix(wizard): add Liens row to indexation recap + gate publish on linker (#2035)

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -21,7 +21,7 @@ from app.domain.models.module import Module
 from app.domain.models.module_unit import ModuleUnit
 from app.domain.models.preassessment import CoursePreAssessment
 from app.domain.models.quiz import PlacementTestAttempt
-from app.domain.models.source_image import SourceImage
+from app.domain.models.source_image import SourceImage, SourceImageChunk
 from app.domain.models.taxonomy import TaxonomyCategory
 from app.domain.models.user import UserRole
 from app.tasks.content_generation import generate_lesson_task, pregenerate_on_publish_task
@@ -1155,11 +1155,23 @@ async def get_rag_index_status(
     )
     images_indexed = image_count.scalar_one()
 
+    # Count chunk↔image join rows. The wizard's recap (#2035) surfaces this
+    # as a third row so admins can see when the linker silently failed —
+    # cached lessons without source_image_refs were the user-visible symptom.
+    link_count = await db.execute(
+        select(func.count())
+        .select_from(SourceImageChunk)
+        .join(SourceImage, SourceImageChunk.source_image_id == SourceImage.id)
+        .where(SourceImage.rag_collection_id == course.rag_collection_id)
+    )
+    links_indexed = link_count.scalar_one()
+
     response: dict = {
         "course_id": str(course_id),
         "rag_collection_id": course.rag_collection_id,
         "chunks_indexed": chunks_indexed,
         "images_indexed": images_indexed,
+        "links_indexed": links_indexed,
         "indexed": chunks_indexed > 0,
     }
 

--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -168,18 +168,23 @@ const IMAGE_STAGES = new Set(["EXTRACTING_IMAGES", "LINKING_IMAGES"]);
 function isIndexationFullyComplete(indexStatus: IndexStatus | null): boolean {
   if (!indexStatus) return false;
   const taskState = indexStatus.task?.state;
-  // Truthful signal: celery task hit COMPLETE/SUCCESS. We also accept the
-  // case where the task was cleaned from the result backend but the live
-  // chunk count + indexed flag say we're done, since those persist.
-  if (taskState === "COMPLETE" || taskState === "SUCCESS") return true;
-  if (
-    !taskState &&
-    indexStatus.indexed &&
-    (indexStatus.chunks_indexed ?? 0) > 0
-  ) {
-    return true;
-  }
-  return false;
+  const taskComplete =
+    taskState === "COMPLETE" ||
+    taskState === "SUCCESS" ||
+    (!taskState &&
+      indexStatus.indexed &&
+      (indexStatus.chunks_indexed ?? 0) > 0);
+  if (!taskComplete) return false;
+
+  // If images were extracted, at least one source_image_chunks row must
+  // exist — otherwise the linker silently failed and lessons would ship
+  // with empty source_image_refs. PDFs with no figures legitimately have
+  // 0 images AND 0 links; that's still publishable. (#2035)
+  const images = indexStatus.images_indexed ?? 0;
+  const links = indexStatus.links_indexed ?? 0;
+  if (images > 0 && links === 0) return false;
+
+  return true;
 }
 
 function IndexationRecap({
@@ -200,13 +205,27 @@ function IndexationRecap({
   const eta = indexStatus?.task?.estimated_seconds_remaining;
   const chunks = indexStatus?.chunks_indexed ?? 0;
   const images = indexStatus?.images_indexed ?? 0;
+  const links = indexStatus?.links_indexed ?? 0;
 
   // Phase derivations based on the celery task state machine.
   const textRunning = !!taskState && TEXT_STAGES.has(taskState);
   const imagesRunning = !!taskState && IMAGE_STAGES.has(taskState);
+  // The linker phase happens at the end of process_pdf_images, signalled
+  // by celery state LINKING_IMAGES. If the task hits COMPLETE without
+  // links being created on a course that has images, the linker silently
+  // failed (a real bug we surface here so the admin doesn't publish blind).
+  const linkingRunning = taskState === "LINKING_IMAGES";
   const fullyDone = isIndexationFullyComplete(indexStatus);
-  const textDone = fullyDone || imagesRunning || chunks > 0;
-  const imagesDone = fullyDone;
+  const textDone = fullyDone || imagesRunning || linkingRunning || chunks > 0;
+  const imagesDone = fullyDone || linkingRunning;
+  // Links are "done" only when the whole task is complete AND either no
+  // images existed (nothing to link) or the join produced rows.
+  const linksDone = fullyDone && (images === 0 || links > 0);
+  const linksFailed =
+    !!taskState &&
+    (taskState === "COMPLETE" || taskState === "SUCCESS") &&
+    images > 0 &&
+    links === 0;
 
   return (
     <div className="rounded-lg border bg-card p-4 space-y-3">
@@ -244,6 +263,36 @@ function IndexationRecap({
             ? t("index.recap.imagesPending")
             : imagesDone
             ? t("index.recap.imagesNone")
+            : "—"}
+        </span>
+      </div>
+
+      {/* Liens (links) row — surfaces the linker phase so admins can see when
+          source_image_chunks failed to populate (#2035). */}
+      <div className="flex items-center gap-2">
+        {linksFailed ? (
+          <AlertCircle className="h-4 w-4 shrink-0 text-destructive" />
+        ) : linksDone ? (
+          <CheckCircle2 className="h-4 w-4 shrink-0 text-green-600" />
+        ) : linkingRunning ? (
+          <div className="h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        ) : (
+          <div className="h-4 w-4 shrink-0 rounded-full border border-muted-foreground/40" />
+        )}
+        <p className="text-sm font-medium">{t("index.recap.linksRow")}</p>
+        <span
+          className={`ml-auto text-xs ${
+            linksFailed ? "text-destructive" : "text-muted-foreground"
+          }`}
+        >
+          {linksFailed
+            ? t("index.recap.linksFailed")
+            : links > 0
+            ? t("index.recap.linksCount", { count: links })
+            : linkingRunning
+            ? t("index.recap.linksPending")
+            : linksDone
+            ? t("index.recap.linksNone")
             : "—"}
         </span>
       </div>

--- a/frontend/components/admin/course-wizard-client.tsx
+++ b/frontend/components/admin/course-wizard-client.tsx
@@ -102,6 +102,9 @@ interface IndexStatus {
   indexed: boolean;
   chunks_indexed: number;
   images_indexed?: number;
+  // Live count of source_image_chunks rows for this course's collection.
+  // Used by the publish gate to detect linker silent failures (#2035).
+  links_indexed?: number;
   task?: TaskProgress;
 }
 
@@ -1545,17 +1548,26 @@ export function CourseWizardClient({
                       disabled={
                         isPublishing ||
                         isIndexing ||
-                        // Match the AI wizard's gate: require the celery
-                        // task to be fully complete (text + image phases),
-                        // not just chunks_indexed > 0. Avoids publishing
-                        // while image extraction is mid-flight (#2032).
-                        !(
-                          indexStatus?.task?.state === "COMPLETE" ||
-                          indexStatus?.task?.state === "SUCCESS" ||
-                          (!indexStatus?.task?.state &&
-                            indexStatus?.indexed === true &&
-                            (indexStatus?.chunks_indexed ?? 0) > 0)
-                        )
+                        !(() => {
+                          // Match the AI wizard's gate: task must be fully
+                          // complete (text + image + linker phases) before
+                          // publish. (#2032 / #2035)
+                          const taskState = indexStatus?.task?.state;
+                          const taskComplete =
+                            taskState === "COMPLETE" ||
+                            taskState === "SUCCESS" ||
+                            (!taskState &&
+                              indexStatus?.indexed === true &&
+                              (indexStatus?.chunks_indexed ?? 0) > 0);
+                          if (!taskComplete) return false;
+                          const images = indexStatus?.images_indexed ?? 0;
+                          const links = indexStatus?.links_indexed ?? 0;
+                          // If the linker had work to do, at least one row
+                          // must exist; otherwise lessons publish without
+                          // figure refs (#2035).
+                          if (images > 0 && links === 0) return false;
+                          return true;
+                        })()
                       }
                     >
                       {isPublishing ? (

--- a/frontend/lib/api-course-admin.ts
+++ b/frontend/lib/api-course-admin.ts
@@ -58,6 +58,11 @@ export interface IndexStatus {
   indexed: boolean;
   chunks_indexed: number;
   images_indexed?: number;
+  // Live count of `source_image_chunks` rows for this course's rag
+  // collection. Surfaced in the wizard recap so the linker phase is
+  // visible — silent linker failures used to ship lessons with empty
+  // source_image_refs (#2035).
+  links_indexed?: number;
   task?: TaskProgress;
 }
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1478,10 +1478,15 @@
         "recap": {
           "textRow": "Text",
           "imagesRow": "Images",
+          "linksRow": "Image-text links",
           "chunksCount": "{count, plural, one {# chunk} other {# chunks}}",
           "imagesCount": "{count, plural, one {# image} other {# images}}",
           "imagesPending": "pending",
-          "imagesNone": "no images"
+          "imagesNone": "no images",
+          "linksCount": "{count, plural, one {# link} other {# links}}",
+          "linksPending": "pending",
+          "linksNone": "no links needed",
+          "linksFailed": "failed — re-run indexation"
         },
         "resumeHint": "You can close and come back later. The task continues in the background.",
         "inProgress": "Indexation in progress",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1478,10 +1478,15 @@
         "recap": {
           "textRow": "Texte",
           "imagesRow": "Images",
+          "linksRow": "Liens images-texte",
           "chunksCount": "{count, plural, one {# fragment} other {# fragments}}",
           "imagesCount": "{count, plural, one {# image} other {# images}}",
           "imagesPending": "en attente",
-          "imagesNone": "aucune image"
+          "imagesNone": "aucune image",
+          "linksCount": "{count, plural, one {# lien} other {# liens}}",
+          "linksPending": "en attente",
+          "linksNone": "aucun lien nécessaire",
+          "linksFailed": "échec — relancer l'indexation"
         },
         "resumeHint": "Vous pouvez fermer et revenir plus tard. La tâche continue en arrière-plan.",
         "inProgress": "Indexation en cours",


### PR DESCRIPTION
## Summary

- Fixes #2035 — extends the recap added in #2033 with a third **Liens** row, surfacing the linker phase that was previously invisible.
- Tightens the publish gate so a course with images but no links can't be published — that's exactly what failed on staging today (course `a8b62017-...` has 460 images but 0 rows in `source_image_chunks`).

## Changes

### Backend (1 file)

[backend/app/api/v1/admin_courses.py](backend/app/api/v1/admin_courses.py) — `/admin/courses/{id}/index-status` now returns `links_indexed: int` (live `SELECT COUNT(*)` on `source_image_chunks` joined to `source_images.rag_collection_id`).

### Frontend (4 files)

- [frontend/lib/api-course-admin.ts](frontend/lib/api-course-admin.ts) — extends `IndexStatus` type with `links_indexed?: number`
- [frontend/components/admin/ai-course-wizard.tsx](frontend/components/admin/ai-course-wizard.tsx) — `IndexationRecap` renders a third Liens row with spinner / check / red AlertCircle (silent-failure case); `isIndexationFullyComplete()` now also requires `images === 0 || links > 0`
- [frontend/components/admin/course-wizard-client.tsx](frontend/components/admin/course-wizard-client.tsx) — local `IndexStatus` extended; manual wizard's publish gate inlined with the same logic
- [frontend/messages/{fr,en}.json](frontend/messages) — adds `index.recap.{linksRow,linksCount,linksPending,linksNone,linksFailed}`

`+116 / −28` total.

## Test plan (staging, after deploy)

- [ ] `GET /admin/courses/{id}/index-status` includes `links_indexed: <int>`.
- [ ] Indexation step shows three rows (Texte / Images / Liens), each with its own state.
- [ ] During EXTRACTING_IMAGES: Liens row shows a dash. During LINKING_IMAGES: Liens row spins. After COMPLETE: Liens row green-checked with "{N} liens".
- [ ] **Failure mode visible**: on a course with 460 images / 0 links (today's staging state), Liens row shows AlertCircle + "échec — relancer l'indexation"; Publier stays disabled.
- [ ] **PDF with no figures** (0 images / 0 links): Liens row shows "aucun lien nécessaire" with check; Publier works.
- [ ] Manual wizard (CourseWizardClient) has the same gate behaviour.

## Out of scope

The reason `source_image_chunks` ends up empty for some courses is a separate **linker quality** bug (chunker doesn't populate `chunk.page` so contextual matching fails; the explicit-Figure regex is strict). That's #2036 territory — this PR only ensures the failure is visible and gates publish appropriately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)