### PR TITLE
chore(compose): default ENABLE_FIGURE_VISION to false

### DIFF
--- a/docker-compose.prod.sira-donnia.yml
+++ b/docker-compose.prod.sira-donnia.yml
@@ -84,7 +84,7 @@ services:
       # Cost kill-switch for Vision-backed figure tasks (#1928). Default
       # true preserves behaviour; flip to false in .env + recreate the
       # worker to stop Claude Vision spend on backfills + ingest.
-      ENABLE_FIGURE_VISION: ${ENABLE_FIGURE_VISION:-true}
+      ENABLE_FIGURE_VISION: ${ENABLE_FIGURE_VISION:-false}
       HEYGEN_API_KEY: ${HEYGEN_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}
@@ -178,7 +178,7 @@ services:
       # Cost kill-switch for Vision-backed figure tasks (#1928). Default
       # true preserves behaviour; flip to false in .env + recreate the
       # worker to stop Claude Vision spend on backfills + ingest.
-      ENABLE_FIGURE_VISION: ${ENABLE_FIGURE_VISION:-true}
+      ENABLE_FIGURE_VISION: ${ENABLE_FIGURE_VISION:-false}
       HEYGEN_API_KEY: ${HEYGEN_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -84,7 +84,7 @@ services:
       # Cost kill-switch for Vision-backed figure tasks (#1928). Default
       # true preserves behaviour; flip to false in .env + recreate the
       # worker to stop Claude Vision spend on backfills + ingest.
-      ENABLE_FIGURE_VISION: ${ENABLE_FIGURE_VISION:-true}
+      ENABLE_FIGURE_VISION: ${ENABLE_FIGURE_VISION:-false}
       HEYGEN_API_KEY: ${HEYGEN_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}
@@ -178,7 +178,7 @@ services:
       # Cost kill-switch for Vision-backed figure tasks (#1928). Default
       # true preserves behaviour; flip to false in .env + recreate the
       # worker to stop Claude Vision spend on backfills + ingest.
-      ENABLE_FIGURE_VISION: ${ENABLE_FIGURE_VISION:-true}
+      ENABLE_FIGURE_VISION: ${ENABLE_FIGURE_VISION:-false}
       HEYGEN_API_KEY: ${HEYGEN_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}


### PR DESCRIPTION
## Summary

- Flip the docker-compose default for \`ENABLE_FIGURE_VISION\` from \`true\` → \`false\` in both \`docker-compose.prod.yml\` and \`docker-compose.prod.sira-donnia.yml\`.

## Why

The kill-switch was added in #1928 after a runaway-cost incident (\$30 in 4 hours). Today on staging, \`/home/deploy/etutor/.env\` had no \`ENABLE_FIGURE_VISION\` entry, so the docker-compose default \`true\` quietly re-enabled Vision after every container restart — defeating the kill-switch's purpose.

After this change, hosts that genuinely want Vision must set \`ENABLE_FIGURE_VISION=true\` explicitly in \`.env\`. Existing hosts with explicit \`true\` are unchanged.

Already done as part of the same task: staging \`.env\` now has \`ENABLE_FIGURE_VISION=false\` and both backend + celery-worker containers are restarted.

## Test plan

- [x] \`grep ENABLE_FIGURE_VISION docker-compose.prod*.yml\` → all show \`:-false\`
- [x] Staging container env confirmed: \`ENABLE_FIGURE_VISION=false\`
- [ ] After main deploy: spot-check that no host without explicit \`.env\` value silently re-enables

Fixes #2082