### PR TITLE
fix(pwa): exclude /api/v1/progress/ from SW StaleWhileRevalidate (#2140)

### DIFF
--- a/frontend/sw.ts
+++ b/frontend/sw.ts
@@ -18,7 +18,7 @@ declare const self: ServiceWorkerGlobalScope;
 const DAY_IN_SECONDS = 24 * 60 * 60;
 
 // Bump when storage shape or routing changes so clients drop stale caches.
-const CACHE_VERSION = "v4-quiz-hydration-race-fix";
+const CACHE_VERSION = "v5-progress-no-cache";
 
 const OFFLINE_FALLBACK_URL = "/offline.html";
 
@@ -94,6 +94,10 @@ const serwist = new Serwist({
         // Same class as #1908: SWR serves the stale conversation list
         // after a delete, so the deleted row appears to come back.
         if (url.pathname.startsWith("/api/v1/tutor/")) return false;
+        // Same class as #1908: after a backend status flip (e.g. #2125
+        // unlocking modules), SWR serves the cached "locked" body and
+        // learners still see the old gating UI.
+        if (url.pathname.startsWith("/api/v1/progress/")) return false;
         if (url.pathname.startsWith("/api/")) return true;
         return false;
       },


### PR DESCRIPTION
## Summary

After #2125 / #2126 deployed and migration 088 relaxed 428 \`locked\` rows to \`not_started\`, learners on existing courses still saw modules 2..N as locked. Backend was correct; the SW was serving the cached pre-deploy \`status: "locked"\` body.

\`frontend/sw.ts:86-99\` catches \`/api/v1/progress/modules\` under \`StaleWhileRevalidate\` (1-day expiration). Adding \`/api/v1/progress/\` to the exclusion list, next to the existing \`/users/\`, \`/auth/\`, \`/tutor/\` exclusions documented as "same class as #1908". Bumping \`CACHE_VERSION\` to \`v5-progress-no-cache\` so the stale \`api-responses-v4-*\` cache is dropped on first SW activation.

Fixes #2140

## Test plan

- [ ] After deploy: existing learner reloads \`/fr/modules?courseId=...\` → modules 2..N show as accessible (no lock icon, no "Prérequis nécessaires").
- [ ] Network tab confirms \`/api/v1/progress/modules\` is fetched fresh, not served from SW cache.
- [ ] No regression on offline mode for other endpoints (lessons, modules detail) — those continue to use SWR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)