### PR TITLE
fix(progress): allow lesson units to be marked complete

### DIFF
--- a/backend/app/api/v1/progress.py
+++ b/backend/app/api/v1/progress.py
@@ -236,9 +236,11 @@ async def complete_lesson(
     """
     Mark a unit/lesson as completed.
 
-    Lesson units require a passing quiz attempt (score ≥ 80%) — returns 403
-    with ``quiz_required`` if no passing attempt exists. Case-study and
-    scenario units have no quiz by design and are marked complete directly.
+    Case-study, scenario, and lesson units (including legacy NULL unit_type
+    rows, which default to "lesson") have no quiz gate and are marked complete
+    directly. Any other unit type is treated as quiz-gated and requires a
+    passing attempt (score ≥ 80%) — returns 403 with ``quiz_required`` if no
+    passing attempt exists.
     """
     try:
         user_id = UUID(str(current_user.id))
@@ -246,17 +248,18 @@ async def complete_lesson(
 
         unit_type = await service.get_unit_type(request.module_id, request.unit_id)
 
-        if unit_type in ("case-study", "scenario"):
+        if unit_type in ("case-study", "scenario", "lesson", None):
             progress = await service.mark_unit_complete_no_quiz(
                 user_id=user_id,
                 module_id=request.module_id,
                 unit_id=request.unit_id,
             )
             logger.info(
-                "Case-study unit completed via complete-lesson endpoint",
+                "Unit completed via complete-lesson endpoint",
                 user_id=str(user_id),
                 module_id=str(request.module_id),
                 unit_id=request.unit_id,
+                unit_type=unit_type,
                 completion_pct=progress.completion_pct,
             )
             return CompleteLessonResponse(

--- a/backend/app/domain/services/progress_service.py
+++ b/backend/app/domain/services/progress_service.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from uuid import UUID
 
 import structlog
-from sqlalchemy import func, or_, select, text, update
+from sqlalchemy import case, func, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.domain.models.course import UserCourseEnrollment
@@ -247,12 +247,17 @@ class ProgressService:
         unit_id: str,
     ) -> UserModuleProgress:
         """
-        Mark a non-quiz unit (case-study / scenario) as completed.
+        Mark a non-quiz unit (case-study / scenario / lesson) as completed.
 
         Persists completion via a ``LessonReading`` row at 100% on the unit's
-        case-study ``GeneratedContent`` so ``_get_completed_units`` recognizes
-        it on later recomputations and ``completion_pct`` does not regress.
-        Does **not** touch ``quiz_score_avg`` — case studies are not quizzes.
+        underlying ``GeneratedContent`` (case-study or lesson) so
+        ``_get_completed_units`` recognizes it on later recomputations and
+        ``completion_pct`` does not regress. Does **not** touch
+        ``quiz_score_avg`` — these unit types are not quizzes.
+
+        When both a ``case`` and a ``lesson`` row exist for the same unit
+        (e.g. an admin attached a case study to a lesson unit), the ``case``
+        row is preferred so case-study units stay bound to their case content.
         """
         from app.domain.models.content import GeneratedContent
         from app.domain.services._unit_resolution import resolve_module_unit_id
@@ -260,26 +265,31 @@ class ProgressService:
         now = datetime.utcnow()
 
         progress_unit_uuid = await resolve_module_unit_id(self.db, module_id, unit_id)
-        case_query = select(GeneratedContent.id).where(
-            GeneratedContent.content_type == "case",
+        content_query = select(GeneratedContent.id).where(
+            GeneratedContent.content_type.in_(("case", "lesson")),
         )
         if progress_unit_uuid is not None:
-            case_query = case_query.where(GeneratedContent.module_unit_id == progress_unit_uuid)
+            content_query = content_query.where(
+                GeneratedContent.module_unit_id == progress_unit_uuid
+            )
         else:
-            case_query = case_query.where(
+            content_query = content_query.where(
                 GeneratedContent.module_id == module_id,
                 GeneratedContent.module_unit_id.is_(None),
                 GeneratedContent.content["unit_id"].astext == unit_id,
             )
-        case_result = await self.db.execute(case_query)
-        case_id = case_result.scalars().first()
+        content_query = content_query.order_by(
+            case((GeneratedContent.content_type == "case", 0), else_=1)
+        )
+        content_result = await self.db.execute(content_query)
+        content_id = content_result.scalars().first()
 
-        if case_id is not None:
+        if content_id is not None:
             self.db.add(
                 LessonReading(
                     id=uuid.uuid4(),
                     user_id=user_id,
-                    lesson_id=case_id,
+                    lesson_id=content_id,
                     time_spent_seconds=0,
                     completion_percentage=100.0,
                     read_at=now,
@@ -590,8 +600,9 @@ class ProgressService:
 
         A unit is considered completed when:
         - It has a quiz and the user passed it (score >= unit pass score), OR
-        - It is a case-study/scenario unit explicitly marked complete (a
-          ``LessonReading`` row at 100% against its case-study content).
+        - It is a case-study/scenario or lesson unit explicitly marked complete
+          (a ``LessonReading`` row at 100% against its case-study or lesson
+          content).
         """
         from app.domain.models.content import GeneratedContent
         from app.domain.models.quiz import QuizAttempt
@@ -606,7 +617,7 @@ class ProgressService:
                 GeneratedContent.content,
             ).where(
                 GeneratedContent.module_id == module_id,
-                GeneratedContent.content_type.in_(("quiz", "case")),
+                GeneratedContent.content_type.in_(("quiz", "case", "lesson")),
             )
         )
         rows = content_result.all()
@@ -643,7 +654,7 @@ class ProgressService:
                 max_score = attempt_result.scalar()
                 if max_score is not None and max_score >= pass_score:
                     completed.add(unit_number)
-            elif row.content_type == "case":
+            elif row.content_type in ("case", "lesson"):
                 reading_result = await self.db.execute(
                     select(func.max(LessonReading.completion_percentage)).where(
                         LessonReading.user_id == user_id,

--- a/backend/tests/test_progress_service.py
+++ b/backend/tests/test_progress_service.py
@@ -624,6 +624,52 @@ class TestMarkUnitCompleteNoQuiz:
         readings = [r for r in added if isinstance(r, LessonReading)]
         assert readings == []
 
+    async def test_lesson_unit_writes_reading_against_lesson_content(
+        self, progress_service, mock_db, user_id, module_id
+    ):
+        """Lesson units (no case-study row) should bind the 100% LessonReading
+        to the unit's lesson GeneratedContent so _get_completed_units credits it."""
+        existing_progress = UserModuleProgress(
+            user_id=user_id,
+            module_id=module_id,
+            status="in_progress",
+            completion_pct=0.0,
+            quiz_score_avg=None,
+            time_spent_minutes=0,
+            last_accessed=None,
+        )
+        unit_uuid = uuid.uuid4()
+        lesson_content_id = uuid.uuid4()
+
+        results = [
+            MagicMock(scalar_one_or_none=MagicMock(return_value=unit_uuid)),
+            # Content lookup returns the lesson row (case row absent)
+            MagicMock(
+                scalars=MagicMock(
+                    return_value=MagicMock(first=MagicMock(return_value=lesson_content_id))
+                )
+            ),
+            MagicMock(scalar_one_or_none=MagicMock(return_value=existing_progress)),
+            MagicMock(scalar=MagicMock(return_value=4)),
+            MagicMock(all=MagicMock(return_value=[])),
+            MagicMock(scalar_one_or_none=MagicMock(return_value=None)),
+            MagicMock(scalar_one_or_none=MagicMock(return_value=None)),
+        ]
+        mock_db.execute = AsyncMock(side_effect=results)
+
+        result = await progress_service.mark_unit_complete_no_quiz(
+            user_id=user_id,
+            module_id=module_id,
+            unit_id="1.1",
+        )
+
+        assert result.completion_pct == 25.0  # 1 of 4
+        added = [c.args[0] for c in mock_db.add.call_args_list]
+        readings = [r for r in added if isinstance(r, LessonReading)]
+        assert len(readings) == 1
+        assert readings[0].lesson_id == lesson_content_id
+        assert readings[0].completion_percentage == 100.0
+
 
 class TestProgressServiceIntegration:
     async def test_tracking_lesson_updates_last_accessed(

--- a/frontend/components/learning/lesson-viewer.tsx
+++ b/frontend/components/learning/lesson-viewer.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { useTranslations } from 'next-intl';
-import { Clock, RefreshCw, Loader2, AlertTriangle } from 'lucide-react';
+import { CheckCircle, Clock, RefreshCw, Loader2, AlertTriangle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -80,6 +80,7 @@ export function LessonViewer({
   estimatedMinutes,
   unitTitle,
   unitDescription,
+  onComplete,
 }: LessonViewerProps) {
   const [lessonData, setLessonData] = useState<LessonData | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -90,6 +91,8 @@ export function LessonViewer({
   const [forceRegenerate, setForceRegenerate] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [contentSource, setContentSource] = useState<'api' | 'indexeddb'>('api');
+  const [isCompleted, setIsCompleted] = useState(false);
+  const [completeError, setCompleteError] = useState<string | null>(null);
   // Which media-tab pane is active. The "Actualiser le contenu" button
   // only makes sense on the Lire pane (it regenerates lesson body, not
   // audio/video) so we hide it on listen/watch.
@@ -262,6 +265,24 @@ export function LessonViewer({
     setLessonData(null);
     setIsRefreshing(true);
     setForceRegenerate(true);
+  };
+
+  const handleMarkComplete = async () => {
+    setCompleteError(null);
+    try {
+      await apiFetch(`/api/v1/progress/complete-lesson`, {
+        method: 'POST',
+        body: JSON.stringify({
+          module_id: moduleId,
+          unit_id: unitId,
+        }),
+      });
+      setIsCompleted(true);
+      onComplete?.();
+    } catch (err) {
+      console.error('Error marking lesson complete:', err);
+      setCompleteError(t('completeError'));
+    }
   };
 
   const mdClass = "prose prose-gray max-w-none prose-headings:text-gray-900 prose-p:text-gray-700 prose-li:text-gray-700 prose-strong:text-gray-900 prose-table:text-sm";
@@ -540,6 +561,34 @@ export function LessonViewer({
 
       {/* Source Citations */}
       <SourceCitations sources={content.sources_cited} />
+
+      {/* Mark as Complete */}
+      <div className="mt-8 text-center">
+        <Button
+          onClick={handleMarkComplete}
+          disabled={isCompleted || isLoading || isGenerating || !isOnline}
+          className="min-h-11 px-8"
+          size="lg"
+        >
+          {isCompleted ? (
+            <>
+              <CheckCircle className="w-4 h-4 mr-2" />
+              {t('completed')}
+            </>
+          ) : (
+            t('markComplete')
+          )}
+        </Button>
+        {completeError && (
+          <p
+            role="alert"
+            className="mt-3 inline-flex items-center gap-2 text-sm text-red-600"
+          >
+            <AlertTriangle className="w-4 h-4" aria-hidden />
+            {completeError}
+          </p>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -735,7 +735,10 @@
     "unitNotFound": "This unit does not exist in this module.",
     "backToModule": "Back to module",
     "contentNotAvailableOffline": "This lesson is not available offline. Download the module to access it without internet.",
-    "countryFallback": "Content optimized for your region will be available shortly"
+    "countryFallback": "Content optimized for your region will be available shortly",
+    "markComplete": "Mark as Complete",
+    "completed": "Completed",
+    "completeError": "Could not mark this lesson as complete. Please try again."
   },
   "LessonAudio": {
     "audioPending": "Generating audio summary...",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -735,7 +735,10 @@
     "unitNotFound": "Cette unité n'existe pas dans ce module.",
     "backToModule": "Retour au module",
     "contentNotAvailableOffline": "Cette leçon n'est pas disponible hors-ligne. Téléchargez le module pour y accéder sans internet.",
-    "countryFallback": "Le contenu adapté à votre région sera disponible prochainement"
+    "countryFallback": "Le contenu adapté à votre région sera disponible prochainement",
+    "markComplete": "Marquer comme Terminé",
+    "completed": "Terminé",
+    "completeError": "Impossible de marquer cette leçon comme terminée. Veuillez réessayer."
   },
   "LessonAudio": {
     "audioPending": "Génération du résumé audio...",


### PR DESCRIPTION
Fixes #2167.

## Summary

- Lesson units cannot be marked complete today: the FE has no button, and the backend `/complete-lesson` endpoint 403s on `unit_type='lesson'`. Even if it didn't 403, `mark_unit_complete_no_quiz` only writes a `LessonReading` against `content_type='case'` content, and `_get_completed_units` only credits `LessonReading>=100` for `content_type='case'` — so lessons would silently no-op end-to-end.
- This PR mirrors the case-study Mark-Complete pattern (#2163/#2164) for lessons.

## Backend changes

- [backend/app/api/v1/progress.py](backend/app/api/v1/progress.py) — `/complete-lesson` now accepts `unit_type in ("case-study", "scenario", "lesson", None)`. NULL-typed legacy units default to "lesson" (consistent with `admin_courses.py` defaults). All other unit types still go through the existing quiz-required path.
- [backend/app/domain/services/progress_service.py](backend/app/domain/services/progress_service.py) `mark_unit_complete_no_quiz` widens its `GeneratedContent` lookup from `content_type='case'` to `IN ('case', 'lesson')`, with `ORDER BY (case=0 else=1)` so case-study units still bind to their case row when both content types are present.
- [backend/app/domain/services/progress_service.py](backend/app/domain/services/progress_service.py) `_get_completed_units` now credits `LessonReading.completion_percentage>=100` against `content_type='lesson'` rows in addition to `content_type='case'`, so `completion_pct` actually moves when a lesson is marked complete.

## Frontend changes

- [frontend/components/learning/lesson-viewer.tsx](frontend/components/learning/lesson-viewer.tsx) — adds a "Mark as Complete" button after `<SourceCitations>`, mirroring `CaseStudyViewer` exactly: direct `apiFetch` on click, optimistic `isCompleted` state, inline `completeError`, button disabled when offline. The component already accepted an unused `onComplete?: () => void` prop; it's now wired and called on success.
- [frontend/messages/en.json](frontend/messages/en.json) and [frontend/messages/fr.json](frontend/messages/fr.json) — new `LessonViewer.markComplete` / `LessonViewer.completed` / `LessonViewer.completeError` keys (FR: "Marquer comme Terminé" / "Terminé" / error message).

## Out of scope (deliberate)

- **Offline-queue parity for Mark-Complete.** The case-study viewer (#2164) does NOT queue an offline action either — it just disables the button when offline. Adding offline support belongs in a separate issue addressing both lessons + case studies together.
- **Lesson-only modules reaching `status='completed'`.** Modules that have lesson units but no quiz units still won't auto-flip to "completed" because `quiz_score_avg` stays NULL and the `>=80` gate fails. This is pre-existing behavior, not introduced or worsened here.

## Tests

- Added `test_lesson_unit_writes_reading_against_lesson_content` to [backend/tests/test_progress_service.py](backend/tests/test_progress_service.py) — verifies a lesson unit's 100% `LessonReading` is bound to the lesson `GeneratedContent`, and `completion_pct` moves accordingly.
- Existing 31 progress-service tests still pass (regression guard for the case-study path's order_by precedence change).

## Test plan

- [ ] Backend: `cd backend && uv run pytest tests/test_progress_service.py` — 32 passed locally.
- [ ] Backend: `uv run ruff check app/api/v1/progress.py app/domain/services/progress_service.py tests/test_progress_service.py` — clean.
- [ ] Frontend: `cd frontend && npx tsc --noEmit` — no new errors on touched files.
- [ ] Manual: open a lesson unit, click "Mark as Complete", navigate back to module overview, confirm pill turns green.
- [ ] Manual: pass all module quizzes after marking lessons complete, confirm module status flips to "completed".
- [ ] Manual: regression — case-study units still mark complete via the same endpoint.
- [ ] Manual: offline — button is disabled when network drops; clicking online surfaces no error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)