### PR TITLE
fix(linker): dedupe semantic pairs against existing junction rows (#2106)

### DIFF
--- a/backend/app/ai/rag/image_linker.py
+++ b/backend/app/ai/rag/image_linker.py
@@ -64,10 +64,11 @@ class ImageLinker:
         explicit_pairs = await self._build_explicit_pairs(source, session)
         contextual_pairs = await self._build_contextual_pairs(source, session, explicit_pairs)
         # Semantic must run last so it can deduplicate against pairs the
-        # higher-precision strategies already produced. The explicit and
-        # contextual matchers already filter against existing DB rows
-        # internally, so semantic only needs to dedupe against the pairs
-        # we just computed — no third _get_existing_pairs call.
+        # higher-precision strategies already produced. It also needs to
+        # dedupe against existing DB rows — explicit/contextual filter
+        # against `_get_existing_pairs` internally, but semantic was
+        # missing that check, so re-running the linker on an
+        # already-linked course raised UniqueViolationError. See #2106.
         semantic_pairs = await self._build_semantic_pairs(
             source, session, explicit_pairs | contextual_pairs
         )
@@ -297,11 +298,15 @@ class ImageLinker:
             """
         ).bindparams(src=source, k=_SEMANTIC_TOP_K, max_dist=_SEMANTIC_DIST_MAX)
 
+        # Filter against rows already in the junction table so a re-run
+        # of the linker doesn't try to insert duplicates. See #2106.
+        existing_pairs = await self._get_existing_pairs(source, session)
+
         result = await session.execute(query)
         pairs: set[tuple] = set()
         for row in result.all():
             pair = (row.image_id, row.chunk_id)
-            if pair in higher_priority:
+            if pair in higher_priority or pair in existing_pairs:
                 continue
             pairs.add(pair)
 

--- a/backend/tests/test_image_linker.py
+++ b/backend/tests/test_image_linker.py
@@ -672,6 +672,7 @@ class TestSemanticLinkage:
             _make_execute_result([]),  # contextual chunks
             _make_execute_result([]),  # contextual existing.image_ids
             _make_count_result(1, 1),  # semantic count: both > 0
+            _make_execute_result([]),  # semantic existing.image_ids (#2106)
             lateral_result,  # lateral join result
         ]
 
@@ -708,6 +709,7 @@ class TestSemanticLinkage:
             _make_execute_result([(chunk_id, 5, None)]),  # contextual chunks
             _make_execute_result([]),
             _make_count_result(1, 1),
+            _make_execute_result([]),  # semantic existing.image_ids (#2106)
             lateral_result,  # would propose the same pair as explicit
         ]
 


### PR DESCRIPTION
## Summary

- Fixes #2106 — `POST /relink-images` 500s with `UniqueViolationError` on `source_image_chunks_pkey` for any course whose links have already been computed.
- Root cause: `ImageLinker._build_semantic_pairs` filtered only against the in-memory set of pairs from explicit/contextual, not against rows already in the junction table. Re-runs re-emit the same semantic pairs and the bulk insert collides on the composite PK.
- Now calls `_get_existing_pairs` after the count probe and skips already-stored pairs — matches the pattern explicit/contextual already follow and honours the documented contract on `/relink-images` ("linker is idempotent and only adds new pairs").
- Latent bug — surfaced once #2103 made indexation actually complete on staging and the wizard repeatedly invoked the linker.

## Test plan

- [x] `pytest backend/tests/test_image_linker.py` — 37 passed (2 semantic tests had their mock `side_effect` extended by one entry for the new `_get_existing_pairs` call)
- [ ] On staging post-deploy: `POST /api/v1/admin/courses/95cf30fd-1aa7-4a15-822a-96406930d493/relink-images` returns 200 with `links_added: 0` (course is already fully linked)
- [ ] No `UniqueViolationError` lines in backend logs after exercising the wizard's Linker step

🤖 Generated with [Claude Code](https://claude.com/claude-code)