### PR TITLE
fix(rag): raise PDF extractor min thresholds to drop stock thumbnails

### DIFF
--- a/backend/app/ai/rag/image_extractor.py
+++ b/backend/app/ai/rag/image_extractor.py
@@ -21,9 +21,15 @@ import structlog
 
 logger = structlog.get_logger(__name__)
 
-MIN_WIDTH_PX = 100
-MIN_HEIGHT_PX = 100
-MIN_SIZE_BYTES = 2 * 1024
+# Raised from 100/100/2KB to 200/200/4KB in #2073. PDFs frequently embed
+# tiny chapter-opener stock photos and preview thumbnails (100-200px,
+# ~3KB) under the same xref table as real figures; `doc.extract_image()`
+# returns these binaries verbatim. Real textbook figures rasterize to
+# >=200px when extracted at native resolution, so this floor drops the
+# placeholders without affecting legitimate diagrams.
+MIN_WIDTH_PX = 200
+MIN_HEIGHT_PX = 200
+MIN_SIZE_BYTES = 4 * 1024
 WEBP_MAX_WIDTH = 1024
 WEBP_QUALITY = 87
 CAPTION_PROXIMITY_PT = 100

--- a/backend/tests/test_image_extractor.py
+++ b/backend/tests/test_image_extractor.py
@@ -916,6 +916,33 @@ class TestExtractImagesFromPDF:
         assert results == []
 
     @patch("pymupdf.open")
+    def test_filters_stock_thumbnail_under_200px(self, mock_open):
+        """Regression test for #2073 — 150×100 stock-photo thumbnails must be filtered."""
+        mock_doc = MagicMock()
+        mock_doc.page_count = 1
+        mock_page = MagicMock()
+        mock_page.get_images.return_value = [(42, 0, 150, 100, 8, "CS", "I")]
+        mock_page.get_image_info.return_value = []
+        mock_page.get_text.side_effect = lambda mode=None: "" if mode != "dict" else {"blocks": []}
+        mock_page.get_drawings.return_value = []
+        thumb_png = _make_minimal_png(150, 100)
+        mock_doc.extract_image.return_value = {
+            "image": thumb_png,
+            "ext": "png",
+            "width": 150,
+            "height": 100,
+        }
+        mock_doc.load_page.return_value = mock_page
+        mock_open.return_value = mock_doc
+        mock_doc.__enter__ = MagicMock(return_value=mock_doc)
+        mock_doc.__exit__ = MagicMock(return_value=False)
+
+        pdf_path = self.resources_path / "test.pdf"
+        pdf_path.touch()
+        results = self.extractor.extract_images_from_pdf(pdf_path, "triola")
+        assert results == []
+
+    @patch("pymupdf.open")
     def test_extracts_valid_image(self, mock_open):
         mock_doc = MagicMock()
         mock_doc.page_count = 1


### PR DESCRIPTION
## Summary

- Bump `MIN_WIDTH_PX` / `MIN_HEIGHT_PX` from 100 → **200**.
- Bump `MIN_SIZE_BYTES` from 2KB → **4KB**.
- Add a regression test (`test_filters_stock_thumbnail_under_200px`) that asserts a 150×100 stock thumbnail is rejected at extraction time.

## Why

PDFs embed chapter-opener stock photos and preview thumbnails (typically 100–200px, ~3KB) under the same xref table as real figures. `doc.extract_image()` returned those binaries verbatim, producing 44+ `figure_kind='photo'` rows in the Triola collection whose captions correctly matched textbook figures but whose binaries were unrelated stock imagery — see #2071/#2073 for the user-visible regression.

This is the **root-cause fix** for new uploads. It pairs with:
- #2074 (already shipped) — runtime filter that hides these rows from existing data.
- #2076 (in flight) — semantic-link demotion, independent.

## Scope

- Forward-only: existing rows in `source_images` are not re-evaluated. The runtime filter from #2074 continues to hide them.
- Re-extraction of `triola.pdf` (and other already-uploaded PDFs) to backfill correct binaries is an operational follow-up, not in this PR.

## Test plan

- [x] `pytest tests/test_image_extractor.py tests/test_pdf_extractor.py tests/test_rag_pipeline_images.py` — 110 passed (1 new)
- [x] `ruff check` clean
- [ ] Post-deploy: upload a small test PDF that has only embedded thumbnails — verify no `source_images` rows created
- [ ] Post-deploy: re-upload Triola PDF (operational, separate task) and verify width≤200 figure_kind=photo rows drop to ~0

Fixes #2073