### PR TITLE
fix(pwa): pre-warm SW page cache so downloaded modules render offline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ node_modules/
 out/
 .turbo/
 
+# Serwist build output (emitted by `next build` from frontend/sw.ts)
+frontend/public/sw.js
+frontend/public/sw.js.map
+frontend/public/swe-worker-*.js
+
 # Environment
 .env
 .env.local

--- a/frontend/components/shared/enrollment-guard.tsx
+++ b/frontend/components/shared/enrollment-guard.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "@/i18n/routing";
 import { useLocale, useTranslations } from "next-intl";
 import { API_BASE } from "@/lib/api";
+import { getOfflineModule } from "@/lib/offline/db";
 
 interface EnrollmentGuardProps {
   moduleId: string;
@@ -50,6 +51,17 @@ export function EnrollmentGuard({ moduleId, children }: EnrollmentGuardProps) {
 
   useEffect(() => {
     if (guardStatus === "allowed") return;
+
+    // Offline + module already downloaded → trust the prior enrollment check.
+    // /api/v1/progress/* is intentionally excluded from SW caching, so we
+    // can't reach the server; gating on the IndexedDB download record both
+    // unblocks the offline path and keeps non-downloaded modules locked.
+    if (typeof navigator !== "undefined" && !navigator.onLine) {
+      getOfflineModule(moduleId).then((mod) => {
+        setGuardStatus(mod?.status === "downloaded" ? "allowed" : "denied");
+      });
+      return;
+    }
 
     const token =
       typeof window !== "undefined" ? localStorage.getItem("access_token") : null;

--- a/frontend/lib/offline/download-manager.ts
+++ b/frontend/lib/offline/download-manager.ts
@@ -269,6 +269,12 @@ export async function downloadModule(
         sizeBytes: estimatedSize,
         updatedAt: Date.now(),
       });
+
+      // Pre-warm the SW page cache with the rendered unit page so an offline
+      // navigation here is served from cache instead of falling through to
+      // /offline.html. The IndexedDB-backed viewer hydrates inside the cached
+      // HTML via content-loader.
+      await prewarmPage(`/${locale}/modules/${moduleId}/units/${unitId}`);
     }
 
     // Step 3: Download module-level flashcards
@@ -303,6 +309,10 @@ export async function downloadModule(
       downloadedAt: Date.now(),
       updatedAt: Date.now(),
     });
+
+    // Pre-warm the module landing too, so reaching it offline doesn't bounce
+    // to /offline.html before the user can navigate to a unit.
+    await prewarmPage(`/${locale}/modules/${moduleId}`);
 
     emit({ phase: "complete", totalUnits, downloadedUnits: totalUnits });
   } catch (err: unknown) {
@@ -445,5 +455,29 @@ async function downloadUnitQuiz(
   } catch (err: unknown) {
     if (err instanceof DOMException && err.name === "AbortError") throw err;
     console.warn(`Failed to download quiz for ${unitId}:`, err);
+  }
+}
+
+// Cache name MUST stay aligned with `pages-${CACHE_VERSION}` in frontend/sw.ts.
+// Bump both together when changing.
+const PAGES_CACHE_NAME = "pages-v6-offline-routes";
+
+/**
+ * Pre-fetch a same-origin page and stash it in the SW page cache so an offline
+ * navigation hits cache instead of falling through to /offline.html.
+ *
+ * Failures are swallowed — pre-warm is best-effort and must never fail a
+ * download.
+ */
+export async function prewarmPage(url: string): Promise<void> {
+  try {
+    if (typeof caches === "undefined") return;
+    const cache = await caches.open(PAGES_CACHE_NAME);
+    const res = await fetch(url, { credentials: "include" });
+    if (res.ok) {
+      await cache.put(url, res.clone());
+    }
+  } catch {
+    // best-effort
   }
 }

