### PR TITLE
chore(merge): main → dev — resolve phantom conflicts after squash sync (#2127)

### DIFF
--- a/backend/app/ai/rag/image_linker.py
+++ b/backend/app/ai/rag/image_linker.py
@@ -64,10 +64,11 @@ class ImageLinker:
         explicit_pairs = await self._build_explicit_pairs(source, session)
         contextual_pairs = await self._build_contextual_pairs(source, session, explicit_pairs)
         # Semantic must run last so it can deduplicate against pairs the
-        # higher-precision strategies already produced. The explicit and
-        # contextual matchers already filter against existing DB rows
-        # internally, so semantic only needs to dedupe against the pairs
-        # we just computed — no third _get_existing_pairs call.
+        # higher-precision strategies already produced. It also needs to
+        # dedupe against existing DB rows — explicit/contextual filter
+        # against `_get_existing_pairs` internally, but semantic was
+        # missing that check, so re-running the linker on an
+        # already-linked course raised UniqueViolationError. See #2106.
         semantic_pairs = await self._build_semantic_pairs(
             source, session, explicit_pairs | contextual_pairs
         )
@@ -297,11 +298,15 @@ class ImageLinker:
             """
         ).bindparams(src=source, k=_SEMANTIC_TOP_K, max_dist=_SEMANTIC_DIST_MAX)
 
+        # Filter against rows already in the junction table so a re-run
+        # of the linker doesn't try to insert duplicates. See #2106.
+        existing_pairs = await self._get_existing_pairs(source, session)
+
         result = await session.execute(query)
         pairs: set[tuple] = set()
         for row in result.all():
             pair = (row.image_id, row.chunk_id)
-            if pair in higher_priority:
+            if pair in higher_priority or pair in existing_pairs:
                 continue
             pairs.add(pair)
 

--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -165,6 +165,52 @@ def _safe_task_meta(task_result: AsyncResult) -> tuple[str, dict]:
     return state, meta
 
 
+_TERMINAL_TASK_STATES = frozenset({"SUCCESS", "FAILURE", "REVOKED"})
+
+
+def _diagnose_indexation_pointer(
+    course: Course,
+    *,
+    chunks_indexed: int = 0,
+    images_indexed: int = 0,
+    require_progress: bool,
+) -> tuple[str, str, dict]:
+    """Classify whether ``course.indexation_task_id`` points at a live task.
+
+    Returns ``(verdict, state, meta)``:
+    - ``"stale_no_pointer"``: ``indexation_task_id`` is null. Only meaningful
+      when ``creation_step`` is itself stuck — the row was wedged without an
+      associated task.
+    - ``"stale_terminal"``: Celery reports a terminal state (SUCCESS/FAILURE/
+      REVOKED) but ``finalize_indexation_state`` never ran (e.g. DB write in
+      the callback failed and was logged as a warning).
+    - ``"stale_evicted"``: ``state == "PENDING"`` with empty meta. Either a
+      Redis-evicted task or a worker that died before publishing meta.
+      ``require_progress=True`` adds the chunks/images > 0 gate used by
+      ``/index-status`` (less aggressive — needs durable evidence the task
+      ran). ``require_progress=False`` is the trigger-side variant: if an
+      admin clicks "Démarrer l'indexation" against a wedged row, we trust
+      the manual signal and clear the pointer.
+    - ``"live"``: Anything else (STARTED/PROGRESS/RETRY, or PENDING with
+      meta — a freshly-enqueued task that's already been picked up). Caller
+      should refuse to start a new task.
+
+    See #2100. Companion to ``_safe_task_meta``; reuses it for state lookup.
+    """
+    if not course.indexation_task_id:
+        return "stale_no_pointer", "", {}
+    state, meta = _safe_task_meta(AsyncResult(course.indexation_task_id))
+    if state in _TERMINAL_TASK_STATES:
+        return "stale_terminal", state, meta
+    if (
+        state == "PENDING"
+        and not meta
+        and (not require_progress or chunks_indexed > 0 or images_indexed > 0)
+    ):
+        return "stale_evicted", state, meta
+    return "live", state, meta
+
+
 async def _require_indexed_sources(course: Course, db) -> None:
     """Refuse AI generation when no indexed source content exists for the course.
 
@@ -1128,8 +1174,15 @@ async def trigger_rag_indexation(
     current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> dict:
-    """Trigger RAG indexation for course resources. Returns Celery task ID."""
-    result = await db.execute(select(Course).where(Course.id == course_id))
+    """Trigger RAG indexation for course resources. Returns Celery task ID.
+
+    Self-heals stuck pointers (#2100): when ``creation_step`` is already
+    ``"generating"`` or ``"indexing"`` but the recorded task is dead
+    (terminal/evicted/null), the row is reset inline and a fresh task
+    enqueued. Only refuses with 409 when a *live* task is genuinely running.
+    The SELECT takes a row lock so two simultaneous admin clicks serialize.
+    """
+    result = await db.execute(select(Course).where(Course.id == course_id).with_for_update())
     course = result.scalar_one_or_none()
     if not course:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
@@ -1140,11 +1193,46 @@ async def trigger_rag_indexation(
             detail="Course has no rag_collection_id",
         )
 
-    if course.creation_step in ("generating", "indexing"):
+    if course.creation_step == "generating":
+        # Syllabus generation uses course.syllabus_task_id (separate pointer)
+        # — out of scope for this endpoint's self-heal. The syllabus endpoint
+        # exposes a `force=true` escape hatch (#2079) for stuck rows.
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail=f"A task is already in progress (step: {course.creation_step})",
+            detail={
+                "code": "SYLLABUS_GENERATION_ACTIVE",
+                "message": (
+                    "Syllabus generation is still in progress for this course. "
+                    "Wait for it to finish, or recover via "
+                    "POST /generate-syllabus?force=true."
+                ),
+                "creation_step": course.creation_step,
+            },
         )
+
+    if course.creation_step == "indexing":
+        verdict, task_state, _ = _diagnose_indexation_pointer(course, require_progress=False)
+        if verdict == "live":
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "code": "INDEX_TASK_ACTIVE",
+                    "message": (f"Indexation task {course.indexation_task_id} is {task_state}"),
+                    "task_id": course.indexation_task_id,
+                    "task_state": task_state,
+                    "creation_step": course.creation_step,
+                },
+            )
+        logger.info(
+            "Self-healing stuck indexation pointer before re-trigger",
+            course_id=str(course_id),
+            verdict=verdict,
+            prior_step=course.creation_step,
+            prior_task_id=course.indexation_task_id,
+            admin_id=current_user.id,
+        )
+        course.creation_step = "generated"
+        course.indexation_task_id = None
 
     task = index_course_resources.delay(str(course_id), course.rag_collection_id)
 

