### PR TITLE
feat(e2e): production read-only smoke (#2116-5/5, closes #2116)

### DIFF
--- a/frontend/e2e/smoke/critical-paths.spec.ts
+++ b/frontend/e2e/smoke/critical-paths.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Production read-only smoke (#2116-5/5, completes #2116; runs hourly via
+ * cron in #2118).
+ *
+ * Targets PROD_URL (default https://sira-donnia.org) — separate from the
+ * persona projects which target staging. Anonymous-only — no fixture
+ * accounts on prod, no CRUD, no AI tokens. Each test is a single GET
+ * assertion; the suite should complete in well under 60s.
+ *
+ * What this catches:
+ *   - Public-facing pages crash or return 5xx
+ *   - PWA service worker disappears (#2113 regression)
+ *   - Curricula index disappears (#2111 regression)
+ *   - Public-settings endpoint becomes unreachable
+ *   - Authenticated endpoints stop returning 401 for anonymous (auth-bypass
+ *     regression — would be a serious security bug)
+ *
+ * What this does NOT catch:
+ *   - Auth flows (covered by persona suite on staging)
+ *   - Role-scoped behavior (covered by persona suite on staging)
+ *   - Anything that requires login
+ */
+
+import { expect, test } from '@playwright/test';
+
+// Prod FE lives at app.sira-donnia.org (the bare sira-donnia.org domain is a
+// parked redirect — staying away from it). API lives at api.sira-donnia.org.
+const PROD_URL = process.env.PROD_URL || 'https://app.sira-donnia.org';
+const PROD_API = process.env.PROD_API || 'https://api.sira-donnia.org';
+
+test.describe('@smoke production read-only', () => {
+  test('backend /health returns healthy', async ({ request }) => {
+    const res = await request.get(`${PROD_API}/health`);
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('healthy');
+  });
+
+  test('public settings endpoint returns 200', async ({ request }) => {
+    const res = await request.get(`${PROD_API}/api/v1/settings/public`);
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('settings');
+    expect(body).toHaveProperty('branding');
+  });
+
+  test.fixme(
+    'PWA service worker /sw.js is reachable — pending #2113 deploy to prod',
+    async ({ request }) => {
+      // F-005 sentinel. #2113 + #2146 added the SW build; both are merged on
+      // main but verified 404 on app.sira-donnia.org/sw.js as of 2026-05-01.
+      // Remove .fixme once a prod deploy ships the fix — then this smoke
+      // catches future regressions.
+      const res = await request.get(`${PROD_URL}/sw.js`);
+      expect(res.status()).toBe(200);
+      const body = await res.text();
+      expect(body.length).toBeGreaterThan(0);
+    },
+  );
+
+  test('anonymous can browse courses catalog', async ({ page }) => {
+    await page.goto(`${PROD_URL}/fr/courses`);
+    await expect(page.locator('main h1')).toContainText(/catalogue|formation/i);
+  });
+
+  test('anonymous can view curricula index', async ({ page }) => {
+    // F-003 sentinel — /fr/curricula was 404 on staging during the 2026-04-30
+    // sweep (#2111). Catches a future regression of the same shape.
+    await page.goto(`${PROD_URL}/fr/curricula`);
+    await expect(page).not.toHaveTitle(/404/i);
+  });
+
+  test('anonymous about page renders', async ({ page }) => {
+    await page.goto(`${PROD_URL}/fr/about`);
+    await expect(page.locator('h1')).toBeVisible();
+  });
+
+  test('anonymous login page renders form', async ({ page }) => {
+    await page.goto(`${PROD_URL}/fr/login`);
+    await expect(page.locator('input[name="identifier"]')).toBeVisible();
+    await expect(page.locator('input[name="password"]')).toBeVisible();
+  });
+
+  test('English locale renders /en/about', async ({ page }) => {
+    await page.goto(`${PROD_URL}/en/about`);
+    await expect(page.locator('h1')).toBeVisible();
+    expect(await page.evaluate(() => document.documentElement.lang)).toBe('en');
+  });
+
+  test('protected admin endpoint rejects anonymous (auth-bypass sentinel)', async ({ request }) => {
+    // Critical security check — if this ever returns 200, it means an
+    // auth-bypass regression shipped to prod.
+    const res = await request.get(`${PROD_API}/api/v1/admin/users?offset=0&limit=1`);
+    expect(res.status()).toBe(401);
+  });
+
+  test('protected user endpoint rejects anonymous', async ({ request }) => {
+    const res = await request.get(`${PROD_API}/api/v1/users/me`);
+    expect(res.status()).toBe(401);
+  });
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -3,6 +3,7 @@ import { defineConfig, devices } from '@playwright/test';
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const STAGING_URL =
   process.env.STAGING_URL || 'https://etutor.elearning.portfolio2.kimbetien.com';
+const PROD_URL = process.env.PROD_URL || 'https://app.sira-donnia.org';
 
 // Persona projects (#2116) authenticate via auth.setup.ts and load the saved
 // storageState file. New specs go under e2e/specs/{persona}/. Old flat specs
@@ -44,12 +45,12 @@ export default defineConfig({
     // they're migrated or retired (cleanup follow-up to #2116).
     {
       name: 'chromium',
-      testIgnore: ['**/specs/**', '**/auth.setup.ts'],
+      testIgnore: ['**/specs/**', '**/smoke/**', '**/auth.setup.ts'],
       use: { ...devices['Desktop Chrome'] },
     },
     {
       name: 'mobile-chrome',
-      testIgnore: ['**/specs/**', '**/auth.setup.ts'],
+      testIgnore: ['**/specs/**', '**/smoke/**', '**/auth.setup.ts'],
       use: { ...devices['Pixel 5'] },
     },
 
@@ -67,6 +68,15 @@ export default defineConfig({
     personaProject('03-org-owner'),
     personaProject('04-sub-admin'),
     personaProject('05-admin'),
+
+    // Production read-only smoke (#2116-5). Anonymous-only; targets PROD_URL
+    // (default https://sira-donnia.org). Run hourly via cron in #2118.
+    // Invoke locally with `--project=smoke`. No setup dependency — no auth.
+    {
+      name: 'smoke',
+      testDir: './e2e/smoke',
+      use: { ...devices['Desktop Chrome'], baseURL: PROD_URL },
+    },
   ],
 
   webServer:


### PR DESCRIPTION
## Summary

PR 5 of 5 — **final slice for #2116**. Adds the smoke folder for hourly prod health checks. Anonymous-only, read-only, ~12s end-to-end against `app.sira-donnia.org`.

After all 5 PRs in the stack (#2153 → #2154 → #2155 → #2156 → this) merge, **#2116 closes**. Next unblocker is **#2118** (cron workflow that invokes this smoke).

## Specs added (10 tests, 9 pass + 1 fixme)

- `backend /health returns healthy` ✓
- `public settings endpoint returns 200` ✓
- `PWA service worker /sw.js is reachable` ⊘ — fixme; #2113's fix is on `main` but not yet rolled out to prod as of 2026-05-01
- `anonymous can browse courses catalog` ✓
- `anonymous can view curricula index` ✓ (F-003 sentinel)
- `anonymous about page renders` ✓
- `anonymous login page renders form` ✓
- `English locale renders /en/about` ✓
- `protected admin endpoint rejects anonymous (auth-bypass sentinel)` ✓
- `protected user endpoint rejects anonymous` ✓

## Domain discovery during dev

Bare `sira-donnia.org` is a **parked redirect** — its root serves `<script>window.location.href="/lander"</script>` which redirects through `searchhounds.com` to a Taiwan dumplings article. The actual prod is at `app.sira-donnia.org`. Hardcoded that as the `PROD_URL` default (per `feedback_no_env_default_for_stable_urls` — stable URLs don't need env wiring).

## Config tweaks

- New `PROD_URL` constant in `playwright.config.ts` defaulting to `https://app.sira-donnia.org`.
- New `smoke` project. `testIgnore` on chromium/mobile-chrome extended to exclude `**/smoke/**` so old flat specs don't pick up the smoke tests.
- API at `https://api.sira-donnia.org` (stable; not env-driven).

## Test plan

- [x] Smoke alone (`--project=smoke --headed --workers=1`): 9 pass + 1 fixme in ~12s.
- [x] Full suite + smoke (5 personas + smoke + setup): 44 pass + 2 fixme in ~40s.
- [x] Hit one transient flake on full-suite re-run (sub_admin nav timed out under high concurrency); CI uses `workers: 1` so this won't recur there.

## Stacking

Base: `feat/issue-2116-4-admin-specs`. Once #2153-#2156 merge to `dev`, retarget via `gh pr edit 2157 --base dev`.

## What's next (separate issues)

- **#2118** — wire this smoke as a cron workflow (`.github/workflows/prod-smoke.yml`) that pages on failure.
- **#2117** — wire the persona suite (01–05) into PR CI on `dev`.
- Cleanup of legacy `frontend/e2e/*.spec.ts` (mocked, flat) once the new pattern proves out — separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)