### PR TITLE
fix(admin-courses): unblock AI wizard 'Proposition IA' step (#2079)

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -16,6 +16,7 @@ from structlog import get_logger
 from app.api.deps import get_db as get_db_session
 from app.api.deps_local_auth import AuthenticatedUser, require_role
 from app.domain.models.course import Course, UserCourseEnrollment
+from app.domain.models.course_resource import EXTRACTION_STATUS_DONE, CourseResource
 from app.domain.models.document_chunk import DocumentChunk
 from app.domain.models.module import Module
 from app.domain.models.module_unit import ModuleUnit
@@ -167,9 +168,14 @@ def _safe_task_meta(task_result: AsyncResult) -> tuple[str, dict]:
 async def _require_indexed_sources(course: Course, db) -> None:
     """Refuse AI generation when no indexed source content exists for the course.
 
-    See #2017: title/description/objectives/syllabus/modules must be grounded in
-    indexed RAG content. Falling through to a prompt-only generation produces
-    fabricated, citation-less material.
+    See #2017: lesson/case-study generation must be grounded in indexed RAG
+    content. Falling through to a prompt-only generation produces fabricated,
+    citation-less material.
+
+    Use only on endpoints that actually consume DocumentChunk via RAG retrieval.
+    For endpoints that consume CourseResource.raw_text directly (suggest-metadata,
+    generate-structure, regenerate-syllabus), use _require_extracted_sources —
+    those run before the dedicated Indexation step (#2079).
     """
     if not course.rag_collection_id:
         chunk_count = 0
@@ -189,6 +195,37 @@ async def _require_indexed_sources(course: Course, db) -> None:
                 "message": (
                     "Upload at least one source document and wait for indexation "
                     "to complete before generating course content."
+                ),
+            },
+        )
+
+
+async def _require_extracted_sources(course: Course, db) -> None:
+    """Refuse AI generation when no extracted source text exists for the course.
+
+    The AI wizard runs Indexation as step 7 (after ai_proposal / generate /
+    syllabus_edit / lesson_preview), so the chunk-based _require_indexed_sources
+    gate is wrong for the earlier endpoints — they consume CourseResource.raw_text
+    populated by extract_course_resource at upload time, not DocumentChunk rows.
+    """
+    result = await db.execute(
+        select(func.count())
+        .select_from(CourseResource)
+        .where(
+            CourseResource.course_id == course.id,
+            CourseResource.extraction_status == EXTRACTION_STATUS_DONE,
+            func.length(CourseResource.raw_text) > 0,
+        )
+    )
+    if result.scalar_one() == 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "no_source_summary",
+                "message_key": "course.generate.no_source_summary",
+                "message": (
+                    "Upload at least one source document and wait for text "
+                    "extraction to complete before generating course content."
                 ),
             },
         )
