### PR TITLE
fix(wizard): fetch index-status on step mount + stale-task escape (#2051)

### DIFF
--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -183,13 +183,33 @@ const IMAGE_STAGES = new Set(["EXTRACTING_IMAGES", "LINKING_IMAGES"]);
 function isExtractionComplete(indexStatus: IndexStatus | null): boolean {
   if (!indexStatus) return false;
   const taskState = indexStatus.task?.state;
-  return (
-    taskState === "COMPLETE" ||
-    taskState === "SUCCESS" ||
-    (!taskState &&
-      indexStatus.indexed &&
-      (indexStatus.chunks_indexed ?? 0) > 0)
-  );
+  if (taskState === "COMPLETE" || taskState === "SUCCESS") return true;
+
+  // No active task and we have indexed data → done.
+  if (
+    !taskState &&
+    indexStatus.indexed &&
+    (indexStatus.chunks_indexed ?? 0) > 0
+  )
+    return true;
+
+  // Stale-task heuristic (#2051): if a task is "still running" but reports
+  // estimated_seconds_remaining=0 with progress<100 and we already have
+  // chunks+images in the DB, the celery worker has crashed silently. Fall
+  // through to "effectively done" so the admin can advance to the linker
+  // step (which has its own recovery path) instead of being stranded.
+  const eta = indexStatus.task?.estimated_seconds_remaining;
+  const progress = indexStatus.task?.progress ?? 0;
+  if (
+    indexStatus.indexed &&
+    (indexStatus.chunks_indexed ?? 0) > 0 &&
+    (indexStatus.images_indexed ?? 0) > 0 &&
+    eta === 0 &&
+    progress < 100
+  )
+    return true;
+
+  return false;
 }
 
 // Linker has populated source_image_chunks, OR there were no images to link.
@@ -924,6 +944,31 @@ export function AICourseWizard({
       // ignore
     }
   }, [courseId]);
+
+  // Fetch index-status on mount of the indexation/linker step when we don't
+  // already have a value. Without this, an admin who opens an already-
+  // generated course and clicks Suivant manually never populates indexStatus
+  // (hydrate only fires for resumeCreationStep="indexing"|"indexed", and the
+  // polling effect only runs while isIndexing=true). Result before this
+  // effect: canGoNext stays false on the indexation step and the user is
+  // stranded with Next disabled (#2051).
+  useEffect(() => {
+    if (!courseId) return;
+    if (step !== "indexation" && step !== "linker") return;
+    if (indexStatus) return;
+    let cancelled = false;
+    getIndexStatusApi(courseId)
+      .then((s) => {
+        if (!cancelled) setIndexStatus(buildIndexStatus(s));
+      })
+      .catch(() => {
+        // Network failure — leave indexStatus null; the user can still
+        // launch indexation explicitly via the step's primary button.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [step, courseId, indexStatus]);
 
   // Auto-advance linker → publish once the join has populated rows. Runs on
   // step change (manual Next from indexation), polling completion, resume,


### PR DESCRIPTION
## Summary

- New on-mount effect fetches \`/index-status\` when the admin navigates to the indexation or linker step and \`indexStatus\` is null. Reuses the \`buildIndexStatus\` helper from #2049.
- Stale-task heuristic in \`isExtractionComplete\`: when chunks + images are already present and the task reports \`eta=0\` with \`progress<100\`, treat as done so the admin lands on the Linker step (with its Relancer recovery) instead of being stranded with Next disabled.

Fixes #2051

## Why

After deploying #2049, opened the AI wizard for course \`a8b62017-...\` and clicked Suivant manually through the steps — Next was disabled at the indexation step. Two gaps:
1. Hydrate only fetches index-status for \`creation_step ∈ {indexing, indexed}\`. For \`generated\`, \`indexStatus\` stayed null and \`isExtractionComplete\` returned false.
2. The course's celery task pointer was stale (worker crashed mid-EMBEDDING). Backend kept serving the frozen meta. The strict \`COMPLETE/SUCCESS\` gate would have rejected this even after I cleared the task pointer manually.

## Test plan

- [ ] Open AI wizard on a course in \`creation_step=generated\` with indexed data — Next on indexation step is now enabled (after the auto-fetch lands).
- [ ] Same course with stale task in \`EMBEDDING/eta=0\` — Next still enabled (heuristic).
- [ ] Course mid-active-indexation — Next stays disabled (stale heuristic doesn't trigger because eta updates and progress climbs normally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)