### PR TITLE
fix(modules): map API 'not_started' to UI 'not-started' (#2143)

### DIFF
--- a/frontend/components/learning/module-map.tsx
+++ b/frontend/components/learning/module-map.tsx
@@ -18,6 +18,8 @@ function apiProgressToModule(p: ModuleProgressResponse): Module {
       ? 'completed'
       : apiStatus === 'in_progress'
       ? 'in-progress'
+      : apiStatus === 'not_started'
+      ? 'not-started'
       : 'locked';
 
   return {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -185,7 +185,7 @@ export interface ModuleProgressResponse {
   description_en?: string | null;
   level: number;
   estimated_hours: number;
-  status: "locked" | "in_progress" | "completed";
+  status: "locked" | "not_started" | "in_progress" | "completed";
   completion_pct: number;
   quiz_score_avg: number | null;
   time_spent_minutes: number;
@@ -215,7 +215,7 @@ export interface ModuleDetailWithProgressResponse {
   description_en?: string;
   estimated_hours: number;
   prereq_modules: string[];
-  status: "locked" | "in_progress" | "completed";
+  status: "locked" | "not_started" | "in_progress" | "completed";
   completion_pct: number;
   quiz_score_avg: number | null;
   time_spent_minutes: number;

--- a/frontend/lib/modules.ts
+++ b/frontend/lib/modules.ts
@@ -1,4 +1,4 @@
-export type ModuleStatus = 'locked' | 'in-progress' | 'completed';
+export type ModuleStatus = 'locked' | 'not-started' | 'in-progress' | 'completed';
 export type UnitStatus = 'pending' | 'in-progress' | 'completed';
 
 export interface Unit {


### PR DESCRIPTION
## Summary

Fixes the missing piece of #2125. The backend correctly returns \`status: "not_started"\` for accessible-but-untouched modules, but the frontend's \`apiProgressToModule\` mapping at \`module-map.tsx:14-22\` squashed any unknown API status to \`'locked'\`, re-triggering the lock UI we meant to remove.

**Verified live on staging** as e2e-learner: \`GET /api/v1/progress/modules\` returns \`{ in_progress: 16, not_started: 258, locked: 0 }\` — backend is correct. UI rendered 152 "Prérequis nécessaires" before this fix because of the mapping bug.

Fixes #2143

## Changes

- \`frontend/lib/modules.ts\` — extend \`ModuleStatus\` to include \`'not-started'\`
- \`frontend/lib/api.ts\` — add \`"not_started"\` to the literal union on \`ModuleProgressResponse.status\` and \`ModuleDetailWithProgressResponse.status\`
- \`frontend/components/learning/module-map.tsx\` — add \`'not_started'\` → \`'not-started'\` branch in \`apiProgressToModule\`. Keep \`'locked'\` as the fallback for legacy persisted rows.

\`module-card.tsx\` / \`module-lock-gate.tsx\` need no changes — their lock branches are explicit \`status === 'locked'\` checks; \`'not-started'\` falls through to the default "Commencer" button.

## Test plan

- [x] Backend status returns the right values (verified on staging)
- [ ] Post-deploy: e2e-learner reloads \`/fr/modules\` → 0 "Prérequis nécessaires" banners; all "Commencer" / "Continuer" / "Revoir" buttons render based on actual status
- [ ] Re-run the API probe: \`statusBreakdown\` matches what the UI shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)