--- a/frontend/lib/offline/sync-manager.ts
+++ b/frontend/lib/offline/sync-manager.ts
@@ -10,9 +10,14 @@ import {
   getPendingOfflineActions,
   markOfflineActionSynced,
   clearSyncedActions,
+  getOfflineModulesByStatus,
+  getOfflineContentByModule,
   type OfflineAction,
 } from './db';
 import { apiFetch } from '@/lib/api';
+import { prewarmPage } from './download-manager';
+
+const PREWARM_V6_DONE_KEY = 'offline_prewarm_v6_done';
 
 export type SyncStatus =
   | { state: 'idle' }
@@ -47,8 +52,16 @@ class SyncManager {
 
     this.onlineHandler = () => {
       this.syncNow();
+      this.runV6PrewarmMigration();
     };
     window.addEventListener('online', this.onlineHandler);
+
+    // Also run on startup in case the app is already online — covers the
+    // common case where a v5 user opens the app online without a network
+    // toggle.
+    if (typeof navigator !== 'undefined' && navigator.onLine) {
+      this.runV6PrewarmMigration();
+    }
   }
 
   /** Clean up event listener. */
@@ -111,6 +124,45 @@ class SyncManager {
 
     this.isSyncing = false;
     return { synced, failed };
+  }
+
+  /**
+   * One-shot migration for users who downloaded a module under SW v5.
+   * Their IndexedDB has the unit content but the v6 SW page cache is empty,
+   * so an offline navigation falls through to /offline.html. This re-runs
+   * the page pre-warm once so they get the same offline experience as
+   * users who download fresh under v6.
+   */
+  async runV6PrewarmMigration(): Promise<void> {
+    if (typeof window === 'undefined') return;
+    try {
+      if (localStorage.getItem(PREWARM_V6_DONE_KEY)) return;
+      if (typeof navigator !== 'undefined' && !navigator.onLine) return;
+
+      const modules = await getOfflineModulesByStatus('downloaded');
+      for (const mod of modules) {
+        const entries = await getOfflineContentByModule(mod.moduleId);
+        const flashcardKey = `__module_${mod.moduleId}__`;
+        const seen = new Set<string>();
+        for (const entry of entries) {
+          if (entry.unitId === flashcardKey) continue;
+          const key = `${entry.locale}|${entry.unitId}`;
+          if (seen.has(key)) continue;
+          seen.add(key);
+          await prewarmPage(
+            `/${entry.locale}/modules/${mod.moduleId}/units/${entry.unitId}`,
+          );
+        }
+        // Pre-warm the module landing in each locale we have content for.
+        const locales = new Set(entries.map((e) => e.locale));
+        for (const loc of locales) {
+          await prewarmPage(`/${loc}/modules/${mod.moduleId}`);
+        }
+      }
+      localStorage.setItem(PREWARM_V6_DONE_KEY, '1');
+    } catch {
+      // best-effort; failure must not break sync
+    }
   }
 
   // --- Private ---

--- a/frontend/sw.ts
+++ b/frontend/sw.ts
@@ -18,7 +18,10 @@ declare const self: ServiceWorkerGlobalScope;
 const DAY_IN_SECONDS = 24 * 60 * 60;
 
 // Bump when storage shape or routing changes so clients drop stale caches.
-const CACHE_VERSION = "v5-progress-no-cache";
+// v6 adds an ExpirationPlugin to the pages cache and is pre-warmed by
+// frontend/lib/offline/download-manager.ts (PAGES_CACHE_NAME constant must
+// match `pages-${CACHE_VERSION}`) so downloaded modules render offline.
+const CACHE_VERSION = "v6-offline-routes";
 
 const OFFLINE_FALLBACK_URL = "/offline.html";
 
