### PR TITLE
docs(qa): production-readiness sweep + consolidation 2026-04-28→30 (epic #2123 + migration epic #2134)

### DIFF
--- a/docs/qa/sweep-2026-04-28.md
+++ b/docs/qa/sweep-2026-04-28.md
@@ -203,9 +203,20 @@ After feedback ("complete the whole picture before fragmenting into issues") the
 
 **Registration flow end-to-end** — `S'inscrire` link → `/register-options` → `/register-password` → fill form → submit → `/fr/onboarding` with valid JWT and `role=user`. Email `e2e-learner-2026-04-30@sira-test.local` accepted (no email verification step). Account ID `f8d60136-adc3-460b-b1a7-93d8def58ae1`.
 
-**Lesson rendering** — `/fr/modules/{id}/units/1.1` renders full lesson with text + image (alt-texted, 248×165 mobile-fit) + audio (`<audio src=/api/v1/audio/{id}>` 5:30) + 4 source citations + breadcrumb + page title hierarchy "{unit title} · {module title} · Sira" (the only page-title pattern that's right, see F-008).
+### What was actually tested as the **learner** (precise scope, no conflation with admin)
 
-**Mobile** — `/fr/dashboard` and `/fr/modules/{id}/units/1.1` at 375×667: no horizontal scroll, bottom nav present, lesson image fits within viewport, only one sub-44px touch target found (F-022).
+The following four cells are the *only* cells that were exercised under the fresh learner session:
+
+1. **Registration flow** — form fill → submit → `/fr/onboarding` redirect with valid JWT (above).
+2. **Dashboard empty state** — `/fr/dashboard` shows zero stats, "Vous n'êtes inscrit à aucune formation" empty-state, public curricula widget. Sidebar renders 9 links (no `/fr/admin/*`, no `/fr/organizations`, no `/fr/qbank` author link).
+3. **Server-side RBAC** — `GET /api/v1/admin/users|courses|audit-logs|settings|users/count` all return `403 {"detail":"Insufficient permissions"}` for the learner JWT. `GET /api/v1/organizations` returns 405 (F-016).
+4. **Frontend route guard** — `/fr/admin/users` direct-URL navigation redirects learner to `/fr/dashboard`. `/fr/organizations` shows empty-state with "Créer une organisation" CTA (any user can create their own org).
+
+That is **all**. Every other persona-row cell was either covered under the cached *admin* session (and so does not transfer to learner) or not covered at all. The matrix below has been corrected to reflect this honestly.
+
+**Lesson rendering (admin session)** — `/fr/modules/{id}/units/1.1` rendered under the cached **admin** session (not the learner). Full lesson with text + image (alt-texted, 248×165 mobile-fit) + audio (`<audio src=/api/v1/audio/{id}>` 5:30) + 4 source citations + breadcrumb + page title hierarchy "{unit title} · {module title} · Sira" (the only page-title pattern that's right, see F-008). **Learner rendering not separately verified** — admin sees all course content by default; a learner with no enrollments may see different paywalls/gates. BLOCKED-pending-#2109 fixture seeding.
+
+**Mobile (admin session)** — `/fr/dashboard` and `/fr/modules/{id}/units/1.1` at 375×667 under admin: no horizontal scroll, bottom nav present, lesson image fits within viewport, only one sub-44px touch target found (F-022). **Mobile not separately verified for learner.**
 
 **Org page subroutes (admin perspective)** — `/fr/org/{slug}/{courses,curricula,qbank,qbank/create,codes,reports,members}` all 200; `/fr/org/{slug}/billing` is 404 (probably not a real subroute, fine).
 
@@ -216,7 +227,7 @@ After feedback ("complete the whole picture before fragmenting into issues") the
 | Persona | Auth | Catalog | Learning | Tutor | Profile | Payments | Org actions | Admin | PWA/Offline | i18n |
 |---|---|---|---|---|---|---|---|---|---|---|
 | Anonymous | login ✅ register ✅ when flag-on / hidden when flag-off ✓ | courses ✅ curricula(index) ❌(F-003) curricula/{slug} ✅ about ✅ | n/a | n/a | n/a | view packages ✅ | n/a | n/a | install prompt ✓ SW ❌(F-005) | toggle ✅ |
-| Learner (`role=user`, fresh fixture) | login ✅ register ✅ logout API ⚠(F-004) | courses ✅ curricula/{slug} ✅ | lesson ✅ quiz intro ✅ — quiz/flashcard/cert flows NOT exercised | tutor page ✅ — chat send NOT exercised | edit ✅ | subscribe ✅ — Paystack NOT exercised | empty-state ✅ create flow NOT exercised | gated 403 ✓ frontend redirects ✓ | mobile ✅ SW ❌ | toggle ✅ |
+| Learner (`role=user`, fresh fixture `f8d60136-…`) | register ✅ end-to-end | dashboard empty-state ✅ — **catalog/curricula/course-detail NOT exercised as learner** | **NOT exercised as learner** (lesson/quiz/flashcard/cert flows were navigated under the cached *admin* session — coverage does not transfer; BLOCKED-pending-#2109) | **NOT exercised as learner** | **NOT exercised as learner** | **NOT exercised as learner** | empty-state at `/fr/organizations` ✅ — create flow NOT exercised | server 403 ✅ FE redirects ✅ (the only learner-specific gating verified) | **NOT exercised as learner** | **NOT exercised as learner** |
 | Org-owner | **BLOCKED** | **BLOCKED** | **BLOCKED** | n/a | **BLOCKED** | **BLOCKED** | **BLOCKED** — covered indirectly via admin (sees all orgs); proper scoping needs a non-admin org-owner. Unblocker: #2109 fixture seeding | n/a | — | — |
 | Sub_admin | **BLOCKED** | n/a | n/a | n/a | — | view txns covered via admin only; sub_admin specific scoping (no AI/prompt settings access) **untested**. Unblocker: #2109 | n/a | covered via admin | — | — |
 | Admin (cached session) | session valid ✅ | admin/courses ✅ admin/curricula ✅ users ✅ taxonomy ✅ groups ✅ payments ✅ audit-logs ✅ analytics ⚠(F-010) settings ⚠(F-011) syllabus ✅ | n/a | n/a | n/a | covered ✅ | full ✅ | full ✅ | mobile sampled ✅ | — |

--- a/docs/qa/sweep-2026-04-28.md
+++ b/docs/qa/sweep-2026-04-28.md
@@ -148,3 +148,108 @@ Comparing against `e2e_issues_2026_03_31.md` and `e2e_issues_2026_04_01.md`:
 3. Compare against this doc to confirm whether each finding still reproduces, then file follow-up issues if regressed/fixed.
 
 The durable, repeatable version of this sweep is the Phase B Playwright suite (epic child).
+
+---
+
+# Update — Resumed sweep 2026-04-30
+
+After feedback ("complete the whole picture before fragmenting into issues") the sweep was resumed with stricter discipline: full anonymous walk through a properly-cleared session, an actual learner journey (lesson + quiz intro), real role-scoping verification using a fresh `role=user` learner created via the public registration flow, mobile re-checks across multiple pages, and English locale parity sampling. This update captures the additional findings, **reframes** several originals that were misdiagnosed, and adds a consolidation table.
+
+## Architectural pivot affecting persona model
+
+**Expert role is collapsing into single-person Organization.** The user announced 2026-04-30 that an "expert" is now just a `role=user` who is `OrgMemberRole.owner` of an org-of-one. Code is **not yet migrated** — `UserRole.expert` still exists in `backend/app/domain/models/user.py:14-18` and is gated across 7 backend endpoints + frontend permission helpers. Sweep persona matrix updated from 6 rows to 5: anonymous, learner, **org-owner** (replaces expert), sub_admin, admin. See plan amendment 2026-04-30 for the full migration plan.
+
+## Reframed findings (originally filed as bugs, actually feature-flag state or working as designed)
+
+**F-001 (was P0, now P2)** — `/fr/register` redirects anonymous users to `/fr/login`. **Reframed:** working as designed when the `auth-self-registration-enabled` setting is `false` (verified empirically: when the user flipped the setting to `true`, register flow became reachable end-to-end, "S'inscrire" link appeared on `/fr/login`, and registration succeeded with `f8d60136-adc3-460b-b1a7-93d8def58ae1` learner created on first try). The defect that remains is a UX one: when the setting is off, the about page CTAs ("Parcourir les cours", "Devenir expert") and the absence of any "registration is invitation-only" banner leave new visitors with no signal about what to do. Demoted to P2 — *issue #2110 should be reframed accordingly, not closed.*
+
+**F-002 (was P0, now resolved)** — `/fr/login` has no link to register. **Resolved:** the link `Vous n'avez pas de compte ? S'inscrire` → `/register-options` is rendered in `frontend/components/auth/password-login-form.tsx:161-167` and `totp-login-form.tsx:279`, gated by `registrationEnabled = getSetting('auth-self-registration-enabled', false)`. Same root cause as F-001 — same single fix.
+
+**F-004 (was P1, now refined)** — JWT in JS-readable storage. **Refined:** `refresh_token` is **HttpOnly** (verified empirically — `localStorage.clear()` + JS cookie clear left a working refresh that auto-restored the access_token on next nav). `access_token` is JS-readable in cookie + localStorage but short-lived (15 min) and behind strong CSP (`script-src 'self'`, no inline eval allowed) + HSTS preload + X-Frame-Options DENY. The remaining real defect is the **logout API requires `refresh_token` in the JSON body** (returns 422 without) — but the refresh token lives in HttpOnly cookie, so the client cannot read it to send it. The current frontend works around this by *also* storing the refresh_token in localStorage on login, defeating the HttpOnly protection. The fix is to move logout to read from the HttpOnly cookie server-side. *Issue #2112 should be refined to focus on the logout-API circularity.*
+
+## New findings from the resumed sweep
+
+**F-016 (P0)** — `/api/v1/organizations` (GET) returns **405 Method Not Allowed** for an authenticated user. Likely missing a "list my orgs" endpoint at this path; backend probably exposes `POST` for create at the same URL only. The frontend's `/fr/organizations` page works correctly for a learner (shows empty state with "create org" CTA) — so it must be using a different endpoint. Worth confirming whether the missing-list endpoint is intentional or a defect.
+
+**F-017 (P2)** — `/api/v1/video/lesson/{lesson_id}` returns **404** for a lesson that has no generated video yet. The lesson page UI shows a "Générer la vidéo" button (so user-facing intent is "create on demand"), but the page also issues a preflight check that 404s in the console. Either the FE shouldn't preflight when the button is "generate", or the BE should return 200 with a `{ status: "not_generated" }` payload.
+
+**F-018 (P3)** — Source citation labels on lesson pages render raw UUIDs without separator: e.g. `1Bd2E9508-9B48-46F4-959C-14B682Cba886, p.11`. Should be `[1] Donaldson's Essential Public Health, p. 11` or similar — i.e. resolve UUID → document title and add visual separator after the index number.
+
+**F-019 (P3)** — `/fr/modules/{module_id}/units/{unit}` next/prev nav buttons concatenate without separator: `PrécédentContexte Politique : AFGHS...`. Should be styled as a button with prev-text labeled and the title on a second line, or with a visible separator.
+
+**F-020 (P3)** — Unit list shows `Unité 015 min de lecture` (collapsed whitespace between unit number and reading time) on the module overview.
+
+**F-021 (P3)** — Quiz unit page header shows `Unit 1.4` (English on FR locale) where lesson units show `Unité 1.1` (correct FR). String inconsistency between unit-type renderers.
+
+**F-022 (P3)** — Mobile (375×667) lesson page has one button under 44×44: "Actualiser le contenu" measured 36×44.
+
+**F-023 (P2)** — Next.js RSC prefetch for the parent path `/fr/modules/{id}/units` (not a real route) returns 404. Console error visible on every lesson nav. Likely the prefetcher walking up the route tree before navigating to a specific unit. Cosmetic but pollutes Sentry / monitoring.
+
+**F-024 (P3)** — Bloom-taxonomy verbs ("understand", "apply", "analyze", "evaluate", "remember") render in English on FR course detail (chip on each module). Same root pattern as F-013 (admin/courses chips raw English).
+
+**F-025 (P3)** — Analytics event-type labels ("tutor message sent", "lesson viewed") render raw English on `/fr/admin/analytics`. Same root pattern as F-013/F-024.
+
+## Verified passing (resumed sweep)
+
+**Role-scoping (server-side)** — verified with the fresh `role=user` learner:
+- `/api/v1/admin/users`, `/admin/courses`, `/admin/audit-logs`, `/admin/settings`, `/admin/users/count` all return **403 with `{"detail":"Insufficient permissions"}`** ✓
+- `/api/v1/auth/refresh` returns only `access_token` in body (refresh_token stays HttpOnly) ✓
+- Strong response headers: CSP `default-src 'self'`, HSTS preload-ready, X-Frame-Options DENY, X-Content-Type-Options nosniff, Permissions-Policy locking down sensors/payment/etc. ✓
+
+**Role-scoping (frontend)** — verified visually:
+- Learner sidebar renders 9 links (Dashboard / Formations / Modules / Flashcards / Tests de révision / Certificats / Tuteur IA / Profil / Abonnement). No `/fr/admin/*`, no `/fr/organizations`, no `/fr/qbank` (qbank-author) link ✓
+- Direct URL `/fr/admin/users` redirects learner to `/fr/dashboard` (frontend route guard) ✓
+- `/fr/organizations` for a learner with no org membership shows empty state + "Créer une organisation" CTA ✓ (any user can create their own org — the single-person-org pattern in action)
+
+**Registration flow end-to-end** — `S'inscrire` link → `/register-options` → `/register-password` → fill form → submit → `/fr/onboarding` with valid JWT and `role=user`. Email `e2e-learner-2026-04-30@sira-test.local` accepted (no email verification step). Account ID `f8d60136-adc3-460b-b1a7-93d8def58ae1`.
+
+**Lesson rendering** — `/fr/modules/{id}/units/1.1` renders full lesson with text + image (alt-texted, 248×165 mobile-fit) + audio (`<audio src=/api/v1/audio/{id}>` 5:30) + 4 source citations + breadcrumb + page title hierarchy "{unit title} · {module title} · Sira" (the only page-title pattern that's right, see F-008).
+
+**Mobile** — `/fr/dashboard` and `/fr/modules/{id}/units/1.1` at 375×667: no horizontal scroll, bottom nav present, lesson image fits within viewport, only one sub-44px touch target found (F-022).
+
+**Org page subroutes (admin perspective)** — `/fr/org/{slug}/{courses,curricula,qbank,qbank/create,codes,reports,members}` all 200; `/fr/org/{slug}/billing` is 404 (probably not a real subroute, fine).
+
+**English locale parity** — `/en/dashboard`, `/en/courses`, `/en/about`, `/en/flashcards` all render with English UI, no FR leaks. `Flashcards.cards` is missing in `en` too (parity confirmed for F-006).
+
+## Coverage matrix — final
+
+| Persona | Auth | Catalog | Learning | Tutor | Profile | Payments | Org actions | Admin | PWA/Offline | i18n |
+|---|---|---|---|---|---|---|---|---|---|---|
+| Anonymous | login ✅ register ✅ when flag-on / hidden when flag-off ✓ | courses ✅ curricula(index) ❌(F-003) curricula/{slug} ✅ about ✅ | n/a | n/a | n/a | view packages ✅ | n/a | n/a | install prompt ✓ SW ❌(F-005) | toggle ✅ |
+| Learner (`role=user`, fresh fixture) | login ✅ register ✅ logout API ⚠(F-004) | courses ✅ curricula/{slug} ✅ | lesson ✅ quiz intro ✅ — quiz/flashcard/cert flows NOT exercised | tutor page ✅ — chat send NOT exercised | edit ✅ | subscribe ✅ — Paystack NOT exercised | empty-state ✅ create flow NOT exercised | gated 403 ✓ frontend redirects ✓ | mobile ✅ SW ❌ | toggle ✅ |
+| Org-owner | **BLOCKED** | **BLOCKED** | **BLOCKED** | n/a | **BLOCKED** | **BLOCKED** | **BLOCKED** — covered indirectly via admin (sees all orgs); proper scoping needs a non-admin org-owner. Unblocker: #2109 fixture seeding | n/a | — | — |
+| Sub_admin | **BLOCKED** | n/a | n/a | n/a | — | view txns covered via admin only; sub_admin specific scoping (no AI/prompt settings access) **untested**. Unblocker: #2109 | n/a | covered via admin | — | — |
+| Admin (cached session) | session valid ✅ | admin/courses ✅ admin/curricula ✅ users ✅ taxonomy ✅ groups ✅ payments ✅ audit-logs ✅ analytics ⚠(F-010) settings ⚠(F-011) syllabus ✅ | n/a | n/a | n/a | covered ✅ | full ✅ | full ✅ | mobile sampled ✅ | — |
+
+Legend: ✅ pass · ⚠ partial / minor defect · ❌ fail · — n/a · **BLOCKED** = persona credentials not seeded.
+
+## Consolidation — issue clusters
+
+The 14 already-filed issues + new findings consolidate into the following 9 product-defect clusters (separate from the 8 prod-readiness scaffolding issues #2109/#2116-#2122 that stay 1:1).
+
+| Cluster | Findings | Disposition | Severity |
+|---|---|---|---|
+| **A — Auth flow UX (registration disabled state)** | F-001, F-002 reframed | Reframe #2110 in-place: "auth: communicate registration-disabled state to anonymous visitors"; demote priority high→medium | P2 |
+| **B — Curricula index missing** | F-003 | Keep #2111 unchanged | P0 |
+| **C — Auth logout API circularity** | F-004 refined | Refine #2112: focus body on logout-needs-cookie-not-body (drop the broader "tokens in LS" framing since refresh_token is HttpOnly) | P1 |
+| **D — PWA service worker not deployed** | F-005 | Keep #2113 unchanged | P1 |
+| **E — i18n audit (FR locale gaps)** | F-006, F-007, F-013, F-024, F-025, F-021, F-011, EN parity | **Close #2114 and #2115; file new consolidated `fix(i18n): FR locale completeness audit` issue** | P2 |
+| **F — Frontend page metadata + a11y polish** | F-008, F-014, F-018, F-019, F-020, F-022 | **File new `polish: page metadata, citation formatting, mobile touch targets`** | P3 |
+| **G — Charts container sizing** | F-010 | **File new `fix(admin): Recharts container sizing on /fr/admin/analytics`** | P2 |
+| **H — Video lesson endpoint state** | F-017 | **File new `fix(lesson): /api/v1/video/lesson/{id} 200+state instead of 404`** | P2 |
+| **I — Org list endpoint missing GET** | F-016 | **File new `fix(api): GET /api/v1/organizations should list current user's orgs (currently 405)`** | P0 |
+| **J — RSC prefetch 404 for parent route** | F-023 | Note in cluster F or skip — noise only | P3 |
+
+## Migration epic (separate from defect clusters)
+
+The expert→org-of-one migration is an architectural blocker for production readiness. Filed as a new epic with 5 phase children (schema → backend routes → frontend → data backfill → cleanup). Linked from #2123. See plan amendment 2026-04-30 for phasing detail.
+
+## Remaining BLOCKED coverage (after fixture seeding via #2109)
+
+- Org-owner permission scoping (sees only own org)
+- Sub_admin scoping (no AI/prompt settings access)
+- Paystack credit purchase end-to-end
+- AI tutor chat send (deferred — token cost)
+- Quiz attempt submission, flashcard review, summative, certificate issue (deferred — would commit progress)
+- Offline mode end-to-end (blocked by F-005)
+- Magic-link email round-trip (needs a mailbox)

--- a/docs/qa/sweep-2026-04-28.md
+++ b/docs/qa/sweep-2026-04-28.md
@@ -1,0 +1,150 @@
+# Production readiness sweep — 2026-04-28
+
+Autonomous browser sweep of the Sira platform on staging. One-shot Phase A of the production-readiness epic. No code changes other than this document and the GitHub issues filed from it.
+
+- **Target**: `https://etutor.elearning.portfolio2.kimbetien.com` (frontend), `https://api.elearning.portfolio2.kimbetien.com` (backend, `/health` returned `{"status":"healthy"}`).
+- **Tooling**: Playwright via MCP (Chromium, viewport 1280×800 desktop + 375×667 mobile).
+- **Personas exercised**:
+  - Anonymous (after explicit storage + cookie clear).
+  - Cached admin session that the MCP browser carried in (`traore.benidrissa@gmail.com`, role=admin) — used **read-only** to verify admin/learner routes render. No destructive CRUD, no AI-token-burning actions.
+- **Personas blocked**: expert, sub_admin, org-owner — no fixture credentials. See child issue 1 below.
+- **Date semantics**: today is 2026-04-28; some sweep activity ran late and is timestamped 2026-04-30 in raw playwright traces. Treat both as part of this sweep.
+
+## Coverage summary
+
+| Persona | Auth | Catalog | Learning | Tutor | Profile | Payments | Admin | PWA/i18n |
+|---|---|---|---|---|---|---|---|---|
+| Anonymous | login✅ register❌ | (couldn't verify, redirect) | n/a | n/a | n/a | n/a | n/a | partial |
+| Learner (via cached admin session, read-only) | session valid ✅ | courses ✅ curricula/{slug} ✅ curricula(index)❌ | modules ✅ flashcards ⚠️ certificates ✅ | tutor ✅ | profile ✅ settings→profile ✅ | subscribe ✅ | n/a | mobile ✅ SW ❌ |
+| Admin (read-only) | session valid ✅ | admin/courses ✅ admin/curricula ✅ admin/users ✅ admin/taxonomy ✅ admin/groups ✅ admin/payments ✅ admin/audit-logs ✅ admin/analytics ⚠️ admin/settings ⚠️ admin/syllabus ✅ | n/a | n/a | n/a | admin/payments ✅ | full ✅ | n/a |
+| Expert / Sub_admin / Org-owner | **BLOCKED** — no fixture creds | — | — | — | — | — | — | — |
+
+Legend: ✅ renders without functional issue · ⚠️ renders with bugs (see findings) · ❌ broken or unreachable.
+
+## Findings
+
+Severity: **P0** = blocks core user flow, **P1** = visible defect or security concern, **P2** = polish/UX, **P3** = nit.
+
+### P0 — Blocking
+
+**F-001 (P0) — `/fr/register` and `/fr/register-options` redirect anonymous users to `/fr/login`**
+- Repro: clear cookies + localStorage, navigate to `/fr/register` → server redirects to `/fr/register-options` → that further redirects to `/fr/login`. Same for direct nav to `/fr/register-options`.
+- Combined with F-002, new users have no reachable path to create an account.
+- Memory `e2e_issues_2026_03_31.md` recorded registration as PASS at the time, so this looks like a regression.
+
+**F-002 (P0) — `/fr/login` has no link to registration; `/fr/about` has no sign-up CTA either**
+- `/fr/login` exposes only "Mot de passe oublié ?" → `/fr/magic-link`. No "Créer un compte" / "Sign up" link.
+- `/fr/about` shows CTAs "Parcourir les cours" and "Devenir expert" only — no registration CTA.
+- New user funnel is dead-ended. If registration is intentionally invitation-only via activation codes (`/fr/activate`), the marketing copy on `/fr/about` should say so.
+
+**F-003 (P0) — `/fr/curricula` index returns 404**
+- Repro: navigate to `/fr/curricula` (no slug). Page title becomes `404: This page could not be found.`
+- Detail pages work: `/fr/curricula/stem-for-kids`, `/fr/curricula/marketing`, etc. all render correctly.
+- Dashboard's "Explorer les curricula" section links to detail pages but there is no public index page. Browsing all curricula requires knowing slugs in advance.
+
+### P1 — Visible defect or security concern
+
+**F-004 (P1) — JWT tokens stored in JS-readable cookies AND in localStorage**
+- Repro: `document.cookie` and `localStorage` both expose `access_token` and `refresh_token` in plaintext.
+- Tokens are JS-readable, so any XSS gives full account takeover. They should live in `HttpOnly; Secure; SameSite=Lax` cookies, not in localStorage.
+- Confirmed empirically: `localStorage.clear()` + `document.cookie` clear via JS removed both tokens (i.e. neither is HttpOnly).
+- Logout endpoint `POST /api/v1/auth/logout` requires `refresh_token` in JSON body (returns 422 without) — this means the client must persist refresh token client-side, reinforcing the same XSS exposure.
+- Compliance: CLAUDE.md notes GDPR / Senegal Loi 2008-12 / Ghana DPA / Nigeria NDPR / Côte d'Ivoire 2013-450 alignment requirements; storing auth credentials in JS-readable storage is a recognized weakness for credential protection obligations.
+
+**F-005 (P1) — Service worker `/sw.js` returns 404 — PWA offline mode broken**
+- Repro: `HEAD /sw.js` → 404. Console error on every page load: `[sw] registration failed: TypeError: Failed to register a ServiceWorker for scope ('https://etutor.elearning.portfolio2.kimbetien.com/') with script ('https://etutor.elearning.portfolio2.kimbetien.com/sw.js'): A bad HTTP response code (404) was received when fetching the script.`
+- `navigator.serviceWorker.getRegistrations()` returns `[]`.
+- CLAUDE.md describes offline-first PWA via Serwist/Workbox with IndexedDB module download. None of that works without an SW.
+
+**F-006 (P1) — Missing i18n key `Flashcards.cards (fr)` leaks raw text into UI**
+- Repro: navigate to `/fr/flashcards`. Visible in the body: `Objectif: 20 Flashcards.cards`.
+- Console: `[ERROR] p: MISSING_MESSAGE: Flashcards.cards (fr)`.
+
+**F-007 (P1) — Missing i18n key `Navigation.curricula (fr)` (sidebar/nav fallback)**
+- Repro: navigate to `/fr/curricula/{any-slug}`.
+- Console: `[ERROR] p: MISSING_MESSAGE: Navigation.curricula (fr)`.
+
+### P2 — Polish / UX
+
+**F-008 (P2) — Inconsistent `<title>` across pages**
+- Pages with page-specific titles: `/fr/tutor` → "Tuteur IA · Sira"; `/fr/flashcards` → "Flashcards · Sira"; `/fr/admin/courses` → "Gestion des formations · Sira".
+- Pages with generic "Sira" only: `/fr/dashboard`, `/fr/profile`, `/fr/courses`, `/fr/courses/{id}`, `/fr/curricula/{slug}`, `/fr/admin/analytics`, `/fr/admin/settings`, `/fr/admin/syllabus`, `/fr/qbank`, `/fr/qbank/tests`, `/fr/about`, `/fr/login`.
+- Hurts SEO and browser tab UX.
+
+**F-009 (P2) — Date format en-US in FR locale on profile**
+- Repro: `/fr/profile` displays "Membre depuis 3/31/2026" (en-US) instead of "31/03/2026" (FR convention).
+
+**F-010 (P2) — `/fr/admin/analytics` charts emit "width(-1) and height(-1)" warnings**
+- Console: `[WARNING] The width(-1) and height(-1) of chart should be greater than 0` (Recharts) — twice per render.
+- Charts visually render but the underlying container sizing is wrong; can break on certain viewports.
+
+**F-011 (P2) — `/fr/admin/settings` category labels mixed FR/EN and lowercase keys**
+- Visible category headers: "AI & Content Generation", "AI Prompt Templates", "Auth & Security", "Flashcards (FSRS)", "marketplace", "Pagination", "Payments & Billing", "Placement Test", "Progress & Unlocking", "Quiz & Assessment", "Rate Limiting", "subscription", "syllabus", "AI Tutor", "video_summary".
+- Several are raw lowercase identifiers (marketplace, subscription, syllabus, video_summary) and most labels are English in the FR locale.
+
+### P3 — Nit
+
+**F-012 (P3) — Bloom-taxonomy verbs in English on FR course detail**
+- `/fr/courses/{id}` shows module level chips "understand", "apply", "analyze", "evaluate", "remember" in English on FR locale.
+
+**F-013 (P3) — Admin course list taxonomy chips raw English**
+- `/fr/admin/courses` shows taxonomy chips "health sciences", "information technology", "intermediate", "advanced" raw — no localization.
+
+**F-014 (P3) — `/fr/login` has no `<h1>` (a11y)**
+- Heading hierarchy: page lacks an `h1`. Screen readers see no top-level page heading.
+
+**F-015 (P3) — Analytics event-type chart labels raw English**
+- `/fr/admin/analytics` event-type axis labels "tutor message sent", "lesson viewed" — raw event-name strings, not localized.
+
+## Routes confirmed rendering (no defect found in this sweep)
+
+`/fr/dashboard`, `/fr/courses`, `/fr/courses/{id}`, `/fr/modules`, `/fr/tutor`, `/fr/profile`, `/fr/settings` (redirects to `/fr/profile`), `/fr/qbank`, `/fr/qbank/tests`, `/fr/certificates`, `/fr/subscribe`, `/fr/organizations`, `/fr/onboarding`, `/fr/activate`, `/fr/about`, `/fr/curricula/{slug}`, `/fr/admin/courses`, `/fr/admin/curricula`, `/fr/admin/users`, `/fr/admin/taxonomy`, `/fr/admin/groups`, `/fr/admin/payments`, `/fr/admin/audit-logs`, `/fr/admin/syllabus`, `/fr/login`, `/fr/magic-link`.
+
+Mobile (375×667): dashboard renders with bottom nav, no horizontal scroll, all sampled buttons ≥ 44×44 touch target.
+
+## Coverage gaps (not exercised in this sweep)
+
+- Anonymous registration full flow (blocked by F-001).
+- Magic-link recovery email round-trip (would require a mailbox).
+- Paystack credit-purchase flow end-to-end (would create real transaction).
+- AI tutor chat send (would burn Anthropic tokens — out of scope per `feedback_paid_external_apis`).
+- Course generation from PDF (would burn AI tokens — out of scope).
+- Lesson rendering inside a unit (`/fr/modules/{id}/units/{unit}`) — needs a known unit UUID; deferred to durable suite.
+- Quiz attempt + grading.
+- Flashcard review session (FSRS scheduling).
+- Summative assessment + certificate issue.
+- Offline mode (blocked by F-005).
+- Expert flows (course creation, code generation, QBank authoring) — needs expert fixture account.
+- Sub_admin / org-owner specific scoping — needs fixture accounts.
+- English locale parity (`/en/*`) — sampled `dashboard` only via redirect; full parity unverified.
+- Lighthouse / TTI / bundle-size measurements (CLAUDE.md targets <3s TTI on 3G, <150KB gzipped) — needs separate run.
+
+These gaps are owned by Phase B (durable Playwright suite) and individual perf/observability child issues. See parent epic.
+
+## What was confirmed fixed since prior sweeps
+
+Comparing against `e2e_issues_2026_03_31.md` and `e2e_issues_2026_04_01.md`:
+
+- `/fr/tutor` — was 404, now renders.
+- `/fr/profile` — was 500 due to missing `users.avatar_url` column, now renders user data.
+- `/fr/settings` — was 404, now redirects to `/fr/profile` (settings merged into profile).
+- `/fr/onboarding` — was leaking raw `Onboarding.*` keys, now returns 200 (i18n parity not deeply verified).
+- Module overview duplicate-header — gone.
+- `/api/v1/dashboard/stats`, `/api/v1/tutor/stats`, `/api/v1/flashcards/upcoming`, `/api/v1/courses/my-enrollments`, `/api/v1/curricula` all return 200 for the admin session.
+
+## Cross-cutting observations
+
+**O-001 — MCP playwright browser carried persistent session between sweep runs.**
+- Implication for Phase B: durable Playwright suite must explicitly clear storage *and* invalidate the HttpOnly refresh cookie at suite setup. The naive `localStorage.clear()` + `document.cookie` clear is insufficient because the refresh path silently re-issues access tokens.
+- Mitigation: each test should run in an isolated browser context (`browser.newContext()`); `auth.ts` fixture should explicitly call the logout endpoint with the stored refresh token.
+
+**O-002 — Logout API requires client-side refresh-token submission (`refresh_token` in body).**
+- This forces the client to persist the refresh token in JS-accessible storage (cookie or localStorage), which conflicts with the F-004 hardening recommendation. Either move to a stateless logout (server-side blacklist + HttpOnly cookie) or accept the trade-off explicitly.
+
+## How to reproduce this sweep
+
+1. `git checkout qa/sweep-2026-04-28-prod-readiness` (this branch).
+2. From an MCP-playwright-enabled session: navigate to each route in *Coverage summary*, run the small `evaluate()` snippets shown in this doc to extract `h1`, console errors, and missing-i18n keys.
+3. Compare against this doc to confirm whether each finding still reproduces, then file follow-up issues if regressed/fixed.
+
+The durable, repeatable version of this sweep is the Phase B Playwright suite (epic child).


### PR DESCRIPTION
## Summary

- **One-shot autonomous browser sweep** of staging across all personas, deepened on 2026-04-30 after feedback to consolidate before fragmenting issues.
- 18 findings (1 P0 confirmed, 1 P0 new, 2 P1, several P2/P3) organized into 9 product-defect clusters in [\`docs/qa/sweep-2026-04-28.md\`](docs/qa/sweep-2026-04-28.md).
- **Architectural pivot captured**: \`expert\` role collapsing into single-person \`Organization\` (target state, code not yet migrated). New migration epic #2134 with 5 phase children #2135–#2139.

This PR adds **only** the findings doc — no code changes. Phase B (durable Playwright suite + CI) and Phase C (deploy/observability hardening) and the migration epic itself live in the child issues.

## Highlights from the consolidated sweep

**P0 (real, confirmed)**:
- [#2111](https://github.com/Benidrissa/etutor-digital-ph/issues/2111) — \`/fr/curricula\` index returns 404 (only \`/fr/curricula/{slug}\` works).
- [#2129](https://github.com/Benidrissa/etutor-digital-ph/issues/2129) — \`GET /api/v1/organizations\` returns 405 instead of listing the user's orgs (new finding from resumed sweep).

**P1**:
- [#2112](https://github.com/Benidrissa/etutor-digital-ph/issues/2112) — Logout API requires \`refresh_token\` in body, but the token lives in HttpOnly cookie — circular. (Refined from broader "JWT in JS storage" framing after \`refresh_token\` was empirically verified HttpOnly.)
- [#2113](https://github.com/Benidrissa/etutor-digital-ph/issues/2113) — \`/sw.js\` returns 404; PWA service worker not deployed; offline mode broken.

**Reframed (originally filed P0, demoted after verification)**:
- [#2110](https://github.com/Benidrissa/etutor-digital-ph/issues/2110) — Was "register redirects to login = bug". Empirically verified: working as designed when \`auth-self-registration-enabled=false\`. Reframed to "UX banner explaining the invitation-only state". P2.

**Consolidated (replaces 2 closed issues with 1 audit)**:
- [#2128](https://github.com/Benidrissa/etutor-digital-ph/issues/2128) — i18n FR + EN locale completeness audit. Closes #2114 and #2115.

**New consolidated findings**:
- [#2130](https://github.com/Benidrissa/etutor-digital-ph/issues/2130) — Video lesson endpoint state (404 instead of 200+state).
- [#2131](https://github.com/Benidrissa/etutor-digital-ph/issues/2131) — Recharts container width=-1 warnings on admin/analytics.
- [#2132](https://github.com/Benidrissa/etutor-digital-ph/issues/2132) — Frontend polish: titles, h1, citation formatting, mobile touch targets.

## What was confirmed fixed since prior sweeps (e2e_issues_2026_03_31)

- \`/fr/tutor\` page no longer 404.
- \`/fr/profile\` no longer 500 (avatar_url column added).
- \`/fr/settings\` redirects to \`/fr/profile\` (settings merged into profile).
- Module overview duplicate-header gone.
- Role-scoping (server-side and frontend) verified working: a fresh \`role=user\` learner sees a 9-link sidebar (no admin/orgs/qbank-author), gets 403 on admin APIs, gets redirected from \`/fr/admin/*\` URLs to dashboard.

## Test plan

- [x] Findings doc reviewed (commit 456c868).
- [x] All consolidated issues filed and parent epic #2123 updated to reference them.
- [x] Migration epic #2134 + 5 phase children #2135-#2139 filed.
- [x] Existing issues #2110, #2112 reframed in-place; #2109, #2116, #2117 edited to drop expert terminology per role-model pivot.
- [ ] (post-merge) #2109 (seed fixture accounts) starts so Phase B (#2116) can begin.
- [ ] (post-merge) Migration epic #2134 phase 1 (schema) is the first migration PR.

## Notes

- Org-owner / sub_admin persona walks are still BLOCKED — coverage matrix in the doc explicitly marks those rows. Unblocker is #2109.
- **Cross-cutting observation O-001** (verified 2026-04-30): durable Playwright suite must use isolated \`browser.newContext()\` per test; the naive \`localStorage.clear()\` is insufficient because the HttpOnly refresh cookie silently re-issues access tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)