### PR TITLE
feat(image): explanatory infographics as lesson hero images

### DIFF
--- a/backend/app/domain/services/image_service.py
+++ b/backend/app/domain/services/image_service.py
@@ -187,12 +187,12 @@ class ImageGenerationService:
             "   - Stay subject-agnostic: derive the visual setting from the lesson content itself "
             "(do not assume any specific country, region, profession, or industry unless the lesson states it).\n"
             "   - 250-400 characters.\n"
-            "   - GOOD example: 'Educational poster titled \"Photosynthesis\". Cross-section of a leaf "
+            '   - GOOD example: \'Educational poster titled "Photosynthesis". Cross-section of a leaf '
             "with labeled callouts: chloroplast, stomata, xylem, phloem. Arrows show CO2 in, O2 out, "
             "water up, sugar down. Flat illustration, muted greens, hand-drawn feel.'\n"
             "   - BAD example: 'A green leaf in nature, vibrant colors' (no labels, no structure).\n"
             "3) A JSON array of 5-8 lowercase semantic tags describing the lesson concept. "
-            "Always include the literal tag \"style:infographic\" as one of the tags.\n"
+            'Always include the literal tag "style:infographic" as one of the tags.\n'
             "Reply ONLY in this exact format:\n"
             "CONCEPT: <concept>\n"
             "PROMPT: <image_prompt>\n"
@@ -352,7 +352,7 @@ def _parse_concept_response(text: str) -> tuple[str, str, list[str]]:
         concept = "lesson concept"
     if not prompt:
         prompt = (
-            f"Editorial-poster-style infographic titled \"{concept}\" with 3-5 labeled "
+            f'Editorial-poster-style infographic titled "{concept}" with 3-5 labeled '
             "components, callouts, and connector arrows. Flat illustration, hand-drawn feel, "
             "muted palette, sans-serif labels."
         )

--- a/backend/app/domain/services/image_service.py
+++ b/backend/app/domain/services/image_service.py
@@ -129,7 +129,7 @@ class ImageGenerationService:
             await session.flush()
 
             image_bytes, image_url = await self._call_dalle(prompt)
-            webp_bytes, width = _resize_to_webp(image_bytes, max_width=512)
+            webp_bytes, width = _resize_to_webp(image_bytes, max_width=1024)
 
             alt_fr, alt_en = await self._generate_alt_text(concept)
 
