### PR TITLE
fix(wizard): dedicated Linker step + relink-images recovery (#2044)

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -1290,6 +1290,65 @@ async def trigger_image_reindexation(
     return {"task_id": task.id, "status": "started"}
 
 
+@router.post("/{course_id}/relink-images")
+async def relink_images(
+    course_id: uuid.UUID,
+    clear_old: bool = False,
+    current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
+    db=Depends(get_db_session),
+) -> dict:
+    """Re-run the chunk↔image linker without re-embedding or re-extracting.
+
+    The linker is fast (single SELECT + simple Python pairing logic, ~1s for
+    several hundred images) and does not call any external APIs. Useful when:
+
+    - The linker was deployed in an updated form (regex change, new heuristic)
+      and existing courses need their join table refreshed.
+    - A previous indexation run had a transient linker failure and the recap
+      shows red on the Liens row.
+
+    `clear_old=True` purges existing junction rows for this course's
+    rag_collection before re-running, so the looser regex from #2038 can
+    fully re-evaluate. Default `False` keeps existing rows (linker is
+    idempotent and only adds new pairs).
+
+    Powers the wizard's "Relancer le linker" button on the Linker step
+    (#2044).
+    """
+    from app.ai.rag.image_linker import ImageLinker
+
+    result = await db.execute(select(Course).where(Course.id == course_id))
+    course = result.scalar_one_or_none()
+    if not course:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
+    if not course.rag_collection_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Course has no rag_collection_id",
+        )
+
+    linker = ImageLinker()
+    cleared = 0
+    if clear_old:
+        cleared = await linker.clear_links_for_source(source=course.rag_collection_id, session=db)
+
+    links_added = await linker.link_images_to_chunks(source=course.rag_collection_id, session=db)
+    await db.commit()
+
+    logger.info(
+        "Linker re-run",
+        course_id=str(course_id),
+        rag_collection_id=course.rag_collection_id,
+        cleared=cleared,
+        links_added=links_added,
+        admin_id=current_user.id,
+    )
+    return {
+        "links_added": links_added,
+        "cleared": cleared,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Resource Upload
 # ---------------------------------------------------------------------------

--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -23,6 +23,7 @@ import {
   StopCircle,
   RotateCcw,
   BookOpen,
+  Link as LinkIcon,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -51,6 +52,7 @@ import {
   getIndexStatusApi,
   cancelIndexationApi,
   reindexImagesApi,
+  relinkImagesApi,
   updateAdminCourse,
   publishAdminCourse,
   suggestCourseMetadata,
@@ -76,6 +78,7 @@ type AIWizardStep =
   | "syllabus_edit"
   | "lesson_preview"
   | "indexation"
+  | "linker"
   | "publish";
 
 const AI_STEPS: AIWizardStep[] = [
@@ -85,9 +88,13 @@ const AI_STEPS: AIWizardStep[] = [
   "generate",
   "syllabus_edit",
   "lesson_preview",
-  // Dedicated indexation step so the Texte/Images/Liens recap is visible
+  // Dedicated indexation step so the Texte/Images recap is visible
   // as its own phase rather than buried inside syllabus_edit (#2041).
   "indexation",
+  // Dedicated linker step — splits the chunk↔image join from the
+  // text+image extraction phase. Lets the admin see the link count and
+  // hit "Relancer le linker" without paying for re-embedding (#2044).
+  "linker",
   "publish",
 ];
 
@@ -99,6 +106,7 @@ const STEP_ICONS: Record<AIWizardStep, React.ReactNode> = {
   syllabus_edit: <GripVertical className="h-4 w-4" />,
   lesson_preview: <BookOpen className="h-4 w-4" />,
   indexation: <Database className="h-4 w-4" />,
+  linker: <LinkIcon className="h-4 w-4" />,
   publish: <Rocket className="h-4 w-4" />,
 };
 
@@ -170,27 +178,32 @@ const TEXT_STAGES = new Set([
 // Stages where the IMAGE phase has begun (text is done by now).
 const IMAGE_STAGES = new Set(["EXTRACTING_IMAGES", "LINKING_IMAGES"]);
 
-function isIndexationFullyComplete(indexStatus: IndexStatus | null): boolean {
+// Text+images extraction has hit COMPLETE/SUCCESS. Linker may not have run.
+// This is the gate for advancing past the "indexation" step (#2044).
+function isExtractionComplete(indexStatus: IndexStatus | null): boolean {
   if (!indexStatus) return false;
   const taskState = indexStatus.task?.state;
-  const taskComplete =
+  return (
     taskState === "COMPLETE" ||
     taskState === "SUCCESS" ||
     (!taskState &&
       indexStatus.indexed &&
-      (indexStatus.chunks_indexed ?? 0) > 0);
-  if (!taskComplete) return false;
-
-  // If images were extracted, at least one source_image_chunks row must
-  // exist — otherwise the linker silently failed and lessons would ship
-  // with empty source_image_refs. PDFs with no figures legitimately have
-  // 0 images AND 0 links; that's still publishable. (#2035)
-  const images = indexStatus.images_indexed ?? 0;
-  const links = indexStatus.links_indexed ?? 0;
-  if (images > 0 && links === 0) return false;
-
-  return true;
+      (indexStatus.chunks_indexed ?? 0) > 0)
+  );
 }
+
+// Linker has populated source_image_chunks, OR there were no images to link.
+// This is the publish gate AND the "linker" step gate. PDFs with no figures
+// legitimately have 0 images AND 0 links; that's still publishable. (#2035)
+function isLinkerComplete(indexStatus: IndexStatus | null): boolean {
+  if (!isExtractionComplete(indexStatus)) return false;
+  const images = indexStatus?.images_indexed ?? 0;
+  const links = indexStatus?.links_indexed ?? 0;
+  return images === 0 || links > 0;
+}
+
+// Back-compat alias kept so the publish-button gate keeps the same name.
+const isIndexationFullyComplete = isLinkerComplete;
 
 function IndexationRecap({
   indexStatus,
@@ -210,27 +223,18 @@ function IndexationRecap({
   const eta = indexStatus?.task?.estimated_seconds_remaining;
   const chunks = indexStatus?.chunks_indexed ?? 0;
   const images = indexStatus?.images_indexed ?? 0;
-  const links = indexStatus?.links_indexed ?? 0;
 
   // Phase derivations based on the celery task state machine.
   const textRunning = !!taskState && TEXT_STAGES.has(taskState);
   const imagesRunning = !!taskState && IMAGE_STAGES.has(taskState);
   // The linker phase happens at the end of process_pdf_images, signalled
-  // by celery state LINKING_IMAGES. If the task hits COMPLETE without
-  // links being created on a course that has images, the linker silently
-  // failed (a real bug we surface here so the admin doesn't publish blind).
+  // by celery state LINKING_IMAGES. The Liens row moved to a dedicated
+  // "linker" step (#2044), so here we only treat LINKING_IMAGES as "image
+  // extraction is done" — the linker substep gets its own UI.
   const linkingRunning = taskState === "LINKING_IMAGES";
-  const fullyDone = isIndexationFullyComplete(indexStatus);
-  const textDone = fullyDone || imagesRunning || linkingRunning || chunks > 0;
-  const imagesDone = fullyDone || linkingRunning;
-  // Links are "done" only when the whole task is complete AND either no
-  // images existed (nothing to link) or the join produced rows.
-  const linksDone = fullyDone && (images === 0 || links > 0);
-  const linksFailed =
-    !!taskState &&
-    (taskState === "COMPLETE" || taskState === "SUCCESS") &&
-    images > 0 &&
-    links === 0;
+  const extractionDone = isExtractionComplete(indexStatus);
+  const textDone = extractionDone || imagesRunning || linkingRunning || chunks > 0;
+  const imagesDone = extractionDone || linkingRunning;
 
   return (
     <div className="rounded-lg border bg-card p-4 space-y-3">
@@ -268,36 +272,6 @@ function IndexationRecap({
             ? t("index.recap.imagesPending")
             : imagesDone
             ? t("index.recap.imagesNone")
-            : "—"}
-        </span>
-      </div>
-
-      {/* Liens (links) row — surfaces the linker phase so admins can see when
-          source_image_chunks failed to populate (#2035). */}
-      <div className="flex items-center gap-2">
-        {linksFailed ? (
-          <AlertCircle className="h-4 w-4 shrink-0 text-destructive" />
-        ) : linksDone ? (
-          <CheckCircle2 className="h-4 w-4 shrink-0 text-green-600" />
-        ) : linkingRunning ? (
-          <div className="h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-        ) : (
-          <div className="h-4 w-4 shrink-0 rounded-full border border-muted-foreground/40" />
-        )}
-        <p className="text-sm font-medium">{t("index.recap.linksRow")}</p>
-        <span
-          className={`ml-auto text-xs ${
-            linksFailed ? "text-destructive" : "text-muted-foreground"
-          }`}
-        >
-          {linksFailed
-            ? t("index.recap.linksFailed")
-            : links > 0
-            ? t("index.recap.linksCount", { count: links })
-            : linkingRunning
-            ? t("index.recap.linksPending")
-            : linksDone
-            ? t("index.recap.linksNone")
             : "—"}
         </span>
       </div>
@@ -810,10 +784,20 @@ export function AICourseWizard({
           setIsIndexing(false);
           setIndexStaleWarning(false);
           queryClient.invalidateQueries({ queryKey: ["admin-courses"] });
-          // Auto-advance to publish if the user is sitting on the indexation
-          // step waiting for completion (#2041). Functional setStep reads
-          // the latest step without needing it in the effect's deps.
-          setStep((s) => (s === "indexation" ? "publish" : s));
+          // Auto-advance through the new linker step (#2044):
+          //   indexation → linker (always)
+          //   linker → publish iff the chunk↔image join produced rows
+          //                     (or there were no images to link)
+          // If the linker silently failed (images > 0, links === 0), stop on
+          // the linker step so the admin can hit "Relancer le linker".
+          const linksOk =
+            (status.images_indexed ?? 0) === 0 ||
+            (status.links_indexed ?? 0) > 0;
+          setStep((s) => {
+            if (s === "indexation") return "linker";
+            if (s === "linker" && linksOk) return "publish";
+            return s;
+          });
           return;
         }
 
@@ -936,6 +920,43 @@ export function AICourseWizard({
     }
   }, [courseId]);
 
+  // Auto-advance linker → publish once the join has populated rows. Runs on
+  // step change (manual Next from indexation), polling completion, resume,
+  // and on relink success (#2044).
+  useEffect(() => {
+    if (step !== "linker") return;
+    if (isLinkerComplete(indexStatus)) {
+      const t = setTimeout(() => setStep("publish"), 800);
+      return () => clearTimeout(t);
+    }
+  }, [step, indexStatus]);
+
+  // Linker recovery — re-runs the chunk↔image join inline (no celery, no
+  // re-embedding, no re-extraction). Powers the "Relancer le linker" button
+  // on the dedicated linker step (#2044).
+  const [isRelinking, setIsRelinking] = useState(false);
+  const [relinkError, setRelinkError] = useState<string | null>(null);
+  const relinkLinker = useCallback(async () => {
+    if (!courseId) return;
+    setIsRelinking(true);
+    setRelinkError(null);
+    try {
+      await relinkImagesApi(courseId);
+      const status = await getIndexStatusApi(courseId);
+      setIndexStatus({
+        indexed: status.indexed,
+        chunks_indexed: status.chunks_indexed,
+        images_indexed: status.images_indexed,
+        links_indexed: status.links_indexed,
+        task: status.task,
+      });
+    } catch {
+      setRelinkError(tAi("linker.error"));
+    } finally {
+      setIsRelinking(false);
+    }
+  }, [courseId, tAi]);
+
   // ── Publish ───────────────────────────────────────────────────────
 
   useEffect(() => {
@@ -992,9 +1013,12 @@ export function AICourseWizard({
     if (step === "generate") return generatedModules.length > 0;
     if (step === "syllabus_edit") return generatedModules.length > 0;
     if (step === "lesson_preview") return true; // Optional step — always skippable
-    // Indexation step: same gate as the publish button — task must be
-    // fully complete (text + images + linker). (#2041)
-    if (step === "indexation") return isIndexationFullyComplete(indexStatus);
+    // Indexation step: text + image extraction must be done. The linker
+    // gets its own step now (#2044) — don't block indexation on link rows.
+    if (step === "indexation") return isExtractionComplete(indexStatus);
+    // Linker step: chunk↔image join must have produced rows (or there were
+    // no images to link). This is also the publish gate.
+    if (step === "linker") return isLinkerComplete(indexStatus);
     return false;
   };
 
@@ -1483,6 +1507,109 @@ export function AICourseWizard({
                 )}
               </div>
             )}
+
+            {/* ── LINKER STEP ───────────────────────────────────────── */}
+            {/* Dedicated step for the chunk↔image linker (#2044). Splits
+                the join phase out of indexation so admins can see when
+                source_image_chunks rows weren't created and re-run the
+                linker without re-embedding text or re-extracting images. */}
+            {step === "linker" && (() => {
+              const taskState = indexStatus?.task?.state;
+              const linkingRunning = taskState === "LINKING_IMAGES";
+              const images = indexStatus?.images_indexed ?? 0;
+              const links = indexStatus?.links_indexed ?? 0;
+              const extractionDone = isExtractionComplete(indexStatus);
+              const linksDone = isLinkerComplete(indexStatus);
+              const linksFailed = extractionDone && images > 0 && links === 0;
+
+              let bannerCls = "border-muted bg-muted/30";
+              let icon = (
+                <div className="h-5 w-5 shrink-0 rounded-full border border-muted-foreground/40" />
+              );
+              let bannerText = tAi("linker.idle");
+              if (linkingRunning || isRelinking) {
+                bannerCls = "border-primary/30 bg-primary/5";
+                icon = (
+                  <div className="h-5 w-5 shrink-0 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                );
+                bannerText = tAi("linker.running");
+              } else if (linksDone) {
+                bannerCls = "border-green-300 bg-green-50 dark:border-green-700/40 dark:bg-green-950/30";
+                icon = <CheckCircle2 className="h-5 w-5 shrink-0 text-green-600" />;
+                bannerText = images === 0
+                  ? tAi("linker.doneNone")
+                  : tAi("linker.done");
+              } else if (linksFailed) {
+                bannerCls = "border-destructive/40 bg-destructive/5";
+                icon = <AlertCircle className="h-5 w-5 shrink-0 text-destructive" />;
+                bannerText = tAi("linker.failed");
+              }
+
+              return (
+                <div className="space-y-4">
+                  <div>
+                    <h3 className="text-xl font-semibold">{tAi("linker.title")}</h3>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      {tAi("linker.description")}
+                    </p>
+                  </div>
+
+                  <div className={`rounded-lg border p-4 space-y-3 ${bannerCls}`}>
+                    <div className="flex items-start gap-3">
+                      {icon}
+                      <p className="text-sm font-medium">{bannerText}</p>
+                    </div>
+
+                    <div className="flex items-center justify-between gap-4 text-sm">
+                      <span className="text-muted-foreground">
+                        {t("index.recap.linksRow")}
+                      </span>
+                      <span className="font-medium">
+                        {linksFailed
+                          ? t("index.recap.linksFailed")
+                          : links > 0
+                          ? t("index.recap.linksCount", { count: links })
+                          : linkingRunning || isRelinking
+                          ? t("index.recap.linksPending")
+                          : linksDone
+                          ? t("index.recap.linksNone")
+                          : "—"}
+                      </span>
+                    </div>
+
+                    {images > 0 && (
+                      <div className="flex items-center justify-between gap-4 text-xs text-muted-foreground">
+                        <span>{t("index.recap.imagesRow")}</span>
+                        <span>{t("index.recap.imagesCount", { count: images })}</span>
+                      </div>
+                    )}
+                  </div>
+
+                  {relinkError && (
+                    <div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+                      <AlertCircle className="h-4 w-4 shrink-0" />
+                      {relinkError}
+                    </div>
+                  )}
+
+                  {extractionDone && !linkingRunning && (
+                    <Button
+                      onClick={relinkLinker}
+                      disabled={isRelinking}
+                      variant={linksFailed ? "default" : "outline"}
+                      className="w-full min-h-11"
+                    >
+                      {isRelinking ? (
+                        <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent mr-2" />
+                      ) : (
+                        <RotateCcw className="mr-2 h-4 w-4" />
+                      )}
+                      {tAi("linker.retryButton")}
+                    </Button>
+                  )}
+                </div>
+              );
+            })()}
 
             {/* ── LESSON PREVIEW STEP ───────────────────────────────── */}
             {step === "lesson_preview" && (

--- a/frontend/lib/api-course-admin.ts
+++ b/frontend/lib/api-course-admin.ts
@@ -227,6 +227,21 @@ export async function reindexImagesApi(
   });
 }
 
+/** Re-run the chunk↔image linker without re-embedding text or re-extracting
+ *  images. Inline async on the backend; ~1s for typical collections.
+ *  Powers the wizard's Linker-step "Relancer le linker" button (#2044).
+ */
+export async function relinkImagesApi(
+  courseId: string,
+  clearOld = false,
+): Promise<{ links_added: number; cleared: number }> {
+  const params = clearOld ? "?clear_old=true" : "";
+  return apiFetch(
+    `/api/v1/admin/courses/${courseId}/relink-images${params}`,
+    { method: "POST" },
+  );
+}
+
 // ── Syllabus ──────────────────────────────────────────────────────────
 
 export interface SyllabusUnit {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1582,6 +1582,7 @@
         "syllabus_edit": "Edit Syllabus",
         "lesson_preview": "Lessons",
         "indexation": "Indexation",
+        "linker": "Linker",
         "publish": "Publish"
       },
       "objectives": {
@@ -1623,6 +1624,17 @@
       },
       "publish": {
         "ragMissing": "RAG indexation has not completed — 0 content fragments indexed. Run indexation before publishing so the AI tutor can cite your resources."
+      },
+      "linker": {
+        "title": "Image-to-text links",
+        "description": "The linker pairs each extracted figure with the paragraph that mentions it. This step is required so generated lessons can cite the right figures.",
+        "idle": "Waiting for image extraction to finish.",
+        "running": "Creating links…",
+        "done": "Links created. Figures are ready to be cited in lessons.",
+        "doneNone": "No figures to link — you can publish the course.",
+        "failed": "No links were created even though figures were extracted. Click Re-run linker to retry without re-indexing everything.",
+        "error": "Failed to re-run the linker. Please try again.",
+        "retryButton": "Re-run linker"
       },
       "skipToPublish": "Skip to Publish"
     },

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1582,6 +1582,7 @@
         "syllabus_edit": "Modifier le programme",
         "lesson_preview": "Leçons",
         "indexation": "Indexation",
+        "linker": "Liens",
         "publish": "Publier"
       },
       "objectives": {
@@ -1623,6 +1624,17 @@
       },
       "publish": {
         "ragMissing": "L'indexation RAG n'est pas terminée — 0 fragment de contenu indexé. Lancez l'indexation avant de publier afin que le tuteur IA puisse citer vos ressources."
+      },
+      "linker": {
+        "title": "Liens entre texte et illustrations",
+        "description": "Le linker associe chaque illustration extraite au paragraphe qui la mentionne. Cette étape est nécessaire pour que les leçons générées puissent citer les bonnes figures.",
+        "idle": "En attente de l'extraction des illustrations.",
+        "running": "Création des liens en cours…",
+        "done": "Liens créés. Les illustrations sont prêtes à être citées dans les leçons.",
+        "doneNone": "Aucune illustration à lier — vous pouvez publier le cours.",
+        "failed": "Aucun lien n'a été créé alors que des illustrations ont été extraites. Cliquez sur Relancer le linker pour réessayer sans tout réindexer.",
+        "error": "Échec de la relance du linker. Réessayez.",
+        "retryButton": "Relancer le linker"
       },
       "skipToPublish": "Passer à la publication"
     },


### PR DESCRIPTION
## Summary

- Adds a dedicated **Linker** step to the AI wizard between **Indexation** and **Publier** so the chunk↔image join phase is visible as its own substep instead of buried inside the Indexation recap.
- Adds `POST /admin/courses/{id}/relink-images` — inline async, calls `ImageLinker().link_images_to_chunks` on the existing rag_collection without re-embedding text or re-extracting images. ~1s for typical collections.
- Frontend: Liens row moves out of `IndexationRecap` (now Texte/Images only) into a dedicated linker step body with banner status (running / done / failed / no-images) and a **Relancer le linker** button.
- Auto-advance: `indexation → linker` (always), `linker → publish` iff the join populated rows (or there were no images to link). On silent linker failure (images > 0, links === 0) the wizard stops on the linker step so the admin can hit **Relancer**.
- Helpers split into `isExtractionComplete` (gates the indexation step) and `isLinkerComplete` (gates the linker step and the publish button). The publish gate keeps the same effective behavior.

Stepper is now 9 pills: `Télécharger | Objectifs | Proposition IA | Générer | Modifier le programme | Leçons | Indexation | Linker | Publier`.

Fixes #2044

## Test plan

- [ ] Trigger indexation on a course with figures (e.g. `triola.pdf`); confirm wizard auto-advances to linker, then auto-advances to publish once links populate.
- [ ] On the same course, force `clear_old=false` relink — link count should not change.
- [ ] On a course where chunks have `page=NULL`/no figure refs, confirm linker step shows the failed state and Relancer is offered (and is a no-op as expected).
- [ ] On a course with no figures, confirm the linker step shows "no images to link" and auto-advances to publish.
- [ ] Verify publish button stays disabled while on the linker step until links populate.
- [ ] FR + EN strings render correctly on the new step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)