### PR TITLE
fix(wizard): self-heal /index-resources 409 wedge so course creation completes

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -165,6 +165,52 @@ def _safe_task_meta(task_result: AsyncResult) -> tuple[str, dict]:
     return state, meta
 
 
+_TERMINAL_TASK_STATES = frozenset({"SUCCESS", "FAILURE", "REVOKED"})
+
+
+def _diagnose_indexation_pointer(
+    course: Course,
+    *,
+    chunks_indexed: int = 0,
+    images_indexed: int = 0,
+    require_progress: bool,
+) -> tuple[str, str, dict]:
+    """Classify whether ``course.indexation_task_id`` points at a live task.
+
+    Returns ``(verdict, state, meta)``:
+    - ``"stale_no_pointer"``: ``indexation_task_id`` is null. Only meaningful
+      when ``creation_step`` is itself stuck — the row was wedged without an
+      associated task.
+    - ``"stale_terminal"``: Celery reports a terminal state (SUCCESS/FAILURE/
+      REVOKED) but ``finalize_indexation_state`` never ran (e.g. DB write in
+      the callback failed and was logged as a warning).
+    - ``"stale_evicted"``: ``state == "PENDING"`` with empty meta. Either a
+      Redis-evicted task or a worker that died before publishing meta.
+      ``require_progress=True`` adds the chunks/images > 0 gate used by
+      ``/index-status`` (less aggressive — needs durable evidence the task
+      ran). ``require_progress=False`` is the trigger-side variant: if an
+      admin clicks "Démarrer l'indexation" against a wedged row, we trust
+      the manual signal and clear the pointer.
+    - ``"live"``: Anything else (STARTED/PROGRESS/RETRY, or PENDING with
+      meta — a freshly-enqueued task that's already been picked up). Caller
+      should refuse to start a new task.
+
+    See #2100. Companion to ``_safe_task_meta``; reuses it for state lookup.
+    """
+    if not course.indexation_task_id:
+        return "stale_no_pointer", "", {}
+    state, meta = _safe_task_meta(AsyncResult(course.indexation_task_id))
+    if state in _TERMINAL_TASK_STATES:
+        return "stale_terminal", state, meta
+    if (
+        state == "PENDING"
+        and not meta
+        and (not require_progress or chunks_indexed > 0 or images_indexed > 0)
+    ):
+        return "stale_evicted", state, meta
+    return "live", state, meta
+
+
 async def _require_indexed_sources(course: Course, db) -> None:
     """Refuse AI generation when no indexed source content exists for the course.
 
@@ -1128,8 +1174,17 @@ async def trigger_rag_indexation(
     current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> dict:
-    """Trigger RAG indexation for course resources. Returns Celery task ID."""
-    result = await db.execute(select(Course).where(Course.id == course_id))
+    """Trigger RAG indexation for course resources. Returns Celery task ID.
+
+    Self-heals stuck pointers (#2100): when ``creation_step`` is already
+    ``"generating"`` or ``"indexing"`` but the recorded task is dead
+    (terminal/evicted/null), the row is reset inline and a fresh task
+    enqueued. Only refuses with 409 when a *live* task is genuinely running.
+    The SELECT takes a row lock so two simultaneous admin clicks serialize.
+    """
+    result = await db.execute(
+        select(Course).where(Course.id == course_id).with_for_update()
+    )
     course = result.scalar_one_or_none()
     if not course:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
@@ -1140,11 +1195,50 @@ async def trigger_rag_indexation(
             detail="Course has no rag_collection_id",
         )
 
-    if course.creation_step in ("generating", "indexing"):
+    if course.creation_step == "generating":
+        # Syllabus generation uses course.syllabus_task_id (separate pointer)
+        # — out of scope for this endpoint's self-heal. The syllabus endpoint
+        # exposes a `force=true` escape hatch (#2079) for stuck rows.
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail=f"A task is already in progress (step: {course.creation_step})",
+            detail={
+                "code": "SYLLABUS_GENERATION_ACTIVE",
+                "message": (
+                    "Syllabus generation is still in progress for this course. "
+                    "Wait for it to finish, or recover via "
+                    "POST /generate-syllabus?force=true."
+                ),
+                "creation_step": course.creation_step,
+            },
         )
+
+    if course.creation_step == "indexing":
+        verdict, task_state, _ = _diagnose_indexation_pointer(
+            course, require_progress=False
+        )
+        if verdict == "live":
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "code": "INDEX_TASK_ACTIVE",
+                    "message": (
+                        f"Indexation task {course.indexation_task_id} is {task_state}"
+                    ),
+                    "task_id": course.indexation_task_id,
+                    "task_state": task_state,
+                    "creation_step": course.creation_step,
+                },
+            )
+        logger.info(
+            "Self-healing stuck indexation pointer before re-trigger",
+            course_id=str(course_id),
+            verdict=verdict,
+            prior_step=course.creation_step,
+            prior_task_id=course.indexation_task_id,
+            admin_id=current_user.id,
+        )
+        course.creation_step = "generated"
+        course.indexation_task_id = None
 
     task = index_course_resources.delay(str(course_id), course.rag_collection_id)
 

--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -1182,9 +1182,7 @@ async def trigger_rag_indexation(
     enqueued. Only refuses with 409 when a *live* task is genuinely running.
     The SELECT takes a row lock so two simultaneous admin clicks serialize.
     """
-    result = await db.execute(
-        select(Course).where(Course.id == course_id).with_for_update()
-    )
+    result = await db.execute(select(Course).where(Course.id == course_id).with_for_update())
     course = result.scalar_one_or_none()
     if not course:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
@@ -1213,17 +1211,13 @@ async def trigger_rag_indexation(
         )
 
     if course.creation_step == "indexing":
-        verdict, task_state, _ = _diagnose_indexation_pointer(
-            course, require_progress=False
-        )
+        verdict, task_state, _ = _diagnose_indexation_pointer(course, require_progress=False)
         if verdict == "live":
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail={
                     "code": "INDEX_TASK_ACTIVE",
-                    "message": (
-                        f"Indexation task {course.indexation_task_id} is {task_state}"
-                    ),
+                    "message": (f"Indexation task {course.indexation_task_id} is {task_state}"),
                     "task_id": course.indexation_task_id,
                     "task_state": task_state,
                     "creation_step": course.creation_step,

--- a/backend/tests/test_admin_courses_helpers.py
+++ b/backend/tests/test_admin_courses_helpers.py
@@ -287,9 +287,7 @@ def test_diagnose_pointer_evicted_pending_no_meta_trigger_path(monkeypatch):
     """
     _patch_async_result(monkeypatch, "PENDING", {})
     course = SimpleNamespace(indexation_task_id="t-1")
-    verdict, _state, _meta = _diagnose_indexation_pointer(
-        course, require_progress=False
-    )
+    verdict, _state, _meta = _diagnose_indexation_pointer(course, require_progress=False)
     assert verdict == "stale_evicted"
 
 
@@ -330,7 +328,5 @@ def test_diagnose_pointer_returns_live_for_pending_with_meta(monkeypatch):
     """
     _patch_async_result(monkeypatch, "PENDING", {"progress": 5})
     course = SimpleNamespace(indexation_task_id="t-1")
-    verdict, _state, _meta = _diagnose_indexation_pointer(
-        course, require_progress=False
-    )
+    verdict, _state, _meta = _diagnose_indexation_pointer(course, require_progress=False)
     assert verdict == "live"

--- a/backend/tests/test_admin_courses_helpers.py
+++ b/backend/tests/test_admin_courses_helpers.py
@@ -14,6 +14,7 @@ import pytest
 from fastapi import HTTPException
 
 from app.api.v1.admin_courses import (
+    _diagnose_indexation_pointer,
     _require_extracted_sources,
     _require_indexed_sources,
     _safe_task_meta,
@@ -228,3 +229,108 @@ def test_save_syllabus_handler_sets_level_in_module_constructor():
 
     src = inspect.getsource(save_syllabus)
     assert "level=1" in src, "save_syllabus must set Module.level — see #2016"
+
+
+# ---------------------------------------------------------------------------
+# #2100 — _diagnose_indexation_pointer classifies stuck pointers
+# ---------------------------------------------------------------------------
+
+
+def _patch_async_result(monkeypatch, state: str, info):
+    """Replace AsyncResult in admin_courses with a stub returning (state, info)."""
+
+    class _Stub:
+        def __init__(self, _task_id):
+            self.state = state
+
+        @property
+        def info(self):
+            return info
+
+    monkeypatch.setattr("app.api.v1.admin_courses.AsyncResult", _Stub)
+
+
+def test_diagnose_pointer_returns_stale_no_pointer_when_task_id_null():
+    course = SimpleNamespace(indexation_task_id=None)
+    verdict, state, meta = _diagnose_indexation_pointer(course, require_progress=False)
+    assert verdict == "stale_no_pointer"
+    assert state == ""
+    assert meta == {}
+
+
+def test_diagnose_pointer_returns_stale_terminal_for_success(monkeypatch):
+    _patch_async_result(monkeypatch, "SUCCESS", {})
+    course = SimpleNamespace(indexation_task_id="t-1")
+    verdict, state, _meta = _diagnose_indexation_pointer(course, require_progress=False)
+    assert verdict == "stale_terminal"
+    assert state == "SUCCESS"
+
+
+def test_diagnose_pointer_returns_stale_terminal_for_failure(monkeypatch):
+    _patch_async_result(monkeypatch, "FAILURE", {})
+    course = SimpleNamespace(indexation_task_id="t-1")
+    verdict, state, _meta = _diagnose_indexation_pointer(course, require_progress=False)
+    assert verdict == "stale_terminal"
+    assert state == "FAILURE"
+
+
+def test_diagnose_pointer_returns_stale_terminal_for_revoked(monkeypatch):
+    _patch_async_result(monkeypatch, "REVOKED", {})
+    course = SimpleNamespace(indexation_task_id="t-1")
+    verdict, _state, _meta = _diagnose_indexation_pointer(course, require_progress=False)
+    assert verdict == "stale_terminal"
+
+
+def test_diagnose_pointer_evicted_pending_no_meta_trigger_path(monkeypatch):
+    """Trigger endpoint (require_progress=False) clears evicted pointers even
+    without indexed chunks/images — the admin's manual click is signal enough.
+    """
+    _patch_async_result(monkeypatch, "PENDING", {})
+    course = SimpleNamespace(indexation_task_id="t-1")
+    verdict, _state, _meta = _diagnose_indexation_pointer(
+        course, require_progress=False
+    )
+    assert verdict == "stale_evicted"
+
+
+def test_diagnose_pointer_evicted_status_path_requires_progress(monkeypatch):
+    """Status endpoint (require_progress=True) needs durable evidence the
+    task ran. PENDING+empty-meta with no chunks looks identical to a freshly
+    enqueued task — hold the verdict at "live".
+    """
+    _patch_async_result(monkeypatch, "PENDING", {})
+    course = SimpleNamespace(indexation_task_id="t-1")
+    verdict, _state, _meta = _diagnose_indexation_pointer(
+        course, require_progress=True, chunks_indexed=0, images_indexed=0
+    )
+    assert verdict == "live"
+
+
+def test_diagnose_pointer_evicted_status_path_with_chunks(monkeypatch):
+    _patch_async_result(monkeypatch, "PENDING", {})
+    course = SimpleNamespace(indexation_task_id="t-1")
+    verdict, _state, _meta = _diagnose_indexation_pointer(
+        course, require_progress=True, chunks_indexed=42, images_indexed=0
+    )
+    assert verdict == "stale_evicted"
+
+
+def test_diagnose_pointer_returns_live_for_started(monkeypatch):
+    _patch_async_result(monkeypatch, "STARTED", {"step": "embedding"})
+    course = SimpleNamespace(indexation_task_id="t-1")
+    verdict, state, meta = _diagnose_indexation_pointer(course, require_progress=False)
+    assert verdict == "live"
+    assert state == "STARTED"
+    assert meta == {"step": "embedding"}
+
+
+def test_diagnose_pointer_returns_live_for_pending_with_meta(monkeypatch):
+    """A freshly-enqueued task picked up by a worker reports PENDING but with
+    meta. Don't treat it as evicted.
+    """
+    _patch_async_result(monkeypatch, "PENDING", {"progress": 5})
+    course = SimpleNamespace(indexation_task_id="t-1")
+    verdict, _state, _meta = _diagnose_indexation_pointer(
+        course, require_progress=False
+    )
+    assert verdict == "live"

--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -58,7 +58,7 @@ import {
   suggestCourseMetadata,
   formatBytes,
 } from "@/lib/api-course-admin";
-import { getCourseTaxonomy, type TaxonomyItem } from "@/lib/api";
+import { ApiError, getCourseTaxonomy, type TaxonomyItem } from "@/lib/api";
 import { SyllabusVisualEditor } from "@/components/admin/syllabus-visual-editor";
 import { LessonPreviewStep } from "@/components/admin/lesson-preview-step";
 import {
@@ -427,6 +427,10 @@ export function AICourseWizard({
   const [indexStatus, setIndexStatus] = useState<IndexStatus | null>(null);
   const [isIndexing, setIsIndexing] = useState(false);
   const [indexError, setIndexError] = useState<string | null>(null);
+  // 409 INDEX_TASK_ACTIVE / SYLLABUS_GENERATION_ACTIVE detail. Distinct from
+  // indexError so the UI can offer a one-click reset-and-retry instead of
+  // a plain retry that would just 409 again (#2100).
+  const [indexConflictDetail, setIndexConflictDetail] = useState<string | null>(null);
   const [indexStaleWarning, setIndexStaleWarning] = useState(false);
   const lastIndexProgressValueRef = useRef(0);
   const lastIndexProgressTimeRef = useRef<number | null>(null);
@@ -772,6 +776,7 @@ export function AICourseWizard({
     if (!courseId) return;
     setIsIndexing(true);
     setIndexError(null);
+    setIndexConflictDetail(null);
     setIndexStaleWarning(false);
     lastIndexProgressValueRef.current = 0;
     lastIndexProgressTimeRef.current = Date.now();
@@ -779,9 +784,19 @@ export function AICourseWizard({
     try {
       const result = await triggerIndexation(courseId);
       setTaskId(result.task_id);
-    } catch {
-      setIndexError(t("index.error"));
+    } catch (err) {
       setIsIndexing(false);
+      if (
+        err instanceof ApiError &&
+        err.status === 409 &&
+        (err.code === "INDEX_TASK_ACTIVE" || err.code === "SYLLABUS_GENERATION_ACTIVE")
+      ) {
+        setIndexConflictDetail(err.message);
+      } else if (err instanceof ApiError) {
+        setIndexError(err.message || t("index.error"));
+      } else {
+        setIndexError(t("index.error"));
+      }
     }
   }, [courseId, t]);
 
@@ -926,6 +941,12 @@ export function AICourseWizard({
       // ignore
     }
   }, [courseId]);
+
+  const resetAndRetryIndexation = useCallback(async () => {
+    setIndexConflictDetail(null);
+    await cancelIndexation();
+    await startIndexation();
+  }, [cancelIndexation, startIndexation]);
 
   const reindexImages = useCallback(async () => {
     if (!courseId) return;
@@ -1502,7 +1523,7 @@ export function AICourseWizard({
                   </p>
                 </div>
 
-                {!isIndexing && !indexStatus?.indexed && (
+                {!isIndexing && !indexStatus?.indexed && !indexConflictDetail && (
                   <Button onClick={startIndexation} className="w-full min-h-11">
                     <Database className="mr-2 h-4 w-4" />
                     {t("index.button")}
@@ -1517,6 +1538,29 @@ export function AICourseWizard({
                     onCancel={cancelIndexation}
                     t={t}
                   />
+                )}
+
+                {indexConflictDetail && !isIndexing && (
+                  <div className="space-y-2">
+                    <div className="rounded-lg border border-amber-500/40 bg-amber-50 p-3 text-sm dark:bg-amber-950/30">
+                      <div className="flex items-start gap-2 text-amber-900 dark:text-amber-200">
+                        <AlertCircle className="h-4 w-4 shrink-0 mt-0.5" />
+                        <div>
+                          <p className="font-medium">{t("index.conflictTitle")}</p>
+                          <p className="mt-1 text-xs opacity-90">{indexConflictDetail}</p>
+                        </div>
+                      </div>
+                    </div>
+                    <Button
+                      onClick={resetAndRetryIndexation}
+                      variant="outline"
+                      size="sm"
+                      className="w-full min-h-[44px]"
+                    >
+                      <RotateCcw className="mr-2 h-4 w-4" />
+                      {t("index.resetAndRetry")}
+                    </Button>
+                  </div>
                 )}
 
                 {indexError && !isIndexing && (

--- a/frontend/components/admin/course-wizard-client.tsx
+++ b/frontend/components/admin/course-wizard-client.tsx
@@ -231,6 +231,9 @@ export function CourseWizardClient({
     resumeCreationStep === "indexing"
   );
   const [indexError, setIndexError] = useState<string | null>(null);
+  // 409 INDEX_TASK_ACTIVE / SYLLABUS_GENERATION_ACTIVE detail (#2100). Distinct
+  // from indexError so the UI offers reset-and-retry instead of plain retry.
+  const [indexConflictDetail, setIndexConflictDetail] = useState<string | null>(null);
   const [isReindexingImages, setIsReindexingImages] = useState(false);
   const [reindexImagesError, setReindexImagesError] = useState<string | null>(null);
   const [isCancellingIndexation, setIsCancellingIndexation] = useState(false);
@@ -691,6 +694,7 @@ export function CourseWizardClient({
     if (!courseId) return;
     setIsIndexing(true);
     setIndexError(null);
+    setIndexConflictDetail(null);
     setIndexStaleWarning(false);
     setCancelIndexationError(null);
     lastIndexProgressValueRef.current = 0;
@@ -702,11 +706,27 @@ export function CourseWizardClient({
         { method: "POST" }
       );
       setTaskId(result.task_id);
-    } catch {
-      setIndexError(t("index.error"));
+    } catch (err) {
       setIsIndexing(false);
+      if (
+        err instanceof ApiError &&
+        err.status === 409 &&
+        (err.code === "INDEX_TASK_ACTIVE" || err.code === "SYLLABUS_GENERATION_ACTIVE")
+      ) {
+        setIndexConflictDetail(err.message);
+      } else if (err instanceof ApiError) {
+        setIndexError(err.message || t("index.error"));
+      } else {
+        setIndexError(t("index.error"));
+      }
     }
   }, [courseId, t]);
+
+  const resetAndRetryIndexation = useCallback(async () => {
+    setIndexConflictDetail(null);
+    await cancelIndexation();
+    await startIndexation();
+  }, [cancelIndexation, startIndexation]);
 
   useEffect(() => {
     if (!courseId || !isIndexing) return;
@@ -1291,11 +1311,34 @@ export function CourseWizardClient({
                   </div>
                 )}
 
-                {!isIndexing && !indexStatus?.indexed && !isCheckingIndexStatus && (
+                {!isIndexing && !indexStatus?.indexed && !isCheckingIndexStatus && !indexConflictDetail && (
                   <Button onClick={startIndexation} className="w-full min-h-11" disabled={isIndexing}>
                     <Database className="mr-2 h-4 w-4" />
                     {t("index.button")}
                   </Button>
+                )}
+
+                {!isIndexing && indexConflictDetail && (
+                  <div className="space-y-2">
+                    <div className="rounded-lg border border-amber-500/40 bg-amber-50 p-3 text-sm dark:bg-amber-950/30">
+                      <div className="flex items-start gap-2 text-amber-900 dark:text-amber-200">
+                        <AlertCircle className="h-4 w-4 shrink-0 mt-0.5" />
+                        <div>
+                          <p className="font-medium">{t("index.conflictTitle")}</p>
+                          <p className="mt-1 text-xs opacity-90">{indexConflictDetail}</p>
+                        </div>
+                      </div>
+                    </div>
+                    <Button
+                      onClick={resetAndRetryIndexation}
+                      variant="outline"
+                      size="sm"
+                      className="w-full min-h-[44px]"
+                    >
+                      <RotateCcw className="mr-2 h-4 w-4" />
+                      {t("index.resetAndRetry")}
+                    </Button>
+                  </div>
                 )}
 
                 {isIndexing && (

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1497,6 +1497,8 @@
         "reindexImagesError": "Image re-indexation failed.",
         "cancelIndexation": "Cancel indexation",
         "retryIndexation": "Retry indexation",
+        "conflictTitle": "Indexation task already active",
+        "resetAndRetry": "Reset and retry indexation",
         "staleWarning": "No progress detected for over 60 seconds. The task may be stuck.",
         "cancelError": "Failed to cancel indexation.",
         "cancelSuccess": "Indexation cancelled. You can restart it."

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1497,6 +1497,8 @@
         "reindexImagesError": "La ré-indexation des images a échoué.",
         "cancelIndexation": "Annuler l'indexation",
         "retryIndexation": "Relancer l'indexation",
+        "conflictTitle": "Tâche d'indexation déjà active",
+        "resetAndRetry": "Réinitialiser et relancer l'indexation",
         "staleWarning": "Aucune progression détectée depuis plus de 60 secondes. La tâche est peut-être bloquée.",
         "cancelError": "Impossible d'annuler l'indexation.",
         "cancelSuccess": "Indexation annulée. Vous pouvez la relancer."


### PR DESCRIPTION
## Summary

- Make \`POST /api/v1/admin/courses/<id>/index-resources\` self-healing: classify the existing \`indexation_task_id\` via Celery \`AsyncResult\` and clear dead pointers (terminal / evicted / null) inline before enqueueing a new task. Only refuse with 409 when a *live* task is genuinely running.
- Surface structured 409 detail in both wizards (\`ai-course-wizard\` and legacy \`course-wizard-client\`) with a one-click \"Réinitialiser et relancer l'indexation\" recovery button that chains cancel + retry. Generic errors no longer mask \`INDEX_TASK_ACTIVE\` / \`SYLLABUS_GENERATION_ACTIVE\` cases.
- Add \`with_for_update()\` on the trigger SELECT to serialize concurrent admin clicks.
- 9 new unit tests for \`_diagnose_indexation_pointer\` covering all 4 verdicts × \`require_progress\` matrix.

Fixes #2100. Related: #2054 (\`/index-status\` stale meta — left unchanged here, semantics preserved), #1113 (\`/cancel-indexation\` endpoint reused), #2085 (\`RAGTask\` callback ownership relied upon).

## Test plan

- [x] \`uv run ruff check app/api/v1/admin_courses.py\` — clean
- [x] \`uv run pytest tests/test_admin_courses_helpers.py -x -q\` — 21 passed (9 new + 12 existing)
- [x] \`npx tsc --noEmit\` — no errors in modified files (pre-existing errors in unrelated files only)
- [x] \`npx eslint components/admin/ai-course-wizard.tsx components/admin/course-wizard-client.tsx\` — no new errors
- [ ] Staging manual: trigger indexation, kill celery-worker mid-task (\`docker compose kill celery-worker\`), wait 60s, click \"Démarrer\" — must self-heal and complete (was 409 forever).
- [ ] Staging manual: simulate wedge via \`UPDATE courses SET creation_step='indexing', indexation_task_id='dead' WHERE id=…\`, load wizard, click \"Démarrer\" → see \"Tâche d'indexation déjà active\" panel → click \"Réinitialiser et relancer\" → completes.
- [ ] Staging manual: trigger indexation, immediately POST again from curl — must 409 with \`detail.code == INDEX_TASK_ACTIVE\` and the real task id + state.
- [ ] Staging manual: existing cancel-mid-stream flow still works.

## Out of scope

- Why the worker is dying in the first place (separate concern, partially tracked in #2054).
- Migration to clean up currently-stuck rows — runtime self-heal handles them on next admin click with full audit logging; a blind migration would risk resetting legitimately-running indexations.
- \`creation_step='generating'\` self-heal — syllabus generation uses a separate \`syllabus_task_id\` pointer with its own \`force=true\` recovery (#2079).

🤖 Generated with [Claude Code](https://claude.com/claude-code)