### PR TITLE
fix(rag): demote semantic-only image-chunk links

### DIFF
--- a/backend/app/ai/rag/retriever.py
+++ b/backend/app/ai/rag/retriever.py
@@ -24,6 +24,14 @@ logger = structlog.get_logger()
 _STOCK_THUMB_MAX_WIDTH = 200
 _STOCK_THUMB_KINDS = ("photo", "decorative")
 
+# High-precision SourceImageChunk reference types. PR #2066 added
+# `semantic` (caption-vs-chunk cosine similarity) which expanded the
+# candidate pool 3.7× on the Triola collection (109 explicit → 400
+# semantic). Lower precision than the others, so semantic links should
+# only fill the slate for a chunk when it has no higher-precision link
+# (issue #2072).
+_HIGH_PRECISION_REF_TYPES = ("explicit", "contextual")
+
 
 @dataclass
 class SearchResult:
@@ -327,7 +335,26 @@ class SemanticRetriever:
         )
         pairs = rows.all()
 
+        # Demote semantic-only links: when a chunk has any explicit or
+        # contextual link, drop semantic rows for that chunk.
+        per_chunk: dict[UUID, list] = {}
         for sic, img in pairs:
+            per_chunk.setdefault(sic.document_chunk_id, []).append((sic, img))
+        filtered_pairs = []
+        for cid, group in per_chunk.items():
+            has_high_precision = any(
+                sic.reference_type in _HIGH_PRECISION_REF_TYPES for sic, _ in group
+            )
+            if has_high_precision:
+                filtered_pairs.extend(
+                    (sic, img)
+                    for sic, img in group
+                    if sic.reference_type in _HIGH_PRECISION_REF_TYPES
+                )
+            else:
+                filtered_pairs.extend(group)
+
+        for sic, img in filtered_pairs:
             if total_collected >= max_total:
                 break
             cid = sic.document_chunk_id

--- a/backend/app/ai/rag/retriever.py
+++ b/backend/app/ai/rag/retriever.py
@@ -341,7 +341,7 @@ class SemanticRetriever:
         for sic, img in pairs:
             per_chunk.setdefault(sic.document_chunk_id, []).append((sic, img))
         filtered_pairs = []
-        for cid, group in per_chunk.items():
+        for group in per_chunk.values():
             has_high_precision = any(
                 sic.reference_type in _HIGH_PRECISION_REF_TYPES for sic, _ in group
             )

--- a/backend/tests/test_retriever_image_lookup.py
+++ b/backend/tests/test_retriever_image_lookup.py
@@ -125,6 +125,86 @@ class TestGetLinkedImages:
         assert result[chunk_id] == []
         assert result[other_chunk_id] == []
 