--- a/backend/app/api/v1/progress.py
+++ b/backend/app/api/v1/progress.py
@@ -109,7 +109,7 @@ async def get_module_progress(
             return ModuleProgressResponse(
                 module_id=resolved_id,
                 user_id=user_id,
-                status="locked",
+                status="not_started",
                 completion_pct=0.0,
                 quiz_score_avg=None,
                 time_spent_minutes=0,
@@ -142,8 +142,9 @@ async def get_all_module_progress(
     Get current user's progress for all modules.
 
     When course_id is provided, only modules belonging to that course are returned.
-    Without course_id, returns ALL modules (including locked ones), ordered by module_number.
-    Locked modules with no progress record have status 'locked' and 0% completion.
+    Without course_id, returns ALL modules, ordered by module_number.
+    Modules with no progress record have status 'not_started' and 0% completion;
+    they remain accessible to enrolled learners (no sequential gating).
     """
     try:
         user_id = UUID(str(current_user.id))

--- a/backend/app/domain/services/image_service.py
+++ b/backend/app/domain/services/image_service.py
@@ -9,7 +9,9 @@ from datetime import datetime
 import structlog
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
+from app.ai.prompts.audience import AudienceContext, detect_audience
 from app.domain.models.generated_image import GeneratedImage
 from app.domain.models.source_image import SourceImage, SourceImageChunk
 from app.infrastructure.config.settings import settings
@@ -17,6 +19,7 @@ from app.infrastructure.config.settings import settings
 logger = structlog.get_logger(__name__)
 
 SEMANTIC_REUSE_THRESHOLD = 0.85
+STYLE_TAG_INFOGRAPHIC = "style:infographic"
 
 
 def _jaccard_similarity(tags_a: list[str], tags_b: list[str]) -> float:
@@ -75,7 +78,10 @@ class ImageGenerationService:
         await session.flush()
 
         try:
-            concept, prompt, tags = await self._extract_concept_and_tags(lesson_content)
+            lesson_row, language, audience = await self._load_lesson_context(lesson_id, session)
+            concept, prompt, tags = await self._extract_concept_and_tags(
+                lesson_content, language, audience
+            )
             image_record.concept = concept
             image_record.prompt = prompt
             image_record.semantic_tags = tags
@@ -100,7 +106,7 @@ class ImageGenerationService:
                 )
                 return image_record
 
-            source_img = await self._find_source_image(lesson_id, session)
+            source_img = await self._find_source_image(lesson_row, session)
             if source_img is not None:
                 image_record.status = "ready"
                 image_record.image_url = (
@@ -162,37 +168,93 @@ class ImageGenerationService:
             )
             return image_record
 
-    async def _extract_concept_and_tags(self, lesson_content: str) -> tuple[str, str, list[str]]:
+    async def _load_lesson_context(
+        self, lesson_id: uuid.UUID, session: AsyncSession
+    ) -> tuple[object | None, str, AudienceContext]:
+        """Eager-load the lesson row plus the course audience taxonomy.
+
+        Returns ``(lesson_row, language, audience)``. Falls back to
+        ``("en", AudienceContext(is_kids=False))`` when the lesson, its module,
+        or its course can't be resolved — image generation must remain best-effort.
+        """
+        from app.domain.models.content import GeneratedContent
+        from app.domain.models.module import Module
+
+        result = await session.execute(
+            select(GeneratedContent)
+            .options(
+                selectinload(GeneratedContent.module).selectinload(Module.course),
+            )
+            .where(GeneratedContent.id == lesson_id)
+        )
+        lesson = result.scalar_one_or_none()
+        if lesson is None:
+            return None, "en", AudienceContext(is_kids=False)
+
+        language = (getattr(lesson, "language", None) or "en").lower()
+        if language not in ("fr", "en"):
+            language = "en"
+
+        course = getattr(getattr(lesson, "module", None), "course", None)
+        audience = detect_audience(course)
+        return lesson, language, audience
+
+    async def _extract_concept_and_tags(
+        self, lesson_content: str, language: str, audience: AudienceContext
+    ) -> tuple[str, str, list[str]]:
         """Use Claude API to extract key concept, DALL-E prompt, and semantic tags."""
         import anthropic
 
         client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key, timeout=600.0)
 
+        language_name = "French" if language == "fr" else "English"
+
+        if audience.is_kids:
+            style_block = (
+                "STYLE for a children's audience: bright friendly cartoon-style flat "
+                "illustration, primary colors, rounded shapes, big readable text, simple "
+                "icons, optional friendly mascot character. Keep visual complexity low; "
+                "callout labels MUST be 1 to 3 words. Show diverse children where people "
+                "appear."
+            )
+        else:
+            style_block = (
+                "STYLE: flat editorial illustration, hand-drawn educational poster feel, "
+                "muted palette with one or two accent colors, lots of whitespace, sans-serif labels."
+            )
+
         system = (
             "You design explanatory infographics for an adaptive multi-subject learning platform. "
             "Given lesson content, extract:\n"
-            "1) A short key concept (5 words max).\n"
+            "1) A short key concept (5 words max, in English).\n"
             "2) A detailed image-generation prompt for an editorial-poster-style INFOGRAPHIC "
             "that explains the concept at a glance. The prompt MUST request:\n"
             "   - A clear short title across the top.\n"
             "   - 3 to 6 named components, objects, or steps drawn as a labeled diagram, "
-            "each with a short callout label (1-3 words).\n"
+            "each with a short callout label.\n"
             "   - Connector arrows or lines that show how the components relate "
             "(flow, hierarchy, before/after, cause/effect).\n"
-            "   - Optional split panels when the concept has natural contrasts "
-            "(e.g. rural vs urban, before vs after, input vs output).\n"
-            "   - An optional small legend or maturity/timeline strip at the bottom only if it fits the concept.\n"
-            "   - Style: flat editorial illustration, hand-drawn educational poster feel, "
-            "muted palette with one or two accent colors, lots of whitespace, sans-serif labels.\n"
+            "   - Optional split panels when the concept has natural contrasts.\n"
+            "   - An optional small legend or maturity/timeline strip at the bottom only if it fits.\n"
+            f"   - {style_block}\n"
+            "   - Human figures (learners, professionals, customers, kids, etc.) ARE allowed and "
+            "even encouraged when they help convey the concept; depict diverse people and avoid "
+            "stereotypes. They are not required if the concept is purely structural.\n"
             "   - Stay subject-agnostic: derive the visual setting from the lesson content itself "
             "(do not assume any specific country, region, profession, or industry unless the lesson states it).\n"
-            "   - 250-400 characters.\n"
-            '   - GOOD example: \'Educational poster titled "Photosynthesis". Cross-section of a leaf '
-            "with labeled callouts: chloroplast, stomata, xylem, phloem. Arrows show CO2 in, O2 out, "
-            "water up, sugar down. Flat illustration, muted greens, hand-drawn feel.'\n"
+            f"   - LANGUAGE: write the in-image title and ALL callout labels in {language_name} "
+            "(natural, idiomatic). The CONCEPT and TAGS fields below MUST stay in English so the "
+            "cache key is language-agnostic.\n"
+            "   - 250-450 characters.\n"
+            '   - GOOD example (en): \'Educational poster titled "Photosynthesis". Cross-section of '
+            "a leaf with labeled callouts in English: chloroplast, stomata, xylem, phloem. Arrows "
+            "show CO2 in, O2 out, water up, sugar down. Flat illustration, muted greens, hand-drawn feel.'\n"
+            "   - GOOD example (fr): 'Affiche éducative titrée « Photosynthèse ». Coupe d'une "
+            "feuille avec des étiquettes en français : chloroplaste, stomate, xylème, phloème. "
+            "Flèches montrant CO2 entrant, O2 sortant, eau qui monte, sucre qui descend.'\n"
             "   - BAD example: 'A green leaf in nature, vibrant colors' (no labels, no structure).\n"
-            "3) A JSON array of 5-8 lowercase semantic tags describing the lesson concept. "
-            'Always include the literal tag "style:infographic" as one of the tags.\n'
+            "3) A JSON array of 5-8 lowercase English semantic tags describing the lesson concept. "
+            f'Always include the literal tag "{STYLE_TAG_INFOGRAPHIC}" as one of the tags.\n'
             "Reply ONLY in this exact format:\n"
             "CONCEPT: <concept>\n"
             "PROMPT: <image_prompt>\n"
@@ -201,7 +263,7 @@ class ImageGenerationService:
 
         message = await client.messages.create(
             model="claude-sonnet-4-6",
-            max_tokens=300,
+            max_tokens=400,
             messages=[
                 {
                     "role": "user",
@@ -212,20 +274,30 @@ class ImageGenerationService:
         )
 
         text = message.content[0].text if message.content else ""
-        return _parse_concept_response(text)
+        concept, prompt, tags = _parse_concept_response(text)
+
+        # Inject server-side discriminator tags so the cache key always matches the
+        # actual generated style/language/audience, regardless of what Claude returned.
+        tag_set = {t.lower() for t in tags}
+        if STYLE_TAG_INFOGRAPHIC not in tag_set:
+            tags.append(STYLE_TAG_INFOGRAPHIC)
+        lang_tag = f"lang:{language}"
+        if lang_tag not in tag_set:
+            tags.append(lang_tag)
+        if audience.is_kids and "audience:kids" not in tag_set:
+            tags.append("audience:kids")
+
+        return concept, prompt, tags
 
     async def _find_source_image(
-        self, lesson_id: uuid.UUID, session: AsyncSession
+        self, lesson: object | None, session: AsyncSession
     ) -> SourceImage | None:
         """Check if any source images are explicitly linked to the lesson's document chunks.
 
         Returns the first SourceImage with image_type in ('diagram', 'chart', 'photo')
         that is explicitly linked to a document chunk via the lesson's generated content.
         """
-        from app.domain.models.content import GeneratedContent
-
-        lesson = await session.get(GeneratedContent, lesson_id)
-        if lesson is None or not lesson.sources_cited:
+        if lesson is None or not getattr(lesson, "sources_cited", None):
             return None
 
         sources = [
@@ -251,11 +323,18 @@ class ImageGenerationService:
     ) -> GeneratedImage | None:
         """Search generated_images for an existing ready image with ≥85% tag overlap.
 
-        Only matches candidates that share the same style discriminator tag
-        (e.g. ``style:infographic``) so older plain-illustration rows are not reused.
+        A candidate must share **every** discriminator-prefixed tag from the new
+        generation — currently ``style:``, ``lang:``, and ``audience:``. This
+        prevents cross-language reuse (an EN infographic for an FR lesson) and
+        cross-audience reuse (an adult infographic for a kids lesson). Old rows
+        that pre-date a discriminator simply lack it and are skipped.
         """
-        style_tags = {t.lower() for t in tags if t.lower().startswith("style:")}
-        if not style_tags:
+        new_discriminators = {
+            t.lower()
+            for t in tags
+            if any(t.lower().startswith(p) for p in ("style:", "lang:", "audience:"))
+        }
+        if not new_discriminators:
             return None
 
         result = await session.execute(
@@ -266,10 +345,12 @@ class ImageGenerationService:
         for candidate in candidates:
             if not candidate.semantic_tags:
                 continue
-            candidate_styles = {
-                t.lower() for t in candidate.semantic_tags if t.lower().startswith("style:")
+            candidate_discriminators = {
+                t.lower()
+                for t in candidate.semantic_tags
+                if any(t.lower().startswith(p) for p in ("style:", "lang:", "audience:"))
             }
-            if not (style_tags & candidate_styles):
+            if not new_discriminators.issubset(candidate_discriminators):
                 continue
             similarity = _jaccard_similarity(tags, candidate.semantic_tags)
             if similarity >= SEMANTIC_REUSE_THRESHOLD:

--- a/backend/app/domain/services/progress_service.py
+++ b/backend/app/domain/services/progress_service.py
@@ -132,8 +132,8 @@ class ProgressService:
         # Get or create progress entry
         progress = await self._get_or_create_progress(user_id, module_id, now)
 
-        # Only move to in_progress if currently locked/not started; preserve completed
-        if progress.status == "locked":
+        # Only move to in_progress if not started; preserve completed
+        if progress.status == "not_started":
             progress.status = "in_progress"
 
         progress.last_accessed = now
@@ -194,7 +194,7 @@ class ProgressService:
 
             if new_pct >= 100.0:
                 progress.status = "completed"
-            elif progress.status == "locked":
+            elif progress.status == "not_started":
                 progress.status = "in_progress"
 
         await self.db.commit()
@@ -295,10 +295,11 @@ class ProgressService:
         self, user_id: UUID, course_id: UUID | None = None
     ) -> list[dict]:
         """
-        Return modules with their real lock/unlock status for the user.
+        Return modules with their progress status for the user.
 
         When course_id is provided, only modules belonging to that course are returned.
-        Modules without a progress record default to 'locked'.
+        Modules without a progress record default to 'not_started' (accessible —
+        sequential gating was removed per issue #2125).
         Returns data ordered by module_number.
         """
         stmt = select(Module).order_by(Module.module_number)
@@ -328,7 +329,7 @@ class ProgressService:
                     "level": module.level,
                     "estimated_hours": module.estimated_hours,
                     "user_id": user_id,
-                    "status": progress.status if progress else "locked",
+                    "status": progress.status if progress else "not_started",
                     "completion_pct": progress.completion_pct if progress else 0.0,
                     "quiz_score_avg": progress.quiz_score_avg if progress else None,
                     "time_spent_minutes": progress.time_spent_minutes if progress else 0,
@@ -399,7 +400,7 @@ class ProgressService:
             "description_en": module.description_en,
             "estimated_hours": module.estimated_hours,
             "prereq_modules": [str(p) for p in (module.prereq_modules or [])],
-            "status": progress.status if progress else "locked",
+            "status": progress.status if progress else "not_started",
             "completion_pct": progress.completion_pct if progress else 0.0,
             "quiz_score_avg": progress.quiz_score_avg if progress else None,
             "time_spent_minutes": progress.time_spent_minutes if progress else 0,
@@ -415,10 +416,11 @@ class ProgressService:
 
     async def _unlock_next_module(self, user_id: UUID, completed_module_id: UUID) -> None:
         """
-        Unlock the module with module_number = N+1 when module N meets threshold.
+        Prefetch first 2 lessons of module N+1 when module N completes.
 
-        Per FR-02.2: creates an in_progress progress record for the next module
-        if it doesn't already have one (i.e. is still locked).
+        Sequential gating was removed per issue #2125 — all modules are accessible
+        on enrollment. This hook is retained only to warm the cache so the next
+        module's content is ready when a learner opens it.
         """
         module_result = await self.db.execute(
             select(Module).where(Module.id == completed_module_id)
@@ -434,43 +436,6 @@ class ProgressService:
         if not next_module:
             return
 
-        existing = await self.db.execute(
-            select(UserModuleProgress).where(
-                UserModuleProgress.user_id == user_id,
-                UserModuleProgress.module_id == next_module.id,
-            )
-        )
-        next_progress = existing.scalar_one_or_none()
-
-        if next_progress is None:
-            now = datetime.utcnow()
-            next_progress = UserModuleProgress(
-                user_id=user_id,
-                module_id=next_module.id,
-                status="in_progress",
-                completion_pct=0.0,
-                quiz_score_avg=None,
-                time_spent_minutes=0,
-                last_accessed=now,
-            )
-            self.db.add(next_progress)
-            await self.db.commit()
-            logger.info(
-                "Next module unlocked",
-                user_id=str(user_id),
-                unlocked_module_number=next_module.module_number,
-                unlocked_module_id=str(next_module.id),
-            )
-        elif next_progress.status == "locked":
-            next_progress.status = "in_progress"
-            await self.db.commit()
-            logger.info(
-                "Next module status updated to in_progress",
-                user_id=str(user_id),
-                module_number=next_module.module_number,
-            )
-
-        # Prefetch first 2 lessons of the newly unlocked module
         self._dispatch_prefetch(user_id, str(next_module.id), "")
 
     async def _dispatch_prefetch_after_quiz(

--- a/backend/app/tasks/rag_indexation.py
+++ b/backend/app/tasks/rag_indexation.py
@@ -452,8 +452,21 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
 
         return total_chunks, total_images
 
+    async def _run_pipeline_with_fresh_engine():
+        # asyncpg + Celery prefork: child workers inherit the parent's engine
+        # but its pooled connections are bound to the parent loop. Dispose
+        # before and after so this task — and the next one to land on this
+        # worker — both start with a clean pool. See #2103.
+        from app.infrastructure.persistence.database import engine
+
+        await engine.dispose()
+        try:
+            return await _run_pipeline()
+        finally:
+            await engine.dispose()
+
     try:
-        total_chunks, total_images = asyncio.run(_run_pipeline())
+        total_chunks, total_images = asyncio.run(_run_pipeline_with_fresh_engine())
 
         self.update_state(
             state="COMPLETE",

--- a/backend/app/tasks/sms_relay.py
+++ b/backend/app/tasks/sms_relay.py
@@ -10,6 +10,7 @@ from app.infrastructure.cache.redis import redis_client
 from app.infrastructure.config.settings import settings
 from app.infrastructure.persistence.database import (
     async_session_factory,
+    engine,
 )
 from app.tasks.celery_app import celery_app
 
@@ -30,34 +31,41 @@ def check_relay_heartbeat(self) -> dict:
     try:
 
         async def _run() -> int:
-            async with async_session_factory() as session:
-                service = SmsRelayService()
-                stale = await service.get_stale_devices(
-                    timeout_minutes=(settings.sms_relay_heartbeat_timeout_minutes),
-                    session=session,
-                )
-
-                if not stale or not settings.sms_relay_alert_email:
-                    return 0
-
-                email_service = EmailService()
-                alerted = 0
-                for device in stale:
-                    key = ALERT_COOLDOWN_KEY.format(device_id=device.device_id)
-                    if redis_client.get(key):
-                        continue
-
-                    sent = await email_service.send_relay_alert(
-                        to_email=settings.sms_relay_alert_email,
-                        device_id=device.device_id,
-                        last_seen=device.last_heartbeat_at.isoformat(),
-                        battery=device.battery,
+            # asyncpg + Celery prefork: dispose any pool inherited from the
+            # parent before/after so we don't reuse connections bound to the
+            # parent's event loop. See #2103.
+            await engine.dispose()
+            try:
+                async with async_session_factory() as session:
+                    service = SmsRelayService()
+                    stale = await service.get_stale_devices(
+                        timeout_minutes=(settings.sms_relay_heartbeat_timeout_minutes),
+                        session=session,
                     )
-                    if sent:
-                        redis_client.set(key, "1", ex=ALERT_COOLDOWN_TTL)
-                        alerted += 1
 
-                return alerted
+                    if not stale or not settings.sms_relay_alert_email:
+                        return 0
+
+                    email_service = EmailService()
+                    alerted = 0
+                    for device in stale:
+                        key = ALERT_COOLDOWN_KEY.format(device_id=device.device_id)
+                        if redis_client.get(key):
+                            continue
+
+                        sent = await email_service.send_relay_alert(
+                            to_email=settings.sms_relay_alert_email,
+                            device_id=device.device_id,
+                            last_seen=device.last_heartbeat_at.isoformat(),
+                            battery=device.battery,
+                        )
+                        if sent:
+                            redis_client.set(key, "1", ex=ALERT_COOLDOWN_TTL)
+                            alerted += 1
+
+                    return alerted
+            finally:
+                await engine.dispose()
 
         count = asyncio.run(_run())
         logger.info(

--- a/backend/migrations/versions/088_relax_module_progress_locked_to_not_started.py
+++ b/backend/migrations/versions/088_relax_module_progress_locked_to_not_started.py
@@ -1,0 +1,39 @@
+"""Backfill: relax legacy 'locked' module progress rows to 'not_started' (#2125).
+
+Revision ID: 088
+Revises: 087
+Create Date: 2026-04-30
+
+Sequential module gating was removed per issue #2125 — once a learner enrolls
+in a course, every module is immediately accessible. The read-side default for
+modules without a ``user_module_progress`` row was flipped from ``'locked'`` to
+``'not_started'``. This migration relaxes any rows that the legacy
+``_unlock_next_module`` path persisted as ``'locked'`` so they match the new
+semantics on next read.
+
+Forward-only: downgrade is a no-op. Reversing ``not_started`` → ``locked``
+would require recomputing which rows had been locked in the legacy ordering,
+and that information is no longer business-meaningful.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "088"
+down_revision: str | None = "087"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    result = bind.execute(
+        sa.text("UPDATE user_module_progress SET status = 'not_started' WHERE status = 'locked'")
+    )
+    print(f"[088] Relaxed {result.rowcount} 'locked' module progress row(s) to 'not_started'")
+
+
+def downgrade() -> None:
+    pass

--- a/backend/tests/test_admin_courses_helpers.py
+++ b/backend/tests/test_admin_courses_helpers.py
@@ -14,6 +14,7 @@ import pytest
 from fastapi import HTTPException
 
 from app.api.v1.admin_courses import (
+    _diagnose_indexation_pointer,
     _require_extracted_sources,
     _require_indexed_sources,
     _safe_task_meta,
@@ -228,3 +229,104 @@ def test_save_syllabus_handler_sets_level_in_module_constructor():
 
     src = inspect.getsource(save_syllabus)
     assert "level=1" in src, "save_syllabus must set Module.level — see #2016"
+
+
+# ---------------------------------------------------------------------------
+# #2100 — _diagnose_indexation_pointer classifies stuck pointers
+# ---------------------------------------------------------------------------
+
+
+def _patch_async_result(monkeypatch, state: str, info):
+    """Replace AsyncResult in admin_courses with a stub returning (state, info)."""
+
+    class _Stub:
+        def __init__(self, _task_id):
+            self.state = state
+
+        @property
+        def info(self):
+            return info
+
+    monkeypatch.setattr("app.api.v1.admin_courses.AsyncResult", _Stub)
+
+
+def test_diagnose_pointer_returns_stale_no_pointer_when_task_id_null():
+    course = SimpleNamespace(indexation_task_id=None)
+    verdict, state, meta = _diagnose_indexation_pointer(course, require_progress=False)
+    assert verdict == "stale_no_pointer"
+    assert state == ""
+    assert meta == {}
+
+
+def test_diagnose_pointer_returns_stale_terminal_for_success(monkeypatch):
+    _patch_async_result(monkeypatch, "SUCCESS", {})
+    course = SimpleNamespace(indexation_task_id="t-1")
+    verdict, state, _meta = _diagnose_indexation_pointer(course, require_progress=False)
+    assert verdict == "stale_terminal"
+    assert state == "SUCCESS"
+
+
+def test_diagnose_pointer_returns_stale_terminal_for_failure(monkeypatch):
+    _patch_async_result(monkeypatch, "FAILURE", {})
+    course = SimpleNamespace(indexation_task_id="t-1")
+    verdict, state, _meta = _diagnose_indexation_pointer(course, require_progress=False)
+    assert verdict == "stale_terminal"
+    assert state == "FAILURE"
+
+
+def test_diagnose_pointer_returns_stale_terminal_for_revoked(monkeypatch):
+    _patch_async_result(monkeypatch, "REVOKED", {})
+    course = SimpleNamespace(indexation_task_id="t-1")
+    verdict, _state, _meta = _diagnose_indexation_pointer(course, require_progress=False)
+    assert verdict == "stale_terminal"
+
+
+def test_diagnose_pointer_evicted_pending_no_meta_trigger_path(monkeypatch):
+    """Trigger endpoint (require_progress=False) clears evicted pointers even
+    without indexed chunks/images — the admin's manual click is signal enough.
+    """
+    _patch_async_result(monkeypatch, "PENDING", {})
+    course = SimpleNamespace(indexation_task_id="t-1")
+    verdict, _state, _meta = _diagnose_indexation_pointer(course, require_progress=False)
+    assert verdict == "stale_evicted"
+
+
+def test_diagnose_pointer_evicted_status_path_requires_progress(monkeypatch):
+    """Status endpoint (require_progress=True) needs durable evidence the
+    task ran. PENDING+empty-meta with no chunks looks identical to a freshly
+    enqueued task — hold the verdict at "live".
+    """
+    _patch_async_result(monkeypatch, "PENDING", {})
+    course = SimpleNamespace(indexation_task_id="t-1")
+    verdict, _state, _meta = _diagnose_indexation_pointer(
+        course, require_progress=True, chunks_indexed=0, images_indexed=0
+    )
+    assert verdict == "live"
+
+
+def test_diagnose_pointer_evicted_status_path_with_chunks(monkeypatch):
+    _patch_async_result(monkeypatch, "PENDING", {})
+    course = SimpleNamespace(indexation_task_id="t-1")
+    verdict, _state, _meta = _diagnose_indexation_pointer(
+        course, require_progress=True, chunks_indexed=42, images_indexed=0
+    )
+    assert verdict == "stale_evicted"
+
+
+def test_diagnose_pointer_returns_live_for_started(monkeypatch):
+    _patch_async_result(monkeypatch, "STARTED", {"step": "embedding"})
+    course = SimpleNamespace(indexation_task_id="t-1")
+    verdict, state, meta = _diagnose_indexation_pointer(course, require_progress=False)
+    assert verdict == "live"
+    assert state == "STARTED"
+    assert meta == {"step": "embedding"}
+
+
+def test_diagnose_pointer_returns_live_for_pending_with_meta(monkeypatch):
+    """A freshly-enqueued task picked up by a worker reports PENDING but with
+    meta. Don't treat it as evicted.
+    """
+    _patch_async_result(monkeypatch, "PENDING", {"progress": 5})
+    course = SimpleNamespace(indexation_task_id="t-1")
+    verdict, _state, _meta = _diagnose_indexation_pointer(course, require_progress=False)
+    assert verdict == "live"

--- a/backend/tests/test_courses.py
+++ b/backend/tests/test_courses.py
@@ -151,10 +151,15 @@ async def test_publish_course(authenticated_client, db_session, admin_with_id_he
 
 @pytest.mark.skip(reason=_SKIP_REASON)
 @pytest.mark.asyncio
-async def test_enrollment_creates_progress_records(
+async def test_enrollment_modules_accessible(
     authenticated_client, db_session, admin_with_id_headers, user_with_id_headers, user_id_str
 ):
-    """Enrolling in a course initializes UserModuleProgress for all course modules."""
+    """Enrolling in a course makes every module accessible (no sequential gating, #2125).
+
+    Progress rows are not pre-created at enrollment; the read API synthesizes
+    a 'not_started' status for any module without a row, and any row that
+    happens to exist must not be 'locked'.
+    """
     from app.domain.models.module import Module
     from app.domain.models.progress import UserModuleProgress
 
@@ -187,8 +192,7 @@ async def test_enrollment_creates_progress_records(
         headers=user_with_id_headers,
     )
     assert enroll_resp.status_code == 200
-    enroll_data = enroll_resp.json()
-    assert enroll_data["status"] == "active"
+    assert enroll_resp.json()["status"] == "active"
 
     progress_result = await db_session.execute(
         select(UserModuleProgress).where(
@@ -197,8 +201,14 @@ async def test_enrollment_creates_progress_records(
         )
     )
     progress = progress_result.scalar_one_or_none()
-    assert progress is not None
-    assert progress.status == "locked"
+    assert progress is None or progress.status != "locked"
+
+    api_resp = await authenticated_client.get(
+        f"/api/v1/progress/modules/{module.id}",
+        headers=user_with_id_headers,
+    )
+    assert api_resp.status_code == 200
+    assert api_resp.json()["status"] == "not_started"
 
 
 @pytest.mark.skip(reason=_SKIP_REASON)

--- a/backend/tests/test_image_generation.py
+++ b/backend/tests/test_image_generation.py
@@ -124,6 +124,16 @@ def _no_existing_image_result() -> MagicMock:
     return result
 
 
+def _empty_lesson_context_result() -> MagicMock:
+    """Mock result for the lesson context load — no GeneratedContent row found.
+
+    Falls back the service to language='en' and AudienceContext(is_kids=False).
+    """
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = None
+    return result
+
+
 def _make_db_image(tags: list[str], status: str = "ready") -> GeneratedImage:
     img_id = uuid.uuid4()
     img = GeneratedImage(
@@ -163,7 +173,7 @@ class TestImageGenerationService:
         content_block.text = (
             "CONCEPT: paludisme\n"
             "PROMPT: Educational poster titled Paludisme with labeled life-cycle stages and arrows\n"
-            'TAGS: ["paludisme", "malaria", "aof", "épidémiologie", "style:infographic"]'
+            'TAGS: ["paludisme", "malaria", "aof", "épidémiologie", "style:infographic", "lang:en"]'
         )
         msg.content = [content_block]
         return msg
@@ -181,14 +191,16 @@ class TestImageGenerationService:
     async def test_semantic_reuse_skips_dalle(self, service, mock_session, mock_claude_response):
         """When a matching image exists (≥85% Jaccard), DALL-E must NOT be called."""
         existing = _make_db_image(
-            ["paludisme", "malaria", "aof", "épidémiologie", "style:infographic"]
+            ["paludisme", "malaria", "aof", "épidémiologie", "style:infographic", "lang:en"]
         )
         existing.reuse_count = 0
 
         dedup_result = _no_existing_image_result()
         reuse_result = MagicMock()
         reuse_result.scalars.return_value.all.return_value = [existing]
-        mock_session.execute = AsyncMock(side_effect=[dedup_result, reuse_result])
+        mock_session.execute = AsyncMock(
+            side_effect=[dedup_result, _empty_lesson_context_result(), reuse_result]
+        )
 
         with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
             mock_client = AsyncMock()
@@ -219,7 +231,9 @@ class TestImageGenerationService:
         dedup_result = _no_existing_image_result()
         reuse_result = MagicMock()
         reuse_result.scalars.return_value.all.return_value = []
-        mock_session.execute = AsyncMock(side_effect=[dedup_result, reuse_result])
+        mock_session.execute = AsyncMock(
+            side_effect=[dedup_result, _empty_lesson_context_result(), reuse_result]
+        )
 
         fake_b64 = base64.b64encode(b"FAKE_PNG_DATA").decode()
         image_api_response = MagicMock()
@@ -288,7 +302,9 @@ class TestImageGenerationService:
         dedup_result = _no_existing_image_result()
         reuse_result = MagicMock()
         reuse_result.scalars.return_value.all.return_value = []
-        mock_session.execute = AsyncMock(side_effect=[dedup_result, reuse_result])
+        mock_session.execute = AsyncMock(
+            side_effect=[dedup_result, _empty_lesson_context_result(), reuse_result]
+        )
 
         fake_b64 = base64.b64encode(b"DATA").decode()
         image_api_response = MagicMock()
@@ -320,14 +336,16 @@ class TestImageGenerationService:
     async def test_reuse_increments_reuse_count(self, service, mock_session, mock_claude_response):
         """Reusing an existing image must increment its reuse_count."""
         existing = _make_db_image(
-            ["paludisme", "malaria", "aof", "épidémiologie", "style:infographic"]
+            ["paludisme", "malaria", "aof", "épidémiologie", "style:infographic", "lang:en"]
         )
         existing.reuse_count = 2
 
         dedup_result = _no_existing_image_result()
         reuse_result = MagicMock()
         reuse_result.scalars.return_value.all.return_value = [existing]
-        mock_session.execute = AsyncMock(side_effect=[dedup_result, reuse_result])
+        mock_session.execute = AsyncMock(
+            side_effect=[dedup_result, _empty_lesson_context_result(), reuse_result]
+        )
 
         with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
             mock_client = AsyncMock()
@@ -377,6 +395,163 @@ class TestImageGenerationService:
         assert '"1536x1024"' in source
         assert '"medium"' in source
 
+    async def test_extract_concept_localizes_to_lesson_language(
+        self, service, mock_claude_response
+    ):
+        """When language='fr', the system prompt sent to Claude must request French labels."""
+        from app.ai.prompts.audience import AudienceContext
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
+            mock_client = AsyncMock()
+            mock_anthropic_cls.return_value = mock_client
+            mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
+
+            await service._extract_concept_and_tags(
+                "Lesson about photosynthesis.",
+                language="fr",
+                audience=AudienceContext(is_kids=False),
+            )
+
+            system_prompt = mock_client.messages.create.call_args.kwargs["system"]
+            assert "French" in system_prompt
+            assert "language-agnostic" in system_prompt.lower()
+
+    async def test_extract_concept_default_english(self, service, mock_claude_response):
+        """Default language='en' must request English labels in the system prompt."""
+        from app.ai.prompts.audience import AudienceContext
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
+            mock_client = AsyncMock()
+            mock_anthropic_cls.return_value = mock_client
+            mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
+
+            await service._extract_concept_and_tags(
+                "Lesson about photosynthesis.",
+                language="en",
+                audience=AudienceContext(is_kids=False),
+            )
+
+            system_prompt = mock_client.messages.create.call_args.kwargs["system"]
+            assert "English" in system_prompt
+
+    async def test_extract_concept_kids_audience_branches_style(
+        self, service, mock_claude_response
+    ):
+        """When audience.is_kids=True, the prompt must request kid-friendly cartoon style."""
+        from app.ai.prompts.audience import AudienceContext
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
+            mock_client = AsyncMock()
+            mock_anthropic_cls.return_value = mock_client
+            mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
+
+            await service._extract_concept_and_tags(
+                "Counting from 1 to 10.",
+                language="en",
+                audience=AudienceContext(is_kids=True, age_min=6, age_max=10),
+            )
+
+            system_prompt = mock_client.messages.create.call_args.kwargs["system"]
+            # Kids style markers (cartoon, primary colors, mascot) must appear.
+            assert "cartoon" in system_prompt.lower()
+            assert "children" in system_prompt.lower() or "child" in system_prompt.lower()
+            # Adult-default style markers must NOT appear in the kids branch.
+            assert "muted palette" not in system_prompt.lower()
+
+    async def test_extract_concept_allows_humans(self, service, mock_claude_response):
+        """The system prompt must explicitly allow human figures in the infographic."""
+        from app.ai.prompts.audience import AudienceContext
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
+            mock_client = AsyncMock()
+            mock_anthropic_cls.return_value = mock_client
+            mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
+
+            await service._extract_concept_and_tags(
+                "Some lesson.",
+                language="en",
+                audience=AudienceContext(is_kids=False),
+            )
+
+            system_prompt = mock_client.messages.create.call_args.kwargs["system"]
+            # Humans must be explicitly allowed (not forbidden).
+            assert "Human figures" in system_prompt or "human figures" in system_prompt
+            assert "allowed" in system_prompt.lower()
+            # Pre-#2088 NO-PEOPLE markers must be gone.
+            assert "no people" not in system_prompt.lower()
+            assert "no human" not in system_prompt.lower()
+
+    async def test_extract_concept_injects_lang_and_audience_tags(
+        self, service, mock_claude_response
+    ):
+        """Server-side discriminator tags (lang:, audience:) must be injected into the tag list."""
+        from app.ai.prompts.audience import AudienceContext
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
+            mock_client = AsyncMock()
+            mock_anthropic_cls.return_value = mock_client
+            mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
+
+            _, _, tags = await service._extract_concept_and_tags(
+                "Counting lesson.",
+                language="fr",
+                audience=AudienceContext(is_kids=True, age_min=6, age_max=10),
+            )
+
+            tags_lower = {t.lower() for t in tags}
+            assert "lang:fr" in tags_lower
+            assert "audience:kids" in tags_lower
+            assert "style:infographic" in tags_lower
+
+    async def test_find_reusable_image_blocks_cross_language_reuse(self, service, mock_session):
+        """An EN-tagged existing image must NOT be reused for a new FR generation."""
+        en_existing = _make_db_image(
+            ["paludisme", "malaria", "aof", "épidémiologie", "style:infographic", "lang:en"]
+        )
+
+        reuse_result = MagicMock()
+        reuse_result.scalars.return_value.all.return_value = [en_existing]
+        mock_session.execute = AsyncMock(return_value=reuse_result)
+
+        new_tags = [
+            "paludisme",
+            "malaria",
+            "aof",
+            "épidémiologie",
+            "style:infographic",
+            "lang:fr",
+        ]
+        result = await service._find_reusable_image(new_tags, mock_session)
+        assert result is None
+
+    async def test_find_reusable_image_allows_same_language_reuse(self, service, mock_session):
+        """Same-language same-style same-audience candidate with ≥85% Jaccard reuses fine."""
+        existing = _make_db_image(
+            [
+                "paludisme",
+                "malaria",
+                "aof",
+                "épidémiologie",
+                "style:infographic",
+                "lang:fr",
+            ]
+        )
+
+        reuse_result = MagicMock()
+        reuse_result.scalars.return_value.all.return_value = [existing]
+        mock_session.execute = AsyncMock(return_value=reuse_result)
+
+        new_tags = [
+            "paludisme",
+            "malaria",
+            "aof",
+            "épidémiologie",
+            "style:infographic",
+            "lang:fr",
+        ]
+        result = await service._find_reusable_image(new_tags, mock_session)
+        assert result is existing
+
     def test_openai_api_key_not_in_frontend_accessible_code(self):
         """Verify OPENAI_API_KEY is loaded from settings (server-side), not hardcoded."""
         import inspect
@@ -412,7 +587,9 @@ class TestImageGenerationService:
         dedup_result = _no_existing_image_result()
         reuse_result = MagicMock()
         reuse_result.scalars.return_value.all.return_value = []
-        mock_session.execute = AsyncMock(side_effect=[dedup_result, reuse_result])
+        mock_session.execute = AsyncMock(
+            side_effect=[dedup_result, _empty_lesson_context_result(), reuse_result]
+        )
 
         fake_b64 = base64.b64encode(b"FAKE_PNG_BINARY_DATA").decode()
         image_api_response = MagicMock()

--- a/backend/tests/test_image_linker.py
+++ b/backend/tests/test_image_linker.py
@@ -672,6 +672,7 @@ class TestSemanticLinkage:
             _make_execute_result([]),  # contextual chunks
             _make_execute_result([]),  # contextual existing.image_ids
             _make_count_result(1, 1),  # semantic count: both > 0
+            _make_execute_result([]),  # semantic existing.image_ids (#2106)
             lateral_result,  # lateral join result
         ]
 
@@ -708,6 +709,7 @@ class TestSemanticLinkage:
             _make_execute_result([(chunk_id, 5, None)]),  # contextual chunks
             _make_execute_result([]),
             _make_count_result(1, 1),
+            _make_execute_result([]),  # semantic existing.image_ids (#2106)
             lateral_result,  # would propose the same pair as explicit
         ]
 

--- a/backend/tests/test_progress_service.py
+++ b/backend/tests/test_progress_service.py
@@ -78,13 +78,13 @@ class TestTrackLessonAccess:
         assert added_obj.time_spent_seconds == 120
         assert added_obj.completion_percentage == 50.0
 
-    async def test_marks_locked_module_as_in_progress(
+    async def test_marks_not_started_module_as_in_progress(
         self, progress_service, mock_db, user_id, module_id, lesson_id
     ):
         existing_progress = UserModuleProgress(
             user_id=user_id,
             module_id=module_id,
-            status="locked",
+            status="not_started",
             completion_pct=0.0,
             quiz_score_avg=None,
             time_spent_minutes=0,
@@ -537,9 +537,12 @@ class TestProgressServiceIntegration:
 
 
 class TestUnlockNextModule:
-    async def test_unlock_threshold_triggers_next_module_unlock(
+    async def test_threshold_does_not_create_next_module_progress_row(
         self, progress_service, mock_db, user_id, module_id
     ):
+        """After issue #2125 removed sequential gating, completing module N must
+        no longer auto-create a progress row for module N+1; the next module is
+        already accessible by default."""
         from app.domain.models.module import Module
 
         next_module_id = uuid.uuid4()
@@ -582,23 +585,15 @@ class TestUnlockNextModule:
             call_count += 1
             mock_result = MagicMock()
             if call_count == 1:
-                # _get_or_create_progress
                 mock_result.scalar_one_or_none = MagicMock(return_value=existing_progress)
             elif call_count == 2:
-                # _calculate_completion_pct: total units
                 mock_result.scalar = MagicMock(return_value=1)
             elif call_count == 3:
-                # _get_completed_units: quiz contents
                 mock_result.all = MagicMock(return_value=[])
             elif call_count == 4:
-                # _unlock_next_module: current module lookup
                 mock_result.scalar_one_or_none = MagicMock(return_value=current_module)
             elif call_count == 5:
-                # _unlock_next_module: next module lookup
                 mock_result.scalar_one_or_none = MagicMock(return_value=next_module)
-            elif call_count == 6:
-                # _unlock_next_module: check existing progress for next module
-                mock_result.scalar_one_or_none = MagicMock(return_value=None)
             else:
                 mock_result.scalar_one_or_none = MagicMock(return_value=None)
                 mock_result.scalar = MagicMock(return_value=None)
@@ -619,13 +614,12 @@ class TestUnlockNextModule:
         assert result.completion_pct == 100.0
         assert result.status == "completed"
 
-        unlocked = [
+        next_module_rows = [
             obj
             for obj in added_objects
             if isinstance(obj, UserModuleProgress) and obj.module_id == next_module_id
         ]
-        assert len(unlocked) == 1
-        assert unlocked[0].status == "in_progress"
+        assert next_module_rows == []
 
     async def test_no_unlock_when_score_below_threshold(
         self, progress_service, mock_db, user_id, module_id
@@ -669,9 +663,12 @@ class TestUnlockNextModule:
         # and rollup_course_completion_by_module (also select Module.course_id).
         assert call_count == 3
 
-    async def test_unlock_updates_existing_locked_next_module(
+    async def test_existing_next_module_progress_row_is_not_modified(
         self, progress_service, mock_db, user_id, module_id
     ):
+        """After issue #2125, completing module N never mutates the status of
+        any existing progress row for module N+1; only the legacy data-fix
+        migration (088) relaxes any historical 'locked' rows."""
         from app.domain.models.module import Module
 
         next_module_id = uuid.uuid4()
@@ -690,15 +687,6 @@ class TestUnlockNextModule:
             title_fr="M04",
             title_en="M04",
             estimated_hours=25,
-        )
-        locked_next_progress = UserModuleProgress(
-            user_id=user_id,
-            module_id=next_module_id,
-            status="locked",
-            completion_pct=0.0,
-            quiz_score_avg=None,
-            time_spent_minutes=0,
-            last_accessed=None,
         )
         existing_progress = UserModuleProgress(
             user_id=user_id,
@@ -725,13 +713,14 @@ class TestUnlockNextModule:
                 mock_result.scalar_one_or_none = MagicMock(return_value=current_module)
             elif call_count == 5:
                 mock_result.scalar_one_or_none = MagicMock(return_value=next_module)
-            elif call_count == 6:
-                mock_result.scalar_one_or_none = MagicMock(return_value=locked_next_progress)
             else:
                 mock_result.scalar_one_or_none = MagicMock(return_value=None)
             return mock_result
 
         mock_db.execute = mock_execute
+
+        added_objects = []
+        mock_db.add = MagicMock(side_effect=lambda obj: added_objects.append(obj))
 
         await progress_service.update_progress_after_quiz(
             user_id=user_id,
@@ -741,7 +730,12 @@ class TestUnlockNextModule:
             passed=True,
         )
 
-        assert locked_next_progress.status == "in_progress"
+        next_module_rows = [
+            obj
+            for obj in added_objects
+            if isinstance(obj, UserModuleProgress) and obj.module_id == next_module_id
+        ]
+        assert next_module_rows == []
 
     async def test_no_unlock_when_no_next_module(
         self, progress_service, mock_db, user_id, module_id
@@ -887,9 +881,11 @@ class TestGetAllModulesWithProgress:
         assert len(result) == 1
         assert result[0]["module_number"] == 1
 
-    async def test_defaults_status_to_locked_when_no_progress(
+    async def test_defaults_status_to_not_started_when_no_progress(
         self, progress_service, mock_db, user_id
     ):
+        """Per issue #2125: modules without a progress row are accessible
+        and report status='not_started' (no sequential gating)."""
         from app.domain.models.module import Module
 
         module = Module(
@@ -918,8 +914,51 @@ class TestGetAllModulesWithProgress:
         result = await progress_service.get_all_modules_with_progress(user_id)
 
         assert len(result) == 1
-        assert result[0]["status"] == "locked"
+        assert result[0]["status"] == "not_started"
         assert result[0]["completion_pct"] == 0.0
+
+    async def test_all_modules_accessible_for_fresh_enrollee(
+        self, progress_service, mock_db, user_id
+    ):
+        """Per issue #2125: a fresh enrollee with zero progress rows must see
+        every module of the course as 'not_started' — not just module 1.
+        Confirms learners can jump directly to module N without progressing
+        through 1..N-1."""
+        from app.domain.models.module import Module
+
+        course_id = uuid.uuid4()
+        modules = [
+            Module(
+                id=uuid.uuid4(),
+                module_number=n,
+                level=1,
+                title_fr=f"M{n} FR",
+                title_en=f"M{n} EN",
+                estimated_hours=20,
+                course_id=course_id,
+            )
+            for n in (1, 2, 3, 4, 5)
+        ]
+
+        call_count = 0
+
+        async def mock_execute(stmt):
+            nonlocal call_count
+            call_count += 1
+            mock_result = MagicMock()
+            if call_count == 1:
+                mock_result.scalars.return_value.all.return_value = modules
+            else:
+                mock_result.scalars.return_value.all.return_value = []
+            return mock_result
+
+        mock_db.execute = mock_execute
+
+        result = await progress_service.get_all_modules_with_progress(user_id, course_id=course_id)
+
+        assert len(result) == 5
+        assert {m["status"] for m in result} == {"not_started"}
+        assert all(m["completion_pct"] == 0.0 for m in result)
 
     async def test_returns_empty_list_when_course_has_no_modules(
         self, progress_service, mock_db, user_id

--- a/backend/tests/test_tutor_source_image.py
+++ b/backend/tests/test_tutor_source_image.py
@@ -388,8 +388,7 @@ class TestFindSourceImage:
         return session
 
     async def test_returns_none_when_lesson_not_found(self, service, mock_session):
-        mock_session.get = AsyncMock(return_value=None)
-        result = await service._find_source_image(uuid.uuid4(), mock_session)
+        result = await service._find_source_image(None, mock_session)
         assert result is None
 
     async def test_returns_none_when_no_sources_cited(self, service, mock_session):
@@ -397,9 +396,8 @@ class TestFindSourceImage:
 
         lesson = MagicMock(spec=GeneratedContent)
         lesson.sources_cited = None
-        mock_session.get = AsyncMock(return_value=lesson)
 
-        result = await service._find_source_image(uuid.uuid4(), mock_session)
+        result = await service._find_source_image(lesson, mock_session)
         assert result is None
 
     async def test_returns_none_when_sources_cited_empty(self, service, mock_session):
@@ -407,9 +405,8 @@ class TestFindSourceImage:
 
         lesson = MagicMock(spec=GeneratedContent)
         lesson.sources_cited = []
-        mock_session.get = AsyncMock(return_value=lesson)
 
-        result = await service._find_source_image(uuid.uuid4(), mock_session)
+        result = await service._find_source_image(lesson, mock_session)
         assert result is None
 
     async def test_returns_source_image_when_explicit_link_exists(self, service, mock_session):
@@ -417,14 +414,13 @@ class TestFindSourceImage:
 
         lesson = MagicMock(spec=GeneratedContent)
         lesson.sources_cited = [{"source": "donaldson", "chapter": "3", "page": 42}]
-        mock_session.get = AsyncMock(return_value=lesson)
 
         source_img = _make_source_image(image_type="diagram")
         mock_execute_result = MagicMock()
         mock_execute_result.scalar_one_or_none = MagicMock(return_value=source_img)
         mock_session.execute = AsyncMock(return_value=mock_execute_result)
 
-        result = await service._find_source_image(uuid.uuid4(), mock_session)
+        result = await service._find_source_image(lesson, mock_session)
         assert result is source_img
 
     async def test_returns_none_when_no_explicit_source_image(self, service, mock_session):
@@ -432,13 +428,12 @@ class TestFindSourceImage:
 
         lesson = MagicMock(spec=GeneratedContent)
         lesson.sources_cited = [{"source": "triola", "chapter": "1", "page": 5}]
-        mock_session.get = AsyncMock(return_value=lesson)
 
         mock_execute_result = MagicMock()
         mock_execute_result.scalar_one_or_none = MagicMock(return_value=None)
         mock_session.execute = AsyncMock(return_value=mock_execute_result)
 
-        result = await service._find_source_image(uuid.uuid4(), mock_session)
+        result = await service._find_source_image(lesson, mock_session)
         assert result is None
 
 
@@ -446,6 +441,13 @@ def _no_existing_image_result() -> MagicMock:
     """Mock result for the dedup check — no existing image found."""
     result = MagicMock()
     result.scalar_one_or_none.return_value = None
+    return result
+
+
+def _lesson_context_result(lesson: object | None) -> MagicMock:
+    """Mock result for ImageGenerationService._load_lesson_context()."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = lesson
     return result
 
 
@@ -485,7 +487,8 @@ class TestDallEFallbackOptimization:
 
         lesson = MagicMock(spec=GeneratedContent)
         lesson.sources_cited = [{"source": "donaldson", "chapter": "3", "page": 42}]
-        mock_session.get = AsyncMock(return_value=lesson)
+        lesson.language = "en"
+        lesson.module = None
 
         reuse_result = MagicMock()
         reuse_result.scalars.return_value.all.return_value = []
@@ -494,7 +497,14 @@ class TestDallEFallbackOptimization:
         source_result.scalar_one_or_none = MagicMock(return_value=source_img)
 
         dedup_result = _no_existing_image_result()
-        mock_session.execute = AsyncMock(side_effect=[dedup_result, reuse_result, source_result])
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                dedup_result,
+                _lesson_context_result(lesson),
+                reuse_result,
+                source_result,
+            ]
+        )
 
         with __import__("unittest.mock", fromlist=["patch"]).patch(
             "anthropic.AsyncAnthropic"
@@ -526,8 +536,6 @@ class TestDallEFallbackOptimization:
         import base64
         from unittest.mock import patch
 
-        mock_session.get = AsyncMock(return_value=None)
-
         dedup_result = _no_existing_image_result()
         reuse_result = MagicMock()
         reuse_result.scalars.return_value.all.return_value = []
@@ -539,7 +547,9 @@ class TestDallEFallbackOptimization:
         image_api_response = MagicMock()
         image_api_response.data = [MagicMock(b64_json=fake_b64)]
 
-        mock_session.execute = AsyncMock(side_effect=[dedup_result, reuse_result])
+        mock_session.execute = AsyncMock(
+            side_effect=[dedup_result, _lesson_context_result(None), reuse_result]
+        )
 
         with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
             mock_client = AsyncMock()
@@ -578,7 +588,8 @@ class TestDallEFallbackOptimization:
 
         lesson = MagicMock(spec=GeneratedContent)
         lesson.sources_cited = [{"source": "triola", "chapter": "5", "page": 90}]
-        mock_session.get = AsyncMock(return_value=lesson)
+        lesson.language = "en"
+        lesson.module = None
 
         reuse_result = MagicMock()
         reuse_result.scalars.return_value.all.return_value = []
@@ -587,7 +598,14 @@ class TestDallEFallbackOptimization:
         source_result.scalar_one_or_none = MagicMock(return_value=source_img)
 
         dedup_result = _no_existing_image_result()
-        mock_session.execute = AsyncMock(side_effect=[dedup_result, reuse_result, source_result])
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                dedup_result,
+                _lesson_context_result(lesson),
+                reuse_result,
+                source_result,
+            ]
+        )
 
         with __import__("unittest.mock", fromlist=["patch"]).patch(
             "anthropic.AsyncAnthropic"

--- a/frontend/app/[locale]/(app)/modules/[moduleId]/units/[unit]/page.tsx
+++ b/frontend/app/[locale]/(app)/modules/[moduleId]/units/[unit]/page.tsx
@@ -8,6 +8,7 @@ import { EnrollmentGuard } from '@/components/shared/enrollment-guard';
 import { LessonViewer } from '@/components/learning/lesson-viewer';
 import { CaseStudyViewer } from '@/components/learning/case-study-viewer';
 import { UnitQuizViewer } from '@/components/learning/unit-quiz-viewer';
+import { UnitNav } from '@/components/learning/unit-nav';
 
 interface UnitPageProps {
   params: Promise<{ moduleId: string; unit: string }>;
@@ -22,10 +23,15 @@ export default async function UnitPage({ params }: UnitPageProps) {
   const moduleData = await getModuleUnits(moduleId).catch(() => null);
   if (!moduleData) notFound();
 
-  const unit = moduleData.units?.find(
+  const units = moduleData.units ?? [];
+  const unit = units.find(
     (u) => u.unit_number === unitParam || u.id === unitParam,
   );
   if (!unit) notFound();
+
+  const idx = units.findIndex((u) => u.id === unit.id);
+  const prev = idx > 0 ? units[idx - 1] : null;
+  const next = idx >= 0 && idx < units.length - 1 ? units[idx + 1] : null;
 
   const moduleTitle = language === 'fr' ? moduleData.title_fr : moduleData.title_en;
   const unitTitle = language === 'fr' ? unit.title_fr : unit.title_en;
@@ -82,6 +88,13 @@ export default async function UnitPage({ params }: UnitPageProps) {
             unitDescription={unitDescription}
           />
         )}
+
+        <UnitNav
+          moduleId={moduleId}
+          prev={prev}
+          next={next}
+          language={language}
+        />
       </div>
     </EnrollmentGuard>
   );

--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -58,7 +58,7 @@ import {
   suggestCourseMetadata,
   formatBytes,
 } from "@/lib/api-course-admin";
-import { getCourseTaxonomy, type TaxonomyItem } from "@/lib/api";
+import { ApiError, getCourseTaxonomy, type TaxonomyItem } from "@/lib/api";
 import { SyllabusVisualEditor } from "@/components/admin/syllabus-visual-editor";
 import { LessonPreviewStep } from "@/components/admin/lesson-preview-step";
 import {
@@ -427,6 +427,10 @@ export function AICourseWizard({
   const [indexStatus, setIndexStatus] = useState<IndexStatus | null>(null);
   const [isIndexing, setIsIndexing] = useState(false);
   const [indexError, setIndexError] = useState<string | null>(null);
+  // 409 INDEX_TASK_ACTIVE / SYLLABUS_GENERATION_ACTIVE detail. Distinct from
+  // indexError so the UI can offer a one-click reset-and-retry instead of
+  // a plain retry that would just 409 again (#2100).
+  const [indexConflictDetail, setIndexConflictDetail] = useState<string | null>(null);
   const [indexStaleWarning, setIndexStaleWarning] = useState(false);
   const lastIndexProgressValueRef = useRef(0);
   const lastIndexProgressTimeRef = useRef<number | null>(null);
@@ -772,6 +776,7 @@ export function AICourseWizard({
     if (!courseId) return;
     setIsIndexing(true);
     setIndexError(null);
+    setIndexConflictDetail(null);
     setIndexStaleWarning(false);
     lastIndexProgressValueRef.current = 0;
     lastIndexProgressTimeRef.current = Date.now();
@@ -779,9 +784,19 @@ export function AICourseWizard({
     try {
       const result = await triggerIndexation(courseId);
       setTaskId(result.task_id);
-    } catch {
-      setIndexError(t("index.error"));
+    } catch (err) {
       setIsIndexing(false);
+      if (
+        err instanceof ApiError &&
+        err.status === 409 &&
+        (err.code === "INDEX_TASK_ACTIVE" || err.code === "SYLLABUS_GENERATION_ACTIVE")
+      ) {
+        setIndexConflictDetail(err.message);
+      } else if (err instanceof ApiError) {
+        setIndexError(err.message || t("index.error"));
+      } else {
+        setIndexError(t("index.error"));
+      }
     }
   }, [courseId, t]);
 
@@ -926,6 +941,12 @@ export function AICourseWizard({
       // ignore
     }
   }, [courseId]);
+
+  const resetAndRetryIndexation = useCallback(async () => {
+    setIndexConflictDetail(null);
+    await cancelIndexation();
+    await startIndexation();
+  }, [cancelIndexation, startIndexation]);
 
   const reindexImages = useCallback(async () => {
     if (!courseId) return;
@@ -1502,7 +1523,7 @@ export function AICourseWizard({
                   </p>
                 </div>
 
-                {!isIndexing && !indexStatus?.indexed && (
+                {!isIndexing && !indexStatus?.indexed && !indexConflictDetail && (
                   <Button onClick={startIndexation} className="w-full min-h-11">
                     <Database className="mr-2 h-4 w-4" />
                     {t("index.button")}
@@ -1517,6 +1538,29 @@ export function AICourseWizard({
                     onCancel={cancelIndexation}
                     t={t}
                   />
+                )}
+
+                {indexConflictDetail && !isIndexing && (
+                  <div className="space-y-2">
+                    <div className="rounded-lg border border-amber-500/40 bg-amber-50 p-3 text-sm dark:bg-amber-950/30">
+                      <div className="flex items-start gap-2 text-amber-900 dark:text-amber-200">
+                        <AlertCircle className="h-4 w-4 shrink-0 mt-0.5" />
+                        <div>
+                          <p className="font-medium">{t("index.conflictTitle")}</p>
+                          <p className="mt-1 text-xs opacity-90">{indexConflictDetail}</p>
+                        </div>
+                      </div>
+                    </div>
+                    <Button
+                      onClick={resetAndRetryIndexation}
+                      variant="outline"
+                      size="sm"
+                      className="w-full min-h-[44px]"
+                    >
+                      <RotateCcw className="mr-2 h-4 w-4" />
+                      {t("index.resetAndRetry")}
+                    </Button>
+                  </div>
                 )}
 
                 {indexError && !isIndexing && (

--- a/frontend/components/admin/course-wizard-client.tsx
+++ b/frontend/components/admin/course-wizard-client.tsx
@@ -231,6 +231,9 @@ export function CourseWizardClient({
     resumeCreationStep === "indexing"
   );
   const [indexError, setIndexError] = useState<string | null>(null);
+  // 409 INDEX_TASK_ACTIVE / SYLLABUS_GENERATION_ACTIVE detail (#2100). Distinct
+  // from indexError so the UI offers reset-and-retry instead of plain retry.
+  const [indexConflictDetail, setIndexConflictDetail] = useState<string | null>(null);
   const [isReindexingImages, setIsReindexingImages] = useState(false);
   const [reindexImagesError, setReindexImagesError] = useState<string | null>(null);
   const [isCancellingIndexation, setIsCancellingIndexation] = useState(false);
@@ -691,6 +694,7 @@ export function CourseWizardClient({
     if (!courseId) return;
     setIsIndexing(true);
     setIndexError(null);
+    setIndexConflictDetail(null);
     setIndexStaleWarning(false);
     setCancelIndexationError(null);
     lastIndexProgressValueRef.current = 0;
@@ -702,11 +706,27 @@ export function CourseWizardClient({
         { method: "POST" }
       );
       setTaskId(result.task_id);
-    } catch {
-      setIndexError(t("index.error"));
+    } catch (err) {
       setIsIndexing(false);
+      if (
+        err instanceof ApiError &&
+        err.status === 409 &&
+        (err.code === "INDEX_TASK_ACTIVE" || err.code === "SYLLABUS_GENERATION_ACTIVE")
+      ) {
+        setIndexConflictDetail(err.message);
+      } else if (err instanceof ApiError) {
+        setIndexError(err.message || t("index.error"));
+      } else {
+        setIndexError(t("index.error"));
+      }
     }
   }, [courseId, t]);
+
+  const resetAndRetryIndexation = useCallback(async () => {
+    setIndexConflictDetail(null);
+    await cancelIndexation();
+    await startIndexation();
+  }, [cancelIndexation, startIndexation]);
 
   useEffect(() => {
     if (!courseId || !isIndexing) return;
@@ -1291,11 +1311,34 @@ export function CourseWizardClient({
                   </div>
                 )}
 
-                {!isIndexing && !indexStatus?.indexed && !isCheckingIndexStatus && (
+                {!isIndexing && !indexStatus?.indexed && !isCheckingIndexStatus && !indexConflictDetail && (
                   <Button onClick={startIndexation} className="w-full min-h-11" disabled={isIndexing}>
                     <Database className="mr-2 h-4 w-4" />
                     {t("index.button")}
                   </Button>
+                )}
+
+                {!isIndexing && indexConflictDetail && (
+                  <div className="space-y-2">
+                    <div className="rounded-lg border border-amber-500/40 bg-amber-50 p-3 text-sm dark:bg-amber-950/30">
+                      <div className="flex items-start gap-2 text-amber-900 dark:text-amber-200">
+                        <AlertCircle className="h-4 w-4 shrink-0 mt-0.5" />
+                        <div>
+                          <p className="font-medium">{t("index.conflictTitle")}</p>
+                          <p className="mt-1 text-xs opacity-90">{indexConflictDetail}</p>
+                        </div>
+                      </div>
+                    </div>
+                    <Button
+                      onClick={resetAndRetryIndexation}
+                      variant="outline"
+                      size="sm"
+                      className="w-full min-h-[44px]"
+                    >
+                      <RotateCcw className="mr-2 h-4 w-4" />
+                      {t("index.resetAndRetry")}
+                    </Button>
+                  </div>
                 )}
 
                 {isIndexing && (

--- a/frontend/components/learning/lesson-image.tsx
+++ b/frontend/components/learning/lesson-image.tsx
@@ -75,7 +75,7 @@ export function LessonImage({ lessonId, language }: LessonImageProps) {
   if (status !== 'ready' || !imageUrl) {
     return (
       <div
-        className="w-full max-w-[512px] mx-auto my-6 rounded-lg overflow-hidden animate-pulse"
+        className="w-full my-6 rounded-lg overflow-hidden animate-pulse"
         aria-busy="true"
         aria-label={t('imagePending')}
       >
@@ -88,7 +88,7 @@ export function LessonImage({ lessonId, language }: LessonImageProps) {
 
   return (
     <>
-      <div className="w-full max-w-[512px] mx-auto my-6">
+      <div className="w-full my-6">
         <button
           type="button"
           className="w-full rounded-lg overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 min-h-11"
@@ -101,7 +101,7 @@ export function LessonImage({ lessonId, language }: LessonImageProps) {
             width={512}
             height={512}
             loading="lazy"
-            sizes="(max-width: 640px) 100vw, 512px"
+            sizes="(max-width: 768px) 100vw, (max-width: 1024px) 90vw, 832px"
             unoptimized
             className={`w-full h-auto object-cover rounded-lg transition-opacity duration-300 ${
               isVisible ? 'opacity-100' : 'opacity-0'

--- a/frontend/components/learning/source-image.tsx
+++ b/frontend/components/learning/source-image.tsx
@@ -38,7 +38,7 @@ export function SourceImage({
 
   return (
     <>
-      <figure className="my-6 w-full max-w-[768px] mx-auto">
+      <figure className="my-6 w-full">
         <button
           type="button"
           className="w-full rounded-lg overflow-hidden border border-stone-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 min-h-11"
@@ -57,7 +57,7 @@ export function SourceImage({
             // from #1616 and #1857.
             width={1024}
             height={768}
-            sizes="(max-width: 768px) 100vw, 768px"
+            sizes="(max-width: 768px) 100vw, (max-width: 1024px) 90vw, 832px"
             loading="lazy"
             unoptimized
             className={`w-full h-auto object-contain rounded-lg transition-opacity duration-300 ${

--- a/frontend/components/learning/unit-nav.tsx
+++ b/frontend/components/learning/unit-nav.tsx
@@ -1,0 +1,66 @@
+import { getTranslations } from 'next-intl/server';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { Link } from '@/i18n/routing';
+
+interface NavUnit {
+  unit_number: string;
+  title_fr: string;
+  title_en: string;
+}
+
+interface UnitNavProps {
+  moduleId: string;
+  prev: NavUnit | null;
+  next: NavUnit | null;
+  language: 'fr' | 'en';
+}
+
+export async function UnitNav({ moduleId, prev, next, language }: UnitNavProps) {
+  if (!prev && !next) return null;
+
+  const t = await getTranslations('UnitPage');
+
+  const prevTitle = prev ? (language === 'fr' ? prev.title_fr : prev.title_en) : '';
+  const nextTitle = next ? (language === 'fr' ? next.title_fr : next.title_en) : '';
+
+  const linkClass =
+    'flex-1 sm:flex-none min-h-11 inline-flex items-center gap-2 rounded-lg border border-stone-200 bg-white px-4 py-2 text-stone-700 hover:bg-stone-50 hover:border-stone-300 transition-colors max-w-full sm:max-w-[45%]';
+
+  return (
+    <nav className="mt-8 flex items-center justify-between gap-3">
+      {prev ? (
+        <Link
+          href={`/modules/${moduleId}/units/${prev.unit_number}`}
+          className={linkClass}
+        >
+          <ChevronLeft className="w-4 h-4 shrink-0" />
+          <span className="flex flex-col items-start min-w-0">
+            <span className="text-xs text-stone-500">{t('previous')}</span>
+            <span className="hidden sm:block text-sm font-medium truncate max-w-full">
+              {prevTitle}
+            </span>
+          </span>
+        </Link>
+      ) : (
+        <div />
+      )}
+
+      {next ? (
+        <Link
+          href={`/modules/${moduleId}/units/${next.unit_number}`}
+          className={`${linkClass} justify-end text-right ml-auto`}
+        >
+          <span className="flex flex-col items-end min-w-0">
+            <span className="text-xs text-stone-500">{t('next')}</span>
+            <span className="hidden sm:block text-sm font-medium truncate max-w-full">
+              {nextTitle}
+            </span>
+          </span>
+          <ChevronRight className="w-4 h-4 shrink-0" />
+        </Link>
+      ) : (
+        <div />
+      )}
+    </nav>
+  );
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -808,7 +808,9 @@
     "countryFallback": "Content optimized for your region will be available shortly"
   },
   "UnitPage": {
-    "backToModule": "Back to {module}"
+    "backToModule": "Back to {module}",
+    "previous": "Previous",
+    "next": "Next"
   },
   "BilingualTooltip": {
     "french": "French",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1497,6 +1497,8 @@
         "reindexImagesError": "Image re-indexation failed.",
         "cancelIndexation": "Cancel indexation",
         "retryIndexation": "Retry indexation",
+        "conflictTitle": "Indexation task already active",
+        "resetAndRetry": "Reset and retry indexation",
         "staleWarning": "No progress detected for over 60 seconds. The task may be stuck.",
         "cancelError": "Failed to cancel indexation.",
         "cancelSuccess": "Indexation cancelled. You can restart it."

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1497,6 +1497,8 @@
         "reindexImagesError": "La ré-indexation des images a échoué.",
         "cancelIndexation": "Annuler l'indexation",
         "retryIndexation": "Relancer l'indexation",
+        "conflictTitle": "Tâche d'indexation déjà active",
+        "resetAndRetry": "Réinitialiser et relancer l'indexation",
         "staleWarning": "Aucune progression détectée depuis plus de 60 secondes. La tâche est peut-être bloquée.",
         "cancelError": "Impossible d'annuler l'indexation.",
         "cancelSuccess": "Indexation annulée. Vous pouvez la relancer."

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -808,7 +808,9 @@
     "countryFallback": "Le contenu adapté à votre région sera disponible prochainement"
   },
   "UnitPage": {
-    "backToModule": "Retour à {module}"
+    "backToModule": "Retour à {module}",
+    "previous": "Précédent",
+    "next": "Suivant"
   },
   "BilingualTooltip": {
     "french": "Français",


### PR DESCRIPTION
## Summary

Standard post-squash cleanup: brings the `--squash` commit from #2127 (and earlier main-only hotfixes) back into `dev` so `dev`'s next branch doesn't phantom-conflict.

Triggered by the dev→main squash in #2127 (29c1d0e7). Before this, `main` is 7 ahead of `dev` and `dev` is 171 behind in commit count (squash collapses the count).

This is the recurring pattern documented in prior commits like "Merge main into dev — resolve phantom conflicts from squash sync".

## Test plan

- [ ] CI green on `dev` after merge
- [ ] Next feature branch off `dev` does not show phantom conflicts against `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)