### PR TITLE
fix(tasks): dispose async engine to fix Celery prefork asyncpg crash (#2103)

### DIFF
--- a/backend/app/tasks/rag_indexation.py
+++ b/backend/app/tasks/rag_indexation.py
@@ -452,8 +452,21 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
 
         return total_chunks, total_images
 
+    async def _run_pipeline_with_fresh_engine():
+        # asyncpg + Celery prefork: child workers inherit the parent's engine
+        # but its pooled connections are bound to the parent loop. Dispose
+        # before and after so this task — and the next one to land on this
+        # worker — both start with a clean pool. See #2103.
+        from app.infrastructure.persistence.database import engine
+
+        await engine.dispose()
+        try:
+            return await _run_pipeline()
+        finally:
+            await engine.dispose()
+
     try:
-        total_chunks, total_images = asyncio.run(_run_pipeline())
+        total_chunks, total_images = asyncio.run(_run_pipeline_with_fresh_engine())
 
         self.update_state(
             state="COMPLETE",

--- a/backend/app/tasks/sms_relay.py
+++ b/backend/app/tasks/sms_relay.py
@@ -10,6 +10,7 @@ from app.infrastructure.cache.redis import redis_client
 from app.infrastructure.config.settings import settings
 from app.infrastructure.persistence.database import (
     async_session_factory,
+    engine,
 )
 from app.tasks.celery_app import celery_app
 
@@ -30,34 +31,41 @@ def check_relay_heartbeat(self) -> dict:
     try:
 
         async def _run() -> int:
-            async with async_session_factory() as session:
-                service = SmsRelayService()
-                stale = await service.get_stale_devices(
-                    timeout_minutes=(settings.sms_relay_heartbeat_timeout_minutes),
-                    session=session,
-                )
-
-                if not stale or not settings.sms_relay_alert_email:
-                    return 0
-
-                email_service = EmailService()
-                alerted = 0
-                for device in stale:
-                    key = ALERT_COOLDOWN_KEY.format(device_id=device.device_id)
-                    if redis_client.get(key):
-                        continue
-
-                    sent = await email_service.send_relay_alert(
-                        to_email=settings.sms_relay_alert_email,
-                        device_id=device.device_id,
-                        last_seen=device.last_heartbeat_at.isoformat(),
-                        battery=device.battery,
+            # asyncpg + Celery prefork: dispose any pool inherited from the
+            # parent before/after so we don't reuse connections bound to the
+            # parent's event loop. See #2103.
+            await engine.dispose()
+            try:
+                async with async_session_factory() as session:
+                    service = SmsRelayService()
+                    stale = await service.get_stale_devices(
+                        timeout_minutes=(settings.sms_relay_heartbeat_timeout_minutes),
+                        session=session,
                     )
-                    if sent:
-                        redis_client.set(key, "1", ex=ALERT_COOLDOWN_TTL)
-                        alerted += 1
 
-                return alerted
+                    if not stale or not settings.sms_relay_alert_email:
+                        return 0
+
+                    email_service = EmailService()
+                    alerted = 0
+                    for device in stale:
+                        key = ALERT_COOLDOWN_KEY.format(device_id=device.device_id)
+                        if redis_client.get(key):
+                            continue
+
+                        sent = await email_service.send_relay_alert(
+                            to_email=settings.sms_relay_alert_email,
+                            device_id=device.device_id,
+                            last_seen=device.last_heartbeat_at.isoformat(),
+                            battery=device.battery,
+                        )
+                        if sent:
+                            redis_client.set(key, "1", ex=ALERT_COOLDOWN_TTL)
+                            alerted += 1
+
+                    return alerted
+            finally:
+                await engine.dispose()
 
         count = asyncio.run(_run())
         logger.info(


### PR DESCRIPTION
## Summary

- Fixes #2103 — the wizard's "Indexation RAG" step was crashing with `asyncpg.InterfaceError: cannot perform operation: another operation is in progress` because `index_course_resources` reuses the shared async engine from `database.py`. Forked Celery workers inherit that engine but its pooled connections are bound to the parent's event loop, so the first DB op fails.
- Wraps the async body of `index_course_resources` and `check_relay_heartbeat` in `try/finally` with `engine.dispose()` before and after, so the worker tears down inherited connections before doing real work and leaves a clean pool for the next task.
- `check_relay_heartbeat` was hitting the identical error every 15 minutes on the beat schedule — same fix applies.

## Why this shape

Other long-running async tasks (`content_generation.py`, `syllabus_generation.py`) avoid this by spinning up a fresh per-task engine. Refactoring `RAGPipeline` to take that path would be a much bigger change. Disposing the shared engine on entry/exit is the minimal surgical fix that's consistent with the established `engine.dispose()` pattern.

## Out of scope

- `rate_limit="2/h"` on `index_course_resources` will still throttle retries during rollout; not changing it here.
- Not touching `_on_worker_process_init` to dispose globally — risks regressing the many tasks already working.

## Test plan

- [ ] Deploy to staging.
- [ ] Open the AI course wizard, click through to Indexation, hit "Démarrer l'indexation".
- [ ] `docker compose logs -f celery-worker | grep -E 'RAG indexation|InterfaceError'` shows no `InterfaceError`; ends with `RAG indexation completed`.
- [ ] `SELECT COUNT(*) FROM document_chunks WHERE source = '<rag_collection_id>'` and `SELECT COUNT(*) FROM source_images WHERE rag_collection_id = '<rag_collection_id>'` both > 0.
- [ ] After at least one `:00 / :15 / :30 / :45` boundary, no `check_relay_heartbeat failed` lines in the worker log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)