### PR TITLE
ci: add E2E persona suite job to CI (Fixes #2117)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,57 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  e2e:
+    name: E2E Persona Suite (Playwright vs staging)
+    runs-on: ubuntu-latest
+    # Skip on push events (avoid running twice for PR + push). PR runs are
+    # what gate merges. Workflow_dispatch keeps manual ad-hoc runs available.
+    if: github.event_name != 'push' || github.ref == 'refs/heads/main'
+    needs: frontend
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run persona suite against staging
+        env:
+          STAGING_URL: https://etutor.elearning.portfolio2.kimbetien.com
+          NO_WEB_SERVER: "1"
+          E2E_LEARNER_PASSWORD: ${{ secrets.E2E_LEARNER_PASSWORD }}
+          E2E_ORG_OWNER_PASSWORD: ${{ secrets.E2E_ORG_OWNER_PASSWORD }}
+          E2E_SUB_ADMIN_PASSWORD: ${{ secrets.E2E_SUB_ADMIN_PASSWORD }}
+          E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
+        run: |
+          npx playwright test \
+            --project=setup \
+            --project=01-anonymous \
+            --project=02-learner \
+            --project=03-org-owner \
+            --project=04-sub-admin \
+            --project=05-admin \
+            --reporter=line,html
+
+      - name: Upload Playwright trace + report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ github.run_id }}
+          path: |
+            frontend/playwright-report/
+            frontend/test-results/
+          retention-days: 14


### PR DESCRIPTION
## Summary

Wires the persona-based Playwright suite from #2116 into CI on every PR + merge to `main`. Failures upload Playwright traces + screenshots as 14-day workflow artifacts.

**Stacked on #2157** (the 2116 stack). Until #2153–#2157 land, this job has nothing to run against on `dev` — it only works on this PR's own branch where the suite is present.

Closes #2117.

## What it does

Single new job `e2e` in [`.github/workflows/ci.yml`](.github/workflows/ci.yml):
- Runs after `frontend` (the build job) succeeds — `needs: frontend` so a broken build short-circuits before the slower E2E run.
- Installs Chromium + deps via `npx playwright install --with-deps chromium`.
- Runs `setup` + the 5 persona projects against staging (`etutor.elearning.portfolio2.kimbetien.com`) using the env-configured `STAGING_URL` (already wired in `playwright.config.ts`).
- Reads `E2E_*_PASSWORD` from GitHub Actions secrets (set 2026-05-01 via `gh secret set`; verified via `gh secret list`).
- On failure, uploads `playwright-report/` and `test-results/` as a workflow artifact named `playwright-report-{run_id}`.

## What it does NOT do

- **Does not run smoke against prod** — that's #2118 (cron, separate workflow).
- **Does not enforce branch protection** — actual gating of merges into `main` is via repo branch-protection rules. This PR adds the *check*; turning it required is a settings-only change you do via the GH UI.
- **Does not include the old flat specs** — only `--project=setup --project=01-anonymous ... --project=05-admin`. Old chromium/mobile-chrome flat specs remain unwired (they target localhost and were already not in CI).

## Trigger logic

```yaml
if: github.event_name != 'push' || github.ref == 'refs/heads/main'
```

Without this, both the `pull_request` event and the `push` event would fire for branch pushes that have an open PR, doubling the suite cost. The condition keeps:
- ✓ All `pull_request` events (the gating signal)
- ✓ `push` to `main` (post-merge verification)
- ✓ Manual `workflow_dispatch`
- ✗ `push` to feature branches (skipped — covered by the PR run)

## Test plan

- [x] YAML syntactically valid (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`).
- [x] All 4 secrets present in repo (`gh secret list | grep E2E_` confirms).
- [ ] (post-merge) First green CI run on a PR to `dev` proves the wiring works end-to-end.
- [ ] (manual) Branch-protection rule added to require `e2e` check on `dev` and `main` (UI-only, separate step).

## Stacking

Base: `feat/issue-2116-5-smoke-folder`. Once #2153–#2157 merge to `dev`, retarget via `gh pr edit 2158 --base dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)