### PR TITLE
fix(rag): figure_number regex + backfill — fixes 2/460 link rate (#2055)

### DIFF
--- a/backend/app/ai/rag/image_extractor.py
+++ b/backend/app/ai/rag/image_extractor.py
@@ -53,39 +53,47 @@ class ExtractedImage:
     section: str | None
 
 
+# Multi-part numbering pattern: matches "1", "1.5", "2-8", "12.3.4", "1-2-3".
+# Mirrors image_linker._FIGURE_RE (#2038). Previous form `(\d+\.?\d*)` only
+# matched chapter-and-optional-decimal — it truncated dashed numbering like
+# "Figure 2-8" to "Figure 2", which collapsed every chapter-N image into the
+# same figure_map key in the linker and was the root cause of the 2/460 link
+# rate on legacy courses (#2055).
+_NUM = r"(\d+(?:[\.\-]\d+)*)"
+
 BOOKS = {
     "donaldson": {
         "filename_pattern": "Donaldson",
-        "figure_patterns": [r"Figure\s+(\d+\.?\d*)", r"Fig\.?\s+(\d+\.?\d*)"],
+        "figure_patterns": [rf"Figure\s+{_NUM}", rf"Fig\.?\s*{_NUM}"],
         "exhibit_patterns": [],
     },
     "scutchfield": {
         "filename_pattern": "Scutchfield",
-        "figure_patterns": [r"Figure\s+(\d+\.?\d*)", r"Fig\.?\s+(\d+\.?\d*)"],
-        "exhibit_patterns": [r"Exhibit\s+(\d+\.?\d*)"],
+        "figure_patterns": [rf"Figure\s+{_NUM}", rf"Fig\.?\s*{_NUM}"],
+        "exhibit_patterns": [rf"Exhibit\s+{_NUM}"],
     },
     "triola": {
         "filename_pattern": "Triola",
-        "figure_patterns": [r"Figure\s+(\d+\.?\d*)", r"Fig\.?\s+(\d+\.?\d*)"],
-        "exhibit_patterns": [r"Table\s+(\d+[\-\.]?\d*)", r"Chart\s+(\d+\.?\d*)"],
+        "figure_patterns": [rf"Figure\s+{_NUM}", rf"Fig\.?\s*{_NUM}"],
+        "exhibit_patterns": [rf"Table\s+{_NUM}", rf"Chart\s+{_NUM}"],
     },
     "generic": {
         "filename_pattern": None,
         "figure_patterns": [
-            r"Figure\s+(\d+\.?\d*)",
-            r"Fig\.?\s+(\d+\.?\d*)",
-            r"Sch[eé]ma\s+(\d+\.?\d*)",
-            r"Tableau\s+(\d+\.?\d*)",
-            r"Graphique\s+(\d+\.?\d*)",
-            r"Illustration\s+(\d+\.?\d*)",
-            r"Diagramme\s+(\d+\.?\d*)",
-            r"Encadr[eé]\s+(\d+\.?\d*)",
+            rf"Figure\s+{_NUM}",
+            rf"Fig\.?\s*{_NUM}",
+            rf"Sch[eé]ma\s+{_NUM}",
+            rf"Tableau\s+{_NUM}",
+            rf"Graphique\s+{_NUM}",
+            rf"Illustration\s+{_NUM}",
+            rf"Diagramme\s+{_NUM}",
+            rf"Encadr[eé]\s+{_NUM}",
         ],
         "exhibit_patterns": [
-            r"Table\s+(\d+[\-\.]?\d*)",
-            r"Chart\s+(\d+\.?\d*)",
-            r"Exhibit\s+(\d+\.?\d*)",
-            r"Box\s+(\d+\.?\d*)",
+            rf"Table\s+{_NUM}",
+            rf"Chart\s+{_NUM}",
+            rf"Exhibit\s+{_NUM}",
+            rf"Box\s+{_NUM}",
         ],
     },
 }

--- a/backend/scripts/backfill_legacy_figure_numbers.py
+++ b/backend/scripts/backfill_legacy_figure_numbers.py
@@ -71,7 +71,7 @@ def _repair_one(figure_number: str | None, caption: str | None) -> tuple[str, st
         return None
     suffix = m.group(1)
     new_figure_number = f"{figure_number.rstrip()}-{suffix}"
-    new_caption = caption[m.end():].lstrip(" .:–—-")
+    new_caption = caption[m.end() :].lstrip(" .:–—-")
     return new_figure_number, new_caption
 
 

--- a/backend/scripts/backfill_legacy_figure_numbers.py
+++ b/backend/scripts/backfill_legacy_figure_numbers.py
@@ -1,0 +1,166 @@
+"""Backfill source_images.figure_number for legacy collections (#2055).
+
+Pre-#2055 the image extractor used `(\\d+\\.?\\d*)` which truncated dashed
+figure labels: "FIGURE 2-8 Pareto Chart" was stored as
+``figure_number="FIGURE 2"`` with ``caption="8 Pareto Chart"`` — the
+subnumber bled into the caption. The linker keys figure_map by the
+extracted number, so every chapter-N image collapsed into one slot and
+explicit matching effectively died (2/460 link rate on the test course).
+
+This script repairs already-extracted rows in place — no PDF re-parse, no
+MinIO writes, no re-embedding. It detects a leading-digit caption (the
+characteristic signature of severed-subnumber rows) and folds those digits
+back into figure_number, stripping the leading digit prefix from caption.
+
+Usage::
+
+    cd backend
+    python scripts/backfill_legacy_figure_numbers.py \\
+        --rag-collection-id 7eb5e3f5-192a-4953-8e87-840e09a0413e
+
+    # Or run against every collection
+    python scripts/backfill_legacy_figure_numbers.py --all
+
+    # Dry-run (default). Add --apply to actually write
+    python scripts/backfill_legacy_figure_numbers.py --all --apply
+
+After this, call POST /api/v1/admin/courses/{id}/relink-images (#2044) on
+each repaired course to materialize the new explicit pairs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.domain.models.source_image import SourceImage  # noqa: E402
+
+# Captures a leading multi-part number at the very start of the caption,
+# allowing the same separators the linker normalizes ("-" or ".").
+_LEADING_NUM = re.compile(r"^(\d+(?:[\.\-]\d+)*)")
+# Used to validate that figure_number does NOT already include a subnumber.
+# We only repair rows whose stored figure_number is chapter-only (e.g. "Figure 2").
+_HAS_SUBNUMBER = re.compile(r"\d+[\.\-]\d+")
+
+
+def _repair_one(figure_number: str | None, caption: str | None) -> tuple[str, str] | None:
+    """Return (new_figure_number, new_caption) if the row should be repaired.
+
+    None when the row is already well-formed or no recovery is possible.
+    """
+    if not figure_number or not caption:
+        return None
+    if _HAS_SUBNUMBER.search(figure_number):
+        # Already has multi-part number — extractor was already correct
+        # for this label, nothing to recover.
+        return None
+    m = _LEADING_NUM.match(caption)
+    if not m:
+        # Caption doesn't start with digits — figure was probably labeled
+        # only at chapter granularity in the source PDF (e.g. "Figure 1"),
+        # leave it alone.
+        return None
+    suffix = m.group(1)
+    new_figure_number = f"{figure_number.rstrip()}-{suffix}"
+    new_caption = caption[m.end():].lstrip(" .:–—-")
+    return new_figure_number, new_caption
+
+
+async def backfill(rag_collection_id: str | None, apply: bool) -> None:
+    database_url = os.environ.get(
+        "DATABASE_URL",
+        "postgresql+asyncpg://postgres:postgres@localhost:5432/santepublique",
+    )
+    if database_url.startswith("postgresql://"):
+        database_url = database_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+
+    engine = create_async_engine(database_url)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        stmt = select(SourceImage).where(SourceImage.figure_number.isnot(None))
+        if rag_collection_id is not None:
+            stmt = stmt.where(SourceImage.rag_collection_id == rag_collection_id)
+
+        result = await session.execute(stmt)
+        rows = result.scalars().all()
+
+        repaired = 0
+        skipped_already_full = 0
+        skipped_no_caption = 0
+        skipped_no_leading_digit = 0
+
+        for img in rows:
+            fix = _repair_one(img.figure_number, img.caption)
+            if fix is None:
+                if not img.caption:
+                    skipped_no_caption += 1
+                elif _HAS_SUBNUMBER.search(img.figure_number or ""):
+                    skipped_already_full += 1
+                else:
+                    skipped_no_leading_digit += 1
+                continue
+
+            new_figure_number, new_caption = fix
+            print(
+                f"  {img.id}  '{img.figure_number}' -> '{new_figure_number}'"
+                f"   caption: '{(img.caption or '')[:50]}...' -> '{new_caption[:50]}...'"
+            )
+            if apply:
+                img.figure_number = new_figure_number
+                img.caption = new_caption
+            repaired += 1
+
+        if apply and repaired:
+            await session.commit()
+            print(f"\n[apply] Committed {repaired} updates.")
+        else:
+            print(f"\n[dry-run] Would repair {repaired} rows. Re-run with --apply to commit.")
+
+        print(
+            f"Summary: scanned={len(rows)} repaired={repaired} "
+            f"already_full={skipped_already_full} no_caption={skipped_no_caption} "
+            f"no_leading_digit={skipped_no_leading_digit}"
+        )
+
+    await engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--rag-collection-id",
+        help="Repair only this rag_collection_id (course's rag_collection_id).",
+    )
+    group.add_argument(
+        "--all",
+        action="store_true",
+        help="Repair every collection in the database.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually write changes. Without this flag the script is a dry-run.",
+    )
+    args = parser.parse_args()
+
+    asyncio.run(
+        backfill(
+            rag_collection_id=None if args.all else args.rag_collection_id,
+            apply=args.apply,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_backfill_legacy_figure_numbers.py
+++ b/backend/tests/test_backfill_legacy_figure_numbers.py
@@ -8,9 +8,7 @@ from pathlib import Path
 # Load the script as a module without depending on packaging changes.
 _SPEC = importlib.util.spec_from_file_location(
     "backfill_legacy_figure_numbers",
-    Path(__file__).resolve().parent.parent
-    / "scripts"
-    / "backfill_legacy_figure_numbers.py",
+    Path(__file__).resolve().parent.parent / "scripts" / "backfill_legacy_figure_numbers.py",
 )
 assert _SPEC and _SPEC.loader, "spec must load"
 _MOD = importlib.util.module_from_spec(_SPEC)
@@ -49,9 +47,7 @@ class TestRepairOne:
     def test_caption_not_starting_with_digit_skipped(self):
         # Genuine chapter-only label, e.g. "Figure 1" with caption starting
         # with "(a)" — leave alone, not a severed-subnumber row
-        assert (
-            _repair_one("Figure 1", "(a) Survey Results 2 CHAPTER 1") is None
-        )
+        assert _repair_one("Figure 1", "(a) Survey Results 2 CHAPTER 1") is None
 
     def test_dotted_subnumber_recovers(self):
         # Some textbooks use "1.5" rather than "1-5"

--- a/backend/tests/test_backfill_legacy_figure_numbers.py
+++ b/backend/tests/test_backfill_legacy_figure_numbers.py
@@ -1,0 +1,72 @@
+"""Tests for the backfill_legacy_figure_numbers script (#2055)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+# Load the script as a module without depending on packaging changes.
+_SPEC = importlib.util.spec_from_file_location(
+    "backfill_legacy_figure_numbers",
+    Path(__file__).resolve().parent.parent
+    / "scripts"
+    / "backfill_legacy_figure_numbers.py",
+)
+assert _SPEC and _SPEC.loader, "spec must load"
+_MOD = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MOD)
+_repair_one = _MOD._repair_one
+
+
+class TestRepairOne:
+    def test_recovers_dashed_subnumber(self):
+        # Real legacy row: figure_number="FIGURE 2", caption starts with "6 ..."
+        new_fn, new_cap = _repair_one("FIGURE 2", "6 Dotplot of Pulse Rates")
+        assert new_fn == "FIGURE 2-6"
+        assert new_cap == "Dotplot of Pulse Rates"
+
+    def test_recovers_titlecase(self):
+        new_fn, new_cap = _repair_one("Figure 1", "2 suggests we begin our prep")
+        assert new_fn == "Figure 1-2"
+        assert new_cap == "suggests we begin our prep"
+
+    def test_strips_dash_after_number(self):
+        new_fn, new_cap = _repair_one("FIGURE 2", "8 Pareto Chart")
+        assert new_fn == "FIGURE 2-8"
+        assert new_cap == "Pareto Chart"
+
+    def test_already_has_subnumber_left_alone(self):
+        # TABLE 1-2 was already correctly extracted, nothing to repair
+        assert _repair_one("TABLE 1-2", "Levels of Measurement") is None
+
+    def test_no_caption_skipped(self):
+        assert _repair_one("Figure 2", None) is None
+        assert _repair_one("Figure 2", "") is None
+
+    def test_no_figure_number_skipped(self):
+        assert _repair_one(None, "6 Dotplot") is None
+
+    def test_caption_not_starting_with_digit_skipped(self):
+        # Genuine chapter-only label, e.g. "Figure 1" with caption starting
+        # with "(a)" — leave alone, not a severed-subnumber row
+        assert (
+            _repair_one("Figure 1", "(a) Survey Results 2 CHAPTER 1") is None
+        )
+
+    def test_dotted_subnumber_recovers(self):
+        # Some textbooks use "1.5" rather than "1-5"
+        new_fn, new_cap = _repair_one("Figure 1", "5 Distribution shapes")
+        assert new_fn == "Figure 1-5"
+        assert new_cap == "Distribution shapes"
+
+    def test_multi_part_subnumber(self):
+        # A leading "5.2" should fold to "Figure 1-5.2"
+        new_fn, new_cap = _repair_one("Figure 1", "5.2 Sub-distribution")
+        assert new_fn == "Figure 1-5.2"
+        assert new_cap == "Sub-distribution"
+
+    def test_strips_separator_chars(self):
+        # The remainder after the number should drop leading punctuation
+        new_fn, new_cap = _repair_one("FIGURE 3", "4 — A unicode em-dash caption")
+        assert new_fn == "FIGURE 3-4"
+        assert new_cap == "A unicode em-dash caption"

--- a/backend/tests/test_image_extractor.py
+++ b/backend/tests/test_image_extractor.py
@@ -1043,6 +1043,85 @@ class TestExtractAllPDFs:
         assert len(result["generic"]) == 2
 
 
+class TestDashedFigureNumberCapture:
+    """Pre-#2055 the regex used `(\\d+\\.?\\d*)` which truncated dashed
+    labels: "FIGURE 2-8 Pareto Chart" stored as figure_number="FIGURE 2"
+    with the "8" bleeding into the caption. Loosened to `\\d+(?:[\\.\\-]\\d+)*`.
+
+    These tests pin the new behaviour for every BOOKS entry that the
+    extractor uses.
+    """
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.extractor = PDFImageExtractor(Path(self.temp_dir))
+
+    def teardown_method(self):
+        import shutil
+
+        shutil.rmtree(self.temp_dir)
+
+    def _extract(self, text: str, book: str = "triola") -> dict:
+        page = MagicMock()
+        page.get_text.return_value = {
+            "blocks": [
+                {
+                    "type": 0,
+                    "bbox": [10, 200, 300, 220],
+                    "lines": [{"spans": [{"text": text}]}],
+                }
+            ]
+        }
+        image_bbox = pymupdf.Rect(10, 160, 300, 200)
+        patterns = _build_figure_patterns(BOOKS[book])
+        return self.extractor._extract_figure_metadata(page, image_bbox, patterns)
+
+    def test_dashed_figure_uppercase(self):
+        meta = self._extract("FIGURE 2-8 Pareto Chart of Causes of Accidental Deaths")
+        assert meta["figure_number"] == "FIGURE 2-8"
+        assert meta["caption"] is not None
+        assert meta["caption"].startswith("Pareto Chart")
+        # The leading "8" must NOT bleed into the caption
+        assert not meta["caption"].lstrip().startswith("8 ")
+
+    def test_dashed_figure_titlecase(self):
+        meta = self._extract("Figure 2-6 Dotplot of Pulse Rates of Males")
+        assert meta["figure_number"] == "Figure 2-6"
+
+    def test_dotted_figure(self):
+        meta = self._extract("Fig. 2.8 Histogram of distributions")
+        assert meta["figure_number"] is not None
+        assert "2.8" in meta["figure_number"]
+
+    def test_multipart_figure(self):
+        meta = self._extract("Figure 12.3.4 Multipart numbering")
+        assert meta["figure_number"] is not None
+        assert "12.3.4" in meta["figure_number"]
+
+    def test_chapter_only_figure_still_works(self):
+        # Backwards compatibility: pre-loosen behaviour for plain chapter-only
+        meta = self._extract("Figure 2 Common Distributions")
+        assert meta["figure_number"] is not None
+        assert "Figure 2" in meta["figure_number"]
+
+    def test_dashed_table_in_triola(self):
+        meta = self._extract("Table 1-3 Levels of Measurement", book="triola")
+        assert meta["figure_number"] is not None
+        assert "1-3" in meta["figure_number"]
+
+    def test_dashed_figure_in_donaldson(self):
+        meta = self._extract("Figure 5-2 Health system pyramid", book="donaldson")
+        assert meta["figure_number"] is not None
+        assert "5-2" in meta["figure_number"]
+
+    def test_dashed_figure_in_generic_fr(self):
+        meta = self._extract(
+            "Schéma 4-2 Organisation des services de santé", book="generic"
+        )
+        assert meta["figure_number"] is not None
+        assert "4-2" in meta["figure_number"]
+
+
 class TestExtractedImageDataclass:
     def test_instantiation(self):
         img = ExtractedImage(

--- a/backend/tests/test_image_extractor.py
+++ b/backend/tests/test_image_extractor.py
@@ -1115,9 +1115,7 @@ class TestDashedFigureNumberCapture:
         assert "5-2" in meta["figure_number"]
 
     def test_dashed_figure_in_generic_fr(self):
-        meta = self._extract(
-            "Schéma 4-2 Organisation des services de santé", book="generic"
-        )
+        meta = self._extract("Schéma 4-2 Organisation des services de santé", book="generic")
         assert meta["figure_number"] is not None
         assert "4-2" in meta["figure_number"]
 


### PR DESCRIPTION
## Summary

The image extractor regex truncated dashed figure labels (\`FIGURE 2-8\` → \`FIGURE 2\`), causing every chapter-N image to collapse into one figure_map slot in the linker. Loosened the regex to mirror the linker (\`\\d+(?:[\\.\\-]\\d+)*\`, same pattern as #2038) and added a backfill script for already-extracted legacy data.

Fixes #2055

## Why it matters

On course \`a8b62017-...\` (Biostatistique Appliquée): 460 images, 1103 chunks, 207 chunks citing figures by number, 74 images with figure_number — but only **2** explicit pairs landed. After this PR + backfill, expected ≥58 figure_number rows recovered and link count rises to **~100-300** without re-extracting PDFs or re-embedding chunks.

## Changes

- [backend/app/ai/rag/image_extractor.py](backend/app/ai/rag/image_extractor.py) — every \`BOOKS\` entry's \`figure_patterns\` and \`exhibit_patterns\` now use \`(\\d+(?:[\\.\\-]\\d+)*)\`. Hoisted to a module-level \`_NUM\` constant so future additions stay consistent.
- [backend/scripts/backfill_legacy_figure_numbers.py](backend/scripts/backfill_legacy_figure_numbers.py) — DB-only repair tool (dry-run by default). Detects rows where \`figure_number\` is chapter-only AND \`caption\` starts with a digit (the severed-subnumber signature), folds those digits back. Per-collection or \`--all\`.
- [backend/tests/test_image_extractor.py](backend/tests/test_image_extractor.py) — new \`TestDashedFigureNumberCapture\` class covering every \`BOOKS\` entry across uppercase, dotted, multipart, dashed, and chapter-only forms.
- [backend/tests/test_backfill_legacy_figure_numbers.py](backend/tests/test_backfill_legacy_figure_numbers.py) — new test file covering the \`_repair_one\` recovery rules including unicode separator stripping.

## Test plan

- [x] 18 new tests pass.
- [x] All 81 existing \`test_image_extractor.py\` tests still pass.
- [x] \`ruff check\` clean.
- [ ] Post-merge on staging:
   1. \`docker exec etutor-celery-worker python -m scripts.backfill_legacy_figure_numbers --rag-collection-id 7eb5e3f5-192a-4953-8e87-840e09a0413e\` (dry-run)
   2. Same with \`--apply\`
   3. \`POST /api/v1/admin/courses/a8b62017-.../relink-images\` and confirm \`links_added\` ≫ 2.
   4. Re-open the AI wizard on the course; the Liens step should show the new count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)