### PR TITLE
fix(rag): filter stock-photo thumbnails out of lesson figure candidates

### DIFF
--- a/backend/app/ai/rag/retriever.py
+++ b/backend/app/ai/rag/retriever.py
@@ -6,7 +6,7 @@ from typing import Any
 from uuid import UUID
 
 import structlog
-from sqlalchemy import select, text
+from sqlalchemy import and_, not_, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.ai.rag.embeddings import EmbeddingService
@@ -15,6 +15,14 @@ from app.domain.models.source_image import SourceImage, SourceImageChunk
 from app.domain.services.platform_settings_service import SettingsCache
 
 logger = structlog.get_logger()
+
+# Stock-photo / chapter-opener thumbnails extracted from PDFs come back as
+# tiny webp/jpeg crops (~100–200px wide, ~3KB). They have correct caption
+# metadata but the binary itself is unrelated to the figure they claim to
+# represent (issue #2071). Until the extractor is fixed (#2073), drop them
+# at retrieval time so the lesson generator never sees them as candidates.
+_STOCK_THUMB_MAX_WIDTH = 200
+_STOCK_THUMB_KINDS = ("photo", "decorative")
 
 
 @dataclass
@@ -300,7 +308,18 @@ class SemanticRetriever:
         rows = await session.execute(
             select(SourceImageChunk, SourceImage)
             .join(SourceImage, SourceImageChunk.source_image_id == SourceImage.id)
-            .where(SourceImageChunk.document_chunk_id.in_(chunk_ids))
+            .where(
+                SourceImageChunk.document_chunk_id.in_(chunk_ids),
+                not_(
+                    and_(
+                        SourceImage.figure_kind.in_(_STOCK_THUMB_KINDS),
+                        or_(
+                            SourceImage.width.is_(None),
+                            SourceImage.width <= _STOCK_THUMB_MAX_WIDTH,
+                        ),
+                    )
+                ),
+            )
             .order_by(
                 SourceImageChunk.document_chunk_id,
                 (SourceImageChunk.reference_type != "explicit"),

--- a/backend/tests/test_retriever_image_lookup.py
+++ b/backend/tests/test_retriever_image_lookup.py
@@ -125,6 +125,23 @@ class TestGetLinkedImages:
         assert result[chunk_id] == []
         assert result[other_chunk_id] == []
 
+    async def test_excludes_stock_thumbnail_kinds_at_query_level(self, retriever):
+        """The compiled SQL must filter (figure_kind in photo/decorative) AND (width<=200 OR null)."""
+        chunk_id = uuid.uuid4()
+        mock_result = MagicMock()
+        mock_result.all.return_value = []
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        await retriever.get_linked_images([chunk_id], session)
+
+        stmt = session.execute.call_args.args[0]
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True})).lower()
+        assert "figure_kind" in compiled
+        assert "'photo'" in compiled and "'decorative'" in compiled
+        assert "width" in compiled
+        assert "200" in compiled
+
 
 class TestSearchSourceImages:
     async def test_empty_query_returns_empty(self, retriever):


### PR DESCRIPTION
## Summary

- Drop `SourceImage` rows where `figure_kind IN ('photo','decorative')` AND `width <= 200` from `get_linked_images()` so the lesson generator never sees them as candidates.
- Add a unit test that verifies the compiled SQL carries the new WHERE clause.

## Why

Investigation of staging module `366ddeb9` showed lesson 1.3 rendering a stock photo of a woman with a headset where TABLE 1-2 (Niveaux de mesure) should appear. Root cause is the PDF extractor producing tiny ~3KB stock-photo thumbnails for ~57 figures in the Triola collection (44 `photo` + 13 `decorative` with width ≤ 200). Captions are correct, binaries are wrong.

This PR is the **quick mitigation** at the retriever boundary. The root-cause extractor fix is tracked in #2073; semantic-link demotion is #2072.

## Test plan

- [x] `pytest tests/test_retriever_image_lookup.py` — 8 passed (1 new)
- [x] `pytest tests/test_image_linker.py tests/test_retriever_source_filter.py` — 43 passed, no regression
- [ ] Post-deploy: re-render unit 1.3 of module `366ddeb9` (FR) — woman/headset photo no longer appears
- [ ] Post-deploy: re-render unit 1.1 — generic bar chart (UUID `6b7ea9b7…`, width=142) no longer appears
- [ ] Post-deploy: spot-check 5 other lessons in the collection — no figure with `width≤200 AND figure_kind IN (photo, decorative)`

Fixes #2071