@@ -169,18 +169,30 @@ class ImageGenerationService:
         client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key, timeout=600.0)
 
         system = (
-            "You are an expert in public health education for West Africa. "
-            "Given lesson content, extract: "
-            "1) A short key concept (5 words max), "
-            "2) A vivid image generation prompt that follows these STRICT rules:\n"
-            "   - NEVER include any text, words, labels, numbers, letters, captions, or titles in the image\n"
-            "   - Focus on visual metaphors, diagrams without text, people, scenes, objects\n"
-            "   - Style: clean flat illustration, infographic style, vibrant colors, educational\n"
-            "   - Context: West African setting, diverse people, health facilities\n"
-            "   - Max 120 chars\n"
-            "   - Examples of GOOD prompts: 'African health worker examining patient in rural clinic, stethoscope, colorful flat illustration'\n"
-            "   - Examples of BAD prompts: 'Chart showing mortality rates with labels and percentages'\n"
-            "3) A JSON array of 5-8 lowercase semantic tags. "
+            "You design explanatory infographics for an adaptive multi-subject learning platform. "
+            "Given lesson content, extract:\n"
+            "1) A short key concept (5 words max).\n"
+            "2) A detailed image-generation prompt for an editorial-poster-style INFOGRAPHIC "
+            "that explains the concept at a glance. The prompt MUST request:\n"
+            "   - A clear short title across the top.\n"
+            "   - 3 to 6 named components, objects, or steps drawn as a labeled diagram, "
+            "each with a short callout label (1-3 words).\n"
+            "   - Connector arrows or lines that show how the components relate "
+            "(flow, hierarchy, before/after, cause/effect).\n"
+            "   - Optional split panels when the concept has natural contrasts "
+            "(e.g. rural vs urban, before vs after, input vs output).\n"
+            "   - An optional small legend or maturity/timeline strip at the bottom only if it fits the concept.\n"
+            "   - Style: flat editorial illustration, hand-drawn educational poster feel, "
+            "muted palette with one or two accent colors, lots of whitespace, sans-serif labels.\n"
+            "   - Stay subject-agnostic: derive the visual setting from the lesson content itself "
+            "(do not assume any specific country, region, profession, or industry unless the lesson states it).\n"
+            "   - 250-400 characters.\n"
+            "   - GOOD example: 'Educational poster titled \"Photosynthesis\". Cross-section of a leaf "
+            "with labeled callouts: chloroplast, stomata, xylem, phloem. Arrows show CO2 in, O2 out, "
+            "water up, sugar down. Flat illustration, muted greens, hand-drawn feel.'\n"
+            "   - BAD example: 'A green leaf in nature, vibrant colors' (no labels, no structure).\n"
+            "3) A JSON array of 5-8 lowercase semantic tags describing the lesson concept. "
+            "Always include the literal tag \"style:infographic\" as one of the tags.\n"
             "Reply ONLY in this exact format:\n"
             "CONCEPT: <concept>\n"
             "PROMPT: <image_prompt>\n"
@@ -237,7 +249,15 @@ class ImageGenerationService:
     async def _find_reusable_image(
         self, tags: list[str], session: AsyncSession
     ) -> GeneratedImage | None:
-        """Search generated_images for an existing ready image with ≥85% tag overlap."""
+        """Search generated_images for an existing ready image with ≥85% tag overlap.
+
+        Only matches candidates that share the same style discriminator tag
+        (e.g. ``style:infographic``) so older plain-illustration rows are not reused.
+        """
+        style_tags = {t.lower() for t in tags if t.lower().startswith("style:")}
+        if not style_tags:
+            return None
+
         result = await session.execute(
             select(GeneratedImage).where(GeneratedImage.status == "ready")
         )
@@ -245,6 +265,11 @@ class ImageGenerationService:
 
         for candidate in candidates:
             if not candidate.semantic_tags:
+                continue
+            candidate_styles = {
+                t.lower() for t in candidate.semantic_tags if t.lower().startswith("style:")
+            }
+            if not (style_tags & candidate_styles):
                 continue
             similarity = _jaccard_similarity(tags, candidate.semantic_tags)
             if similarity >= SEMANTIC_REUSE_THRESHOLD:
@@ -259,14 +284,11 @@ class ImageGenerationService:
 
         client = AsyncOpenAI(api_key=settings.openai_api_key)
 
-        no_text_suffix = " I NEED this image to contain absolutely NO text, letters, numbers, or written words anywhere."
-        final_prompt = prompt + no_text_suffix
-
         response = await client.images.generate(
             model="gpt-image-1",
-            prompt=final_prompt,
-            size="1024x1024",
-            quality="low",
+            prompt=prompt,
+            size="1536x1024",
+            quality="medium",
         )
 
         image_bytes = base64.b64decode(response.data[0].b64_json)
@@ -287,11 +309,12 @@ class ImageGenerationService:
                 {
                     "role": "user",
                     "content": (
-                        f"Write a short accessibility alt-text for an educational illustration "
-                        f"about '{concept}' for West African public health students.\n"
+                        f"Write a short accessibility alt-text for an explanatory infographic "
+                        f"about '{concept}'. Describe the labeled components, panels, "
+                        f"and relationships shown — not just the topic.\n"
                         "Reply in this exact format:\n"
-                        "FR: <alt text in French, max 15 words>\n"
-                        "EN: <alt text in English, max 15 words>"
+                        "FR: <alt text in French, max 20 words>\n"
+                        "EN: <alt text in English, max 20 words>"
                     ),
                 }
             ],
