### PR TITLE
fix(rag): chunk per-page so linker contextual matching works (#2038)

### DIFF
--- a/backend/app/ai/rag/chunker.py
+++ b/backend/app/ai/rag/chunker.py
@@ -209,23 +209,36 @@ class TextChunker:
         return " ".join(overlap_words)
 
 
-def extract_text_from_pdf(pdf_path: str) -> str:
-    """Extract text from PDF using PyMuPDF."""
+def extract_pages_from_pdf(pdf_path: str) -> list[tuple[int, str]]:
+    """Extract text from a PDF as a list of `(page_number, text)` tuples.
+
+    Page numbers are 1-indexed. Empty pages are skipped (returned list is
+    sparse on page numbers, never sparse on indices). Used by the chunker
+    so each `DocumentChunk.page` reflects the source page — the linker's
+    contextual matching is dead without this (#2038).
+    """
     import fitz  # PyMuPDF
 
-    text_content = []
-
+    pages: list[tuple[int, str]] = []
     try:
         doc = fitz.open(pdf_path)
-        for page in doc:
+        for idx, page in enumerate(doc):
             text = page.get_text()
-            if text.strip():
-                text_content.append(text)
+            if text and text.strip():
+                pages.append((idx + 1, text))
         doc.close()
     except Exception as e:
         raise ValueError(f"Failed to extract text from {pdf_path}: {e}")
+    return pages
 
-    return "\n".join(text_content)
+
+def extract_text_from_pdf(pdf_path: str) -> str:
+    """Extract text from PDF using PyMuPDF. Joins pages with newlines.
+
+    Kept as a thin wrapper around `extract_pages_from_pdf` for callers
+    that don't care about page boundaries.
+    """
+    return "\n".join(text for _, text in extract_pages_from_pdf(pdf_path))
 
 
 def detect_language(text: str) -> str:

--- a/backend/app/ai/rag/image_linker.py
+++ b/backend/app/ai/rag/image_linker.py
@@ -19,7 +19,11 @@ from app.domain.models.source_image import SourceImage, SourceImageChunk
 
 logger = structlog.get_logger(__name__)
 
-_FIGURE_RE = re.compile(r"(?:Figure|Fig\.?)\s+(\d+[\.\-]?\d*)", re.IGNORECASE)
+# Match "Figure 1.5", "Fig 1-5", "Fig. 1.5.3", "FIGURE1.5", etc. The `.?\s*`
+# lets the period-and-space after "Fig"/"Figure" be optional. The
+# `(?:[\.\-]\d+)*` allows multi-part numbering ("1.5.3") rather than the
+# previous two-part cap. (#2038)
+_FIGURE_RE = re.compile(r"(?:Figure|Fig)\.?\s*(\d+(?:[\.\-]\d+)*)", re.IGNORECASE)
 
 _PAGE_ADJACENCY = 1
 

--- a/backend/app/ai/rag/pipeline.py
+++ b/backend/app/ai/rag/pipeline.py
@@ -9,7 +9,11 @@ import structlog
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.ai.rag.chunker import TextChunker, detect_language, extract_text_from_pdf
+from app.ai.rag.chunker import (
+    TextChunker,
+    detect_language,
+    extract_pages_from_pdf,
+)
 from app.ai.rag.embeddings import EmbeddingService
 from app.ai.rag.image_extractor import PDFImageExtractor
 from app.ai.rag.image_linker import ImageLinker
@@ -65,25 +69,45 @@ class RAGPipeline:
 
         logger.info("Starting PDF processing", pdf_path=str(pdf_path), source=source)
 
-        # Extract text from PDF
+        # Extract text per page so each chunk can record its page number.
+        # The image linker's contextual matching joins on chunk.page == image.page_number;
+        # before #2038 this was always None and that match path was dead.
         try:
-            text = extract_text_from_pdf(str(pdf_path))
+            pages = extract_pages_from_pdf(str(pdf_path))
         except Exception as e:
             logger.error("Failed to extract text from PDF", pdf_path=str(pdf_path), error=str(e))
             raise
 
-        if not text.strip():
+        if not pages:
             logger.warning("No text extracted from PDF", pdf_path=str(pdf_path))
             return 0
 
-        # Detect language
-        language = detect_language(text)
-        logger.info("Detected language", language=language, text_length=len(text))
-
-        # Create chunks
-        chunks = list(
-            self.chunker.chunk_document(text=text, source=source, level=level, language=language)
+        # Sample first 5 pages for language detection — full document join would
+        # waste memory on a 600-page textbook for the same answer.
+        sample = " ".join(t for _, t in pages[:5])
+        language = detect_language(sample)
+        total_chars = sum(len(t) for _, t in pages)
+        logger.info(
+            "Detected language",
+            language=language,
+            text_length=total_chars,
+            page_count=len(pages),
         )
+
+        # Chunk page-by-page so each emitted DocumentChunk inherits its page.
+        chunks = []
+        for page_num, page_text in pages:
+            if not page_text.strip():
+                continue
+            chunks.extend(
+                self.chunker.chunk_document(
+                    text=page_text,
+                    source=source,
+                    level=level,
+                    language=language,
+                    page=page_num,
+                )
+            )
 
         if not chunks:
             logger.warning("No chunks created from document", pdf_path=str(pdf_path))


### PR DESCRIPTION
## Summary

Fixes #2038 — the linker's contextual-matching rule was completely dead because `chunk.page` was always NULL, which is why the staging biostat course got just **2 chunk-image links from 460 images** (and the new Liens row in #2035 will display the failure red).

## Root cause

`backend/app/ai/rag/chunker.py:212` — `extract_text_from_pdf()` walked pages with PyMuPDF but flattened them into a single `\n`-joined string. The downstream `chunk_document(text, …, page=None)` then ran once with no page boundary, so every emitted `DocumentChunk` had `page = None`. The linker's contextual SQL (`chunks.page == images.page_number`) couldn't match anything.

## Changes (3 files, +61 / −20)

1. [backend/app/ai/rag/chunker.py](backend/app/ai/rag/chunker.py) — adds `extract_pages_from_pdf(pdf_path) -> list[tuple[int, str]]` returning per-page tuples. `extract_text_from_pdf` becomes a thin join-wrapper for backward-compat callers.

2. [backend/app/ai/rag/pipeline.py](backend/app/ai/rag/pipeline.py) — `process_pdf_document` now calls the per-page extractor and chunks page-by-page (`chunk_document(text=page_text, …, page=page_num)`). Language detection samples the first 5 pages instead of joining the whole document.

3. [backend/app/ai/rag/image_linker.py](backend/app/ai/rag/image_linker.py) — loosens the explicit-figure regex so `"Fig 1"` (no period), `"FIGURE1.5"` (no space), and three-part numbers (`"1.5.3"`) all match.

## Expected impact

Re-running the full pipeline on `triola.pdf`:
- Contextual links: **0 → hundreds** (most images on pages 1–564 will hit chunks on the same page)
- Explicit links: **2 → many** (looser regex catches common variations)
- Liens row in the wizard recap turns green ✓ instead of red AlertCircle for that course

## Test plan (staging, after deploy)

- [ ] Trigger full re-indexation (`POST /admin/courses/{id}/index-resources` after `cancel-indexation` clears the old state) on a course with figures.
- [ ] After it completes: `SELECT COUNT(*) FROM document_chunks WHERE source = … AND page IS NOT NULL` → non-zero (≈ chunk count).
- [ ] `SELECT reference_type, COUNT(*) FROM source_image_chunks WHERE source_image_id IN (SELECT id FROM source_images WHERE rag_collection_id = …) GROUP BY reference_type` → both `explicit` and `contextual` non-zero.
- [ ] Wizard's Liens row shows a non-trivial count, no red AlertCircle.
- [ ] Existing courses pre-fix can be brought into compliance by `POST /reindex-images` only — no need to re-embed text — once the contextual-match SQL has chunks with pages. (Contextual matching is server-side: it runs against current chunk page values, so re-running just the linker on existing-but-paged chunks will populate links. Old chunks with NULL pages would need a full re-index. Operational note, not a code task.)

## Out of scope

- Backfill of existing courses (operational task, not in the codebase)
- The pre-existing `reindex_course_images` asyncio "different loop" crash when `clear_old=True` (separate issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)