### PR TITLE
chore(backend): ship scripts/ in the runtime image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,6 +16,12 @@ COPY app/ app/
 COPY migrations/ migrations/
 COPY alembic.ini .
 
+# Operational scripts shipped so they can be invoked via
+# `docker exec etutor-celery-worker uv run python scripts/<name>.py ...`
+# without docker cp gymnastics. Examples: backfill jobs, one-off RAG
+# maintenance. Adds <50 KB to the image.
+COPY scripts/ scripts/
+
 EXPOSE 8000
 
 # Traefik-compatible healthcheck (NOT wget/curl — they fail silently in slim images)


### PR DESCRIPTION
## Summary

Add `COPY scripts/ scripts/` to [backend/Dockerfile](backend/Dockerfile). Operational scripts (backfills, one-off RAG maintenance) can now be invoked directly without `docker cp` gymnastics.

## Why

Surfaced while running the #2055 `backfill_legacy_figure_numbers.py` against staging — the script wasn't in the deployed image and had to be copied in manually before `docker exec` could run it.

## Test plan

- [ ] After deploy, `docker exec etutor-celery-worker ls /app/scripts/` lists the scripts.
- [ ] `docker exec etutor-celery-worker bash -c 'cd /app && uv run python scripts/backfill_legacy_figure_numbers.py --help'` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)