### PR TITLE
fix(image): localize infographic, allow humans, adapt to audience

### DIFF
--- a/backend/app/domain/services/image_service.py
+++ b/backend/app/domain/services/image_service.py
@@ -9,7 +9,9 @@ from datetime import datetime
 import structlog
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
+from app.ai.prompts.audience import AudienceContext, detect_audience
 from app.domain.models.generated_image import GeneratedImage
 from app.domain.models.source_image import SourceImage, SourceImageChunk
 from app.infrastructure.config.settings import settings
@@ -17,6 +19,7 @@ from app.infrastructure.config.settings import settings
 logger = structlog.get_logger(__name__)
 
 SEMANTIC_REUSE_THRESHOLD = 0.85
+STYLE_TAG_INFOGRAPHIC = "style:infographic"
 
 
 def _jaccard_similarity(tags_a: list[str], tags_b: list[str]) -> float:
@@ -75,7 +78,10 @@ class ImageGenerationService:
         await session.flush()
 
         try:
-            concept, prompt, tags = await self._extract_concept_and_tags(lesson_content)
+            lesson_row, language, audience = await self._load_lesson_context(lesson_id, session)
+            concept, prompt, tags = await self._extract_concept_and_tags(
+                lesson_content, language, audience
+            )
             image_record.concept = concept
             image_record.prompt = prompt
             image_record.semantic_tags = tags
@@ -100,7 +106,7 @@ class ImageGenerationService:
                 )
                 return image_record
 
-            source_img = await self._find_source_image(lesson_id, session)
+            source_img = await self._find_source_image(lesson_row, session)
             if source_img is not None:
                 image_record.status = "ready"
                 image_record.image_url = (
@@ -162,37 +168,93 @@ class ImageGenerationService:
             )
             return image_record
 
-    async def _extract_concept_and_tags(self, lesson_content: str) -> tuple[str, str, list[str]]:
+    async def _load_lesson_context(
+        self, lesson_id: uuid.UUID, session: AsyncSession
+    ) -> tuple[object | None, str, AudienceContext]:
+        """Eager-load the lesson row plus the course audience taxonomy.
+
+        Returns ``(lesson_row, language, audience)``. Falls back to
+        ``("en", AudienceContext(is_kids=False))`` when the lesson, its module,
+        or its course can't be resolved — image generation must remain best-effort.
+        """
+        from app.domain.models.content import GeneratedContent
+        from app.domain.models.module import Module
+
+        result = await session.execute(
+            select(GeneratedContent)
+            .options(
+                selectinload(GeneratedContent.module).selectinload(Module.course),
+            )
+            .where(GeneratedContent.id == lesson_id)
+        )
+        lesson = result.scalar_one_or_none()
+        if lesson is None:
+            return None, "en", AudienceContext(is_kids=False)
+
+        language = (getattr(lesson, "language", None) or "en").lower()
+        if language not in ("fr", "en"):
+            language = "en"
+
+        course = getattr(getattr(lesson, "module", None), "course", None)
+        audience = detect_audience(course)
+        return lesson, language, audience
+
+    async def _extract_concept_and_tags(
+        self, lesson_content: str, language: str, audience: AudienceContext
+    ) -> tuple[str, str, list[str]]:
         """Use Claude API to extract key concept, DALL-E prompt, and semantic tags."""
         import anthropic
 
         client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key, timeout=600.0)
 
