### PR TITLE
feat(e2e): sub_admin persona specs (#2116-3/5)

### DIFF
--- a/frontend/e2e/auth.setup.ts
+++ b/frontend/e2e/auth.setup.ts
@@ -21,6 +21,12 @@ import path from 'node:path';
 
 import { applyAuthToLocalStorage, loginViaApi, PERSONAS, type Persona } from './fixtures/auth';
 
+// Serial mode — running 4 persona setup tests in parallel races on
+// page.context().storageState() and some files end up missing localStorage
+// entries set by an earlier evaluate. Serial setup keeps all 4 outputs
+// complete; total cost ~6s vs the parallel cost of flaky CI.
+setup.describe.configure({ mode: 'serial' });
+
 const STAGING_URL =
   process.env.STAGING_URL ?? 'https://etutor.elearning.portfolio2.kimbetien.com';
 

--- a/frontend/e2e/specs/04-sub-admin/admin-pages.spec.ts
+++ b/frontend/e2e/specs/04-sub-admin/admin-pages.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * Sub_admin admin-page reachability — confirms sub_admin can navigate to and
+ * load the admin pages they're authorized for.
+ *
+ * Per `backend/app/api/v1/admin_*.py`, sub_admin is included in
+ * `require_role(UserRole.admin, UserRole.sub_admin)` for users / courses /
+ * curricula / taxonomy / groups / payments / audit-logs / analytics / qbank.
+ * Only `/admin/settings/*` is admin-only — covered by settings-403.spec.ts.
+ */
+
+import { expect, test } from '@playwright/test';
+
+test.describe('@sub-admin admin pages', () => {
+  test('/fr/admin/users renders user-management page', async ({ page }) => {
+    await page.goto('/fr/admin/users');
+    await expect(page.locator('main h1')).toContainText(/utilisateurs|user/i);
+  });
+
+  test('/fr/admin/courses renders course-management page', async ({ page }) => {
+    await page.goto('/fr/admin/courses');
+    await expect(page.locator('main h1')).toContainText(/formations|courses/i);
+  });
+
+  test('/fr/admin/curricula renders curriculum-management page', async ({ page }) => {
+    await page.goto('/fr/admin/curricula');
+    await expect(page.locator('main h1')).toContainText(/curricula/i);
+  });
+
+  test('/fr/admin/taxonomy renders taxonomy page', async ({ page }) => {
+    await page.goto('/fr/admin/taxonomy');
+    await expect(page.locator('main h1')).toContainText(/taxonom/i);
+  });
+});

--- a/frontend/e2e/specs/04-sub-admin/nav.spec.ts
+++ b/frontend/e2e/specs/04-sub-admin/nav.spec.ts
@@ -1,0 +1,27 @@
+/**
+ * Sub_admin sidebar nav — verifies role-scoped UI.
+ *
+ * Sub_admin sees the same admin nav links as admin (Administration,
+ * Organisations, QBank-author) but the API gates `/admin/settings/*`
+ * to UserRole.admin only — that's the canary in settings-403.spec.ts.
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { DashboardPage } from '../../pages/dashboard-page';
+
+test.describe('@sub-admin nav', () => {
+  test('sidebar shows Administration link', async ({ page }) => {
+    const dashboard = new DashboardPage(page);
+    await dashboard.goto('fr');
+
+    await expect(dashboard.sidebarLink('Administration')).toBeVisible();
+  });
+
+  test('sidebar shows Organisations link (admin/sub_admin gated)', async ({ page }) => {
+    const dashboard = new DashboardPage(page);
+    await dashboard.goto('fr');
+
+    await expect(dashboard.sidebarLink('Organisations')).toBeVisible();
+  });
+});

--- a/frontend/e2e/specs/04-sub-admin/settings-403.spec.ts
+++ b/frontend/e2e/specs/04-sub-admin/settings-403.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Sub_admin settings restriction — the distinguishing canary for this role.
+ *
+ * `backend/app/api/v1/admin_settings.py:57,71,99,125` gates ALL settings
+ * endpoints on `UserRole.admin` only — sub_admin is NOT included. This spec
+ * confirms the restriction holds at the API layer.
+ *
+ * Memory `project_saas_reseller` notes: "Phase 0 done (BACKEND_URL,
+ * sub_admin)" and #1365 added sub_admin specifically to restrict AI/prompt
+ * settings access. The current implementation is broader — sub_admin can't
+ * touch ANY settings — but that's the production state we want pinned.
+ */
+
+import { expect, test } from '@playwright/test';
+
+const STAGING_API =
+  process.env.STAGING_API ||
+  (process.env.STAGING_URL || 'https://etutor.elearning.portfolio2.kimbetien.com').replace(
+    /^https:\/\/etutor\./,
+    'https://api.',
+  );
+
+test.describe('@sub-admin settings restriction', () => {
+  // Navigate to origin first so localStorage is accessible (otherwise
+  // page.evaluate fires on about:blank and SecurityError-rejects the
+  // localStorage read).
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/fr/dashboard');
+  });
+
+  test('GET /api/v1/admin/settings returns 403 for sub_admin (admin-only endpoint)', async ({
+    page,
+  }) => {
+    const accessToken = await page.evaluate(() => localStorage.getItem('access_token'));
+    expect(accessToken, 'sub_admin storageState should include access_token').toBeTruthy();
+
+    const res = await page.request.get(`${STAGING_API}/api/v1/admin/settings`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    expect(res.status()).toBe(403);
+
+    const body = await res.json();
+    expect(body.detail).toMatch(/insufficient permissions|forbidden/i);
+  });
+
+  test('GET /api/v1/admin/users succeeds for sub_admin (allowed admin endpoint)', async ({
+    page,
+  }) => {
+    // Negative-control: confirm the 403 above isn't a generic "all admin
+    // routes are blocked" — sub_admin should reach /admin/users fine.
+    const accessToken = await page.evaluate(() => localStorage.getItem('access_token'));
+    const res = await page.request.get(`${STAGING_API}/api/v1/admin/users?offset=0&limit=1`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    expect(res.status()).toBe(200);
+  });
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -65,8 +65,8 @@ export default defineConfig({
     personaProject('01-anonymous'),
     personaProject('02-learner'),
     personaProject('03-org-owner'),
-    // 04-sub-admin / 05-admin: declared in follow-up PRs (2116-3..2116-4)
-    // once their spec dirs exist.
+    personaProject('04-sub-admin'),
+    // 05-admin: declared in 2116-4 once its spec dir exists.
   ],
 
   webServer:


### PR DESCRIPTION
## Summary

PR 3 of 5 for issue #2116. Adds the **04-sub-admin** persona suite. **Stacked on #2154** (which is stacked on #2153) — merge order: #2153 → #2154 → this. Retarget base to `dev` after both merge.

7 specs added (no new page object — reuses `DashboardPage` from #2153):

- [`specs/04-sub-admin/nav.spec.ts`](frontend/e2e/specs/04-sub-admin/nav.spec.ts) — sidebar shows Administration + Organisations links (both gated on `admin/sub_admin` in `sidebar.tsx`).
- [`specs/04-sub-admin/admin-pages.spec.ts`](frontend/e2e/specs/04-sub-admin/admin-pages.spec.ts) — `/fr/admin/{users,courses,curricula,taxonomy}` all reach correct h1.
- [`specs/04-sub-admin/settings-403.spec.ts`](frontend/e2e/specs/04-sub-admin/settings-403.spec.ts) — **the canary that distinguishes sub_admin from admin**: `GET /api/v1/admin/settings` returns 403 (admin-only per [`admin_settings.py:57`](backend/app/api/v1/admin_settings.py#L57)). Negative-control: `/admin/users` still 200s for the same JWT.

## Two snags fixed during dev (worth flagging)

1. **Setup race condition** — running the 4 persona setup tests in parallel raced on `page.context().storageState()`; some output files were missing localStorage entries set earlier. Added `setup.describe.configure({ mode: 'serial' })` to [`auth.setup.ts`](frontend/e2e/auth.setup.ts). Total setup cost ~6s vs flaky CI later. **This is a backport-worthy fix from PR1's scaffolding** — already part of this PR's diff since both `auth.setup.ts` and the new spec dir live in the stack.

2. **`localStorage` SecurityError on `about:blank`** — `settings-403` spec called `page.evaluate(() => localStorage.getItem(...))` before any navigation, which fires on `about:blank` and gets SecurityError. Added `test.beforeEach` with `page.goto('/fr/dashboard')` to bind the origin first.

## Test plan

- [x] **Headed run** (per user request): 13/13 pass with `--project=setup --project=04-sub-admin --headed --workers=1` against staging.
- [x] **Full suite** (01+02+03+04 + setup) headless: 26 pass + 1 fixme (the org-owner Organisations-link fixme from #2154, pending #2137) in ~26s.

## Stacking

Base: `feat/issue-2116-2-org-owner-specs`. Once #2153 and #2154 merge to `dev`, retarget this PR's base via `gh pr edit 2155 --base dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)