### PR TITLE
feat(unit): add prev/next navigation at the end of unit pages

### DIFF
--- a/frontend/app/[locale]/(app)/modules/[moduleId]/units/[unit]/page.tsx
+++ b/frontend/app/[locale]/(app)/modules/[moduleId]/units/[unit]/page.tsx
@@ -8,6 +8,7 @@ import { EnrollmentGuard } from '@/components/shared/enrollment-guard';
 import { LessonViewer } from '@/components/learning/lesson-viewer';
 import { CaseStudyViewer } from '@/components/learning/case-study-viewer';
 import { UnitQuizViewer } from '@/components/learning/unit-quiz-viewer';
+import { UnitNav } from '@/components/learning/unit-nav';
 
 interface UnitPageProps {
   params: Promise<{ moduleId: string; unit: string }>;
@@ -22,10 +23,15 @@ export default async function UnitPage({ params }: UnitPageProps) {
   const moduleData = await getModuleUnits(moduleId).catch(() => null);
   if (!moduleData) notFound();
 
-  const unit = moduleData.units?.find(
+  const units = moduleData.units ?? [];
+  const unit = units.find(
     (u) => u.unit_number === unitParam || u.id === unitParam,
   );
   if (!unit) notFound();
+
+  const idx = units.findIndex((u) => u.id === unit.id);
+  const prev = idx > 0 ? units[idx - 1] : null;
+  const next = idx >= 0 && idx < units.length - 1 ? units[idx + 1] : null;
 
   const moduleTitle = language === 'fr' ? moduleData.title_fr : moduleData.title_en;
   const unitTitle = language === 'fr' ? unit.title_fr : unit.title_en;
@@ -82,6 +88,13 @@ export default async function UnitPage({ params }: UnitPageProps) {
             unitDescription={unitDescription}
           />
         )}
+
+        <UnitNav
+          moduleId={moduleId}
+          prev={prev}
+          next={next}
+          language={language}
+        />
       </div>
     </EnrollmentGuard>
   );

--- a/frontend/components/learning/unit-nav.tsx
+++ b/frontend/components/learning/unit-nav.tsx
@@ -1,0 +1,66 @@
+import { getTranslations } from 'next-intl/server';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { Link } from '@/i18n/routing';
+
+interface NavUnit {
+  unit_number: string;
+  title_fr: string;
+  title_en: string;
+}
+
+interface UnitNavProps {
+  moduleId: string;
+  prev: NavUnit | null;
+  next: NavUnit | null;
+  language: 'fr' | 'en';
+}
+
+export async function UnitNav({ moduleId, prev, next, language }: UnitNavProps) {
+  if (!prev && !next) return null;
+
+  const t = await getTranslations('UnitPage');
+
+  const prevTitle = prev ? (language === 'fr' ? prev.title_fr : prev.title_en) : '';
+  const nextTitle = next ? (language === 'fr' ? next.title_fr : next.title_en) : '';
+
+  const linkClass =
+    'flex-1 sm:flex-none min-h-11 inline-flex items-center gap-2 rounded-lg border border-stone-200 bg-white px-4 py-2 text-stone-700 hover:bg-stone-50 hover:border-stone-300 transition-colors max-w-full sm:max-w-[45%]';
+
+  return (
+    <nav className="mt-8 flex items-center justify-between gap-3">
+      {prev ? (
+        <Link
+          href={`/modules/${moduleId}/units/${prev.unit_number}`}
+          className={linkClass}
+        >
+          <ChevronLeft className="w-4 h-4 shrink-0" />
+          <span className="flex flex-col items-start min-w-0">
+            <span className="text-xs text-stone-500">{t('previous')}</span>
+            <span className="hidden sm:block text-sm font-medium truncate max-w-full">
+              {prevTitle}
+            </span>
+          </span>
+        </Link>
+      ) : (
+        <div />
+      )}
+
+      {next ? (
+        <Link
+          href={`/modules/${moduleId}/units/${next.unit_number}`}
+          className={`${linkClass} justify-end text-right ml-auto`}
+        >
+          <span className="flex flex-col items-end min-w-0">
+            <span className="text-xs text-stone-500">{t('next')}</span>
+            <span className="hidden sm:block text-sm font-medium truncate max-w-full">
+              {nextTitle}
+            </span>
+          </span>
+          <ChevronRight className="w-4 h-4 shrink-0" />
+        </Link>
+      ) : (
+        <div />
+      )}
+    </nav>
+  );
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -808,7 +808,9 @@
     "countryFallback": "Content optimized for your region will be available shortly"
   },
   "UnitPage": {
-    "backToModule": "Back to {module}"
+    "backToModule": "Back to {module}",
+    "previous": "Previous",
+    "next": "Next"
   },
   "BilingualTooltip": {
     "french": "French",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -808,7 +808,9 @@
     "countryFallback": "Le contenu adapté à votre région sera disponible prochainement"
   },
   "UnitPage": {
-    "backToModule": "Retour à {module}"
+    "backToModule": "Retour à {module}",
+    "previous": "Précédent",
+    "next": "Suivant"
   },
   "BilingualTooltip": {
     "french": "Français",


### PR DESCRIPTION
## Summary

- Adds **Previous** / **Next** buttons at the bottom of every unit page (lesson, case study, quiz) so users can flow through a module sequentially without returning to the module index.
- New presentational server component `frontend/components/learning/unit-nav.tsx`.
- `prev`/`next` computed page-side from the already-fetched `moduleData.units` (sorted by `order_index`) — no new API call.
- FR/EN strings added to the existing `UnitPage` namespace.

Fixes #2097

## Test plan

- [ ] Open an interior unit (e.g. 1.2) — both **Précédent** and **Suivant** appear and navigate correctly.
- [ ] Open the first unit — only **Suivant** is shown, right-aligned.
- [ ] Open the last unit — only **Précédent** is shown, left-aligned.
- [ ] Switch locale to EN — labels become "Previous" / "Next".
- [ ] Buttons render on a quiz unit and a case-study unit too.
- [ ] At ~360px width, buttons keep 44px touch targets and labels stay clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)