### PR TITLE
feat(e2e): org-owner persona specs (#2116-2/5)

### DIFF
--- a/frontend/e2e/pages/org-page.ts
+++ b/frontend/e2e/pages/org-page.ts
@@ -1,0 +1,59 @@
+/**
+ * Page object for /[locale]/org/{slug} and its sub-routes.
+ *
+ * Thin wrapper — locators only.
+ *
+ * Routes covered (verified during 2026-04-30 sweep — all 200):
+ *   /fr/org/{slug}                org dashboard (stats, quick links)
+ *   /fr/org/{slug}/courses        course list
+ *   /fr/org/{slug}/curricula      curriculum list
+ *   /fr/org/{slug}/qbank          question banks
+ *   /fr/org/{slug}/codes          activation codes
+ *   /fr/org/{slug}/reports        learner reports
+ *   /fr/org/{slug}/members        org members
+ */
+
+import type { Locator, Page } from '@playwright/test';
+
+export class OrgPage {
+  constructor(public readonly page: Page) {}
+
+  async gotoDashboard(slug: string, locale: 'fr' | 'en' = 'fr'): Promise<void> {
+    await this.page.goto(`/${locale}/org/${slug}`);
+  }
+
+  async gotoCourses(slug: string, locale: 'fr' | 'en' = 'fr'): Promise<void> {
+    await this.page.goto(`/${locale}/org/${slug}/courses`);
+  }
+
+  async gotoCodes(slug: string, locale: 'fr' | 'en' = 'fr'): Promise<void> {
+    await this.page.goto(`/${locale}/org/${slug}/codes`);
+  }
+
+  async gotoMembers(slug: string, locale: 'fr' | 'en' = 'fr'): Promise<void> {
+    await this.page.goto(`/${locale}/org/${slug}/members`);
+  }
+
+  /** Org-name heading on the dashboard view. */
+  heading(): Locator {
+    return this.page.locator('main h1');
+  }
+
+  /** Stat tile by label (e.g. "Total codes", "Apprenants total"). */
+  statTile(label: string): Locator {
+    return this.page.locator('main', { hasText: label });
+  }
+
+  /** Course card by slug (the slug is rendered as a link href). */
+  courseLink(slug: string): Locator {
+    return this.page.locator(`main a[href*="/courses/"][href$="${slug}"], main a[href*="/${slug}"]`);
+  }
+
+  /**
+   * Activation code row by code value.
+   * Matches any element whose text contains the code (the table cell or chip).
+   */
+  activationCodeRow(code: string): Locator {
+    return this.page.locator('main').getByText(code, { exact: true });
+  }
+}

--- a/frontend/e2e/specs/03-org-owner/nav.spec.ts
+++ b/frontend/e2e/specs/03-org-owner/nav.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Org-owner sidebar nav — verifies role-scoped UI gating.
+ *
+ * The org-owner is a `role=user` who owns at least one organization. Per the
+ * role-model pivot (#2134, project_role_model_pivot.md), this is the new
+ * canonical "expert" — their elevated capabilities come from
+ * OrgMemberRole.owner, not from a platform UserRole.
+ *
+ * Expected sidebar shape:
+ *   - all 9 learner links visible (Dashboard / Formations / Modules / etc.)
+ *   - "Organisations" visible (they own one)
+ *   - "Administration" hidden (platform-admin gating, not theirs)
+ *
+ * Server-side RBAC for admin endpoints was independently verified during the
+ * 2026-04-30 sweep — this spec catches frontend nav-gating regressions
+ * specifically.
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { DashboardPage } from '../../pages/dashboard-page';
+
+test.describe('@org-owner nav', () => {
+  test.fixme(
+    'sidebar shows Organisations link (user has org membership) — BLOCKED on #2137',
+    async ({ page }) => {
+      const dashboard = new DashboardPage(page);
+      await dashboard.goto('fr');
+
+      // Today this fails because frontend/components/layout/sidebar.tsx:163-172
+      // gates Organisations on `userRole === "admin" || userRole === "sub_admin"`
+      // — explicitly NOT on expert or on "user with org membership". So a
+      // role=user org-owner (the new canonical "expert" per role-model pivot
+      // #2134) does NOT see the link.
+      //
+      // The frontend phase of the migration (#2137) replaces that gating with
+      // a "user has at least one OrgMembership" check. When that lands,
+      // remove the .fixme — this test should pass.
+      await expect(
+        dashboard.sidebarLink('Organisations'),
+        'expected Organisations link visible for an org-member user (post-migration target state)',
+      ).toBeVisible();
+    },
+  );
+
+  test('sidebar hides Administration link (org-owner is not platform admin)', async ({ page }) => {
+    const dashboard = new DashboardPage(page);
+    await dashboard.goto('fr');
+
+    await expect(
+      dashboard.sidebarLink('Administration'),
+      'expected Administration link hidden for an org-owner who is not role=admin',
+    ).toHaveCount(0);
+  });
+});

--- a/frontend/e2e/specs/03-org-owner/org-codes.spec.ts
+++ b/frontend/e2e/specs/03-org-owner/org-codes.spec.ts
@@ -1,0 +1,22 @@
+/**
+ * Org-owner activation codes view — /[locale]/org/{slug}/codes lists
+ * activation codes scoped to the org. Seeded code: E2E-FIXTURE-CODE
+ * (see SEED_ACTIVATION_CODE in fixtures/seed-data.ts).
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { OrgPage } from '../../pages/org-page';
+import { SEED_ACTIVATION_CODE, SEED_ORG } from '../../fixtures/seed-data';
+
+test.describe('@org-owner activation codes', () => {
+  test('lists the seeded fixture activation code', async ({ page }) => {
+    const org = new OrgPage(page);
+    await org.gotoCodes(SEED_ORG.slug, 'fr');
+
+    await expect(
+      page.getByText(SEED_ACTIVATION_CODE, { exact: false }).first(),
+      `expected activation code "${SEED_ACTIVATION_CODE}" visible in org's codes list`,
+    ).toBeVisible();
+  });
+});

--- a/frontend/e2e/specs/03-org-owner/org-courses.spec.ts
+++ b/frontend/e2e/specs/03-org-owner/org-courses.spec.ts
@@ -1,0 +1,24 @@
+/**
+ * Org-owner courses view — /[locale]/org/{slug}/courses lists the org's
+ * courses (e2e-published-course + e2e-draft-course from the #2109 seed).
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { OrgPage } from '../../pages/org-page';
+import { SEED_COURSES, SEED_ORG } from '../../fixtures/seed-data';
+
+test.describe('@org-owner courses', () => {
+  test('lists both seeded courses (published + draft)', async ({ page }) => {
+    const org = new OrgPage(page);
+    await org.gotoCourses(SEED_ORG.slug, 'fr');
+
+    // Match by visible title — seed sets title to "E2E — {slug}".
+    for (const slug of [SEED_COURSES.published.slug, SEED_COURSES.draft.slug]) {
+      await expect(
+        page.getByText(`E2E — ${slug}`, { exact: false }).first(),
+        `expected course "${slug}" visible in org's courses list`,
+      ).toBeVisible();
+    }
+  });
+});

--- a/frontend/e2e/specs/03-org-owner/org-dashboard.spec.ts
+++ b/frontend/e2e/specs/03-org-owner/org-dashboard.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Org-owner dashboard — /[locale]/org/{slug} renders the org's dashboard
+ * with the org name as h1 and stat tiles.
+ *
+ * Fixture: e2e-test-org (slug from #2109 seed, see SEED_ORG in fixtures/seed-data.ts).
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { OrgPage } from '../../pages/org-page';
+import { SEED_ORG } from '../../fixtures/seed-data';
+
+test.describe('@org-owner dashboard', () => {
+  test('renders the org name as h1', async ({ page }) => {
+    const org = new OrgPage(page);
+    await org.gotoDashboard(SEED_ORG.slug, 'fr');
+
+    await expect(org.heading()).toHaveText(SEED_ORG.name, { ignoreCase: true });
+  });
+
+  test('shows the standard org stat tiles (codes, apprenants, complétion, crédits)', async ({
+    page,
+  }) => {
+    const org = new OrgPage(page);
+    await org.gotoDashboard(SEED_ORG.slug, 'fr');
+
+    // Stat tile labels confirmed during the 2026-04-30 sweep.
+    for (const label of ['Total codes', 'Apprenants total', 'Complétion', 'Crédits']) {
+      await expect(
+        page.getByText(label, { exact: false }).first(),
+        `expected stat tile "${label}" visible on org dashboard`,
+      ).toBeVisible();
+    }
+  });
+
+  test('navigates from /fr/organizations index to the org dashboard', async ({ page }) => {
+    await page.goto('/fr/organizations');
+
+    // The org-owner sees their org listed as a card with "Propriétaire" badge.
+    const orgCard = page.locator('main a').filter({ hasText: SEED_ORG.name });
+    await expect(orgCard).toBeVisible();
+
+    // Click through to /fr/org/{slug}.
+    await orgCard.click();
+    await expect(page).toHaveURL(new RegExp(`/fr/org/${SEED_ORG.slug}/?$`));
+  });
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -64,8 +64,9 @@ export default defineConfig({
     },
     personaProject('01-anonymous'),
     personaProject('02-learner'),
-    // 03-org-owner / 04-sub-admin / 05-admin: declared in follow-up PRs
-    // (2116-2..2116-4) once their spec dirs exist.
+    personaProject('03-org-owner'),
+    // 04-sub-admin / 05-admin: declared in follow-up PRs (2116-3..2116-4)
+    // once their spec dirs exist.
   ],
 
   webServer:


### PR DESCRIPTION
## Summary

PR 2 of 5 for issue #2116. Adds the **03-org-owner** persona suite. **Stacked on #2153** (2116-1 scaffolding) — that must merge first; this PR's base branch is the 2116-1 PR branch, retarget to `dev` after #2153 lands.

5 specs, 1 page object, 1-line config update:

- [`pages/org-page.ts`](frontend/e2e/pages/org-page.ts) — thin POM for `/fr/org/{slug}` + sub-routes (`/courses`, `/codes`, `/members`)
- [`specs/03-org-owner/nav.spec.ts`](frontend/e2e/specs/03-org-owner/nav.spec.ts) — sidebar gating (Organisations link, Administration hidden)
- [`specs/03-org-owner/org-dashboard.spec.ts`](frontend/e2e/specs/03-org-owner/org-dashboard.spec.ts) — h1, stat tiles, navigation from `/fr/organizations`
- [`specs/03-org-owner/org-courses.spec.ts`](frontend/e2e/specs/03-org-owner/org-courses.spec.ts) — published + draft course visibility
- [`specs/03-org-owner/org-codes.spec.ts`](frontend/e2e/specs/03-org-owner/org-codes.spec.ts) — `E2E-FIXTURE-CODE` listed
- [`playwright.config.ts`](frontend/playwright.config.ts) — registers `03-org-owner` project

## Real bug found during canary

The "Organisations" sidebar link is gated on `userRole === "admin" || userRole === "sub_admin"` in [`frontend/components/layout/sidebar.tsx:163-172`](frontend/components/layout/sidebar.tsx#L163-L172) — explicitly NOT on `expert` or "user with org membership". So a `role=user` org-owner (the new canonical "expert" per role-model pivot #2134) does **NOT** see the link to their own org from the sidebar.

This is exactly what frontend phase #2137 of the migration epic is meant to fix. The test is marked `test.fixme` with a clear comment pointing at #2137 — when that PR lands and replaces the role-keyed gate with a "user has at least one OrgMembership" check, deleting `.fixme` should turn this test green automatically.

The `Administration` link gate is also wrong (#2137 will fix it too) but that test currently passes because the org-owner is `role=user`, not `expert`. So today's behavior matches my expectation that admin nav stays hidden.

## Test plan

- [x] **Headed run** (per user request, watching the org-owner journey):
      `--project=setup --project=03-org-owner --headed --workers=1` → 5 pass + 1 fixme
- [x] **Full suite** (01+02+03 + setup): 18 pass + 1 fixme in ~18s
- [x] No regression to existing flat specs (still under chromium/mobile-chrome with `testIgnore`)

## Stacking note

This PR is targeted at `feat/issue-2116-1-playwright-suite-scaffolding` (the 2116-1 PR branch). Once #2153 merges to `dev`, **retarget this PR's base to `dev`** (`gh pr edit 2154 --base dev`) so it can land cleanly. Until then, the diff shown is correctly only the 2116-2 incremental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)