### PR TITLE
feat(modules): make all modules accessible after enrollment (#2125)

### DIFF
--- a/backend/app/api/v1/progress.py
+++ b/backend/app/api/v1/progress.py
@@ -109,7 +109,7 @@ async def get_module_progress(
             return ModuleProgressResponse(
                 module_id=resolved_id,
                 user_id=user_id,
-                status="locked",
+                status="not_started",
                 completion_pct=0.0,
                 quiz_score_avg=None,
                 time_spent_minutes=0,
@@ -142,8 +142,9 @@ async def get_all_module_progress(
     Get current user's progress for all modules.
 
     When course_id is provided, only modules belonging to that course are returned.
-    Without course_id, returns ALL modules (including locked ones), ordered by module_number.
-    Locked modules with no progress record have status 'locked' and 0% completion.
+    Without course_id, returns ALL modules, ordered by module_number.
+    Modules with no progress record have status 'not_started' and 0% completion;
+    they remain accessible to enrolled learners (no sequential gating).
     """
     try:
         user_id = UUID(str(current_user.id))

--- a/backend/app/domain/services/progress_service.py
+++ b/backend/app/domain/services/progress_service.py
@@ -132,8 +132,8 @@ class ProgressService:
         # Get or create progress entry
         progress = await self._get_or_create_progress(user_id, module_id, now)
 
-        # Only move to in_progress if currently locked/not started; preserve completed
-        if progress.status == "locked":
+        # Only move to in_progress if not started; preserve completed
+        if progress.status == "not_started":
             progress.status = "in_progress"
 
         progress.last_accessed = now
@@ -194,7 +194,7 @@ class ProgressService:
 
             if new_pct >= 100.0:
                 progress.status = "completed"
-            elif progress.status == "locked":
+            elif progress.status == "not_started":
                 progress.status = "in_progress"
 
         await self.db.commit()
@@ -295,10 +295,11 @@ class ProgressService:
         self, user_id: UUID, course_id: UUID | None = None
     ) -> list[dict]:
         """
-        Return modules with their real lock/unlock status for the user.
+        Return modules with their progress status for the user.
 
         When course_id is provided, only modules belonging to that course are returned.
-        Modules without a progress record default to 'locked'.
+        Modules without a progress record default to 'not_started' (accessible —
+        sequential gating was removed per issue #2125).
         Returns data ordered by module_number.
         """
         stmt = select(Module).order_by(Module.module_number)
@@ -328,7 +329,7 @@ class ProgressService:
                     "level": module.level,
                     "estimated_hours": module.estimated_hours,
                     "user_id": user_id,
-                    "status": progress.status if progress else "locked",
+                    "status": progress.status if progress else "not_started",
                     "completion_pct": progress.completion_pct if progress else 0.0,
                     "quiz_score_avg": progress.quiz_score_avg if progress else None,
                     "time_spent_minutes": progress.time_spent_minutes if progress else 0,
@@ -399,7 +400,7 @@ class ProgressService:
             "description_en": module.description_en,
             "estimated_hours": module.estimated_hours,
             "prereq_modules": [str(p) for p in (module.prereq_modules or [])],
-            "status": progress.status if progress else "locked",
+            "status": progress.status if progress else "not_started",
             "completion_pct": progress.completion_pct if progress else 0.0,
             "quiz_score_avg": progress.quiz_score_avg if progress else None,
             "time_spent_minutes": progress.time_spent_minutes if progress else 0,
@@ -415,10 +416,11 @@ class ProgressService:
 
     async def _unlock_next_module(self, user_id: UUID, completed_module_id: UUID) -> None:
         """
-        Unlock the module with module_number = N+1 when module N meets threshold.
+        Prefetch first 2 lessons of module N+1 when module N completes.
 
-        Per FR-02.2: creates an in_progress progress record for the next module
-        if it doesn't already have one (i.e. is still locked).
+        Sequential gating was removed per issue #2125 — all modules are accessible
+        on enrollment. This hook is retained only to warm the cache so the next
+        module's content is ready when a learner opens it.
         """
         module_result = await self.db.execute(
             select(Module).where(Module.id == completed_module_id)
@@ -434,43 +436,6 @@ class ProgressService:
         if not next_module:
             return
 
-        existing = await self.db.execute(
-            select(UserModuleProgress).where(
-                UserModuleProgress.user_id == user_id,
-                UserModuleProgress.module_id == next_module.id,
-            )
-        )
-        next_progress = existing.scalar_one_or_none()
-
-        if next_progress is None:
-            now = datetime.utcnow()
-            next_progress = UserModuleProgress(
-                user_id=user_id,
-                module_id=next_module.id,
-                status="in_progress",
-                completion_pct=0.0,
-                quiz_score_avg=None,
-                time_spent_minutes=0,
-                last_accessed=now,
-            )
-            self.db.add(next_progress)
-            await self.db.commit()
-            logger.info(
-                "Next module unlocked",
-                user_id=str(user_id),
-                unlocked_module_number=next_module.module_number,
-                unlocked_module_id=str(next_module.id),
-            )
-        elif next_progress.status == "locked":
-            next_progress.status = "in_progress"
-            await self.db.commit()
-            logger.info(
-                "Next module status updated to in_progress",
-                user_id=str(user_id),
-                module_number=next_module.module_number,
-            )
-
-        # Prefetch first 2 lessons of the newly unlocked module
         self._dispatch_prefetch(user_id, str(next_module.id), "")
 
     async def _dispatch_prefetch_after_quiz(

--- a/backend/migrations/versions/088_relax_module_progress_locked_to_not_started.py
+++ b/backend/migrations/versions/088_relax_module_progress_locked_to_not_started.py
@@ -30,11 +30,7 @@ depends_on: str | Sequence[str] | None = None
 def upgrade() -> None:
     bind = op.get_bind()
     result = bind.execute(
-        sa.text(
-            "UPDATE user_module_progress "
-            "SET status = 'not_started' "
-            "WHERE status = 'locked'"
-        )
+        sa.text("UPDATE user_module_progress SET status = 'not_started' WHERE status = 'locked'")
     )
     print(f"[088] Relaxed {result.rowcount} 'locked' module progress row(s) to 'not_started'")
 

--- a/backend/migrations/versions/088_relax_module_progress_locked_to_not_started.py
+++ b/backend/migrations/versions/088_relax_module_progress_locked_to_not_started.py
@@ -1,0 +1,43 @@
+"""Backfill: relax legacy 'locked' module progress rows to 'not_started' (#2125).
+
+Revision ID: 088
+Revises: 087
+Create Date: 2026-04-30
+
+Sequential module gating was removed per issue #2125 — once a learner enrolls
+in a course, every module is immediately accessible. The read-side default for
+modules without a ``user_module_progress`` row was flipped from ``'locked'`` to
+``'not_started'``. This migration relaxes any rows that the legacy
+``_unlock_next_module`` path persisted as ``'locked'`` so they match the new
+semantics on next read.
+
+Forward-only: downgrade is a no-op. Reversing ``not_started`` → ``locked``
+would require recomputing which rows had been locked in the legacy ordering,
+and that information is no longer business-meaningful.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "088"
+down_revision: str | None = "087"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    result = bind.execute(
+        sa.text(
+            "UPDATE user_module_progress "
+            "SET status = 'not_started' "
+            "WHERE status = 'locked'"
+        )
+    )
+    print(f"[088] Relaxed {result.rowcount} 'locked' module progress row(s) to 'not_started'")
+
+
+def downgrade() -> None:
+    pass

--- a/backend/tests/test_courses.py
+++ b/backend/tests/test_courses.py
@@ -151,10 +151,15 @@ async def test_publish_course(authenticated_client, db_session, admin_with_id_he
 
 @pytest.mark.skip(reason=_SKIP_REASON)
 @pytest.mark.asyncio
-async def test_enrollment_creates_progress_records(
+async def test_enrollment_modules_accessible(
     authenticated_client, db_session, admin_with_id_headers, user_with_id_headers, user_id_str
 ):
-    """Enrolling in a course initializes UserModuleProgress for all course modules."""
+    """Enrolling in a course makes every module accessible (no sequential gating, #2125).
+
+    Progress rows are not pre-created at enrollment; the read API synthesizes
+    a 'not_started' status for any module without a row, and any row that
+    happens to exist must not be 'locked'.
+    """
     from app.domain.models.module import Module
     from app.domain.models.progress import UserModuleProgress
 
@@ -187,8 +192,7 @@ async def test_enrollment_creates_progress_records(
         headers=user_with_id_headers,
     )
     assert enroll_resp.status_code == 200
-    enroll_data = enroll_resp.json()
-    assert enroll_data["status"] == "active"
+    assert enroll_resp.json()["status"] == "active"
 
     progress_result = await db_session.execute(
         select(UserModuleProgress).where(
@@ -197,8 +201,14 @@ async def test_enrollment_creates_progress_records(
         )
     )
     progress = progress_result.scalar_one_or_none()
-    assert progress is not None
-    assert progress.status == "locked"
+    assert progress is None or progress.status != "locked"
+
+    api_resp = await authenticated_client.get(
+        f"/api/v1/progress/modules/{module.id}",
+        headers=user_with_id_headers,
+    )
+    assert api_resp.status_code == 200
+    assert api_resp.json()["status"] == "not_started"
 
 
 @pytest.mark.skip(reason=_SKIP_REASON)

--- a/backend/tests/test_progress_service.py
+++ b/backend/tests/test_progress_service.py
@@ -954,9 +954,7 @@ class TestGetAllModulesWithProgress:
 
         mock_db.execute = mock_execute
 
-        result = await progress_service.get_all_modules_with_progress(
-            user_id, course_id=course_id
-        )
+        result = await progress_service.get_all_modules_with_progress(user_id, course_id=course_id)
 
         assert len(result) == 5
         assert {m["status"] for m in result} == {"not_started"}

--- a/backend/tests/test_progress_service.py
+++ b/backend/tests/test_progress_service.py
@@ -78,13 +78,13 @@ class TestTrackLessonAccess:
         assert added_obj.time_spent_seconds == 120
         assert added_obj.completion_percentage == 50.0
 
-    async def test_marks_locked_module_as_in_progress(
+    async def test_marks_not_started_module_as_in_progress(
         self, progress_service, mock_db, user_id, module_id, lesson_id
     ):
         existing_progress = UserModuleProgress(
             user_id=user_id,
             module_id=module_id,
-            status="locked",
+            status="not_started",
             completion_pct=0.0,
             quiz_score_avg=None,
             time_spent_minutes=0,
@@ -537,9 +537,12 @@ class TestProgressServiceIntegration:
 
 
 class TestUnlockNextModule:
-    async def test_unlock_threshold_triggers_next_module_unlock(
+    async def test_threshold_does_not_create_next_module_progress_row(
         self, progress_service, mock_db, user_id, module_id
     ):
+        """After issue #2125 removed sequential gating, completing module N must
+        no longer auto-create a progress row for module N+1; the next module is
+        already accessible by default."""
         from app.domain.models.module import Module
 
         next_module_id = uuid.uuid4()
@@ -582,23 +585,15 @@ class TestUnlockNextModule:
             call_count += 1
             mock_result = MagicMock()
             if call_count == 1:
-                # _get_or_create_progress
                 mock_result.scalar_one_or_none = MagicMock(return_value=existing_progress)
             elif call_count == 2:
-                # _calculate_completion_pct: total units
                 mock_result.scalar = MagicMock(return_value=1)
             elif call_count == 3:
-                # _get_completed_units: quiz contents
                 mock_result.all = MagicMock(return_value=[])
             elif call_count == 4:
-                # _unlock_next_module: current module lookup
                 mock_result.scalar_one_or_none = MagicMock(return_value=current_module)
             elif call_count == 5:
-                # _unlock_next_module: next module lookup
                 mock_result.scalar_one_or_none = MagicMock(return_value=next_module)
-            elif call_count == 6:
-                # _unlock_next_module: check existing progress for next module
-                mock_result.scalar_one_or_none = MagicMock(return_value=None)
             else:
                 mock_result.scalar_one_or_none = MagicMock(return_value=None)
                 mock_result.scalar = MagicMock(return_value=None)
@@ -619,13 +614,12 @@ class TestUnlockNextModule:
         assert result.completion_pct == 100.0
         assert result.status == "completed"
 
-        unlocked = [
+        next_module_rows = [
             obj
             for obj in added_objects
             if isinstance(obj, UserModuleProgress) and obj.module_id == next_module_id
         ]
-        assert len(unlocked) == 1
-        assert unlocked[0].status == "in_progress"
+        assert next_module_rows == []
 
     async def test_no_unlock_when_score_below_threshold(
         self, progress_service, mock_db, user_id, module_id
@@ -669,9 +663,12 @@ class TestUnlockNextModule:
         # and rollup_course_completion_by_module (also select Module.course_id).
         assert call_count == 3
 
-    async def test_unlock_updates_existing_locked_next_module(
+    async def test_existing_next_module_progress_row_is_not_modified(
         self, progress_service, mock_db, user_id, module_id
     ):
+        """After issue #2125, completing module N never mutates the status of
+        any existing progress row for module N+1; only the legacy data-fix
+        migration (088) relaxes any historical 'locked' rows."""
         from app.domain.models.module import Module
 
         next_module_id = uuid.uuid4()
@@ -690,15 +687,6 @@ class TestUnlockNextModule:
             title_fr="M04",
             title_en="M04",
             estimated_hours=25,
-        )
-        locked_next_progress = UserModuleProgress(
-            user_id=user_id,
-            module_id=next_module_id,
-            status="locked",
-            completion_pct=0.0,
-            quiz_score_avg=None,
-            time_spent_minutes=0,
-            last_accessed=None,
         )
         existing_progress = UserModuleProgress(
             user_id=user_id,
@@ -725,13 +713,14 @@ class TestUnlockNextModule:
                 mock_result.scalar_one_or_none = MagicMock(return_value=current_module)
             elif call_count == 5:
                 mock_result.scalar_one_or_none = MagicMock(return_value=next_module)
-            elif call_count == 6:
-                mock_result.scalar_one_or_none = MagicMock(return_value=locked_next_progress)
             else:
                 mock_result.scalar_one_or_none = MagicMock(return_value=None)
             return mock_result
 
         mock_db.execute = mock_execute
+
+        added_objects = []
+        mock_db.add = MagicMock(side_effect=lambda obj: added_objects.append(obj))
 
         await progress_service.update_progress_after_quiz(
             user_id=user_id,
@@ -741,7 +730,12 @@ class TestUnlockNextModule:
             passed=True,
         )
 
-        assert locked_next_progress.status == "in_progress"
+        next_module_rows = [
+            obj
+            for obj in added_objects
+            if isinstance(obj, UserModuleProgress) and obj.module_id == next_module_id
+        ]
+        assert next_module_rows == []
 
     async def test_no_unlock_when_no_next_module(
         self, progress_service, mock_db, user_id, module_id
@@ -887,9 +881,11 @@ class TestGetAllModulesWithProgress:
         assert len(result) == 1
         assert result[0]["module_number"] == 1
 
-    async def test_defaults_status_to_locked_when_no_progress(
+    async def test_defaults_status_to_not_started_when_no_progress(
         self, progress_service, mock_db, user_id
     ):
+        """Per issue #2125: modules without a progress row are accessible
+        and report status='not_started' (no sequential gating)."""
         from app.domain.models.module import Module
 
         module = Module(
@@ -918,8 +914,53 @@ class TestGetAllModulesWithProgress:
         result = await progress_service.get_all_modules_with_progress(user_id)
 
         assert len(result) == 1
-        assert result[0]["status"] == "locked"
+        assert result[0]["status"] == "not_started"
         assert result[0]["completion_pct"] == 0.0
+
+    async def test_all_modules_accessible_for_fresh_enrollee(
+        self, progress_service, mock_db, user_id
+    ):
+        """Per issue #2125: a fresh enrollee with zero progress rows must see
+        every module of the course as 'not_started' — not just module 1.
+        Confirms learners can jump directly to module N without progressing
+        through 1..N-1."""
+        from app.domain.models.module import Module
+
+        course_id = uuid.uuid4()
+        modules = [
+            Module(
+                id=uuid.uuid4(),
+                module_number=n,
+                level=1,
+                title_fr=f"M{n} FR",
+                title_en=f"M{n} EN",
+                estimated_hours=20,
+                course_id=course_id,
+            )
+            for n in (1, 2, 3, 4, 5)
+        ]
+
+        call_count = 0
+
+        async def mock_execute(stmt):
+            nonlocal call_count
+            call_count += 1
+            mock_result = MagicMock()
+            if call_count == 1:
+                mock_result.scalars.return_value.all.return_value = modules
+            else:
+                mock_result.scalars.return_value.all.return_value = []
+            return mock_result
+
+        mock_db.execute = mock_execute
+
+        result = await progress_service.get_all_modules_with_progress(
+            user_id, course_id=course_id
+        )
+
+        assert len(result) == 5
+        assert {m["status"] for m in result} == {"not_started"}
+        assert all(m["completion_pct"] == 0.0 for m in result)
 
     async def test_returns_empty_list_when_course_has_no_modules(
         self, progress_service, mock_db, user_id


### PR DESCRIPTION
## Summary

- Removes sequential module gating: once a learner enrolls, every module of the course is immediately accessible — they can jump straight to a topic of interest instead of progressing 1..N.
- Backend read-side default for missing `UserModuleProgress` rows flips from `"locked"` to `"not_started"`. Frontend lock UI keys on `status === 'locked'` and naturally never triggers under the new default.
- **Certificate issuance is unchanged.** `CertificateService.check_course_completion` still requires a passing `SummativeAssessmentAttempt` for every module of the course (`backend/app/domain/services/certificate_service.py:74-102`). No edits there.

Fixes #2125

## Changes

- `backend/app/api/v1/progress.py` — default `"locked"` → `"not_started"` in the `get_module_progress` no-row branch; docstring updated to reflect the new contract.
- `backend/app/domain/services/progress_service.py`:
  - `get_all_modules_with_progress` and `get_module_with_progress` defaults flipped.
  - Internal flips in `track_lesson_access` and `update_progress_after_quiz` updated from `"locked"` → `"not_started"` (the previous form is now unreachable).
  - `_unlock_next_module` trimmed to keep only the next-module **lesson prefetch dispatch**. The status-flip / row-creation block is removed — N+1 is already accessible by default, so the only remaining value is warming the cache.
- `backend/migrations/versions/088_relax_module_progress_locked_to_not_started.py` — new migration: one-shot `UPDATE user_module_progress SET status = 'not_started' WHERE status = 'locked'` for any historical rows persisted by the legacy code path. Forward-only.
- `backend/tests/test_progress_service.py`:
  - `test_marks_locked_module_as_in_progress` → renamed to `test_marks_not_started_module_as_in_progress`, fixture updated.
  - `test_unlock_threshold_triggers_next_module_unlock` → reframed as `test_threshold_does_not_create_next_module_progress_row` (asserts the trimmed contract).
  - `test_unlock_updates_existing_locked_next_module` → reframed as `test_existing_next_module_progress_row_is_not_modified`.
  - `test_defaults_status_to_locked_when_no_progress` → renamed and asserts `"not_started"`.
  - **New** `test_all_modules_accessible_for_fresh_enrollee` covers the multi-module case (5 modules, all return `not_started` for an enrollee with zero progress rows).
- `backend/tests/test_courses.py` — already-skipped `test_enrollment_creates_progress_records` repurposed as `test_enrollment_modules_accessible` matching the new contract (rows are not pre-created at enrollment; the read API surfaces `not_started`).

## Frontend

**No frontend changes required.** `isModuleUnlocked = module.status !== 'locked'` at `frontend/components/learning/module-map.tsx:117` evaluates `true` for `"not_started"`. The lock icon, opacity-60 styling, "Prérequis nécessaires" banner, and disabled "Commencer" button at `module-card.tsx` plus the full-page `module-lock-gate.tsx` redirect all branch on `status === 'locked'` and never trigger.

## Out of scope (flagged, not fixed in this PR)

- Pre-existing hyphen/underscore mismatch at `frontend/components/learning/module-card.tsx:107` (`'in-progress'` vs backend `'in_progress'`). Means `in_progress` modules render "Commencer" instead of "Continuer". Unrelated; address separately.
- i18n keys `ModuleCard.prerequisitesRequired` (`frontend/messages/{fr,en}.json:222`) become orphans. Left in place to keep the diff surgical.
- `Module.prereq_modules` array column — stays as informational metadata; never enforced before this change either.

## Test plan

- [x] `uv run pytest tests/test_progress_service.py tests/test_certificate_service.py tests/test_courses.py tests/test_prefetch_lessons.py` — 49 passed, 7 skipped (pre-existing).
- [ ] After deploy: enroll fresh learner in a ≥3-module course → visit `/fr/modules?courseId=...` → every module card clickable, no lock UI.
- [ ] Open module 3 directly without touching modules 1-2 → unit list and lessons load.
- [ ] Pass module 1 summative ≥80% → module 1 flips to `completed`. Module 2 stays `not_started` until learner opens it. Prefetch still dispatches (logs).
- [ ] Pass summatives for every module → `POST /api/v1/certificates/{course_id}` issues cert. Skip one summative → endpoint still refuses (existing behavior — confirms cert rule preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)