@@ -431,14 +468,12 @@ async def suggest_course_metadata(
 
     Synchronous single-turn call — returns within ~10s. Not a Celery task.
     """
-    from app.domain.models.course_resource import CourseResource
-
     result = await db.execute(select(Course).where(Course.id == course_id))
     course = result.scalar_one_or_none()
     if not course:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
 
-    await _require_indexed_sources(course, db)
+    await _require_extracted_sources(course, db)
 
     # Gather context from uploaded resources
     res_result = await db.execute(
@@ -834,7 +869,7 @@ async def generate_course_structure(
             detail=f"A task is already in progress (step: {course.creation_step})",
         )
 
-    await _require_indexed_sources(course, db)
+    await _require_extracted_sources(course, db)
 
     from app.domain.services.platform_settings_service import SettingsCache
 
@@ -901,7 +936,7 @@ async def regenerate_course_syllabus(
             detail="A generation task is already in progress",
         )
 
-    await _require_indexed_sources(course, db)
+    await _require_extracted_sources(course, db)
 
     from app.domain.services.platform_settings_service import SettingsCache
 

--- a/backend/tests/test_admin_courses_helpers.py
+++ b/backend/tests/test_admin_courses_helpers.py
@@ -13,7 +13,11 @@ from unittest.mock import AsyncMock
 import pytest
 from fastapi import HTTPException
 
-from app.api.v1.admin_courses import _require_indexed_sources, _safe_task_meta
+from app.api.v1.admin_courses import (
+    _require_extracted_sources,
+    _require_indexed_sources,
+    _safe_task_meta,
+)
 
 
 class _RaisingInfoAsyncResult:
@@ -133,6 +137,65 @@ async def test_require_indexed_sources_blocks_when_zero_chunks():
         await _require_indexed_sources(course, db)
     assert exc_info.value.status_code == 400
     assert exc_info.value.detail["code"] == "no_source_summary"
+
+
+# ---------------------------------------------------------------------------
+# #2079 — _require_extracted_sources gate (raw_text-based, not chunk-based)
+# ---------------------------------------------------------------------------
+
+
+def _make_db_with_extracted_count(count: int):
+    """Mock db.execute that returns a count for the extracted-resources query."""
+
+    class _Result:
+        def scalar_one(self):
+            return count
+
+    db = SimpleNamespace()
+    db.execute = AsyncMock(return_value=_Result())
+    return db
+
+
+@pytest.mark.asyncio
+async def test_require_extracted_sources_passes_when_raw_text_present():
+    """Regression case for #2079: AI wizard reaches ai_proposal before Indexation.
+
+    raw_text is populated by extract_course_resource at upload time (well before
+    the dedicated Indexation step), so suggest-metadata / generate-structure /
+    regenerate-syllabus must succeed even when DocumentChunk count is zero.
+    """
+    course = SimpleNamespace(id="course-1", rag_collection_id="col-1")
+    db = _make_db_with_extracted_count(1)
+    await _require_extracted_sources(course, db)  # no exception
+
+
+@pytest.mark.asyncio
+async def test_require_extracted_sources_blocks_when_no_extracted_text():
+    course = SimpleNamespace(id="course-1", rag_collection_id="col-1")
+    db = _make_db_with_extracted_count(0)
+    with pytest.raises(HTTPException) as exc_info:
+        await _require_extracted_sources(course, db)
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail["code"] == "no_source_summary"
+    assert exc_info.value.detail["message_key"] == "course.generate.no_source_summary"
+
+
+@pytest.mark.asyncio
+async def test_require_extracted_sources_query_filters_on_done_and_nonempty():
+    """The SQL must filter on extraction_status=DONE AND length(raw_text) > 0.
+
+    Source-level assertion catches accidental regressions if someone weakens
+    the predicate (e.g. drops the length check, which would let
+    extraction_status=DONE with empty raw_text slip through).
+    """
+    import inspect
+
+    from app.api.v1 import admin_courses
+
+    src = inspect.getsource(admin_courses._require_extracted_sources)
+    assert "EXTRACTION_STATUS_DONE" in src
+    assert "raw_text" in src
+    assert "length" in src.lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Split the post-#2017 \`_require_indexed_sources()\` gate so the AI wizard can reach Proposition IA, Générer, and Modifier le programme without first running Indexation.
- New \`_require_extracted_sources()\` checks \`CourseResource.extraction_status == DONE AND raw_text != ''\` for endpoints that consume \`raw_text\` directly. The chunk-count gate stays on \`/modules/{module_id}/generate-content\`, which is the only one that actually performs RAG retrieval.
- 3 new unit tests; all 12 helper tests green.

Fixes #2079

## Why

PR #2017 (commit \`f0ec003e\`, 2026-04-26) wired a chunk-count gate into four AI endpoints:

| Endpoint | Reads | Was gated | Should be gated on |
| --- | --- | --- | --- |
| \`/suggest-metadata\` | \`CourseResource.raw_text\` | DocumentChunk count | raw_text presence |
| \`/generate-structure\` | \`CourseResource.raw_text\` (via syllabus_generation task) | DocumentChunk count | raw_text presence |
| \`/regenerate-syllabus\` | cached \`syllabus_context\` / \`raw_text\` | DocumentChunk count | raw_text presence |
| \`/modules/{module_id}/generate-content\` | RAG retrieval (chunks) | DocumentChunk count ✓ | DocumentChunk count ✓ |

The AI wizard step order ([ai-course-wizard.tsx#L84-L99](https://github.com/Benidrissa/etutor-digital-ph/blob/dev/frontend/components/admin/ai-course-wizard.tsx#L84-L99)) is:

\`\`\`
upload → objectives → ai_proposal → generate → syllabus_edit
       → lesson_preview → indexation → linker → publish
\`\`\`

The dedicated **Indexation** step (which writes \`DocumentChunk\` rows) sits at position 7, but the chunk-count gate fires from position 3 onward — so users got stuck at Proposition IA with a 400 \`no_source_summary\`.

\`raw_text\` is populated by \`extract_course_resource\` at upload time, before the wizard ever advances past Téléverser, so gating on it preserves #2017's anti-ungrounded-content intent without blocking the wizard.

## Test plan

- [x] \`uv run pytest tests/test_admin_courses_helpers.py\` → 12 passed
- [x] \`uv run ruff check\` clean on both files
- [ ] After staging deploy: full AI wizard run with a fresh PDF — verify Proposition IA returns title+description, then Générer → Modifier → Leçons → Indexation → Linker → Publier all advance
- [ ] Negative check: skip Indexation and call \`/modules/{id}/generate-content\` — must still 400 with \`no_source_summary\` (#2017 guarantee preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)