@@ -116,6 +119,13 @@ const serwist = new Serwist({
       handler: new NetworkFirst({
         cacheName: `pages-${CACHE_VERSION}`,
         networkTimeoutSeconds: 3,
+        plugins: [
+          new ExpirationPlugin({
+            maxEntries: 60,
+            maxAgeSeconds: 30 * DAY_IN_SECONDS,
+            purgeOnQuotaError: true,
+          }),
+        ],
       }),
     },
   ],


### PR DESCRIPTION
## Summary

PR #2146 fixed the missing `/sw.js` (SW now registers on staging), but a follow-up bug surfaced: a user downloads a course module, goes offline, navigates to a unit page, and still sees the static "No Connection" `/offline.html` page instead of the cached lesson.

Root cause:
1. `frontend/lib/offline/download-manager.ts` only writes JSON to IndexedDB, never to the SW Cache API. So `pages-${CACHE_VERSION}` is empty for the unit URL, NetworkFirst misses, and `fallbacks.entries` returns `/offline.html`.
2. Even if the cache had the page, `EnrollmentGuard` calls `/api/v1/progress/modules/...` (intentionally SW-excluded — sw.ts:100), fails offline, and shows the lock screen.
3. The IndexedDB-aware client viewers (`LessonViewer`, etc.) already handle offline correctly via `content-loader.ts` — they were unreachable, not broken.

## Changes

- **`frontend/lib/offline/download-manager.ts`** — new `prewarmPage()` helper that fetches the rendered unit-page HTML and module-landing HTML and stores them in `pages-v6-offline-routes`. Called per-unit and once for the module landing inside `downloadModule()`. Best-effort, swallows failures.
- **`frontend/sw.ts`** — bump `CACHE_VERSION` to `v6-offline-routes`. Add `ExpirationPlugin{maxEntries:60, maxAgeSeconds:30d, purgeOnQuotaError:true}` to the navigation `NetworkFirst` handler so pre-warmed pages survive quota pressure on low-storage mobile devices.
- **`frontend/components/shared/enrollment-guard.tsx`** — short-circuit to `"allowed"` when `!navigator.onLine` AND `getOfflineModule(moduleId).status === "downloaded"`. Online enrollment enforcement and non-downloaded offline lockout both preserved.
- **`frontend/lib/offline/sync-manager.ts`** — one-shot v6 migration on `online` event (and on startup if already online) that re-prewarms pages for v5 downloads. Gated by `localStorage.offline_prewarm_v6_done`.
- **`.gitignore`** — ignore `frontend/public/sw.js{,.map}` build artifacts.

## Test plan

- [x] Local: `npm run build` emits `public/sw.js` (57 KB) containing `v6-offline-routes` and the new `ExpirationPlugin` on the pages cache; zero references to old `v5-progress-no-cache`.
- [ ] Staging post-deploy: `curl -s https://etutor.elearning.portfolio2.kimbetien.com/sw.js | grep -o 'v6-offline-routes' | head -1` matches.
- [ ] Staging post-deploy: log in, download a module, then DevTools → Application → Cache Storage → confirm `pages-v6-offline-routes` contains `/fr/modules/{id}` and `/fr/modules/{id}/units/{unit}`.
- [ ] Staging post-deploy: DevTools → Offline + hard reload a unit URL → expect cached lesson, no `/offline.html`, no enrollment lock screen. `LessonViewer` logs `source: "indexeddb"`.
- [ ] Staging post-deploy: DevTools → Offline + a *non-downloaded* module URL → expect `/offline.html` (sanity check).
- [ ] Staging post-deploy: toggle Online → confirm one-shot v6 migration runs (`localStorage["offline_prewarm_v6_done"] === "1"`).

## Out of scope

Encrypted offline bundles (#909), offline JWT validation (#910), refactoring the unit-page server component into a client shell (avoided by pre-warming), backend changes.

https://claude.ai/code/session_01HunUdcmBSvuhxE2CnY4b5A

---
_Generated by [Claude Code](https://claude.ai/code/session_01HunUdcmBSvuhxE2CnY4b5A)_