@@ -326,11 +349,17 @@ def _parse_concept_response(text: str) -> tuple[str, str, list[str]]:
                 tags = re.findall(r'"([^"]+)"', raw)
 
     if not concept:
-        concept = "public health"
+        concept = "lesson concept"
     if not prompt:
-        prompt = f"Educational illustration of {concept} for West African public health"
+        prompt = (
+            f"Editorial-poster-style infographic titled \"{concept}\" with 3-5 labeled "
+            "components, callouts, and connector arrows. Flat illustration, hand-drawn feel, "
+            "muted palette, sans-serif labels."
+        )
     if not tags:
         tags = [concept.lower()]
+    if "style:infographic" not in {t.lower() for t in tags}:
+        tags.append("style:infographic")
 
     return concept, prompt, tags
 

--- a/backend/tests/test_image_generation.py
+++ b/backend/tests/test_image_generation.py
@@ -51,8 +51,9 @@ class TestParseConceptResponse:
 
     def test_defaults_when_empty(self):
         concept, prompt, tags = _parse_concept_response("")
-        assert concept == "public health"
+        assert concept == "lesson concept"
         assert len(tags) > 0
+        assert "style:infographic" in tags
 
     def test_tags_lowercased(self):
         text = 'CONCEPT: Malaria\nPROMPT: Illustration\nTAGS: ["MALARIA", "AOF"]'
@@ -161,8 +162,8 @@ class TestImageGenerationService:
         content_block = MagicMock()
         content_block.text = (
             "CONCEPT: paludisme\n"
-            "PROMPT: Malaria parasite life cycle in West Africa illustration\n"
-            'TAGS: ["paludisme", "malaria", "aof", "épidémiologie"]'
+            "PROMPT: Educational poster titled Paludisme with labeled life-cycle stages and arrows\n"
+            'TAGS: ["paludisme", "malaria", "aof", "épidémiologie", "style:infographic"]'
         )
         msg.content = [content_block]
         return msg
@@ -179,7 +180,9 @@ class TestImageGenerationService:
 
     async def test_semantic_reuse_skips_dalle(self, service, mock_session, mock_claude_response):
         """When a matching image exists (≥85% Jaccard), DALL-E must NOT be called."""
-        existing = _make_db_image(["paludisme", "malaria", "aof", "épidémiologie"])
+        existing = _make_db_image(
+            ["paludisme", "malaria", "aof", "épidémiologie", "style:infographic"]
+        )
         existing.reuse_count = 0
 
         dedup_result = _no_existing_image_result()
@@ -245,9 +248,11 @@ class TestImageGenerationService:
             mock_openai.images.generate.assert_called_once()
             call_kwargs = mock_openai.images.generate.call_args.kwargs
             assert call_kwargs.get("model") == "gpt-image-1"
-            assert call_kwargs.get("size") == "1024x1024"
+            assert call_kwargs.get("size") == "1536x1024"
+            assert call_kwargs.get("quality") == "medium"
             prompt_sent = call_kwargs.get("prompt", "")
-            assert "NO text" in prompt_sent or "no text" in prompt_sent.lower()
+            assert "NO text" not in prompt_sent
+            assert "no text, letters, numbers" not in prompt_sent.lower()
 
         assert result.status == "ready"
         assert result.image_url == f"/api/v1/images/{result.id}/data"
@@ -314,7 +319,9 @@ class TestImageGenerationService:
 
     async def test_reuse_increments_reuse_count(self, service, mock_session, mock_claude_response):
         """Reusing an existing image must increment its reuse_count."""
-        existing = _make_db_image(["paludisme", "malaria", "aof", "épidémiologie"])
+        existing = _make_db_image(
+            ["paludisme", "malaria", "aof", "épidémiologie", "style:infographic"]
+        )
         existing.reuse_count = 2
 
         dedup_result = _no_existing_image_result()
