### PR TITLE
fix(progress): hydrate lesson/case-study completion on mount

### DIFF
--- a/frontend/components/learning/case-study-viewer.tsx
+++ b/frontend/components/learning/case-study-viewer.tsx
@@ -15,7 +15,7 @@ import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import { LessonSkeleton } from './lesson-skeleton';
 import { SourceCitations } from './source-citations';
-import { apiFetch } from '@/lib/api';
+import { apiFetch, getModuleDetailWithProgress } from '@/lib/api';
 import { useCurrentUser } from '@/lib/hooks/use-current-user';
 import { loadCaseStudy, OfflineContentNotAvailable } from '@/lib/offline/content-loader';
 import { OfflineBadge } from '@/components/shared/offline-badge';
@@ -117,6 +117,23 @@ export function CaseStudyViewer({
   const { isOnline } = useNetworkStatus();
 
   const t = useTranslations('CaseStudyViewer');
+
+  useEffect(() => {
+    if (!isHydrated || !moduleId || !unitId) return;
+    let cancelled = false;
+    getModuleDetailWithProgress(moduleId)
+      .then((detail) => {
+        if (cancelled) return;
+        const match = detail.units.find((u) => u.unit_number === unitId);
+        if (match?.status === 'completed') setIsCompleted(true);
+      })
+      .catch((err) => {
+        console.warn('Failed to hydrate case study completion state', err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isHydrated, moduleId, unitId]);
 
   useEffect(() => {
     // Wait for the localStorage-backed user to settle before fetching, otherwise

--- a/frontend/components/learning/lesson-viewer.tsx
+++ b/frontend/components/learning/lesson-viewer.tsx
@@ -15,7 +15,7 @@ import { LessonImage } from './lesson-image';
 import { LessonMediaTabs, type LessonMediaTab } from './lesson-media-tabs';
 import { SourceImage } from './source-image';
 import { SourceCitations } from './source-citations';
-import { apiFetch, ApiError } from '@/lib/api';
+import { apiFetch, ApiError, getModuleDetailWithProgress } from '@/lib/api';
 import type { SourceImageMeta } from '@/lib/api';
 import { SOURCE_IMAGE_RE, splitWithSourceImageMarkers } from '@/lib/source-image-utils';
 import { useCurrentUser } from '@/lib/hooks/use-current-user';
@@ -109,6 +109,23 @@ export function LessonViewer({
   const { isOnline } = useNetworkStatus();
 
   const t = useTranslations('LessonViewer');
+
+  useEffect(() => {
+    if (!isHydrated || !moduleId || !unitId) return;
+    let cancelled = false;
+    getModuleDetailWithProgress(moduleId)
+      .then((detail) => {
+        if (cancelled) return;
+        const match = detail.units.find((u) => u.unit_number === unitId);
+        if (match?.status === 'completed') setIsCompleted(true);
+      })
+      .catch((err) => {
+        console.warn('Failed to hydrate lesson completion state', err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isHydrated, moduleId, unitId]);
 
   const stopGenerating = (errMsg: string, type: 'load' | 'generation' | 'timeout' | 'no_content') => {
     if (slowWarningTimerRef.current) {


### PR DESCRIPTION
Fixes #2175

## Summary
- Hydrate `isCompleted` in `LessonViewer` and `CaseStudyViewer` on mount by calling `getModuleDetailWithProgress(moduleId)` and matching the unit by `unit_number`
- Backend write/read paths from #2167 are correct — this only fixes the client-side state that was always initialized to `false` and never refreshed from the server

## Test plan
- [ ] Mark a lesson complete → refresh page → button still shows "Completed"
- [ ] Mark a case-study unit complete → refresh page → button still shows "Completed"
- [ ] Sidebar overlay check-mark and viewer button agree
- [ ] Fresh, never-completed lesson shows "Mark Complete" on first visit (no false positive)
- [ ] Network tab: `GET /api/v1/progress/modules/<id>/detail` fires once on mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)