### PR TITLE
fix(backend): remove scripts/ from .dockerignore so #2060 build succeeds

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -8,7 +8,10 @@ __pycache__/
 htmlcov/
 *.egg-info/
 data/
-scripts/
+# scripts/ is intentionally NOT excluded — operational scripts (backfills,
+# RAG maintenance) ship in the runtime image so they can be invoked via
+# `docker exec etutor-celery-worker uv run python scripts/<name>.py ...`.
+# Adds <50 KB. Test files stay excluded via tests/.
 .env
 .env.*
 .git/


### PR DESCRIPTION
## Summary

Hotfix for #2060. The Dockerfile change to `COPY scripts/ scripts/` failed at build time because `backend/.dockerignore` excluded the directory. Removed the entry.

Build error from run 24998794096:

```
[9/9] COPY scripts/ scripts/:
ERROR: failed to compute cache key: failed to calculate checksum of ref ::
  "/scripts": not found
- CopyIgnoredFile: Attempting to Copy file "scripts" that is excluded by .dockerignore
```

Tests directory is not excluded either but doesn't ship because the Dockerfile only COPYs specific subdirectories (`app/`, `migrations/`, `scripts/`).

## Test plan

- [ ] CI green (build succeeds, no other regressions).
- [ ] Post-deploy: `docker exec etutor-celery-worker ls /app/scripts/` lists the scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)