### PR TITLE
fix(progress): allow case-study units to be marked complete without a quiz

### DIFF
--- a/backend/app/api/v1/progress.py
+++ b/backend/app/api/v1/progress.py
@@ -236,12 +236,35 @@ async def complete_lesson(
     """
     Mark a unit/lesson as completed.
 
-    Requires a passing quiz attempt (score ≥ 80%) for the given module + unit.
-    Returns 403 with error code 'quiz_required' if no passing attempt exists.
+    Lesson units require a passing quiz attempt (score ≥ 80%) — returns 403
+    with ``quiz_required`` if no passing attempt exists. Case-study and
+    scenario units have no quiz by design and are marked complete directly.
     """
     try:
         user_id = UUID(str(current_user.id))
         service = ProgressService(db)
+
+        unit_type = await service.get_unit_type(request.module_id, request.unit_id)
+
+        if unit_type in ("case-study", "scenario"):
+            progress = await service.mark_unit_complete_no_quiz(
+                user_id=user_id,
+                module_id=request.module_id,
+                unit_id=request.unit_id,
+            )
+            logger.info(
+                "Case-study unit completed via complete-lesson endpoint",
+                user_id=str(user_id),
+                module_id=str(request.module_id),
+                unit_id=request.unit_id,
+                completion_pct=progress.completion_pct,
+            )
+            return CompleteLessonResponse(
+                completed=True,
+                module_progress=_make_module_progress_response(
+                    user_id, request.module_id, progress
+                ),
+            )
 
         quiz_passed = await service.check_quiz_passed_for_unit(
             user_id=user_id,

--- a/backend/app/domain/services/progress_service.py
+++ b/backend/app/domain/services/progress_service.py
@@ -229,6 +229,97 @@ class ProgressService:
             await self.db.commit()
         return progress
 
+    async def get_unit_type(self, module_id: UUID, unit_id: str) -> str | None:
+        """Return ``module_units.unit_type`` for ``(module_id, unit_id)`` or None."""
+        result = await self.db.execute(
+            select(ModuleUnit.unit_type).where(
+                ModuleUnit.module_id == module_id,
+                ModuleUnit.unit_number == unit_id,
+            )
+        )
+        row = result.first()
+        return row[0] if row is not None else None
+
+    async def mark_unit_complete_no_quiz(
+        self,
+        user_id: UUID,
+        module_id: UUID,
+        unit_id: str,
+    ) -> UserModuleProgress:
+        """
+        Mark a non-quiz unit (case-study / scenario) as completed.
+
+        Persists completion via a ``LessonReading`` row at 100% on the unit's
+        case-study ``GeneratedContent`` so ``_get_completed_units`` recognizes
+        it on later recomputations and ``completion_pct`` does not regress.
+        Does **not** touch ``quiz_score_avg`` — case studies are not quizzes.
+        """
+        from app.domain.models.content import GeneratedContent
+        from app.domain.services._unit_resolution import resolve_module_unit_id
+
+        now = datetime.utcnow()
+
+        progress_unit_uuid = await resolve_module_unit_id(self.db, module_id, unit_id)
+        case_query = select(GeneratedContent.id).where(
+            GeneratedContent.content_type == "case",
+        )
+        if progress_unit_uuid is not None:
+            case_query = case_query.where(GeneratedContent.module_unit_id == progress_unit_uuid)
+        else:
+            case_query = case_query.where(
+                GeneratedContent.module_id == module_id,
+                GeneratedContent.module_unit_id.is_(None),
+                GeneratedContent.content["unit_id"].astext == unit_id,
+            )
+        case_result = await self.db.execute(case_query)
+        case_id = case_result.scalars().first()
+
+        if case_id is not None:
+            self.db.add(
+                LessonReading(
+                    id=uuid.uuid4(),
+                    user_id=user_id,
+                    lesson_id=case_id,
+                    time_spent_seconds=0,
+                    completion_percentage=100.0,
+                    read_at=now,
+                )
+            )
+
+        progress = await self._get_or_create_progress(user_id, module_id, now)
+        progress.last_accessed = now
+
+        new_pct = await self._calculate_completion_pct(
+            user_id=user_id,
+            module_id=module_id,
+            just_completed_unit_id=unit_id,
+            current_progress=progress,
+        )
+        progress.completion_pct = new_pct
+
+        if new_pct >= 100.0:
+            progress.status = "completed"
+        elif progress.status == "not_started":
+            progress.status = "in_progress"
+
+        await self.db.commit()
+        await self.db.refresh(progress)
+
+        logger.info(
+            "Case-study unit completed",
+            user_id=str(user_id),
+            module_id=str(module_id),
+            unit_id=unit_id,
+            new_completion_pct=progress.completion_pct,
+            status=progress.status,
+        )
+        with contextlib.suppress(Exception):
+            await touch_course_interaction_by_module(self.db, user_id, module_id)
+        with contextlib.suppress(Exception):
+            await rollup_course_completion_by_module(self.db, user_id, module_id)
+            await self.db.commit()
+        return progress
+
     async def check_quiz_passed_for_unit(
         self,
         user_id: UUID,
@@ -497,39 +588,71 @@ class ProgressService:
         """
         Return the set of unit_numbers that have been completed.
 
-        A unit is considered completed when the user passes its associated quiz
-        (stored in user_module_progress.content JSON or quiz_attempts).
-        For now we derive this from quiz_attempts where score >= 80 for the
-        quiz content linked to this module and unit.
+        A unit is considered completed when:
+        - It has a quiz and the user passed it (score >= unit pass score), OR
+        - It is a case-study/scenario unit explicitly marked complete (a
+          ``LessonReading`` row at 100% against its case-study content).
         """
         from app.domain.models.content import GeneratedContent
         from app.domain.models.quiz import QuizAttempt
 
-        # Find all quiz content IDs for this module
+        completed: set[str] = set()
+
         content_result = await self.db.execute(
-            select(GeneratedContent.id, GeneratedContent.content).where(
+            select(
+                GeneratedContent.id,
+                GeneratedContent.content_type,
+                GeneratedContent.module_unit_id,
+                GeneratedContent.content,
+            ).where(
                 GeneratedContent.module_id == module_id,
-                GeneratedContent.content_type == "quiz",
+                GeneratedContent.content_type.in_(("quiz", "case")),
             )
         )
-        quiz_contents = content_result.all()
+        rows = content_result.all()
+        if not rows:
+            return completed
 
-        completed: set[str] = set()
-        for quiz_id, content_data in quiz_contents:
-            unit_id = content_data.get("unit_id", "") if content_data else ""
-            if not unit_id:
-                continue
-
-            # Check if user passed this quiz (score >= 80)
-            attempt_result = await self.db.execute(
-                select(func.max(QuizAttempt.score)).where(
-                    QuizAttempt.user_id == user_id,
-                    QuizAttempt.quiz_id == quiz_id,
+        unit_uuid_to_number: dict[uuid.UUID, str] = {}
+        unit_uuids_needed = {r.module_unit_id for r in rows if r.module_unit_id is not None}
+        if unit_uuids_needed:
+            unit_rows = await self.db.execute(
+                select(ModuleUnit.id, ModuleUnit.unit_number).where(
+                    ModuleUnit.id.in_(unit_uuids_needed)
                 )
             )
-            max_score = attempt_result.scalar()
-            if max_score is not None and max_score >= _unit_pass_score():
-                completed.add(unit_id)
+            unit_uuid_to_number = {r.id: r.unit_number for r in unit_rows.all()}
+
+        pass_score = _unit_pass_score()
+
+        for row in rows:
+            if row.module_unit_id is not None:
+                unit_number = unit_uuid_to_number.get(row.module_unit_id, "")
+            else:
+                unit_number = (row.content or {}).get("unit_id", "") or ""
+            if not unit_number or unit_number in completed:
+                continue
+
+            if row.content_type == "quiz":
+                attempt_result = await self.db.execute(
+                    select(func.max(QuizAttempt.score)).where(
+                        QuizAttempt.user_id == user_id,
+                        QuizAttempt.quiz_id == row.id,
+                    )
+                )
+                max_score = attempt_result.scalar()
+                if max_score is not None and max_score >= pass_score:
+                    completed.add(unit_number)
+            elif row.content_type == "case":
+                reading_result = await self.db.execute(
+                    select(func.max(LessonReading.completion_percentage)).where(
+                        LessonReading.user_id == user_id,
+                        LessonReading.lesson_id == row.id,
+                    )
+                )
+                max_pct = reading_result.scalar()
+                if max_pct is not None and max_pct >= 100.0:
+                    completed.add(unit_number)
 
         return completed
 

--- a/backend/tests/test_progress_service.py
+++ b/backend/tests/test_progress_service.py
@@ -511,9 +511,7 @@ class TestCheckQuizPassedForUnit:
 
 
 class TestGetUnitType:
-    async def test_returns_unit_type_when_present(
-        self, progress_service, mock_db, module_id
-    ):
+    async def test_returns_unit_type_when_present(self, progress_service, mock_db, module_id):
         mock_db.execute = AsyncMock(
             return_value=MagicMock(first=MagicMock(return_value=("case-study",)))
         )
@@ -522,9 +520,7 @@ class TestGetUnitType:
 
         assert result == "case-study"
 
-    async def test_returns_none_when_unit_missing(
-        self, progress_service, mock_db, module_id
-    ):
+    async def test_returns_none_when_unit_missing(self, progress_service, mock_db, module_id):
         mock_db.execute = AsyncMock(return_value=MagicMock(first=MagicMock(return_value=None)))
 
         result = await progress_service.get_unit_type(module_id, "9.9")
@@ -552,7 +548,11 @@ class TestMarkUnitCompleteNoQuiz:
             # resolve_module_unit_id
             MagicMock(scalar_one_or_none=MagicMock(return_value=unit_uuid)),
             # case content lookup -> scalars().first()
-            MagicMock(scalars=MagicMock(return_value=MagicMock(first=MagicMock(return_value=case_content_id)))),
+            MagicMock(
+                scalars=MagicMock(
+                    return_value=MagicMock(first=MagicMock(return_value=case_content_id))
+                )
+            ),
             # _get_or_create_progress
             MagicMock(scalar_one_or_none=MagicMock(return_value=existing_progress)),
             # _calculate_completion_pct -> total units count
@@ -601,7 +601,9 @@ class TestMarkUnitCompleteNoQuiz:
         results = [
             MagicMock(scalar_one_or_none=MagicMock(return_value=unit_uuid)),
             # No case content row
-            MagicMock(scalars=MagicMock(return_value=MagicMock(first=MagicMock(return_value=None)))),
+            MagicMock(
+                scalars=MagicMock(return_value=MagicMock(first=MagicMock(return_value=None)))
+            ),
             MagicMock(scalar_one_or_none=MagicMock(return_value=existing_progress)),
             MagicMock(scalar=MagicMock(return_value=2)),
             MagicMock(all=MagicMock(return_value=[])),

--- a/backend/tests/test_progress_service.py
+++ b/backend/tests/test_progress_service.py
@@ -510,6 +510,119 @@ class TestCheckQuizPassedForUnit:
         assert result is False
 
 
+class TestGetUnitType:
+    async def test_returns_unit_type_when_present(
+        self, progress_service, mock_db, module_id
+    ):
+        mock_db.execute = AsyncMock(
+            return_value=MagicMock(first=MagicMock(return_value=("case-study",)))
+        )
+
+        result = await progress_service.get_unit_type(module_id, "1.2")
+
+        assert result == "case-study"
+
+    async def test_returns_none_when_unit_missing(
+        self, progress_service, mock_db, module_id
+    ):
+        mock_db.execute = AsyncMock(return_value=MagicMock(first=MagicMock(return_value=None)))
+
+        result = await progress_service.get_unit_type(module_id, "9.9")
+
+        assert result is None
+
+
+class TestMarkUnitCompleteNoQuiz:
+    async def test_does_not_touch_quiz_score_avg(
+        self, progress_service, mock_db, user_id, module_id
+    ):
+        existing_progress = UserModuleProgress(
+            user_id=user_id,
+            module_id=module_id,
+            status="in_progress",
+            completion_pct=0.0,
+            quiz_score_avg=70.0,
+            time_spent_minutes=0,
+            last_accessed=None,
+        )
+        unit_uuid = uuid.uuid4()
+        case_content_id = uuid.uuid4()
+
+        results = [
+            # resolve_module_unit_id
+            MagicMock(scalar_one_or_none=MagicMock(return_value=unit_uuid)),
+            # case content lookup -> scalars().first()
+            MagicMock(scalars=MagicMock(return_value=MagicMock(first=MagicMock(return_value=case_content_id)))),
+            # _get_or_create_progress
+            MagicMock(scalar_one_or_none=MagicMock(return_value=existing_progress)),
+            # _calculate_completion_pct -> total units count
+            MagicMock(scalar=MagicMock(return_value=4)),
+            # _get_completed_units -> no quiz/case rows
+            MagicMock(all=MagicMock(return_value=[])),
+            # touch_course_interaction_by_module: select(Module.course_id)
+            MagicMock(scalar_one_or_none=MagicMock(return_value=None)),
+            # rollup_course_completion_by_module: select(Module.course_id)
+            MagicMock(scalar_one_or_none=MagicMock(return_value=None)),
+        ]
+        mock_db.execute = AsyncMock(side_effect=results)
+
+        result = await progress_service.mark_unit_complete_no_quiz(
+            user_id=user_id,
+            module_id=module_id,
+            unit_id="1.2",
+        )
+
+        assert result.quiz_score_avg == 70.0  # untouched
+        assert result.completion_pct == 25.0  # 1 of 4 units
+        assert result.last_accessed is not None
+        # LessonReading row was added at 100%
+        added = [c.args[0] for c in mock_db.add.call_args_list]
+        readings = [r for r in added if isinstance(r, LessonReading)]
+        assert len(readings) == 1
+        assert readings[0].lesson_id == case_content_id
+        assert readings[0].completion_percentage == 100.0
+
+    async def test_skips_lesson_reading_when_case_content_missing(
+        self, progress_service, mock_db, user_id, module_id
+    ):
+        """User clicks Mark Complete before generation finishes — no content row
+        exists yet. We still mark the module progress, just skip the LessonReading."""
+        existing_progress = UserModuleProgress(
+            user_id=user_id,
+            module_id=module_id,
+            status="not_started",
+            completion_pct=0.0,
+            quiz_score_avg=None,
+            time_spent_minutes=0,
+            last_accessed=None,
+        )
+        unit_uuid = uuid.uuid4()
+
+        results = [
+            MagicMock(scalar_one_or_none=MagicMock(return_value=unit_uuid)),
+            # No case content row
+            MagicMock(scalars=MagicMock(return_value=MagicMock(first=MagicMock(return_value=None)))),
+            MagicMock(scalar_one_or_none=MagicMock(return_value=existing_progress)),
+            MagicMock(scalar=MagicMock(return_value=2)),
+            MagicMock(all=MagicMock(return_value=[])),
+            MagicMock(scalar_one_or_none=MagicMock(return_value=None)),
+            MagicMock(scalar_one_or_none=MagicMock(return_value=None)),
+        ]
+        mock_db.execute = AsyncMock(side_effect=results)
+
+        result = await progress_service.mark_unit_complete_no_quiz(
+            user_id=user_id,
+            module_id=module_id,
+            unit_id="1.2",
+        )
+
+        assert result.status == "in_progress"
+        assert result.completion_pct == 50.0  # 1 of 2
+        added = [c.args[0] for c in mock_db.add.call_args_list]
+        readings = [r for r in added if isinstance(r, LessonReading)]
+        assert readings == []
+
+
 class TestProgressServiceIntegration:
     async def test_tracking_lesson_updates_last_accessed(
         self, progress_service, mock_db, user_id, module_id, lesson_id

--- a/frontend/components/learning/case-study-viewer.tsx
+++ b/frontend/components/learning/case-study-viewer.tsx
@@ -102,6 +102,7 @@ export function CaseStudyViewer({
   const [isGenerating, setIsGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isCompleted, setIsCompleted] = useState(false);
+  const [completeError, setCompleteError] = useState<string | null>(null);
   const [correctionVisible, setCorrectionVisible] = useState(false);
   const [forceRegenerate, setForceRegenerate] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -225,6 +226,7 @@ export function CaseStudyViewer({
   };
 
   const handleMarkComplete = async () => {
+    setCompleteError(null);
     try {
       await apiFetch(`/api/v1/progress/complete-lesson`, {
         method: 'POST',
@@ -237,6 +239,7 @@ export function CaseStudyViewer({
       onComplete?.();
     } catch (err) {
       console.error('Error marking case study complete:', err);
+      setCompleteError(t('completeError'));
     }
   };
 
@@ -551,6 +554,15 @@ export function CaseStudyViewer({
             t('markComplete')
           )}
         </Button>
+        {completeError && (
+          <p
+            role="alert"
+            className="mt-3 inline-flex items-center gap-2 text-sm text-red-600"
+          >
+            <AlertTriangle className="w-4 h-4" aria-hidden />
+            {completeError}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/frontend/lib/offline/sync-manager.ts
+++ b/frontend/lib/offline/sync-manager.ts
@@ -258,13 +258,11 @@ class SyncManager {
         break;
 
       case 'case_study_complete':
-        await apiFetch('/api/v1/progress/lesson-access', {
+        await apiFetch('/api/v1/progress/complete-lesson', {
           method: 'POST',
           body: JSON.stringify({
             module_id: payload.module_id,
-            lesson_id: payload.lesson_id,
-            time_spent_seconds: payload.time_spent_seconds,
-            completion_percentage: payload.completion_percentage,
+            unit_id: payload.unit_id,
           }),
         });
         break;

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -797,6 +797,7 @@
     "sourceCitations": "Source Citations",
     "markComplete": "Mark as Complete",
     "completed": "Completed",
+    "completeError": "Could not mark this case study as complete. Please try again.",
     "refreshContent": "Refresh content",
     "learningObjectives": "Learning Objectives",
     "showObjectives": "Show objectives",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -797,6 +797,7 @@
     "sourceCitations": "Sources citées",
     "markComplete": "Marquer comme Terminé",
     "completed": "Terminé",
+    "completeError": "Impossible de valider cette étude de cas. Veuillez réessayer.",
     "refreshContent": "Actualiser le contenu",
     "learningObjectives": "Objectifs pédagogiques",
     "showObjectives": "Afficher les objectifs",


### PR DESCRIPTION
## Summary

- Backend: `/api/v1/progress/complete-lesson` now branches on `ModuleUnit.unit_type`. Case-study/scenario units no longer require a quiz attempt — they're marked complete via a new `mark_unit_complete_no_quiz` service method that writes a `LessonReading` at 100% and bumps `completion_pct` without polluting `quiz_score_avg`.
- Backend: `_get_completed_units` now also includes case-study units whose content has a 100% `LessonReading`, so completion does not regress on subsequent quiz passes.
- Frontend: `case-study-viewer.tsx` surfaces API failures inline under the **Mark Complete** button (previously `console.error`-only). Adds `CaseStudyViewer.completeError` translation key in EN + FR.
- Frontend: offline `sync-manager.ts` routes `case_study_complete` actions to `/complete-lesson` with `{ module_id, unit_id }` (was `/lesson-access`, which only logs access).

## Why

The `complete-lesson` endpoint required a passing quiz attempt (≥80%) for every unit (FR-02.2). Case-study units have no quiz by design — only `aof_context`, `real_data`, `guided_questions`, `annotated_correction` — so the **Mark Complete** button always 403'd with `quiz_required` and the frontend swallowed the error.

The valid `unit_type` enum from [`syllabus_generation.py:558-563`](backend/app/tasks/syllabus_generation.py#L558-L563) is `{"lesson", "quiz", "case-study", "scenario"}`. Reuses the same `unit_type ∈ ("case-study", "scenario")` predicate already used in [`content.py:774`](backend/app/api/v1/content.py#L774) for the streaming generation branch.

## Test plan

- [x] `uv run pytest tests/test_progress_service.py` — 31 passed (4 new: `TestGetUnitType` × 2, `TestMarkUnitCompleteNoQuiz` × 2).
- [x] `uv run ruff check` + `ruff format --check` — clean.
- [x] `npx tsc --noEmit` + `npx eslint` on changed frontend files — clean (remaining tsc errors are pre-existing in unrelated files).
- [ ] Local online: enroll in a course with a `case-study` unit, click **Mark Complete**, verify button flips to "Completed" and module progress % increases.
- [ ] Local offline: queue `case_study_complete`, go online, verify SyncManager hits `/complete-lesson` and progress updates.
- [ ] Verify a lesson unit without a passing quiz still returns 403 `quiz_required` (no regression on the existing path).

## Out of scope

- Hydrating `isCompleted` in `case-study-viewer.tsx` from server state on page load — separate UX gap; the button still resets to "Mark Complete" after a refresh on already-completed units.
- The orthogonal offline-tracking gap covered by #2151 (no caller currently *enqueues* `case_study_complete`); this PR fixes the receiving side so when #2151 lands, the route is correct.

Fixes #2163

🤖 Generated with [Claude Code](https://claude.com/claude-code)