+        language_name = "French" if language == "fr" else "English"
+
+        if audience.is_kids:
+            style_block = (
+                "STYLE for a children's audience: bright friendly cartoon-style flat "
+                "illustration, primary colors, rounded shapes, big readable text, simple "
+                "icons, optional friendly mascot character. Keep visual complexity low; "
+                "callout labels MUST be 1 to 3 words. Show diverse children where people "
+                "appear."
+            )
+        else:
+            style_block = (
+                "STYLE: flat editorial illustration, hand-drawn educational poster feel, "
+                "muted palette with one or two accent colors, lots of whitespace, sans-serif labels."
+            )
+
         system = (
             "You design explanatory infographics for an adaptive multi-subject learning platform. "
             "Given lesson content, extract:\n"
-            "1) A short key concept (5 words max).\n"
+            "1) A short key concept (5 words max, in English).\n"
             "2) A detailed image-generation prompt for an editorial-poster-style INFOGRAPHIC "
             "that explains the concept at a glance. The prompt MUST request:\n"
             "   - A clear short title across the top.\n"
             "   - 3 to 6 named components, objects, or steps drawn as a labeled diagram, "
-            "each with a short callout label (1-3 words).\n"
+            "each with a short callout label.\n"
             "   - Connector arrows or lines that show how the components relate "
             "(flow, hierarchy, before/after, cause/effect).\n"
-            "   - Optional split panels when the concept has natural contrasts "
-            "(e.g. rural vs urban, before vs after, input vs output).\n"
-            "   - An optional small legend or maturity/timeline strip at the bottom only if it fits the concept.\n"
-            "   - Style: flat editorial illustration, hand-drawn educational poster feel, "
-            "muted palette with one or two accent colors, lots of whitespace, sans-serif labels.\n"
+            "   - Optional split panels when the concept has natural contrasts.\n"
+            "   - An optional small legend or maturity/timeline strip at the bottom only if it fits.\n"
+            f"   - {style_block}\n"
+            "   - Human figures (learners, professionals, customers, kids, etc.) ARE allowed and "
+            "even encouraged when they help convey the concept; depict diverse people and avoid "
+            "stereotypes. They are not required if the concept is purely structural.\n"
             "   - Stay subject-agnostic: derive the visual setting from the lesson content itself "
             "(do not assume any specific country, region, profession, or industry unless the lesson states it).\n"
-            "   - 250-400 characters.\n"
-            '   - GOOD example: \'Educational poster titled "Photosynthesis". Cross-section of a leaf '
-            "with labeled callouts: chloroplast, stomata, xylem, phloem. Arrows show CO2 in, O2 out, "
-            "water up, sugar down. Flat illustration, muted greens, hand-drawn feel.'\n"
+            f"   - LANGUAGE: write the in-image title and ALL callout labels in {language_name} "
+            "(natural, idiomatic). The CONCEPT and TAGS fields below MUST stay in English so the "
+            "cache key is language-agnostic.\n"
+            "   - 250-450 characters.\n"
+            '   - GOOD example (en): \'Educational poster titled "Photosynthesis". Cross-section of '
+            "a leaf with labeled callouts in English: chloroplast, stomata, xylem, phloem. Arrows "
+            "show CO2 in, O2 out, water up, sugar down. Flat illustration, muted greens, hand-drawn feel.'\n"
+            "   - GOOD example (fr): 'Affiche éducative titrée « Photosynthèse ». Coupe d'une "
+            "feuille avec des étiquettes en français : chloroplaste, stomate, xylème, phloème. "
+            "Flèches montrant CO2 entrant, O2 sortant, eau qui monte, sucre qui descend.'\n"
             "   - BAD example: 'A green leaf in nature, vibrant colors' (no labels, no structure).\n"
-            "3) A JSON array of 5-8 lowercase semantic tags describing the lesson concept. "
-            'Always include the literal tag "style:infographic" as one of the tags.\n'
+            "3) A JSON array of 5-8 lowercase English semantic tags describing the lesson concept. "
+            f'Always include the literal tag "{STYLE_TAG_INFOGRAPHIC}" as one of the tags.\n'
             "Reply ONLY in this exact format:\n"
             "CONCEPT: <concept>\n"
             "PROMPT: <image_prompt>\n"
@@ -201,7 +263,7 @@ class ImageGenerationService:
 
         message = await client.messages.create(
             model="claude-sonnet-4-6",
-            max_tokens=300,
+            max_tokens=400,
             messages=[
                 {
                     "role": "user",
@@ -212,20 +274,30 @@ class ImageGenerationService:
         )
 
         text = message.content[0].text if message.content else ""
-        return _parse_concept_response(text)
+        concept, prompt, tags = _parse_concept_response(text)
+
+        # Inject server-side discriminator tags so the cache key always matches the
+        # actual generated style/language/audience, regardless of what Claude returned.
+        tag_set = {t.lower() for t in tags}
+        if STYLE_TAG_INFOGRAPHIC not in tag_set:
+            tags.append(STYLE_TAG_INFOGRAPHIC)
+        lang_tag = f"lang:{language}"
+        if lang_tag not in tag_set:
+            tags.append(lang_tag)
+        if audience.is_kids and "audience:kids" not in tag_set:
+            tags.append("audience:kids")
+
+        return concept, prompt, tags
 
     async def _find_source_image(
-        self, lesson_id: uuid.UUID, session: AsyncSession
+        self, lesson: object | None, session: AsyncSession
     ) -> SourceImage | None:
         """Check if any source images are explicitly linked to the lesson's document chunks.
 
         Returns the first SourceImage with image_type in ('diagram', 'chart', 'photo')
         that is explicitly linked to a document chunk via the lesson's generated content.
         """
-        from app.domain.models.content import GeneratedContent
-
-        lesson = await session.get(GeneratedContent, lesson_id)
-        if lesson is None or not lesson.sources_cited:
+        if lesson is None or not getattr(lesson, "sources_cited", None):
             return None
 
         sources = [
@@ -251,11 +323,18 @@ class ImageGenerationService:
     ) -> GeneratedImage | None:
         """Search generated_images for an existing ready image with ≥85% tag overlap.
 
-        Only matches candidates that share the same style discriminator tag
-        (e.g. ``style:infographic``) so older plain-illustration rows are not reused.
+        A candidate must share **every** discriminator-prefixed tag from the new
+        generation — currently ``style:``, ``lang:``, and ``audience:``. This
+        prevents cross-language reuse (an EN infographic for an FR lesson) and
+        cross-audience reuse (an adult infographic for a kids lesson). Old rows
+        that pre-date a discriminator simply lack it and are skipped.
         """
-        style_tags = {t.lower() for t in tags if t.lower().startswith("style:")}
-        if not style_tags:
+        new_discriminators = {
+            t.lower()
+            for t in tags
+            if any(t.lower().startswith(p) for p in ("style:", "lang:", "audience:"))
+        }
+        if not new_discriminators:
             return None
 
         result = await session.execute(
@@ -266,10 +345,12 @@ class ImageGenerationService:
         for candidate in candidates:
             if not candidate.semantic_tags:
                 continue
-            candidate_styles = {
-                t.lower() for t in candidate.semantic_tags if t.lower().startswith("style:")
+            candidate_discriminators = {
+                t.lower()
+                for t in candidate.semantic_tags
+                if any(t.lower().startswith(p) for p in ("style:", "lang:", "audience:"))
             }
-            if not (style_tags & candidate_styles):
+            if not new_discriminators.issubset(candidate_discriminators):
                 continue
             similarity = _jaccard_similarity(tags, candidate.semantic_tags)
             if similarity >= SEMANTIC_REUSE_THRESHOLD:

--- a/backend/tests/test_image_generation.py
+++ b/backend/tests/test_image_generation.py
@@ -124,6 +124,16 @@ def _no_existing_image_result() -> MagicMock:
     return result
 
 
+def _empty_lesson_context_result() -> MagicMock:
+    """Mock result for the lesson context load — no GeneratedContent row found.
+
+    Falls back the service to language='en' and AudienceContext(is_kids=False).
+    """
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = None
+    return result
+
+
 def _make_db_image(tags: list[str], status: str = "ready") -> GeneratedImage:
     img_id = uuid.uuid4()
     img = GeneratedImage(
@@ -163,7 +173,7 @@ class TestImageGenerationService:
         content_block.text = (
             "CONCEPT: paludisme\n"
             "PROMPT: Educational poster titled Paludisme with labeled life-cycle stages and arrows\n"
-            'TAGS: ["paludisme", "malaria", "aof", "épidémiologie", "style:infographic"]'
+            'TAGS: ["paludisme", "malaria", "aof", "épidémiologie", "style:infographic", "lang:en"]'
         )
         msg.content = [content_block]
         return msg
@@ -181,14 +191,16 @@ class TestImageGenerationService:
     async def test_semantic_reuse_skips_dalle(self, service, mock_session, mock_claude_response):
         """When a matching image exists (≥85% Jaccard), DALL-E must NOT be called."""
         existing = _make_db_image(
-            ["paludisme", "malaria", "aof", "épidémiologie", "style:infographic"]
+            ["paludisme", "malaria", "aof", "épidémiologie", "style:infographic", "lang:en"]
         )
         existing.reuse_count = 0
 
         dedup_result = _no_existing_image_result()
         reuse_result = MagicMock()
         reuse_result.scalars.return_value.all.return_value = [existing]
-        mock_session.execute = AsyncMock(side_effect=[dedup_result, reuse_result])
+        mock_session.execute = AsyncMock(
+            side_effect=[dedup_result, _empty_lesson_context_result(), reuse_result]
+        )
 
         with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
             mock_client = AsyncMock()
@@ -219,7 +231,9 @@ class TestImageGenerationService:
         dedup_result = _no_existing_image_result()
         reuse_result = MagicMock()
         reuse_result.scalars.return_value.all.return_value = []
-        mock_session.execute = AsyncMock(side_effect=[dedup_result, reuse_result])
+        mock_session.execute = AsyncMock(
+            side_effect=[dedup_result, _empty_lesson_context_result(), reuse_result]
+        )
 
         fake_b64 = base64.b64encode(b"FAKE_PNG_DATA").decode()
         image_api_response = MagicMock()
@@ -288,7 +302,9 @@ class TestImageGenerationService:
         dedup_result = _no_existing_image_result()
         reuse_result = MagicMock()
         reuse_result.scalars.return_value.all.return_value = []
-        mock_session.execute = AsyncMock(side_effect=[dedup_result, reuse_result])
+        mock_session.execute = AsyncMock(
+            side_effect=[dedup_result, _empty_lesson_context_result(), reuse_result]
+        )
 
         fake_b64 = base64.b64encode(b"DATA").decode()
         image_api_response = MagicMock()
@@ -320,14 +336,16 @@ class TestImageGenerationService:
     async def test_reuse_increments_reuse_count(self, service, mock_session, mock_claude_response):
         """Reusing an existing image must increment its reuse_count."""
         existing = _make_db_image(
-            ["paludisme", "malaria", "aof", "épidémiologie", "style:infographic"]
+            ["paludisme", "malaria", "aof", "épidémiologie", "style:infographic", "lang:en"]
         )
         existing.reuse_count = 2
 
         dedup_result = _no_existing_image_result()
         reuse_result = MagicMock()
         reuse_result.scalars.return_value.all.return_value = [existing]
-        mock_session.execute = AsyncMock(side_effect=[dedup_result, reuse_result])
+        mock_session.execute = AsyncMock(
+            side_effect=[dedup_result, _empty_lesson_context_result(), reuse_result]
+        )
 
         with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
             mock_client = AsyncMock()
@@ -377,6 +395,163 @@ class TestImageGenerationService:
         assert '"1536x1024"' in source
         assert '"medium"' in source
 
+    async def test_extract_concept_localizes_to_lesson_language(
+        self, service, mock_claude_response
+    ):
+        """When language='fr', the system prompt sent to Claude must request French labels."""
+        from app.ai.prompts.audience import AudienceContext
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
+            mock_client = AsyncMock()
+            mock_anthropic_cls.return_value = mock_client
+            mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
+
+            await service._extract_concept_and_tags(
+                "Lesson about photosynthesis.",
+                language="fr",
+                audience=AudienceContext(is_kids=False),
+            )
+
+            system_prompt = mock_client.messages.create.call_args.kwargs["system"]
+            assert "French" in system_prompt
+            assert "language-agnostic" in system_prompt.lower()
+
+    async def test_extract_concept_default_english(self, service, mock_claude_response):
+        """Default language='en' must request English labels in the system prompt."""
+        from app.ai.prompts.audience import AudienceContext
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
+            mock_client = AsyncMock()
+            mock_anthropic_cls.return_value = mock_client
+            mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
+
+            await service._extract_concept_and_tags(
+                "Lesson about photosynthesis.",
+                language="en",
+                audience=AudienceContext(is_kids=False),
+            )
+
+            system_prompt = mock_client.messages.create.call_args.kwargs["system"]
+            assert "English" in system_prompt
+
+    async def test_extract_concept_kids_audience_branches_style(
+        self, service, mock_claude_response
+    ):
+        """When audience.is_kids=True, the prompt must request kid-friendly cartoon style."""
+        from app.ai.prompts.audience import AudienceContext
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
+            mock_client = AsyncMock()
+            mock_anthropic_cls.return_value = mock_client
+            mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
+
+            await service._extract_concept_and_tags(
+                "Counting from 1 to 10.",
+                language="en",
+                audience=AudienceContext(is_kids=True, age_min=6, age_max=10),
+            )
+
+            system_prompt = mock_client.messages.create.call_args.kwargs["system"]
+            # Kids style markers (cartoon, primary colors, mascot) must appear.
+            assert "cartoon" in system_prompt.lower()
+            assert "children" in system_prompt.lower() or "child" in system_prompt.lower()
+            # Adult-default style markers must NOT appear in the kids branch.
+            assert "muted palette" not in system_prompt.lower()
+
+    async def test_extract_concept_allows_humans(self, service, mock_claude_response):
+        """The system prompt must explicitly allow human figures in the infographic."""
+        from app.ai.prompts.audience import AudienceContext
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
+            mock_client = AsyncMock()
+            mock_anthropic_cls.return_value = mock_client
+            mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
+
+            await service._extract_concept_and_tags(
+                "Some lesson.",
+                language="en",
+                audience=AudienceContext(is_kids=False),
+            )
+
+            system_prompt = mock_client.messages.create.call_args.kwargs["system"]
+            # Humans must be explicitly allowed (not forbidden).
+            assert "Human figures" in system_prompt or "human figures" in system_prompt
+            assert "allowed" in system_prompt.lower()
+            # Pre-#2088 NO-PEOPLE markers must be gone.
+            assert "no people" not in system_prompt.lower()
+            assert "no human" not in system_prompt.lower()
+
+    async def test_extract_concept_injects_lang_and_audience_tags(
+        self, service, mock_claude_response
+    ):
+        """Server-side discriminator tags (lang:, audience:) must be injected into the tag list."""
+        from app.ai.prompts.audience import AudienceContext
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
+            mock_client = AsyncMock()
+            mock_anthropic_cls.return_value = mock_client
+            mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
+
+            _, _, tags = await service._extract_concept_and_tags(
+                "Counting lesson.",
+                language="fr",
+                audience=AudienceContext(is_kids=True, age_min=6, age_max=10),
+            )
+
+            tags_lower = {t.lower() for t in tags}
+            assert "lang:fr" in tags_lower
+            assert "audience:kids" in tags_lower
+            assert "style:infographic" in tags_lower
+
+    async def test_find_reusable_image_blocks_cross_language_reuse(self, service, mock_session):
+        """An EN-tagged existing image must NOT be reused for a new FR generation."""
+        en_existing = _make_db_image(
+            ["paludisme", "malaria", "aof", "épidémiologie", "style:infographic", "lang:en"]
+        )
+
+        reuse_result = MagicMock()
+        reuse_result.scalars.return_value.all.return_value = [en_existing]
+        mock_session.execute = AsyncMock(return_value=reuse_result)
+
+        new_tags = [
+            "paludisme",
+            "malaria",
+            "aof",
+            "épidémiologie",
+            "style:infographic",
+            "lang:fr",
+        ]
+        result = await service._find_reusable_image(new_tags, mock_session)
+        assert result is None
+
+    async def test_find_reusable_image_allows_same_language_reuse(self, service, mock_session):
+        """Same-language same-style same-audience candidate with ≥85% Jaccard reuses fine."""
+        existing = _make_db_image(
+            [
+                "paludisme",
+                "malaria",
+                "aof",
+                "épidémiologie",
+                "style:infographic",
+                "lang:fr",
+            ]
+        )
+
+        reuse_result = MagicMock()
+        reuse_result.scalars.return_value.all.return_value = [existing]
+        mock_session.execute = AsyncMock(return_value=reuse_result)
+
+        new_tags = [
+            "paludisme",
+            "malaria",
+            "aof",
+            "épidémiologie",
+            "style:infographic",
+            "lang:fr",
+        ]
+        result = await service._find_reusable_image(new_tags, mock_session)
+        assert result is existing
+
     def test_openai_api_key_not_in_frontend_accessible_code(self):
         """Verify OPENAI_API_KEY is loaded from settings (server-side), not hardcoded."""
         import inspect
@@ -412,7 +587,9 @@ class TestImageGenerationService:
         dedup_result = _no_existing_image_result()
         reuse_result = MagicMock()
         reuse_result.scalars.return_value.all.return_value = []
-        mock_session.execute = AsyncMock(side_effect=[dedup_result, reuse_result])
+        mock_session.execute = AsyncMock(
+            side_effect=[dedup_result, _empty_lesson_context_result(), reuse_result]
+        )
 
         fake_b64 = base64.b64encode(b"FAKE_PNG_BINARY_DATA").decode()
         image_api_response = MagicMock()

--- a/backend/tests/test_tutor_source_image.py
+++ b/backend/tests/test_tutor_source_image.py
@@ -388,8 +388,7 @@ class TestFindSourceImage:
         return session
 
     async def test_returns_none_when_lesson_not_found(self, service, mock_session):
-        mock_session.get = AsyncMock(return_value=None)
-        result = await service._find_source_image(uuid.uuid4(), mock_session)
+        result = await service._find_source_image(None, mock_session)
         assert result is None
 
     async def test_returns_none_when_no_sources_cited(self, service, mock_session):
@@ -397,9 +396,8 @@ class TestFindSourceImage:
 
         lesson = MagicMock(spec=GeneratedContent)
         lesson.sources_cited = None
-        mock_session.get = AsyncMock(return_value=lesson)
 
-        result = await service._find_source_image(uuid.uuid4(), mock_session)
+        result = await service._find_source_image(lesson, mock_session)
         assert result is None
 
     async def test_returns_none_when_sources_cited_empty(self, service, mock_session):
@@ -407,9 +405,8 @@ class TestFindSourceImage:
 
         lesson = MagicMock(spec=GeneratedContent)
         lesson.sources_cited = []
-        mock_session.get = AsyncMock(return_value=lesson)
 
-        result = await service._find_source_image(uuid.uuid4(), mock_session)
+        result = await service._find_source_image(lesson, mock_session)
         assert result is None
 
     async def test_returns_source_image_when_explicit_link_exists(self, service, mock_session):
@@ -417,14 +414,13 @@ class TestFindSourceImage:
 
         lesson = MagicMock(spec=GeneratedContent)
         lesson.sources_cited = [{"source": "donaldson", "chapter": "3", "page": 42}]
-        mock_session.get = AsyncMock(return_value=lesson)
 
         source_img = _make_source_image(image_type="diagram")
         mock_execute_result = MagicMock()
         mock_execute_result.scalar_one_or_none = MagicMock(return_value=source_img)
         mock_session.execute = AsyncMock(return_value=mock_execute_result)
 
-        result = await service._find_source_image(uuid.uuid4(), mock_session)
+        result = await service._find_source_image(lesson, mock_session)
         assert result is source_img
 
     async def test_returns_none_when_no_explicit_source_image(self, service, mock_session):
@@ -432,13 +428,12 @@ class TestFindSourceImage:
 
         lesson = MagicMock(spec=GeneratedContent)
         lesson.sources_cited = [{"source": "triola", "chapter": "1", "page": 5}]
-        mock_session.get = AsyncMock(return_value=lesson)
 
         mock_execute_result = MagicMock()
         mock_execute_result.scalar_one_or_none = MagicMock(return_value=None)
         mock_session.execute = AsyncMock(return_value=mock_execute_result)
 
-        result = await service._find_source_image(uuid.uuid4(), mock_session)
+        result = await service._find_source_image(lesson, mock_session)
         assert result is None
 
 
@@ -446,6 +441,13 @@ def _no_existing_image_result() -> MagicMock:
     """Mock result for the dedup check — no existing image found."""
     result = MagicMock()
     result.scalar_one_or_none.return_value = None
+    return result
+
+
+def _lesson_context_result(lesson: object | None) -> MagicMock:
+    """Mock result for ImageGenerationService._load_lesson_context()."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = lesson
     return result
 
 
@@ -485,7 +487,8 @@ class TestDallEFallbackOptimization:
 
         lesson = MagicMock(spec=GeneratedContent)
         lesson.sources_cited = [{"source": "donaldson", "chapter": "3", "page": 42}]
-        mock_session.get = AsyncMock(return_value=lesson)
+        lesson.language = "en"
+        lesson.module = None
 
         reuse_result = MagicMock()
         reuse_result.scalars.return_value.all.return_value = []
@@ -494,7 +497,14 @@ class TestDallEFallbackOptimization:
         source_result.scalar_one_or_none = MagicMock(return_value=source_img)
 
         dedup_result = _no_existing_image_result()
-        mock_session.execute = AsyncMock(side_effect=[dedup_result, reuse_result, source_result])
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                dedup_result,
+                _lesson_context_result(lesson),
+                reuse_result,
+                source_result,
+            ]
+        )
 
         with __import__("unittest.mock", fromlist=["patch"]).patch(
             "anthropic.AsyncAnthropic"
@@ -526,8 +536,6 @@ class TestDallEFallbackOptimization:
         import base64
         from unittest.mock import patch
 
-        mock_session.get = AsyncMock(return_value=None)
-
         dedup_result = _no_existing_image_result()
         reuse_result = MagicMock()
         reuse_result.scalars.return_value.all.return_value = []
@@ -539,7 +547,9 @@ class TestDallEFallbackOptimization:
         image_api_response = MagicMock()
         image_api_response.data = [MagicMock(b64_json=fake_b64)]
 
-        mock_session.execute = AsyncMock(side_effect=[dedup_result, reuse_result])
+        mock_session.execute = AsyncMock(
+            side_effect=[dedup_result, _lesson_context_result(None), reuse_result]
+        )
 
         with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
             mock_client = AsyncMock()
@@ -578,7 +588,8 @@ class TestDallEFallbackOptimization:
 
         lesson = MagicMock(spec=GeneratedContent)
         lesson.sources_cited = [{"source": "triola", "chapter": "5", "page": 90}]
-        mock_session.get = AsyncMock(return_value=lesson)
+        lesson.language = "en"
+        lesson.module = None
 
         reuse_result = MagicMock()
         reuse_result.scalars.return_value.all.return_value = []
@@ -587,7 +598,14 @@ class TestDallEFallbackOptimization:
         source_result.scalar_one_or_none = MagicMock(return_value=source_img)
 
         dedup_result = _no_existing_image_result()
-        mock_session.execute = AsyncMock(side_effect=[dedup_result, reuse_result, source_result])
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                dedup_result,
+                _lesson_context_result(lesson),
+                reuse_result,
+                source_result,
+            ]
+        )
 
         with __import__("unittest.mock", fromlist=["patch"]).patch(
             "anthropic.AsyncAnthropic"


### PR DESCRIPTION
## Summary

Three follow-up fixes after #2088 surfaced on the staging smoke:

1. **Language mismatch (most critical):** the lesson hero infographic always rendered in English, even for French lessons — `_extract_concept_and_tags` never received the lesson language. Now plumbed through.
2. **Humans implicitly excluded:** the previous prompt didn't forbid people but never invited them, so DALL-E almost never produced human figures. Now explicitly allowed and encouraged when the concept benefits.
3. **No audience adaptation:** kid-targeted courses got the same editorial-poster style. Now branches on `audience.is_kids` (resolved via the existing `detect_audience(course)` helper from [app/ai/prompts/audience.py](backend/app/ai/prompts/audience.py)) into a cartoon-friendly style with shorter captions.

Single backend file changed plus its tests:
- [backend/app/domain/services/image_service.py](backend/app/domain/services/image_service.py)
- [backend/tests/test_image_generation.py](backend/tests/test_image_generation.py)

## How

- New `_load_lesson_context()` eager-loads `GeneratedContent → Module → Course → taxonomy_categories` in one query and returns `(lesson_row, language, AudienceContext)`.
- `_extract_concept_and_tags(lesson_content, language, audience)` writes a system prompt that requests in-image title and labels in the lesson language, explicitly allows human figures, and branches the style block on `audience.is_kids`. CONCEPT and TAGS stay in English so the cache key remains language-agnostic.
- Server-side `lang:<fr|en>` and `audience:kids` (when applicable) tags injected into `semantic_tags` after parsing Claude's response.
- `_find_reusable_image` now requires every discriminator-prefixed tag (`style:`, `lang:`, `audience:`) to match on both sides — no cross-language or cross-audience reuse, and old non-discriminated rows still skipped.
- `_find_source_image` now takes the already-loaded lesson row instead of re-fetching it.

## Alt-text

Kept bilingual FR+EN unconditionally — alt-text is a separate accessibility surface and we want both regardless of the lesson language. Not changed in this PR.

Fixes #2091

## Test plan

- [x] `uv run ruff check . && uv run ruff format --check .` — clean.
- [x] `uv run pytest tests/test_image_generation.py --no-cov -q` — 32 passed.
- [ ] After staging deploy: trigger generation on a French lesson — confirm French title and callouts in the rendered image, `lang:fr` on the row.
- [ ] Trigger generation on a kids-course lesson — confirm cartoon-leaning style + `audience:kids` tag.
- [ ] Trigger generation on a third FR lesson with overlapping concept tags — confirm cache reuse hits and only one OpenAI billing event.
- [ ] No prod deploy until staging smoke passes (per `feedback_never_prod_without_green_staging`).