### PR TITLE
fix(citations): SourceImage.surrounding_text tiebreaker (#2181)

### DIFF
--- a/backend/app/domain/services/citation_formatter.py
+++ b/backend/app/domain/services/citation_formatter.py
@@ -33,6 +33,7 @@ from app.domain.models.course import Course
 from app.domain.models.course_resource import CourseResource
 from app.domain.models.document_chunk import DocumentChunk
 from app.domain.models.module import Module
+from app.domain.models.source_image import SourceImage, SourceImageChunk
 
 _UUID_PREFIX_RE = re.compile(
     r"^\s*([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})",
@@ -151,8 +152,11 @@ async def _resolve_per_citation_map(
     For each ``(chapter, page)`` pair, fetch the matching ``DocumentChunk`` rows
     (scoped by the course's ``rag_collection_id``), then identify which
     ``CourseResource`` the chunk came from by substring-matching the chunk's
-    content prefix inside each resource's normalized ``raw_text``. Pairs that
-    don't yield a unique resource are simply omitted from the map.
+    content prefix inside each resource's normalized ``raw_text``. When the
+    chunk content itself matches multiple resources (boilerplate / shared
+    front-matter), fall back to the chunk's linked ``SourceImage.surrounding_text``
+    as a tiebreaker (#2181). Pairs that still don't yield a unique resource
+    are simply omitted from the map.
     """
     rag_id = getattr(course, "rag_collection_id", None)
     if not rag_id or not pairs or not resources:
@@ -171,7 +175,12 @@ async def _resolve_per_citation_map(
             clauses.append(DocumentChunk.page == p)
         conditions.append(and_(*clauses))
     stmt = (
-        select(DocumentChunk.chapter, DocumentChunk.page, DocumentChunk.content)
+        select(
+            DocumentChunk.id,
+            DocumentChunk.chapter,
+            DocumentChunk.page,
+            DocumentChunk.content,
+        )
         .where(or_(*conditions))
         .limit(200)
     )
@@ -185,15 +194,26 @@ async def _resolve_per_citation_map(
     if not normalized_resources:
         return {}
 
-    out: dict[tuple[str | None, int | None], str] = {}
-    # Track ambiguity: if two different resources match the same (chapter, page)
-    # via different chunk rows, drop the pair.
-    seen: dict[tuple[str | None, int | None], CourseResource | None] = {}
-    AMBIGUOUS = object()
+    AMBIGUOUS: object = object()
+    seen: dict[tuple[str | None, int | None], CourseResource | object] = {}
+    # Chunks whose content matched 2+ resources — defer to the image-text
+    # tiebreaker pass below.
+    deferred: list[tuple[Any, str | None, int | None, list[CourseResource]]] = []
+
+    def _record(key: tuple[str | None, int | None], winner: CourseResource) -> None:
+        prior = seen.get(key)
+        if prior is None:
+            seen[key] = winner
+        elif prior is AMBIGUOUS:
+            return
+        elif getattr(prior, "id", None) != winner.id:
+            seen[key] = AMBIGUOUS
+
     for row in rows:
-        chunk_chapter = row[0]
-        chunk_page = row[1]
-        chunk_content = row[2] or ""
+        chunk_id = row[0]
+        chunk_chapter = row[1]
+        chunk_page = row[2]
+        chunk_content = row[3] or ""
         normalized = _normalize_for_match(chunk_content)
         fingerprint = normalized[:_FINGERPRINT_LEN]
         if len(fingerprint) < 40:
@@ -202,20 +222,48 @@ async def _resolve_per_citation_map(
         for resource, normalized_text in normalized_resources:
             if fingerprint in normalized_text:
                 matches.append(resource)
-                if len(matches) > 1:
-                    break
-        if len(matches) != 1:
-            continue
-        winner = matches[0]
-        key = (chunk_chapter, chunk_page)
-        prior = seen.get(key)
-        if prior is None:
-            seen[key] = winner
-        elif prior is AMBIGUOUS:
-            continue
-        elif prior.id != winner.id:
-            seen[key] = AMBIGUOUS  # type: ignore[assignment]
+        if len(matches) == 1:
+            _record((chunk_chapter, chunk_page), matches[0])
+        elif len(matches) > 1:
+            deferred.append((chunk_id, chunk_chapter, chunk_page, matches))
 
+    if deferred:
+        chunk_ids = list({d[0] for d in deferred if d[0] is not None})
+        if chunk_ids:
+            img_stmt = (
+                select(SourceImageChunk.document_chunk_id, SourceImage.surrounding_text)
+                .join(SourceImage, SourceImage.id == SourceImageChunk.source_image_id)
+                .where(SourceImageChunk.document_chunk_id.in_(chunk_ids))
+            )
+            img_rows = (await session.execute(img_stmt)).all()
+            surrounding_by_chunk: dict[Any, list[str]] = {}
+            for cid, st in img_rows:
+                if not st:
+                    continue
+                surrounding_by_chunk.setdefault(cid, []).append(st)
+
+            for chunk_id, chunk_chapter, chunk_page, candidates in deferred:
+                sts = surrounding_by_chunk.get(chunk_id, [])
+                if not sts:
+                    continue
+                # Vote: which candidate uniquely contains a surrounding_text?
+                # Pre-compute candidate normalized_text lookup.
+                candidate_texts = {
+                    r.id: t for (r, t) in normalized_resources for c in candidates if c.id == r.id
+                }
+                tiebreaker_winner: CourseResource | None = None
+                for st in sts:
+                    fp = _normalize_for_match(st)[:_FINGERPRINT_LEN]
+                    if len(fp) < 40:
+                        continue
+                    sub_matches = [r for r in candidates if fp in candidate_texts.get(r.id, "")]
+                    if len(sub_matches) == 1:
+                        tiebreaker_winner = sub_matches[0]
+                        break
+                if tiebreaker_winner is not None:
+                    _record((chunk_chapter, chunk_page), tiebreaker_winner)
+
+    out: dict[tuple[str | None, int | None], str] = {}
     for key, winner in seen.items():
         if winner is None or winner is AMBIGUOUS:
             continue

--- a/backend/tests/test_citation_formatter.py
+++ b/backend/tests/test_citation_formatter.py
@@ -52,9 +52,14 @@ def _make_module(course_id: str = "course-id") -> SimpleNamespace:
     return SimpleNamespace(id="module-id", course_id=course_id)
 
 
-def _make_chunk_row(chapter: str | None, page: int | None, content: str) -> tuple:
-    """Mimic an SQLAlchemy Row for the (chapter, page, content) projection."""
-    return (chapter, page, content)
+def _make_chunk_row(
+    chapter: str | None,
+    page: int | None,
+    content: str,
+    chunk_id: str | None = None,
+) -> tuple:
+    """Mimic an SQLAlchemy Row for the (id, chapter, page, content) projection."""
+    return (chunk_id or f"chunk-{chapter}-{page}", chapter, page, content)
 
 
 class _FakeAsyncSession:
@@ -370,8 +375,8 @@ class TestRewriteForModuleMultiResource:
 
     async def test_ambiguous_chunk_falls_back_to_course_title(self):
         # Boilerplate paragraph appears in both PDFs — chunk fingerprint
-        # matches both resources, so that pair's citation falls back to the
-        # course title.
+        # matches both resources. With no linked image text to break the tie,
+        # the citation falls back to the course title.
         boilerplate = "this generic introduction paragraph " * 20
         pdf_a = _make_resource(
             "alpha_textbook.pdf",
@@ -393,7 +398,8 @@ class TestRewriteForModuleMultiResource:
             },
             execute_queue=[
                 _scalar_result([pdf_a, pdf_b]),
-                _row_result([_make_chunk_row("1", 1, boilerplate)]),
+                _row_result([("chunk-amb-1", "1", 1, boilerplate)]),
+                _row_result([]),  # no linked images for the deferred chunk
             ],
         )
         sources = [f"{_UUID} Ch.1, p.1"]
@@ -422,6 +428,106 @@ class TestRewriteForModuleMultiResource:
         sources = [f"{_UUID}, p.43", f"{_UUID} Ch.2, p.50"]
         out = await rewrite_uuid_citations_for_module(sources, "module-id", session, "fr")
         assert out == ["Alpha Textbook, p.43", "Alpha Textbook Ch.2, p.50"]
+
+
+@pytest.mark.asyncio
+class TestImageTiebreaker:
+    """When chunk content matches multiple resources, ``SourceImage.surrounding_text``
+    breaks ties (#2181)."""
+
+    async def test_surrounding_text_breaks_tie(self):
+        # Both PDFs share a paragraph (boilerplate). Chunk content matches
+        # both. But a linked SourceImage's surrounding_text appears in only
+        # one — that's the winner.
+        boilerplate = "shared header paragraph " * 30
+        pdf_a_unique = "alpha-only specific marker " * 20
+        pdf_b_unique = "beta-only specific marker " * 20
+        pdf_a = _make_resource(
+            "alpha.pdf",
+            raw_text=boilerplate + pdf_a_unique,
+            rid="rid-a",
+        )
+        pdf_b = _make_resource(
+            "beta.pdf",
+            raw_text=boilerplate + pdf_b_unique,
+            rid="rid-b",
+        )
+        course = _make_course()
+        module = _make_module()
+
+        chunk_id = "chunk-1"
+        # Chunk content == boilerplate, so it matches BOTH resources.
+        chunk_row = (chunk_id, "1", 5, boilerplate)
+        # Linked surrounding_text contains alpha-specific marker → unique to A.
+        img_row = (chunk_id, "alpha-only specific marker " * 5)
+
+        session = _FakeAsyncSession(
+            gets={
+                ("Module", "module-id"): module,
+                ("Course", "course-id"): course,
+            },
+            execute_queue=[
+                _scalar_result([pdf_a, pdf_b]),
+                _row_result([chunk_row]),
+                _row_result([img_row]),
+            ],
+        )
+        sources = [f"{_UUID} Ch.1, p.5"]
+        out = await rewrite_uuid_citations_for_module(sources, "module-id", session, "fr")
+        assert out == ["Alpha Ch.1, p.5"]
+
+    async def test_no_image_keeps_ambiguous_fallback(self):
+        # Chunk content matches both resources, no linked image → still
+        # ambiguous, falls back to course title.
+        boilerplate = "shared header paragraph " * 30
+        pdf_a = _make_resource("alpha.pdf", raw_text=boilerplate + "x" * 200, rid="rid-a")
+        pdf_b = _make_resource("beta.pdf", raw_text=boilerplate + "y" * 200, rid="rid-b")
+        course = _make_course()
+        module = _make_module()
+
+        chunk_row = ("chunk-1", "1", 5, boilerplate)
+
+        session = _FakeAsyncSession(
+            gets={
+                ("Module", "module-id"): module,
+                ("Course", "course-id"): course,
+            },
+            execute_queue=[
+                _scalar_result([pdf_a, pdf_b]),
+                _row_result([chunk_row]),
+                _row_result([]),  # no linked images
+            ],
+        )
+        sources = [f"{_UUID} Ch.1, p.5"]
+        out = await rewrite_uuid_citations_for_module(sources, "module-id", session, "fr")
+        assert out == ["Statistiques de Santé Publique Ch.1, p.5"]
+
+    async def test_image_text_ambiguous_keeps_fallback(self):
+        # Chunk content + linked image text both match multiple resources →
+        # still ambiguous, falls back.
+        boilerplate = "shared header paragraph " * 30
+        pdf_a = _make_resource("alpha.pdf", raw_text=boilerplate + "alpha-x " * 50, rid="rid-a")
+        pdf_b = _make_resource("beta.pdf", raw_text=boilerplate + "beta-y " * 50, rid="rid-b")
+        course = _make_course()
+        module = _make_module()
+
+        chunk_row = ("chunk-1", "1", 5, boilerplate)
+        img_row = ("chunk-1", boilerplate)  # surrounding_text is also shared
+
+        session = _FakeAsyncSession(
+            gets={
+                ("Module", "module-id"): module,
+                ("Course", "course-id"): course,
+            },
+            execute_queue=[
+                _scalar_result([pdf_a, pdf_b]),
+                _row_result([chunk_row]),
+                _row_result([img_row]),
+            ],
+        )
+        sources = [f"{_UUID} Ch.1, p.5"]
+        out = await rewrite_uuid_citations_for_module(sources, "module-id", session, "fr")
+        assert out == ["Statistiques de Santé Publique Ch.1, p.5"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Resolves #2181. Lifts multi-PDF citation resolution coverage by adding \`SourceImage.surrounding_text\` as a tiebreaker when chunk-content fingerprints match more than one PDF.

The primary chunk-content vote (#2179) handles the unambiguous majority. For chunks where multiple PDFs share text (boilerplate, cross-references, common methodology), the tiebreaker JOINs through \`source_image_chunks\` → \`source_images\` and uses each linked figure's surrounding paragraph as a second fingerprint. If exactly one PDF contains it, that's the winner.

- One extra \`SELECT\` per page render, fired **only** for chunks that the primary vote couldn't resolve.
- No schema, no re-index, no embeddings, no regen — same constraints as #2179.
- Per-citation fallback to course title still applies as the floor.

## Test plan

- [x] 42 unit tests including: tiebreaker breaks tie via surrounding_text, no-image case still falls back, both-fingerprints-ambiguous still falls back.
- [ ] Staging: re-hit \`/api/v1/content/lessons/45e59070-1196-406f-b6c4-3d49221b51aa/1.1\` (the multi-PDF lesson from #2179 verification, currently 2/8 resolved) and confirm a higher resolution rate.