@@ -337,25 +344,38 @@ class TestImageGenerationService:
 
         assert existing.reuse_count == 3
 
-    def test_system_prompt_contains_no_text_rules(self):
-        """System prompt for concept extraction must contain strict no-text rules."""
+    def test_system_prompt_requests_infographic_style(self):
+        """System prompt for concept extraction must ask for an infographic with labels."""
         import inspect
 
         from app.domain.services import image_service
 
         source = inspect.getsource(image_service)
-        assert "NEVER include any text" in source
-        assert "West African setting" in source
-        assert "flat illustration" in source
+        assert "INFOGRAPHIC" in source
+        assert "callout" in source.lower()
+        assert "subject-agnostic" in source.lower()
+        # West-Africa / public-health framing must be gone.
+        assert "West African setting" not in source
+        assert "public health education for West Africa" not in source
 
-    def test_dalle_prompt_suffix_enforces_no_text(self):
-        """DALL-E prompt must include the no-text enforcement suffix."""
+    def test_dalle_prompt_does_not_append_no_text_suffix(self):
+        """The legacy NO-TEXT enforcement suffix must no longer be present."""
         import inspect
 
         from app.domain.services import image_service
 
         source = inspect.getsource(image_service)
-        assert "NO text, letters, numbers, or written words" in source
+        assert "NO text, letters, numbers, or written words" not in source
+
+    def test_dalle_call_uses_medium_quality_landscape(self):
+        """gpt-image-1 must be invoked at medium quality, 1536x1024."""
+        import inspect
+
+        from app.domain.services import image_service
+
+        source = inspect.getsource(image_service)
+        assert '"1536x1024"' in source
+        assert '"medium"' in source
 
     def test_openai_api_key_not_in_frontend_accessible_code(self):
         """Verify OPENAI_API_KEY is loaded from settings (server-side), not hardcoded."""


### PR DESCRIPTION
## Summary

- Rewrite the lesson hero image pipeline so it produces an editorial-poster-style **infographic** (labeled components, callouts, connector arrows, optional split panels) instead of a text-free flat illustration.
- Drop the hardcoded "West African / public health" framing — Sira is now a general-purpose learning platform; the visual setting is derived from the lesson content itself.
- Bump `gpt-image-1` `quality` low → medium, `size` 1024×1024 → 1536×1024, and the WebP downscale target 512 → 1024 px so labels render legibly.
- Inject a `style:infographic` discriminator tag and require it on both sides of the Jaccard match in `_find_reusable_image` so old plain-illustration rows are never reused for new lessons.
- Tighten the alt-text prompt to describe the infographic structure rather than a generic illustration.

Single file changed: [backend/app/domain/services/image_service.py](backend/app/domain/services/image_service.py).

The GitHub issue documents per-concept infographics as a follow-up — they are explicitly **not** in this PR.

Fixes #2088

## Cost note

`gpt-image-1` medium 1536×1024 is roughly \$0.04 per image vs. \$0.01 at low 1024×1024. We dispatch one generation per lesson on first access. The bump is required for label legibility.

## Test plan

- [ ] `cd backend && uv run ruff check app/domain/services/image_service.py` — passes.
- [ ] After deploy to staging: pick a lesson with no `generated_image` row yet, hit `/api/v1/images/lesson/{lesson_id}` until status=`ready`, open `/api/v1/images/{id}/data`, confirm the rendered image has a title, ≥3 labeled components, arrows, and is not framed as West-African / health unless the lesson is.
- [ ] Generate a 2nd lesson with overlapping concept tags, confirm it gets its own new infographic (old non-`style:infographic` rows are not matched).
- [ ] OpenAI dashboard shows one billing event ~\$0.04 for the smoke run, not multiple.
- [ ] No prod deploy until the staging smoke is green.