### PR TITLE
feat(e2e): admin persona specs (#2116-4/5)

### DIFF
--- a/frontend/e2e/specs/05-admin/admin-pages.spec.ts
+++ b/frontend/e2e/specs/05-admin/admin-pages.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * Admin admin-page reachability — confirms admin can navigate the admin
+ * panel. Same scope as sub_admin's reachability spec, plus the audit-logs +
+ * analytics + payments pages which are admin/sub_admin shared but were
+ * already verified in the sweep doc to render.
+ */
+
+import { expect, test } from '@playwright/test';
+
+test.describe('@admin admin pages', () => {
+  test('/fr/admin/users renders user-management page', async ({ page }) => {
+    await page.goto('/fr/admin/users');
+    await expect(page.locator('main h1')).toContainText(/utilisateurs|user/i);
+  });
+
+  test('/fr/admin/courses renders course-management page', async ({ page }) => {
+    await page.goto('/fr/admin/courses');
+    await expect(page.locator('main h1')).toContainText(/formations|courses/i);
+  });
+
+  test('/fr/admin/curricula renders curriculum-management page', async ({ page }) => {
+    await page.goto('/fr/admin/curricula');
+    await expect(page.locator('main h1')).toContainText(/curricula/i);
+  });
+
+  test('/fr/admin/audit-logs renders audit log page', async ({ page }) => {
+    await page.goto('/fr/admin/audit-logs');
+    await expect(page.locator('main h1')).toContainText(/audit|journal/i);
+  });
+
+  test('/fr/admin/analytics renders analytics page', async ({ page }) => {
+    await page.goto('/fr/admin/analytics');
+    await expect(page.locator('main h1')).toContainText(/analy/i);
+  });
+});

--- a/frontend/e2e/specs/05-admin/nav.spec.ts
+++ b/frontend/e2e/specs/05-admin/nav.spec.ts
@@ -1,0 +1,27 @@
+/**
+ * Admin sidebar nav — verifies the highest-privilege persona's nav.
+ *
+ * Admin sees the same admin nav links as sub_admin (Administration,
+ * Organisations, QBank-author). The distinguishing capability — settings
+ * page access — is covered by settings.spec.ts via direct API + UI checks.
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { DashboardPage } from '../../pages/dashboard-page';
+
+test.describe('@admin nav', () => {
+  test('sidebar shows Administration link', async ({ page }) => {
+    const dashboard = new DashboardPage(page);
+    await dashboard.goto('fr');
+
+    await expect(dashboard.sidebarLink('Administration')).toBeVisible();
+  });
+
+  test('sidebar shows Organisations link', async ({ page }) => {
+    const dashboard = new DashboardPage(page);
+    await dashboard.goto('fr');
+
+    await expect(dashboard.sidebarLink('Organisations')).toBeVisible();
+  });
+});

--- a/frontend/e2e/specs/05-admin/settings.spec.ts
+++ b/frontend/e2e/specs/05-admin/settings.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Admin settings access — the distinguishing canary for admin vs sub_admin.
+ *
+ * Sub_admin gets 403 on /api/v1/admin/settings (verified in 04-sub-admin/
+ * settings-403.spec.ts); admin should get 200 and the page should render
+ * the categories list.
+ *
+ * Per `backend/app/api/v1/admin_settings.py:57`, /admin/settings is gated on
+ * UserRole.admin only.
+ */
+
+import { expect, test } from '@playwright/test';
+
+const STAGING_API =
+  process.env.STAGING_API ||
+  (process.env.STAGING_URL || 'https://etutor.elearning.portfolio2.kimbetien.com').replace(
+    /^https:\/\/etutor\./,
+    'https://api.',
+  );
+
+test.describe('@admin settings access', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/fr/dashboard');
+  });
+
+  test('GET /api/v1/admin/settings returns 200 for admin', async ({ page }) => {
+    const accessToken = await page.evaluate(() => localStorage.getItem('access_token'));
+    const res = await page.request.get(`${STAGING_API}/api/v1/admin/settings`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    expect(res.status()).toBe(200);
+
+    // Response is a list of category objects; quick shape check.
+    const body = await res.json();
+    expect(Array.isArray(body), 'expected /admin/settings to return an array of categories').toBe(
+      true,
+    );
+    expect(body.length).toBeGreaterThan(0);
+  });
+
+  test('/fr/admin/settings page renders the categories list', async ({ page }) => {
+    await page.goto('/fr/admin/settings');
+
+    await expect(page.locator('main h1')).toContainText(/paramètres|settings/i);
+
+    // Verified during 2026-04-30 sweep — these category labels appear on
+    // /fr/admin/settings (some are correctly localized, some leak raw
+    // English — see #2128 for the i18n audit follow-up). Just check that
+    // *some* categories render.
+    await expect(
+      page.getByText(/AI.*Content Generation|Auth.*Security|Quiz.*Assessment/i).first(),
+    ).toBeVisible();
+  });
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -66,7 +66,7 @@ export default defineConfig({
     personaProject('02-learner'),
     personaProject('03-org-owner'),
     personaProject('04-sub-admin'),
-    // 05-admin: declared in 2116-4 once its spec dir exists.
+    personaProject('05-admin'),
   ],
 
   webServer:


### PR DESCRIPTION
## Summary

PR 4 of 5 for issue #2116. Adds the **05-admin** persona suite. **Stacked on #2155** (which is stacked on #2154, on #2153). Merge order: #2153 → #2154 → #2155 → this. Retarget base to `dev` after each merges.

9 specs across 3 files. The settings canary completes the role-distinguishing matrix:

| Persona | Admin endpoints | Settings endpoint |
|---|---|---|
| learner | 403 (#2153) | n/a |
| org-owner | 403 on `/admin/*`, allowed on `/org/{slug}/*` (#2154) | n/a |
| sub_admin | 200 on `/admin/users/courses/etc`, **403 on /admin/settings** (#2155) | 403 |
| admin | 200 on everything | **200 (this PR)** |

## Files added

- [`05-admin/nav.spec.ts`](frontend/e2e/specs/05-admin/nav.spec.ts) — 2 tests: Administration + Organisations links visible.
- [`05-admin/admin-pages.spec.ts`](frontend/e2e/specs/05-admin/admin-pages.spec.ts) — 5 tests: `/fr/admin/{users,courses,curricula,audit-logs,analytics}` reach correct h1. Two more pages than sub_admin's set (audit-logs + analytics).
- [`05-admin/settings.spec.ts`](frontend/e2e/specs/05-admin/settings.spec.ts) — 2 tests: API returns 200, page renders categories list. The distinguishing canary.

## One regex tightening during dev

`/fr/admin/analytics` h1 is "Analytique" (FR), which doesn't contain "analytic". Loosened to `/analy/i` to match all localized variants.

## Test plan

- [x] **Headed run** (per user request): 14/14 pass against staging.
- [x] **Full suite** all 5 personas + setup: **35 pass + 1 fixme** in ~33s.

After this PR lands, only **2116-5** remains (smoke folder for hourly prod, #2118) before #2116 closes.

## Stacking

Base: `feat/issue-2116-3-sub-admin-specs`. Once each upstream PR merges to `dev`, retarget via `gh pr edit 2156 --base feat/issue-2116-3-sub-admin-specs` (and so on) until eventually `--base dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)