### PR TITLE
fix(lesson): flex-width lesson images aligned to text column

### DIFF
--- a/frontend/components/learning/lesson-image.tsx
+++ b/frontend/components/learning/lesson-image.tsx
@@ -75,7 +75,7 @@ export function LessonImage({ lessonId, language }: LessonImageProps) {
   if (status !== 'ready' || !imageUrl) {
     return (
       <div
-        className="w-full max-w-[512px] mx-auto my-6 rounded-lg overflow-hidden animate-pulse"
+        className="w-full my-6 rounded-lg overflow-hidden animate-pulse"
         aria-busy="true"
         aria-label={t('imagePending')}
       >
@@ -88,7 +88,7 @@ export function LessonImage({ lessonId, language }: LessonImageProps) {
 
   return (
     <>
-      <div className="w-full max-w-[512px] mx-auto my-6">
+      <div className="w-full my-6">
         <button
           type="button"
           className="w-full rounded-lg overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 min-h-11"
@@ -101,7 +101,7 @@ export function LessonImage({ lessonId, language }: LessonImageProps) {
             width={512}
             height={512}
             loading="lazy"
-            sizes="(max-width: 640px) 100vw, 512px"
+            sizes="(max-width: 768px) 100vw, (max-width: 1024px) 90vw, 832px"
             unoptimized
             className={`w-full h-auto object-cover rounded-lg transition-opacity duration-300 ${
               isVisible ? 'opacity-100' : 'opacity-0'

--- a/frontend/components/learning/source-image.tsx
+++ b/frontend/components/learning/source-image.tsx
@@ -38,7 +38,7 @@ export function SourceImage({
 
   return (
     <>
-      <figure className="my-6 w-full max-w-[768px] mx-auto">
+      <figure className="my-6 w-full">
         <button
           type="button"
           className="w-full rounded-lg overflow-hidden border border-stone-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 min-h-11"
@@ -57,7 +57,7 @@ export function SourceImage({
             // from #1616 and #1857.
             width={1024}
             height={768}
-            sizes="(max-width: 768px) 100vw, 768px"
+            sizes="(max-width: 768px) 100vw, (max-width: 1024px) 90vw, 832px"
             loading="lazy"
             unoptimized
             className={`w-full h-auto object-contain rounded-lg transition-opacity duration-300 ${


### PR DESCRIPTION
## Summary
- Drop redundant `max-w-[512px]` / `max-w-[768px]` + `mx-auto` from `LessonImage` and `SourceImage` so figures span the full reading column governed by the page-level `max-w-4xl`.
- Update `sizes` prop on both `<Image>` calls to match the new rendered width (column-aware estimate instead of the old fixed 512/768px).

## Test plan
- [ ] Dev server, open a lesson with a top illustration and an embedded source figure (e.g. `Fondements des Systèmes de Santé en Afrique de l'Ouest` → unit 1.2)
- [ ] Top illustration spans the full reading column (no left/right gutter)
- [ ] Inline source figures span the full reading column
- [ ] At 375px viewport, images scale down to viewport width without overflow
- [ ] FR/EN toggle, captions stay visually balanced under the wider figure
- [ ] Fullscreen modal still opens at prior size (unchanged code path)

Fixes #2094