### PR TITLE
fix(citations): match 8-char hex source prefixes (#2174)

### DIFF
--- a/backend/app/domain/services/citation_formatter.py
+++ b/backend/app/domain/services/citation_formatter.py
@@ -35,8 +35,14 @@ from app.domain.models.document_chunk import DocumentChunk
 from app.domain.models.module import Module
 from app.domain.models.source_image import SourceImage, SourceImageChunk
 
+# Match either the full UUID form (``8-4-4-4-12``) or a bare 8-char hex
+# stem (#2174) — Claude sometimes echoes only the leading segment back.
+# The lookahead pins the 8-char form to a separator (whitespace / comma /
+# end-of-string) so a normal word that *happens* to start with hex letters
+# (e.g. ``"Cafebabe Ch.1"``) is the only false positive we accept;
+# ordinary names like ``"Donaldson"`` have non-hex chars and won't match.
 _UUID_PREFIX_RE = re.compile(
-    r"^\s*([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})",
+    r"^\s*(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9a-f]{8}(?=\s|,|$))",
     re.IGNORECASE,
 )
 _CHAPTER_RE = re.compile(r"\bCh\.([^,\s]+)", re.IGNORECASE)

--- a/backend/tests/test_citation_formatter.py
+++ b/backend/tests/test_citation_formatter.py
@@ -117,6 +117,27 @@ class TestUUIDDetection:
         assert not _starts_with_uuid("")
         assert not _starts_with_uuid(None)  # type: ignore[arg-type]
 
+    # 8-char hex stem variants (#2174)
+    def test_detects_8char_hex_with_chapter(self):
+        assert _starts_with_uuid("E8883D1E Ch.1")
+
+    def test_detects_8char_hex_with_page(self):
+        assert _starts_with_uuid("F89C2931, p.43")
+
+    def test_detects_8char_hex_alone(self):
+        assert _starts_with_uuid("E8883D1E")
+
+    def test_rejects_8char_word_followed_by_non_separator(self):
+        # ``Donaldso`` (the first 8 chars of "Donaldson") contains 'o', 'n',
+        # 'l', 's' which aren't hex, so it doesn't match anyway. But this
+        # also guards against a hypothetical hex-shaped word that is
+        # actually part of a longer identifier.
+        assert not _starts_with_uuid("Cafebabexyz Ch.1")  # not separated
+        assert not _starts_with_uuid("Donaldson")
+
+    def test_rejects_seven_char_hex(self):
+        assert not _starts_with_uuid("E8883D1 Ch.1")  # only 7 hex chars
+
 
 class TestHumanizeFilename:
     def test_strips_extension_and_titlecases(self):
@@ -205,6 +226,27 @@ class TestRewriteWithContext:
     def test_empty_returns_empty(self):
         assert rewrite_uuid_citations_with_context([], _make_course(), [], "fr") == []
         assert rewrite_uuid_citations_with_context(None, _make_course(), [], "fr") == []
+
+    # 8-char hex variants (#2174)
+    def test_rewrites_8char_hex_with_chapter(self):
+        course = _make_course()
+        resources = [_make_resource("triola.pdf")]
+        result = rewrite_uuid_citations_with_context(["E8883D1E Ch.1"], course, resources, "fr")
+        assert result == ["Triola Ch.1"]
+
+    def test_rewrites_8char_hex_with_page(self):
+        course = _make_course()
+        resources = [_make_resource("triola.pdf")]
+        result = rewrite_uuid_citations_with_context(["F89C2931, p.43"], course, resources, "fr")
+        assert result == ["Triola, p.43"]
+
+    def test_rewrites_mixed_full_and_short_uuids(self):
+        course = _make_course()
+        resources = [_make_resource("triola.pdf")]
+        result = rewrite_uuid_citations_with_context(
+            [f"{_UUID}, p.43", "E8883D1E Ch.1", "Donaldson, p.67"], course, resources, "fr"
+        )
+        assert result == ["Triola, p.43", "Triola Ch.1", "Donaldson, p.67"]
 
 
 class TestRewriteUUIDInString:


### PR DESCRIPTION
## Summary

Resolves #2174. Some cached lessons display sources like \`E8883D1E Ch.1\` — Claude echoed only the first hex segment of the \`rag_collection_id\` back, and the existing rewriter regex only matched the full 36-char UUID form, so these 8-char variants slipped through.

Extends \`_UUID_PREFIX_RE\` to also match a bare 8-char hex stem, pinned via a lookahead to a separator (whitespace / comma / end-of-string) so ordinary words don't false-positive.

## Test plan

- [x] 50 unit tests; new cases include 8-char hex with chapter/page, 8-char alone, mixed full + short UUID lists, rejection of non-separated hex words and 7-char hex.
- [ ] Staging: hit \`/api/v1/content/lessons/2263b50e-677c-4dbc-9612-842ad282476a/1.1\` (the lesson with \`E8883D1E Ch.1\` cached) — confirm rewritten to \"Donaldson Ch.1\" or whichever PDF resolves.