+    async def test_demotes_semantic_when_explicit_exists_for_chunk(self, retriever):
+        """Chunk with 1 explicit + 2 semantic returns only the explicit row (#2072)."""
+        chunk_id = uuid.uuid4()
+        explicit_img = _make_image()
+        semantic_imgs = [_make_image(), _make_image()]
+        pairs = [
+            _make_chunk_pair(chunk_id, explicit_img, ref_type="explicit"),
+            _make_chunk_pair(chunk_id, semantic_imgs[0], ref_type="semantic"),
+            _make_chunk_pair(chunk_id, semantic_imgs[1], ref_type="semantic"),
+        ]
+        mock_result = MagicMock()
+        mock_result.all.return_value = pairs
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        result = await retriever.get_linked_images([chunk_id], session)
+
+        returned_ids = [r["id"] for r in result[chunk_id]]
+        assert returned_ids == [str(explicit_img.id)]
+
+    async def test_demotes_semantic_when_contextual_exists_for_chunk(self, retriever):
+        """Contextual is also high-precision; semantic for the same chunk is dropped (#2072)."""
+        chunk_id = uuid.uuid4()
+        contextual_img = _make_image()
+        semantic_img = _make_image()
+        pairs = [
+            _make_chunk_pair(chunk_id, contextual_img, ref_type="contextual"),
+            _make_chunk_pair(chunk_id, semantic_img, ref_type="semantic"),
+        ]
+        mock_result = MagicMock()
+        mock_result.all.return_value = pairs
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        result = await retriever.get_linked_images([chunk_id], session)
+
+        returned_ids = [r["id"] for r in result[chunk_id]]
+        assert returned_ids == [str(contextual_img.id)]
+
+    async def test_keeps_semantic_when_no_higher_precision_link(self, retriever):
+        """Chunk with 0 explicit + 0 contextual + 2 semantic keeps semantic rows (#2072)."""
+        chunk_id = uuid.uuid4()
+        semantic_imgs = [_make_image(), _make_image()]
+        pairs = [
+            _make_chunk_pair(chunk_id, semantic_imgs[0], ref_type="semantic"),
+            _make_chunk_pair(chunk_id, semantic_imgs[1], ref_type="semantic"),
+        ]
+        mock_result = MagicMock()
+        mock_result.all.return_value = pairs
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        result = await retriever.get_linked_images([chunk_id], session)
+
+        returned_ids = sorted(r["id"] for r in result[chunk_id])
+        expected_ids = sorted(str(i.id) for i in semantic_imgs)
+        assert returned_ids == expected_ids
+
+    async def test_demotion_is_per_chunk_not_global(self, retriever):
+        """Chunk A (with explicit) drops its semantic; chunk B (no explicit) keeps its semantic (#2072)."""
+        chunk_a = uuid.uuid4()
+        chunk_b = uuid.uuid4()
+        explicit_a = _make_image()
+        semantic_a = _make_image()
+        semantic_b = _make_image()
+        pairs = [
+            _make_chunk_pair(chunk_a, explicit_a, ref_type="explicit"),
+            _make_chunk_pair(chunk_a, semantic_a, ref_type="semantic"),
+            _make_chunk_pair(chunk_b, semantic_b, ref_type="semantic"),
+        ]
+        mock_result = MagicMock()
+        mock_result.all.return_value = pairs
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        result = await retriever.get_linked_images([chunk_a, chunk_b], session)
+
+        assert [r["id"] for r in result[chunk_a]] == [str(explicit_a.id)]
+        assert [r["id"] for r in result[chunk_b]] == [str(semantic_b.id)]
+
     async def test_excludes_stock_thumbnail_kinds_at_query_level(self, retriever):
         """The compiled SQL must filter (figure_kind in photo/decorative) AND (width<=200 OR null)."""
         chunk_id = uuid.uuid4()


### PR DESCRIPTION
## Summary

- In `get_linked_images()`, when a chunk has any `explicit` or `contextual` link, drop `semantic` links for that chunk.
- Semantic links remain available for chunks that have no higher-precision link, so the recall benefit of PR #2066 is preserved.
- 4 new unit tests (per-chunk demotion, contextual demotion, semantic-kept-when-alone, demotion is per-chunk not global).

## Why

PR #2066 expanded the candidate pool 3.7× on the Triola collection (109 explicit → 400 semantic). The retriever's existing 5-image budget was getting filled by lower-precision semantic matches even when the lesson had higher-precision explicit/contextual links available.

Independent of #2071 (placeholder thumbnails) and #2073 (extractor root cause).

## Test plan

- [x] `pytest tests/test_retriever_image_lookup.py tests/test_image_linker.py tests/test_retriever_source_filter.py` — 55 passed (4 new)
- [ ] Post-deploy: re-render module `366ddeb9` lessons; the 1.3 image (UUID `74b88440…`, 0 explicit / 0 contextual / 2 semantic) is now allowed *only* because chunk has no high-precision link — combined with #2071/#2074 it gets filtered out by the thumbnail rule.
- [ ] Spot-check 5 lessons in Triola collection — distinct returned UUIDs drop ≥30% vs. pre-PR.

Fixes #2072