### PR TITLE
fix(indexation): own task lifecycle in Celery callbacks

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -1249,9 +1249,7 @@ async def get_rag_index_status(
                 "files_processed": meta.get("files_processed", 0),
                 "current_file": meta.get("current_file"),
                 "chunks_processed": meta.get("chunks_processed", 0),
-                "estimated_seconds_remaining": meta.get(
-                    "estimated_seconds_remaining"
-                ),
+                "estimated_seconds_remaining": meta.get("estimated_seconds_remaining"),
             }
 
     return response

--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -1214,18 +1214,45 @@ async def get_rag_index_status(
     if effective_task_id:
         task_result = AsyncResult(effective_task_id)
         state, meta = _safe_task_meta(task_result)
-        response["task"] = {
-            "id": effective_task_id,
-            "state": state,
-            "step": meta.get("step"),
-            "step_label": meta.get("step_label"),
-            "progress": meta.get("progress", 0),
-            "files_total": meta.get("files_total", 0),
-            "files_processed": meta.get("files_processed", 0),
-            "current_file": meta.get("current_file"),
-            "chunks_processed": meta.get("chunks_processed", 0),
-            "estimated_seconds_remaining": meta.get("estimated_seconds_remaining"),
-        }
+
+        # Self-heal Redis-evicted task pointers (#2085). When a worker dies
+        # via SIGKILL (deploy, OOM, container restart) Celery callbacks
+        # don't run, so courses.indexation_task_id can outlive its task.
+        # AsyncResult on an evicted/unknown task returns state=PENDING with
+        # an empty meta — indistinguishable from a freshly-enqueued task
+        # *unless* the course already has indexed data (chunks/images
+        # committed mid-run). When both conditions hold, the pointer is
+        # provably dead; null it on read so the wizard returns to a clean
+        # state without admin intervention.
+        is_evicted_pointer = (
+            state == "PENDING"
+            and not meta
+            and effective_task_id == course.indexation_task_id
+            and (chunks_indexed > 0 or images_indexed > 0)
+        )
+        if is_evicted_pointer:
+            course.indexation_task_id = None
+            await db.commit()
+            logger.info(
+                "Cleared evicted indexation_task_id pointer",
+                course_id=str(course_id),
+                task_id=effective_task_id,
+            )
+        else:
+            response["task"] = {
+                "id": effective_task_id,
+                "state": state,
+                "step": meta.get("step"),
+                "step_label": meta.get("step_label"),
+                "progress": meta.get("progress", 0),
+                "files_total": meta.get("files_total", 0),
+                "files_processed": meta.get("files_processed", 0),
+                "current_file": meta.get("current_file"),
+                "chunks_processed": meta.get("chunks_processed", 0),
+                "estimated_seconds_remaining": meta.get(
+                    "estimated_seconds_remaining"
+                ),
+            }
 
     return response
 

--- a/backend/app/tasks/image_indexation.py
+++ b/backend/app/tasks/image_indexation.py
@@ -14,13 +14,36 @@ UPLOAD_DIR = Path("uploads/course_resources")
 
 
 class ImageIndexTask(Task):
-    """Base task for image indexation with error logging."""
+    """Base task for image-only re-indexation. Clears
+    ``courses.indexation_task_id`` on every terminal exit so the
+    wizard's polling can never wedge on a stale pointer. Does not
+    transition ``creation_step`` — image-only re-index runs at any
+    creation_step (typically 'published') and doesn't change it.
+    See #2085.
+    """
 
     def on_success(self, retval, task_id, args, kwargs):
-        logger.info("Image re-indexation completed", task_id=task_id, result=retval)
+        course_id = args[0] if args else kwargs.get("course_id")
+        logger.info(
+            "Image re-indexation completed",
+            task_id=task_id,
+            course_id=course_id,
+        )
+        from app.tasks.rag_indexation import finalize_indexation_state
+
+        finalize_indexation_state(course_id)
 
     def on_failure(self, exc, task_id, args, kwargs, einfo):
-        logger.error("Image re-indexation failed", task_id=task_id, exception=str(exc))
+        course_id = args[0] if args else kwargs.get("course_id")
+        logger.error(
+            "Image re-indexation failed",
+            task_id=task_id,
+            course_id=course_id,
+            exception=str(exc),
+        )
+        from app.tasks.rag_indexation import finalize_indexation_state
+
+        finalize_indexation_state(course_id)
 
 
 @celery_app.task(

--- a/backend/app/tasks/rag_indexation.py
+++ b/backend/app/tasks/rag_indexation.py
@@ -26,36 +26,88 @@ def _estimate_seconds(pdf_files: list[Path]) -> int:
     return max(30, int(extraction_s + embedding_s))
 
 
-class RAGTask(Task):
-    """Base task for RAG indexation with progress tracking."""
+def finalize_indexation_state(
+    course_id: str | None,
+    *,
+    transition: tuple[str, str] | None = None,
+) -> None:
+    """Clear ``courses.indexation_task_id``; optionally transition ``creation_step``.
 
-    def on_success(self, retval, task_id, args, kwargs):
-        logger.info("RAG indexation completed", task_id=task_id, result=retval)
+    Called from Celery task lifecycle callbacks so the
+    ``(creation_step, indexation_task_id)`` pair is always written
+    atomically on every terminal exit. The conditional ``creation_step``
+    transition is idempotent — if the user cancelled while the task was
+    running, the WHERE clause skips the transition and we still null
+    the task pointer. See #2085.
+    """
+    if not course_id:
+        return
+    try:
+        from sqlalchemy import create_engine, text
+        from sqlalchemy.orm import Session
 
-    def on_failure(self, exc, task_id, args, kwargs, einfo):
-        logger.error("RAG indexation failed", task_id=task_id, exception=str(exc))
-        # Reset creation_step so the user can retry
+        from app.infrastructure.config.settings import settings
+
+        engine = create_engine(settings.database_url_sync, pool_pre_ping=True)
         try:
-            course_id = args[0] if args else kwargs.get("course_id")
-            if course_id:
-                from sqlalchemy import create_engine, text
-                from sqlalchemy.orm import Session
-
-                from app.infrastructure.config.settings import settings
-
-                engine = create_engine(settings.database_url_sync, pool_pre_ping=True)
-                with Session(engine) as session:
+            with Session(engine) as session:
+                if transition is None:
                     session.execute(
                         text(
-                            "UPDATE courses SET creation_step = 'generated'"
-                            " WHERE id = :cid AND creation_step = 'indexing'"
+                            "UPDATE courses SET indexation_task_id = NULL"
+                            " WHERE id = :cid"
                         ),
                         {"cid": course_id},
                     )
-                    session.commit()
-                engine.dispose()
-        except Exception as reset_exc:
-            logger.warning("Failed to reset creation_step", error=str(reset_exc))
+                else:
+                    from_step, to_step = transition
+                    session.execute(
+                        text(
+                            "UPDATE courses SET indexation_task_id = NULL,"
+                            " creation_step = CASE WHEN creation_step = :from_step"
+                            " THEN :to_step ELSE creation_step END"
+                            " WHERE id = :cid"
+                        ),
+                        {
+                            "cid": course_id,
+                            "from_step": from_step,
+                            "to_step": to_step,
+                        },
+                    )
+                session.commit()
+        finally:
+            engine.dispose()
+    except Exception as exc:
+        logger.warning(
+            "Failed to finalize indexation state",
+            course_id=course_id,
+            transition=transition,
+            error=str(exc),
+        )
+
+
+class RAGTask(Task):
+    """Base task for RAG indexation. Owns the lifecycle of
+    ``(creation_step, indexation_task_id)`` so terminal exits — success,
+    raised exception, or revoke — always converge to a consistent state.
+    See #2085 for the bug this prevents (dangling task pointer wedging
+    the wizard).
+    """
+
+    def on_success(self, retval, task_id, args, kwargs):
+        course_id = args[0] if args else kwargs.get("course_id")
+        logger.info("RAG indexation completed", task_id=task_id, course_id=course_id)
+        finalize_indexation_state(course_id, transition=("indexing", "indexed"))
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        course_id = args[0] if args else kwargs.get("course_id")
+        logger.error(
+            "RAG indexation failed",
+            task_id=task_id,
+            course_id=course_id,
+            exception=str(exc),
+        )
+        finalize_indexation_state(course_id, transition=("indexing", "generated"))
 
 
 @celery_app.task(
@@ -420,28 +472,9 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
             },
         )
 
-        from sqlalchemy import create_engine
-        from sqlalchemy.orm import Session
-
-        from app.infrastructure.config.settings import settings
-
-        sync_engine = create_engine(
-            settings.database_url_sync,
-            pool_pre_ping=True,
-            pool_size=2,
-            max_overflow=0,
-        )
-        try:
-            from sqlalchemy import text
-
-            with Session(sync_engine) as session:
-                session.execute(
-                    text("UPDATE courses SET creation_step = 'indexed' WHERE id = :cid"),
-                    {"cid": course_id},
-                )
-                session.commit()
-        finally:
-            sync_engine.dispose()
+        # State transition (creation_step → 'indexed', indexation_task_id → NULL)
+        # is owned by RAGTask.on_success so success/failure/revoke all converge
+        # through one code path. See #2085.
 
         return {
             "status": "complete",

--- a/backend/app/tasks/rag_indexation.py
+++ b/backend/app/tasks/rag_indexation.py
@@ -53,10 +53,7 @@ def finalize_indexation_state(
             with Session(engine) as session:
                 if transition is None:
                     session.execute(
-                        text(
-                            "UPDATE courses SET indexation_task_id = NULL"
-                            " WHERE id = :cid"
-                        ),
+                        text("UPDATE courses SET indexation_task_id = NULL WHERE id = :cid"),
                         {"cid": course_id},
                     )
                 else:

--- a/backend/migrations/versions/087_clear_dangling_indexation_task_id.py
+++ b/backend/migrations/versions/087_clear_dangling_indexation_task_id.py
@@ -46,9 +46,7 @@ def upgrade() -> None:
             """
         )
     )
-    print(
-        f"[087] Cleared {result.rowcount} dangling indexation_task_id pointer(s)"
-    )
+    print(f"[087] Cleared {result.rowcount} dangling indexation_task_id pointer(s)")
 
 
 def downgrade() -> None:

--- a/backend/migrations/versions/087_clear_dangling_indexation_task_id.py
+++ b/backend/migrations/versions/087_clear_dangling_indexation_task_id.py
@@ -1,0 +1,55 @@
+"""Backfill: clear dangling courses.indexation_task_id pointers (#2085).
+
+Revision ID: 087
+Revises: 086
+Create Date: 2026-04-28
+
+The Celery task lifecycle didn't always clear ``indexation_task_id``
+on terminal exits (success / raised exception / worker SIGKILL),
+leaving stale references that wedge the AI-course-creation wizard's
+"Indexation RAG" step on the next page reload. The code-side fix
+(``RAGTask`` / ``ImageIndexTask`` lifecycle callbacks owning the
+state transition) prevents future leaks; this migration clears
+pointers already in the broken state so existing wedged courses heal
+on first poll after deploy.
+
+Conservative cleanup: only nulls pointers on courses where
+``creation_step`` proves the task can't be live. Skips ``'indexing'``
+(an actively running text+image indexation) and ``'published'`` (a
+``reindex_course_images`` task can legitimately run there). The
+read-side guard added in this PR catches the ``'published'`` cases on
+next poll.
+
+Forward-only: downgrade is a no-op (the cleared values were dead
+task IDs that had no useful state to restore).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "087"
+down_revision: str | None = "086"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    result = bind.execute(
+        sa.text(
+            """
+            UPDATE courses SET indexation_task_id = NULL
+            WHERE indexation_task_id IS NOT NULL
+              AND creation_step IN ('generated', 'indexed')
+            """
+        )
+    )
+    print(
+        f"[087] Cleared {result.rowcount} dangling indexation_task_id pointer(s)"
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/tests/test_indexation_lifecycle.py
+++ b/backend/tests/test_indexation_lifecycle.py
@@ -37,9 +37,7 @@ class TestFinalizeIndexationState:
 
         with (
             patch("sqlalchemy.create_engine") as mock_engine,
-            patch(
-                "sqlalchemy.orm.Session", return_value=mock_session
-            ),
+            patch("sqlalchemy.orm.Session", return_value=mock_session),
         ):
             mock_engine.return_value = MagicMock()
             finalize_indexation_state("abc-123")
@@ -65,14 +63,10 @@ class TestFinalizeIndexationState:
 
         with (
             patch("sqlalchemy.create_engine") as mock_engine,
-            patch(
-                "sqlalchemy.orm.Session", return_value=mock_session
-            ),
+            patch("sqlalchemy.orm.Session", return_value=mock_session),
         ):
             mock_engine.return_value = MagicMock()
-            finalize_indexation_state(
-                "abc-123", transition=("indexing", "indexed")
-            )
+            finalize_indexation_state("abc-123", transition=("indexing", "indexed"))
 
         sql = captured["sql"]
         assert "indexation_task_id = NULL" in sql
@@ -90,9 +84,7 @@ class TestFinalizeIndexationState:
         task as failed-after-success and the queue would loop."""
         from app.tasks.rag_indexation import finalize_indexation_state
 
-        with patch(
-            "sqlalchemy.create_engine", side_effect=RuntimeError("db down")
-        ):
+        with patch("sqlalchemy.create_engine", side_effect=RuntimeError("db down")):
             finalize_indexation_state("abc-123")  # must not raise
 
 
@@ -106,9 +98,7 @@ class TestRAGTaskCallbacks:
 
         task = RAGTask()
 
-        with patch(
-            "app.tasks.rag_indexation.finalize_indexation_state"
-        ) as mock_finalize:
+        with patch("app.tasks.rag_indexation.finalize_indexation_state") as mock_finalize:
             task.on_success(
                 retval={"status": "complete"},
                 task_id="task-1",
@@ -116,18 +106,14 @@ class TestRAGTaskCallbacks:
                 kwargs={},
             )
 
-        mock_finalize.assert_called_once_with(
-            "course-abc", transition=("indexing", "indexed")
-        )
+        mock_finalize.assert_called_once_with("course-abc", transition=("indexing", "indexed"))
 
     def test_on_failure_transitions_indexing_to_generated(self) -> None:
         from app.tasks.rag_indexation import RAGTask
 
         task = RAGTask()
 
-        with patch(
-            "app.tasks.rag_indexation.finalize_indexation_state"
-        ) as mock_finalize:
+        with patch("app.tasks.rag_indexation.finalize_indexation_state") as mock_finalize:
             task.on_failure(
                 exc=RuntimeError("boom"),
                 task_id="task-1",
@@ -136,18 +122,14 @@ class TestRAGTaskCallbacks:
                 einfo=None,
             )
 
-        mock_finalize.assert_called_once_with(
-            "course-abc", transition=("indexing", "generated")
-        )
+        mock_finalize.assert_called_once_with("course-abc", transition=("indexing", "generated"))
 
     def test_callback_reads_course_id_from_kwargs(self) -> None:
         from app.tasks.rag_indexation import RAGTask
 
         task = RAGTask()
 
-        with patch(
-            "app.tasks.rag_indexation.finalize_indexation_state"
-        ) as mock_finalize:
+        with patch("app.tasks.rag_indexation.finalize_indexation_state") as mock_finalize:
             task.on_success(
                 retval={},
                 task_id="task-1",
@@ -155,9 +137,7 @@ class TestRAGTaskCallbacks:
                 kwargs={"course_id": "course-abc"},
             )
 
-        mock_finalize.assert_called_once_with(
-            "course-abc", transition=("indexing", "indexed")
-        )
+        mock_finalize.assert_called_once_with("course-abc", transition=("indexing", "indexed"))
 
 
 class TestImageIndexTaskCallbacks:
@@ -170,9 +150,7 @@ class TestImageIndexTaskCallbacks:
 
         task = ImageIndexTask()
 
-        with patch(
-            "app.tasks.rag_indexation.finalize_indexation_state"
-        ) as mock_finalize:
+        with patch("app.tasks.rag_indexation.finalize_indexation_state") as mock_finalize:
             task.on_success(
                 retval={"status": "complete"},
                 task_id="task-1",
@@ -187,9 +165,7 @@ class TestImageIndexTaskCallbacks:
 
         task = ImageIndexTask()
 
-        with patch(
-            "app.tasks.rag_indexation.finalize_indexation_state"
-        ) as mock_finalize:
+        with patch("app.tasks.rag_indexation.finalize_indexation_state") as mock_finalize:
             task.on_failure(
                 exc=RuntimeError("boom"),
                 task_id="task-1",

--- a/backend/tests/test_indexation_lifecycle.py
+++ b/backend/tests/test_indexation_lifecycle.py
@@ -1,0 +1,201 @@
+"""Tests for the indexation lifecycle ownership fix (#2085).
+
+Verifies that ``RAGTask`` / ``ImageIndexTask`` Celery callbacks always
+clear ``courses.indexation_task_id`` on terminal exits, and that
+``finalize_indexation_state`` writes the right SQL for each call shape.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestFinalizeIndexationState:
+    """Unit tests for the lifecycle helper that owns
+    (creation_step, indexation_task_id) writes.
+    """
+
+    def test_no_op_on_missing_course_id(self) -> None:
+        from app.tasks.rag_indexation import finalize_indexation_state
+
+        with patch("sqlalchemy.create_engine") as mock_engine:
+            finalize_indexation_state(None)
+            mock_engine.assert_not_called()
+
+    def test_clears_pointer_only_when_no_transition(self) -> None:
+        from app.tasks.rag_indexation import finalize_indexation_state
+
+        captured: dict = {}
+
+        def _capture_execute(stmt, params):
+            captured["sql"] = str(stmt)
+            captured["params"] = params
+            return MagicMock()
+
+        mock_session = MagicMock()
+        mock_session.execute.side_effect = _capture_execute
+        mock_session.__enter__ = lambda self: self
+        mock_session.__exit__ = lambda *a: None
+
+        with (
+            patch("sqlalchemy.create_engine") as mock_engine,
+            patch(
+                "sqlalchemy.orm.Session", return_value=mock_session
+            ),
+        ):
+            mock_engine.return_value = MagicMock()
+            finalize_indexation_state("abc-123")
+
+        assert "indexation_task_id = NULL" in captured["sql"]
+        assert "creation_step" not in captured["sql"]
+        assert captured["params"] == {"cid": "abc-123"}
+
+    def test_transitions_creation_step_idempotently(self) -> None:
+        from app.tasks.rag_indexation import finalize_indexation_state
+
+        captured: dict = {}
+
+        def _capture_execute(stmt, params):
+            captured["sql"] = str(stmt)
+            captured["params"] = params
+            return MagicMock()
+
+        mock_session = MagicMock()
+        mock_session.execute.side_effect = _capture_execute
+        mock_session.__enter__ = lambda self: self
+        mock_session.__exit__ = lambda *a: None
+
+        with (
+            patch("sqlalchemy.create_engine") as mock_engine,
+            patch(
+                "sqlalchemy.orm.Session", return_value=mock_session
+            ),
+        ):
+            mock_engine.return_value = MagicMock()
+            finalize_indexation_state(
+                "abc-123", transition=("indexing", "indexed")
+            )
+
+        sql = captured["sql"]
+        assert "indexation_task_id = NULL" in sql
+        # Idempotent transition: only flip if currently in from_step.
+        # Protects against user-cancel races during success.
+        assert "CASE WHEN creation_step = :from_step" in sql
+        assert captured["params"] == {
+            "cid": "abc-123",
+            "from_step": "indexing",
+            "to_step": "indexed",
+        }
+
+    def test_swallows_db_errors(self) -> None:
+        """Lifecycle callbacks must never raise — Celery would mark the
+        task as failed-after-success and the queue would loop."""
+        from app.tasks.rag_indexation import finalize_indexation_state
+
+        with patch(
+            "sqlalchemy.create_engine", side_effect=RuntimeError("db down")
+        ):
+            finalize_indexation_state("abc-123")  # must not raise
+
+
+class TestRAGTaskCallbacks:
+    """RAGTask owns the (creation_step, indexation_task_id) transition
+    for the full text+image indexation flow.
+    """
+
+    def test_on_success_transitions_indexing_to_indexed(self) -> None:
+        from app.tasks.rag_indexation import RAGTask
+
+        task = RAGTask()
+
+        with patch(
+            "app.tasks.rag_indexation.finalize_indexation_state"
+        ) as mock_finalize:
+            task.on_success(
+                retval={"status": "complete"},
+                task_id="task-1",
+                args=("course-abc",),
+                kwargs={},
+            )
+
+        mock_finalize.assert_called_once_with(
+            "course-abc", transition=("indexing", "indexed")
+        )
+
+    def test_on_failure_transitions_indexing_to_generated(self) -> None:
+        from app.tasks.rag_indexation import RAGTask
+
+        task = RAGTask()
+
+        with patch(
+            "app.tasks.rag_indexation.finalize_indexation_state"
+        ) as mock_finalize:
+            task.on_failure(
+                exc=RuntimeError("boom"),
+                task_id="task-1",
+                args=("course-abc",),
+                kwargs={},
+                einfo=None,
+            )
+
+        mock_finalize.assert_called_once_with(
+            "course-abc", transition=("indexing", "generated")
+        )
+
+    def test_callback_reads_course_id_from_kwargs(self) -> None:
+        from app.tasks.rag_indexation import RAGTask
+
+        task = RAGTask()
+
+        with patch(
+            "app.tasks.rag_indexation.finalize_indexation_state"
+        ) as mock_finalize:
+            task.on_success(
+                retval={},
+                task_id="task-1",
+                args=(),
+                kwargs={"course_id": "course-abc"},
+            )
+
+        mock_finalize.assert_called_once_with(
+            "course-abc", transition=("indexing", "indexed")
+        )
+
+
+class TestImageIndexTaskCallbacks:
+    """ImageIndexTask clears the pointer but does NOT transition
+    creation_step — image-only re-index runs against any creation_step.
+    """
+
+    def test_on_success_clears_pointer_no_transition(self) -> None:
+        from app.tasks.image_indexation import ImageIndexTask
+
+        task = ImageIndexTask()
+
+        with patch(
+            "app.tasks.rag_indexation.finalize_indexation_state"
+        ) as mock_finalize:
+            task.on_success(
+                retval={"status": "complete"},
+                task_id="task-1",
+                args=("course-abc",),
+                kwargs={},
+            )
+
+        mock_finalize.assert_called_once_with("course-abc")
+
+    def test_on_failure_clears_pointer_no_transition(self) -> None:
+        from app.tasks.image_indexation import ImageIndexTask
+
+        task = ImageIndexTask()
+
+        with patch(
+            "app.tasks.rag_indexation.finalize_indexation_state"
+        ) as mock_finalize:
+            task.on_failure(
+                exc=RuntimeError("boom"),
+                task_id="task-1",
+                args=("course-abc",),
+                kwargs={},
+                einfo=None,
+            )
+
+        mock_finalize.assert_called_once_with("course-abc")


### PR DESCRIPTION
## Summary

- Move `(creation_step, indexation_task_id)` writes into `RAGTask` / `ImageIndexTask` `on_success` / `on_failure` callbacks via a shared `finalize_indexation_state` helper. Every terminal exit (success, raised exception, revoke) now converges through one path with both fields written atomically.
- Add a read-side self-heal in `/index-status`: if `AsyncResult` returns `state=PENDING` with empty meta AND the course already has indexed data committed, the pointer is provably dead — null it on read. Catches the SIGKILL case where Celery callbacks don't fire (deploy / OOM / container restart).
- Alembic migration `087` clears dangling pointers already in the broken state so existing wedged courses heal on first poll after deploy.

## Why this fixes #2085

Before: `courses.indexation_task_id` was set by API endpoints on trigger and cleared only by `/cancel-indexation`. Task body wrote `creation_step = 'indexed'` on success and `RAGTask.on_failure` reset it to `'generated'` — but neither path nulled the task pointer. SIGKILL did nothing at all. The wizard's `/index-status` fallback ([admin_courses.py:1213](backend/app/api/v1/admin_courses.py#L1213)) then read the stale ID, `AsyncResult` returned `PENDING` (Celery's default for unknown task IDs once Redis evicted the result), and the "Indexation RAG" Images row spun forever.

After: `indexation_task_id` is non-null **only** while a live task is running. The two-write coupling is enforced at one place (the helper), and the SIGKILL case self-heals on next poll.

## Test plan

- [x] `pytest tests/test_indexation_lifecycle.py` — 9/9 pass
- [x] `ruff check` clean on all touched files
- [ ] Reproduce on staging: trigger indexation, kill worker mid-run via `docker kill`, verify next `/index-status` poll returns clean state and "Suivant" enables
- [ ] Deploy → run migration → confirm staging course `0ee3e3e5-94e0-45a9-b8f6-9ffd22a89c28` becomes navigable in the wizard

Fixes #2085

🤖 Generated with [Claude Code](https://claude.com/claude-code)