### PR TITLE
fix(citations): rewrite UUID source labels to readable names (#2168)

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -832,6 +832,7 @@ async def preview_lesson(
     db=Depends(get_db_session),
 ) -> dict:
     """Generate a lesson preview for admin review before publishing."""
+    from app.domain.services.citation_formatter import rewrite_response_citations
     from app.domain.services.lesson_service import LessonGenerationService
 
     service = LessonGenerationService()
@@ -844,6 +845,7 @@ async def preview_lesson(
         session=db,
         user_id=uuid.UUID(current_user.id),
     )
+    await rewrite_response_citations(lesson, db)
     return lesson.model_dump()
 
 

--- a/backend/app/api/v1/content.py
+++ b/backend/app/api/v1/content.py
@@ -41,6 +41,10 @@ from app.domain.models.content import GeneratedContent
 from app.domain.models.module import Module
 from app.domain.models.module_unit import ModuleUnit
 from app.domain.services.analytics_service import AnalyticsService
+from app.domain.services.citation_formatter import (
+    rewrite_response_citations,
+    rewrite_uuid_citations_for_module,
+)
 from app.domain.services.flashcard_service import FlashcardGenerationService
 from app.domain.services.lesson_service import CaseStudyGenerationService, LessonGenerationService
 from app.domain.services.progress_service import ProgressService
@@ -266,6 +270,7 @@ async def generate_lesson(
             cached=lesson_response.cached,
         )
 
+        await rewrite_response_citations(lesson_response, session)
         return lesson_response
 
     except ValueError as e:
@@ -493,6 +498,12 @@ async def get_or_generate_lesson_by_module_and_unit(
                     from app.api.v1.schemas.content import CaseStudyContent as _CaseStudyContent
 
                     content_dict = {k: v for k, v in cached.content.items() if k != "unit_id"}
+                    content_dict["sources_cited"] = await rewrite_uuid_citations_for_module(
+                        content_dict.get("sources_cited"),
+                        cached.module_id,
+                        session,
+                        language=cached.language,
+                    )
                     case_study_response = CaseStudyResponse(
                         id=cached.id,
                         module_id=cached.module_id,
@@ -548,6 +559,12 @@ async def get_or_generate_lesson_by_module_and_unit(
                 from app.api.v1.schemas.content import LessonContent as _LessonContent
 
                 content_dict = {k: v for k, v in cached.content.items() if k != "unit_id"}
+                content_dict["sources_cited"] = await rewrite_uuid_citations_for_module(
+                    content_dict.get("sources_cited"),
+                    cached.module_id,
+                    session,
+                    language=cached.language,
+                )
 
                 source_image_refs = await lesson_service._extract_source_image_refs(
                     " ".join(str(v or "") for v in cached.content.values() if isinstance(v, str))
@@ -864,14 +881,22 @@ async def get_lesson(
 
         from app.api.v1.schemas.content import LessonContent
 
+        content_dict = dict(lesson_content.content)
+        content_dict["sources_cited"] = await rewrite_uuid_citations_for_module(
+            content_dict.get("sources_cited"),
+            lesson_content.module_id,
+            session,
+            language=lesson_content.language,
+        )
+
         return LessonResponse(
             id=lesson_content.id,
             module_id=lesson_content.module_id,
-            unit_id=lesson_content.content.get("unit_id", ""),
+            unit_id=content_dict.get("unit_id", ""),
             language=lesson_content.language,
             level=lesson_content.level,
             country_context=lesson_content.country_context or "",
-            content=LessonContent(**lesson_content.content),
+            content=LessonContent(**content_dict),
             generated_at=lesson_content.generated_at.isoformat(),
             cached=True,
         )
@@ -1235,6 +1260,12 @@ async def get_or_generate_case_study(
                 from app.api.v1.schemas.content import CaseStudyContent as _CaseStudyContent
 
                 content_dict = {k: v for k, v in cached.content.items() if k != "unit_id"}
+                content_dict["sources_cited"] = await rewrite_uuid_citations_for_module(
+                    content_dict.get("sources_cited"),
+                    cached.module_id,
+                    session,
+                    language=cached.language,
+                )
                 case_study_response = CaseStudyResponse(
                     id=cached.id,
                     module_id=cached.module_id,

--- a/backend/app/domain/services/citation_formatter.py
+++ b/backend/app/domain/services/citation_formatter.py
@@ -1,0 +1,225 @@
+"""Read-side rewriter for citation strings produced by the lesson generator.
+
+The lesson/case-study generators store ``DocumentChunk.source =
+rag_collection_id`` (a course UUID) for AI-generated courses, then format
+``sources_cited`` as ``"<UUID>, p.43"`` strings via ``source.title()``. This
+module rewrites those UUID-prefixed strings into a human-readable form
+**after** generation, without touching the generation pipeline:
+
+  ``"Bd2E9508-9B48-46F4-959C-14B682Cba886, p.43"``  →  ``"Triola Chapter 3, p.43"``
+
+The mapping is purely a presentation-layer transform. It uses information
+already on disk — ``CourseResource.filename`` and ``Course.title_*`` — so no
+schema changes, no re-indexation, and no Claude API spend.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import re
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.models.course import Course
+from app.domain.models.course_resource import CourseResource
+from app.domain.models.module import Module
+
+_UUID_PREFIX_RE = re.compile(
+    r"^\s*([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})",
+    re.IGNORECASE,
+)
+
+
+def _starts_with_uuid(s: str) -> bool:
+    return bool(_UUID_PREFIX_RE.match(s)) if isinstance(s, str) else False
+
+
+def humanize_filename(filename: str | None) -> str:
+    """``triola_chapter_3.pdf`` -> ``Triola Chapter 3``."""
+    if not filename:
+        return ""
+    name = filename.strip()
+    if "." in name:
+        stem, _, ext = name.rpartition(".")
+        if 1 <= len(ext) <= 5 and ext.isalnum():
+            name = stem
+    name = name.replace("_", " ").replace("-", " ")
+    name = re.sub(r"\s+", " ", name).strip()
+    return name.title() if name else ""
+
+
+def _pick_display_name(
+    course: Course | None,
+    resources: list[CourseResource],
+    language: str,
+) -> str | None:
+    """Pick the label that replaces a UUID prefix.
+
+    - Single CourseResource: humanized filename of that PDF.
+    - Multiple resources: course title (we can't disambiguate from a
+      flat string alone).
+    - No resources: course title.
+    """
+    if len(resources) == 1:
+        only = resources[0]
+        return humanize_filename(only.parent_filename or only.filename) or None
+    if course is None:
+        return None
+    if language == "en":
+        return getattr(course, "title_en", None) or getattr(course, "title_fr", None)
+    return getattr(course, "title_fr", None) or getattr(course, "title_en", None)
+
+
+def _replace_uuid_prefix(s: str, display: str) -> str:
+    """Swap a leading UUID with ``display``, preserving the trailing suffix."""
+    m = _UUID_PREFIX_RE.match(s)
+    if not m:
+        return s
+    return display + s[m.end() :]
+
+
+async def rewrite_uuid_citations_for_module(
+    sources: list | None,
+    module_id: UUID | None,
+    session: AsyncSession,
+    language: str = "fr",
+) -> list[str]:
+    """Rewrite UUID-prefixed citation strings to human-readable form.
+
+    Returns a new list. Strings that don't start with a UUID are passed
+    through unchanged. If the module/course can't be resolved or there's
+    no readable label available, the input is returned as-is.
+    """
+    if not sources:
+        return [] if sources is None else list(sources)
+    str_sources = [s for s in sources if isinstance(s, str)]
+    if not any(_starts_with_uuid(s) for s in str_sources):
+        return list(str_sources)
+    if module_id is None:
+        return list(str_sources)
+
+    module = await session.get(Module, module_id)
+    if module is None or module.course_id is None:
+        return list(str_sources)
+
+    course = await session.get(Course, module.course_id)
+    res_result = await session.execute(
+        select(CourseResource).where(CourseResource.course_id == module.course_id)
+    )
+    resources = list(res_result.scalars().all())
+
+    display = _pick_display_name(course, resources, language)
+    if not display:
+        return list(str_sources)
+
+    return [_replace_uuid_prefix(s, display) if _starts_with_uuid(s) else s for s in str_sources]
+
+
+def rewrite_uuid_citations_with_context(
+    sources: list | None,
+    course: Course | None,
+    resources: list[CourseResource],
+    language: str = "fr",
+) -> list[str]:
+    """Synchronous variant for callers that already have ``course`` and resources loaded.
+
+    Used by the tutor service, which resolves the active course up front
+    and shouldn't hit the DB again per emitted source.
+    """
+    if not sources:
+        return [] if sources is None else list(sources)
+    str_sources = [s for s in sources if isinstance(s, str)]
+    if not any(_starts_with_uuid(s) for s in str_sources):
+        return list(str_sources)
+
+    display = _pick_display_name(course, resources, language)
+    if not display:
+        return list(str_sources)
+
+    return [_replace_uuid_prefix(s, display) if _starts_with_uuid(s) else s for s in str_sources]
+
+
+def rewrite_uuid_in_string(
+    source: str | None,
+    course: Course | None,
+    resources: list[CourseResource],
+    language: str = "fr",
+) -> str:
+    """Single-string variant for use in dict construction sites (tutor)."""
+    if not source or not isinstance(source, str):
+        return source or ""
+    if not _starts_with_uuid(source):
+        return source
+    display = _pick_display_name(course, resources, language)
+    if not display:
+        return source
+    return _replace_uuid_prefix(source, display)
+
+
+async def rewrite_uuid_in_source_dicts(
+    sources: list[dict] | None,
+    course: Course | None,
+    session: AsyncSession,
+    language: str = "fr",
+) -> list[dict]:
+    """Tutor-side variant that rewrites the ``source`` field in each dict.
+
+    Tutor citations are emitted as ``{"source": <str>, "chapter": ..., "page": ...}``
+    dicts. Walks the list, swapping any UUID-prefixed ``source`` for a
+    human-readable label.
+    """
+    if not sources:
+        return list(sources or [])
+    needs_rewrite = any(
+        _starts_with_uuid(s.get("source", "")) for s in sources if isinstance(s, dict)
+    )
+    if not needs_rewrite:
+        return list(sources)
+    if course is None or getattr(course, "id", None) is None:
+        return list(sources)
+
+    res_result = await session.execute(
+        select(CourseResource).where(CourseResource.course_id == course.id)
+    )
+    resources = list(res_result.scalars().all())
+    display = _pick_display_name(course, resources, language)
+    if not display:
+        return list(sources)
+
+    rewritten: list[dict] = []
+    for entry in sources:
+        if isinstance(entry, dict):
+            src = entry.get("source", "")
+            if _starts_with_uuid(src):
+                entry = {**entry, "source": _replace_uuid_prefix(src, display)}
+        rewritten.append(entry)
+    return rewritten
+
+
+async def rewrite_response_citations(response, session: AsyncSession):
+    """Rewrite ``response.content.sources_cited`` in place.
+
+    Convenience wrapper for endpoint handlers that return a
+    ``LessonResponse``/``CaseStudyResponse`` straight from a service call,
+    so they can apply the citation rewrite without restructuring the
+    response.
+    """
+    content = getattr(response, "content", None)
+    if content is None:
+        return response
+    sources = getattr(content, "sources_cited", None)
+    module_id = getattr(response, "module_id", None)
+    if not sources or module_id is None:
+        return response
+    language = getattr(response, "language", "fr") or "fr"
+    rewritten = await rewrite_uuid_citations_for_module(
+        sources, module_id, session, language=language
+    )
+    # Frozen pydantic models reject attribute assignment; in that case the
+    # endpoint reconstructs the content dict before instantiating, so this
+    # silent fallthrough is intentional.
+    with contextlib.suppress(AttributeError, ValueError):
+        content.sources_cited = rewritten
+    return response

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -1613,6 +1613,14 @@ class TutorService:
                 api_messages.append({"role": "user", "content": tool_results})
 
             unique_sources = _deduplicate_sources(sources_cited)
+            # Citation surface: swap any rag_collection_id UUID labels for the
+            # course's PDF/title before they hit the wire (#2168). Pure
+            # post-processing — does not change how tool-call results are built.
+            from app.domain.services.citation_formatter import rewrite_uuid_in_source_dicts
+
+            unique_sources = await rewrite_uuid_in_source_dicts(
+                unique_sources, course, session, language=effective_language
+            )
 
             activity_suggestions = self._extract_activity_suggestions(
                 full_response, context_type, user.current_level
@@ -1799,6 +1807,25 @@ class TutorService:
             messages_full = conversation.messages or []
 
         messages_out = await _attach_source_image_refs(messages_full, session)
+
+        # Rewrite UUID-shaped citations stored on older messages (#2168).
+        # New messages have already been rewritten before storage; this pass
+        # is idempotent and only acts on legacy entries that still carry the
+        # raw rag_collection_id.
+        if conversation.course_id is not None:
+            from app.domain.models.course import Course as _Course
+            from app.domain.services.citation_formatter import rewrite_uuid_in_source_dicts
+
+            course_for_citations = await session.get(_Course, conversation.course_id)
+            user_lang = "fr"
+            user_row = await session.get(User, user_id)
+            if user_row is not None and getattr(user_row, "preferred_language", None):
+                user_lang = user_row.preferred_language
+            for msg in messages_out:
+                if isinstance(msg, dict) and isinstance(msg.get("sources"), list):
+                    msg["sources"] = await rewrite_uuid_in_source_dicts(
+                        msg["sources"], course_for_citations, session, language=user_lang
+                    )
 
         return {
             "id": conversation.id,

--- a/backend/tests/test_citation_formatter.py
+++ b/backend/tests/test_citation_formatter.py
@@ -1,0 +1,185 @@
+"""Tests for the read-side citation rewriter (#2168)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.domain.services.citation_formatter import (
+    _replace_uuid_prefix,
+    _starts_with_uuid,
+    humanize_filename,
+    rewrite_uuid_citations_with_context,
+    rewrite_uuid_in_source_dicts,
+    rewrite_uuid_in_string,
+)
+
+
+_UUID = "bd2e9508-9b48-46f4-959c-14b682cba886"
+
+
+def _make_resource(filename: str, parent_filename: str | None = None) -> SimpleNamespace:
+    return SimpleNamespace(filename=filename, parent_filename=parent_filename)
+
+
+def _make_course(title_fr: str = "Statistiques de Santé Publique", title_en: str = "Public Health Statistics") -> SimpleNamespace:
+    return SimpleNamespace(id="course-id", title_fr=title_fr, title_en=title_en)
+
+
+class TestUUIDDetection:
+    def test_detects_lowercase_uuid(self):
+        assert _starts_with_uuid(f"{_UUID}, p.43")
+
+    def test_detects_mixed_case_uuid(self):
+        assert _starts_with_uuid("Bd2E9508-9B48-46F4-959C-14B682Cba886, p.43")
+
+    def test_rejects_normal_text(self):
+        assert not _starts_with_uuid("Donaldson Ch.4, p.67")
+        assert not _starts_with_uuid("Triola, p.43")
+
+    def test_rejects_empty(self):
+        assert not _starts_with_uuid("")
+        assert not _starts_with_uuid(None)  # type: ignore[arg-type]
+
+
+class TestHumanizeFilename:
+    def test_strips_extension_and_titlecases(self):
+        assert humanize_filename("triola_chapter_3.pdf") == "Triola Chapter 3"
+
+    def test_handles_dashes(self):
+        assert humanize_filename("public-health-essentials.pdf") == "Public Health Essentials"
+
+    def test_no_extension(self):
+        assert humanize_filename("biology_textbook") == "Biology Textbook"
+
+    def test_empty(self):
+        assert humanize_filename("") == ""
+        assert humanize_filename(None) == ""
+
+    def test_keeps_unusually_long_extension(self):
+        # Anything longer than 5 chars isn't treated as an extension.
+        assert humanize_filename("file.archive_v2") == "File.Archive V2"
+
+
+class TestReplaceUUIDPrefix:
+    def test_replaces_uuid_with_label(self):
+        s = f"{_UUID}, p.43"
+        assert _replace_uuid_prefix(s, "Triola Chapter 3") == "Triola Chapter 3, p.43"
+
+    def test_preserves_chapter_and_page(self):
+        s = f"{_UUID} Ch.5, p.120"
+        assert _replace_uuid_prefix(s, "Donaldson") == "Donaldson Ch.5, p.120"
+
+    def test_passes_through_non_uuid(self):
+        s = "Donaldson Ch.4, p.67"
+        assert _replace_uuid_prefix(s, "Other") == s
+
+
+class TestRewriteWithContext:
+    def test_single_resource_uses_filename(self):
+        course = _make_course()
+        resources = [_make_resource("triola_chapter_3.pdf")]
+        sources = [f"{_UUID}, p.43", f"{_UUID}, p.45"]
+        result = rewrite_uuid_citations_with_context(sources, course, resources, "fr")
+        assert result == ["Triola Chapter 3, p.43", "Triola Chapter 3, p.45"]
+
+    def test_single_resource_prefers_parent_filename(self):
+        course = _make_course()
+        resources = [_make_resource("triola_part1.pdf", parent_filename="triola_full.pdf")]
+        sources = [f"{_UUID}, p.43"]
+        result = rewrite_uuid_citations_with_context(sources, course, resources, "fr")
+        assert result == ["Triola Full, p.43"]
+
+    def test_multi_resource_falls_back_to_course_title(self):
+        course = _make_course()
+        resources = [
+            _make_resource("triola.pdf"),
+            _make_resource("donaldson.pdf"),
+        ]
+        sources = [f"{_UUID}, p.43"]
+        result = rewrite_uuid_citations_with_context(sources, course, resources, "fr")
+        assert result == ["Statistiques de Santé Publique, p.43"]
+
+    def test_english_uses_english_title(self):
+        course = _make_course()
+        resources = [_make_resource("a.pdf"), _make_resource("b.pdf")]
+        result = rewrite_uuid_citations_with_context(
+            [f"{_UUID}, p.43"], course, resources, "en"
+        )
+        assert result == ["Public Health Statistics, p.43"]
+
+    def test_no_resources_no_course_keeps_input(self):
+        result = rewrite_uuid_citations_with_context([f"{_UUID}, p.43"], None, [], "fr")
+        assert result == [f"{_UUID}, p.43"]
+
+    def test_legacy_named_source_passes_through(self):
+        course = _make_course()
+        resources = [_make_resource("triola.pdf")]
+        result = rewrite_uuid_citations_with_context(
+            ["Donaldson Ch.4, p.67"], course, resources, "fr"
+        )
+        assert result == ["Donaldson Ch.4, p.67"]
+
+    def test_mixed_input_only_rewrites_uuid_entries(self):
+        course = _make_course()
+        resources = [_make_resource("triola.pdf")]
+        result = rewrite_uuid_citations_with_context(
+            [f"{_UUID}, p.43", "Donaldson Ch.4, p.67"], course, resources, "fr"
+        )
+        assert result == ["Triola, p.43", "Donaldson Ch.4, p.67"]
+
+    def test_empty_returns_empty(self):
+        assert rewrite_uuid_citations_with_context([], _make_course(), [], "fr") == []
+        assert rewrite_uuid_citations_with_context(None, _make_course(), [], "fr") == []
+
+
+class TestRewriteUUIDInString:
+    def test_single_resource(self):
+        course = _make_course()
+        resources = [_make_resource("triola.pdf")]
+        assert rewrite_uuid_in_string(f"{_UUID}, p.43", course, resources) == "Triola, p.43"
+
+    def test_legacy_passes_through(self):
+        assert rewrite_uuid_in_string("Donaldson", None, []) == "Donaldson"
+
+    def test_none(self):
+        assert rewrite_uuid_in_string(None, None, []) == ""
+
+
+@pytest.mark.asyncio
+class TestRewriteUUIDInSourceDicts:
+    async def test_no_uuids_short_circuits(self):
+        # Should not even hit the DB.
+        sources = [{"source": "Donaldson", "page": 67}]
+        session = MagicMock()
+        result = await rewrite_uuid_in_source_dicts(sources, _make_course(), session, "fr")
+        assert result == sources
+        session.execute.assert_not_called()
+
+    async def test_no_course_passes_through(self):
+        sources = [{"source": _UUID, "page": 43}]
+        session = MagicMock()
+        result = await rewrite_uuid_in_source_dicts(sources, None, session, "fr")
+        assert result == sources
+
+    async def test_single_resource_rewrites_uuid_field(self):
+        sources = [{"source": _UUID, "page": 43, "chapter": "3"}]
+
+        course = _make_course()
+        course.id = "course-uuid"
+
+        # Build a fake async session whose execute() returns a result whose
+        # .scalars().all() yields our resource list.
+        from unittest.mock import AsyncMock
+
+        scalars = MagicMock()
+        scalars.all.return_value = [_make_resource("triola_chapter_3.pdf")]
+        result_obj = MagicMock()
+        result_obj.scalars.return_value = scalars
+        session = MagicMock()
+        session.execute = AsyncMock(return_value=result_obj)
+
+        out = await rewrite_uuid_in_source_dicts(sources, course, session, "fr")
+        assert out[0]["source"] == "Triola Chapter 3"
+        assert out[0]["page"] == 43
+        assert out[0]["chapter"] == "3"

--- a/backend/tests/test_citation_formatter.py
+++ b/backend/tests/test_citation_formatter.py
@@ -21,7 +21,9 @@ def _make_resource(filename: str, parent_filename: str | None = None) -> SimpleN
     return SimpleNamespace(filename=filename, parent_filename=parent_filename)
 
 
-def _make_course(title_fr: str = "Statistiques de Santé Publique", title_en: str = "Public Health Statistics") -> SimpleNamespace:
+def _make_course(
+    title_fr: str = "Statistiques de Santé Publique", title_en: str = "Public Health Statistics"
+) -> SimpleNamespace:
     return SimpleNamespace(id="course-id", title_fr=title_fr, title_en=title_en)
 
 
@@ -102,9 +104,7 @@ class TestRewriteWithContext:
     def test_english_uses_english_title(self):
         course = _make_course()
         resources = [_make_resource("a.pdf"), _make_resource("b.pdf")]
-        result = rewrite_uuid_citations_with_context(
-            [f"{_UUID}, p.43"], course, resources, "en"
-        )
+        result = rewrite_uuid_citations_with_context([f"{_UUID}, p.43"], course, resources, "en")
         assert result == ["Public Health Statistics, p.43"]
 
     def test_no_resources_no_course_keeps_input(self):

--- a/backend/tests/test_citation_formatter.py
+++ b/backend/tests/test_citation_formatter.py
@@ -14,7 +14,6 @@ from app.domain.services.citation_formatter import (
     rewrite_uuid_in_string,
 )
 
-
 _UUID = "bd2e9508-9b48-46f4-959c-14b682cba886"
 
 


### PR DESCRIPTION
## Summary

Pure read-side fix for #2168 — \"Sources Citées\" displayed
``Bd2E9508-9B48-46F4-959C-14B682Cba886, p.43`` instead of a human-readable
PDF/course name.

Root cause: ingestion stores ``DocumentChunk.source = rag_collection_id``
(course UUID), then ``source.title()`` renders the UUID at display time.

Fix: a new ``citation_formatter`` module that rewrites UUID-prefixed
citation strings into a readable label. Applied **only** at the
citation surface — generation pipeline, prompt formatters, cache
content, and the chunker are not touched.

- Single-PDF course → humanized ``CourseResource.filename``
  (e.g. ``triola_chapter_3.pdf`` → ``Triola Chapter 3, p.43``)
- Multi-PDF course → fallback to the course title (per-PDF granularity
  isn't recoverable from a flat string alone, but anything beats the UUID)
- Legacy named sources (``donaldson``, ``triola``) pass through untouched

### Surfaces patched

- ``GET /content/lessons/{module_id}/{unit_id}`` cache-hit branch
- ``GET /content/cases/{module_id}/{unit_id}`` cache-hit branch
- ``GET /content/lessons/{lesson_id}`` (single-content endpoint)
- ``POST /content/generate-lesson``
- ``POST /admin/courses/.../preview-lesson``
- Tutor live-stream ``sources_cited`` event
- Tutor ``GET /tutor/conversations/{id}`` (rewrites legacy stored sources)

## Verification

- 26 new unit tests in ``tests/test_citation_formatter.py`` (all green)
- ``ruff check`` clean on all touched files
- Adjacent test suites pass: ``tests/test_tutor_service.py``,
  ``tests/test_lesson_audio_service.py``, ``tests/test_courses.py``

## What this PR does NOT do

- No migration / schema change
- No re-indexation of any course (no OpenAI embedding spend)
- No changes to lesson/case-study generation, RAG retrieval, or prompts
- No changes to the cached ``generated_content`` rows themselves

## Test plan

- [ ] On staging, open the unit from the screenshot — confirm \"Sources Citées\" shows the humanized PDF name
- [ ] Open a case study unit — confirm same readable format
- [ ] Open a tutor chat with citations — confirm same readable format
- [ ] Open an old tutor conversation — confirm legacy UUID sources are rewritten on read

Fixes #2168