### PR TITLE
fix(citations): add course_resource_id FK on document_chunks (#2186)

### DIFF
--- a/backend/app/ai/rag/chunker.py
+++ b/backend/app/ai/rag/chunker.py
@@ -6,6 +6,7 @@ Splits documents into 512-token chunks with 50-token overlap for optimal embeddi
 import re
 from collections.abc import Generator
 from dataclasses import dataclass
+from uuid import UUID
 
 import tiktoken
 
@@ -22,6 +23,7 @@ class DocumentChunk:
     page: int | None = None
     level: int | None = None
     language: str = "en"
+    course_resource_id: UUID | None = None
 
 
 class TextChunker:
@@ -67,6 +69,7 @@ class TextChunker:
         page: int | None = None,
         level: int | None = None,
         language: str = "en",
+        course_resource_id: UUID | None = None,
     ) -> Generator[DocumentChunk, None, None]:
         """
         Split document into overlapping chunks.
@@ -78,6 +81,9 @@ class TextChunker:
             page: Page number if available
             level: Difficulty level (1-4) for targeting
             language: Language code ("fr" or "en")
+            course_resource_id: FK back to ``course_resources.id`` so the
+                citation formatter can resolve a chunk to its originating
+                PDF without fingerprint matching (#2186).
 
         Yields:
             DocumentChunk objects with metadata
@@ -112,6 +118,7 @@ class TextChunker:
                             page=page,
                             level=level,
                             language=language,
+                            course_resource_id=course_resource_id,
                         )
                         chunk_index += 1
                         overlap_text = self._get_overlap_text(current_chunk, self.overlap_size)
@@ -136,6 +143,7 @@ class TextChunker:
                     page=page,
                     level=level,
                     language=language,
+                    course_resource_id=course_resource_id,
                 )
 
                 chunk_index += 1
@@ -163,6 +171,7 @@ class TextChunker:
                 page=page,
                 level=level,
                 language=language,
+                course_resource_id=course_resource_id,
             )
 
     def _clean_text(self, text: str) -> str:

--- a/backend/app/ai/rag/pipeline.py
+++ b/backend/app/ai/rag/pipeline.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import structlog
 from sqlalchemy import delete, select
@@ -50,6 +50,7 @@ class RAGPipeline:
         source: str,
         level: int | None = None,
         session: AsyncSession | None = None,
+        course_resource_id: UUID | None = None,
     ) -> int:
         """
         Process a single PDF document through the complete RAG pipeline.
@@ -59,6 +60,8 @@ class RAGPipeline:
             source: Source identifier (e.g., "donaldson", "triola")
             level: Optional difficulty level (1-4)
             session: Database session (will create one if not provided)
+            course_resource_id: FK back to ``course_resources.id`` (#2186) so
+                stored chunks know their originating PDF.
 
         Returns:
             Number of chunks processed
@@ -106,6 +109,7 @@ class RAGPipeline:
                     level=level,
                     language=language,
                     page=page_num,
+                    course_resource_id=course_resource_id,
                 )
             )
 
@@ -169,6 +173,7 @@ class RAGPipeline:
                 language=chunk_data.language,
                 token_count=chunk_data.token_count,
                 chunk_index=chunk_data.chunk_index,
+                course_resource_id=getattr(chunk_data, "course_resource_id", None),
             )
 
             session.add(db_chunk)

--- a/backend/app/domain/models/document_chunk.py
+++ b/backend/app/domain/models/document_chunk.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from uuid import UUID, uuid4
 
-from sqlalchemy import ARRAY, Float, Integer, String, Text
+from sqlalchemy import ARRAY, Float, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
 
@@ -33,6 +33,14 @@ class DocumentChunk(Base):
     page: Mapped[int | None] = mapped_column(Integer, nullable=True)
     level: Mapped[int | None] = mapped_column(Integer, nullable=True)  # 1-4 difficulty
     language: Mapped[str] = mapped_column(String(2), nullable=False)  # "fr" or "en"
+
+    # Per-PDF identity (#2186). NULL on rows ingested before migration 089;
+    # the citation_formatter falls back to fingerprint matching for those.
+    course_resource_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("course_resources.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
 
     # Chunk metadata
     token_count: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/backend/app/domain/services/citation_formatter.py
+++ b/backend/app/domain/services/citation_formatter.py
@@ -155,14 +155,17 @@ async def _resolve_per_citation_map(
 ) -> dict[tuple[str | None, int | None], str]:
     """Return ``{(chapter, page): humanized_filename}`` for resolvable citations.
 
-    For each ``(chapter, page)`` pair, fetch the matching ``DocumentChunk`` rows
-    (scoped by the course's ``rag_collection_id``), then identify which
-    ``CourseResource`` the chunk came from by substring-matching the chunk's
-    content prefix inside each resource's normalized ``raw_text``. When the
-    chunk content itself matches multiple resources (boilerplate / shared
-    front-matter), fall back to the chunk's linked ``SourceImage.surrounding_text``
-    as a tiebreaker (#2181). Pairs that still don't yield a unique resource
-    are simply omitted from the map.
+    Resolution order:
+
+    1. **Direct FK** (#2186): if a chunk row has ``course_resource_id`` set
+       (populated by ingest from migration 089 onward), use it directly.
+    2. **Content fingerprint vote** (#2178): substring-match chunk content
+       against each ``CourseResource.raw_text``.
+    3. **SourceImage.surrounding_text tiebreaker** (#2181): for chunks where
+       step 2 matched multiple resources, look up linked figures and use
+       the surrounding paragraph as a second fingerprint.
+
+    Pairs that don't yield a unique resource are simply omitted from the map.
     """
     rag_id = getattr(course, "rag_collection_id", None)
     if not rag_id or not pairs or not resources:
@@ -186,6 +189,7 @@ async def _resolve_per_citation_map(
             DocumentChunk.chapter,
             DocumentChunk.page,
             DocumentChunk.content,
+            DocumentChunk.course_resource_id,
         )
         .where(or_(*conditions))
         .limit(200)
@@ -206,6 +210,9 @@ async def _resolve_per_citation_map(
     # tiebreaker pass below.
     deferred: list[tuple[Any, str | None, int | None, list[CourseResource]]] = []
 
+    # Build resource-by-id lookup once for the FK fast path.
+    resource_by_id = {r.id: r for r in resources}
+
     def _record(key: tuple[str | None, int | None], winner: CourseResource) -> None:
         prior = seen.get(key)
         if prior is None:
@@ -220,6 +227,17 @@ async def _resolve_per_citation_map(
         chunk_chapter = row[1]
         chunk_page = row[2]
         chunk_content = row[3] or ""
+        chunk_resource_id = row[4]
+
+        # Fast path (#2186): chunks ingested after migration 089 carry a
+        # direct FK to their originating CourseResource. Skip all the
+        # fingerprint dance for those.
+        if chunk_resource_id is not None:
+            direct = resource_by_id.get(chunk_resource_id)
+            if direct is not None:
+                _record((chunk_chapter, chunk_page), direct)
+                continue
+
         normalized = _normalize_for_match(chunk_content)
         fingerprint = normalized[:_FINGERPRINT_LEN]
         if len(fingerprint) < 40:

--- a/backend/app/tasks/rag_indexation.py
+++ b/backend/app/tasks/rag_indexation.py
@@ -244,7 +244,12 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
                 text = res.raw_text
                 language = detect_language(text)
                 chunks = list(
-                    chunker.chunk_document(text=text, source=rag_collection_id, language=language)
+                    chunker.chunk_document(
+                        text=text,
+                        source=rag_collection_id,
+                        language=language,
+                        course_resource_id=res.id,
+                    )
                 )
                 if not chunks:
                     continue
@@ -286,6 +291,37 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
                         )
 
             return total_chunks, total_images
+
+        # Build pdf_path → course_resource_id lookup so chunks land with
+        # their originating PDF identity (#2186). Resolves by `filename` or
+        # `parent_filename` (DB stores stems without extension).
+        resource_id_by_stem: dict[str, uuid.UUID] = {}
+        if pdf_files:
+            from sqlalchemy import create_engine, select
+            from sqlalchemy.orm import Session
+
+            from app.domain.models.course_resource import CourseResource
+            from app.infrastructure.config.settings import settings
+
+            _eng = create_engine(settings.database_url_sync, pool_pre_ping=True)
+            try:
+                with Session(_eng) as _sess:
+                    res_rows = (
+                        _sess.execute(
+                            select(
+                                CourseResource.id,
+                                CourseResource.filename,
+                                CourseResource.parent_filename,
+                            ).where(CourseResource.course_id == uuid.UUID(course_id))
+                        )
+                    ).all()
+                    for rid, fname, parent in res_rows:
+                        if fname:
+                            resource_id_by_stem.setdefault(fname, rid)
+                        if parent:
+                            resource_id_by_stem.setdefault(parent, rid)
+            finally:
+                _eng.dispose()
 
         for i, pdf_path in enumerate(pdf_files):
             extract_progress = 5 + int((i / len(pdf_files)) * 30)
@@ -332,9 +368,13 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
                 },
             )
 
+            resource_id = resource_id_by_stem.get(pdf_path.stem) or resource_id_by_stem.get(
+                pdf_path.name
+            )
             chunks = await pipeline.process_pdf_document(
                 pdf_path=str(pdf_path),
                 source=rag_collection_id,
+                course_resource_id=resource_id,
             )
             total_chunks += chunks
 

--- a/backend/migrations/versions/089_add_course_resource_id_to_document_chunks.py
+++ b/backend/migrations/versions/089_add_course_resource_id_to_document_chunks.py
@@ -1,0 +1,65 @@
+"""Add course_resource_id FK to document_chunks (#2186).
+
+Revision ID: 089
+Revises: 088
+Create Date: 2026-05-03
+
+The citation rewriter at ``backend/app/domain/services/citation_formatter.py``
+currently has to *back-derive* which PDF a given chunk came from by
+substring-matching ``DocumentChunk.content`` against each
+``CourseResource.raw_text`` (#2178/#2179) and using
+``SourceImage.surrounding_text`` as a tiebreaker (#2181). The fingerprint
+heuristics top out around 25-37% per-PDF resolution on real multi-PDF
+courses because PDFs covering overlapping subject matter share text.
+
+The information *was* known at ingest time — both ingestion paths
+(``rag_indexation.py`` DB-resources path line 228, PDF-on-disk path line
+290) have the originating ``CourseResource`` in scope. It was simply
+discarded when the chunker stored ``source = rag_collection_id``.
+
+This migration adds a nullable FK column so that:
+
+- New chunks from this point on land with ``course_resource_id`` populated
+  directly at ingest — read-side resolution becomes a single indexed JOIN
+  and is exact, not heuristic.
+- Existing chunks keep ``course_resource_id = NULL`` and continue to use
+  the existing fingerprint-match fallback path. A separate one-shot
+  backfill script can be run per-environment to populate them after deploy.
+
+ON DELETE SET NULL keeps the index safe if a CourseResource is later
+removed (e.g. PDF replaced); chunks fall back to the heuristic path.
+
+Forward-only: ``downgrade`` drops the column + index. Reversible.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "089"
+down_revision: str | None = "088"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "document_chunks",
+        sa.Column(
+            "course_resource_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("course_resources.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_document_chunks_course_resource_id",
+        "document_chunks",
+        ["course_resource_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_document_chunks_course_resource_id", table_name="document_chunks")
+    op.drop_column("document_chunks", "course_resource_id")

--- a/backend/tests/test_citation_formatter.py
+++ b/backend/tests/test_citation_formatter.py
@@ -57,9 +57,16 @@ def _make_chunk_row(
     page: int | None,
     content: str,
     chunk_id: str | None = None,
+    course_resource_id: object | None = None,
 ) -> tuple:
-    """Mimic an SQLAlchemy Row for the (id, chapter, page, content) projection."""
-    return (chunk_id or f"chunk-{chapter}-{page}", chapter, page, content)
+    """Mimic an SQLAlchemy Row for the (id, chapter, page, content, course_resource_id) projection."""
+    return (
+        chunk_id or f"chunk-{chapter}-{page}",
+        chapter,
+        page,
+        content,
+        course_resource_id,
+    )
 
 
 class _FakeAsyncSession:
@@ -440,7 +447,7 @@ class TestRewriteForModuleMultiResource:
             },
             execute_queue=[
                 _scalar_result([pdf_a, pdf_b]),
-                _row_result([("chunk-amb-1", "1", 1, boilerplate)]),
+                _row_result([("chunk-amb-1", "1", 1, boilerplate, None)]),
                 _row_result([]),  # no linked images for the deferred chunk
             ],
         )
@@ -473,6 +480,109 @@ class TestRewriteForModuleMultiResource:
 
 
 @pytest.mark.asyncio
+class TestFKFastPath:
+    """Chunks with course_resource_id set bypass the fingerprint vote (#2186)."""
+
+    async def test_fk_fast_path_resolves_directly(self):
+        # Both PDFs would substring-match the chunk content (boilerplate),
+        # but the FK on the chunk row is decisive.
+        boilerplate = "shared paragraph " * 30
+        pdf_a = _make_resource("alpha.pdf", raw_text=boilerplate, rid="rid-a")
+        pdf_b = _make_resource("beta.pdf", raw_text=boilerplate, rid="rid-b")
+        course = _make_course()
+        module = _make_module()
+
+        # FK -> rid-b (beta), even though substring vote would be ambiguous.
+        chunk_row = _make_chunk_row("1", 5, boilerplate, course_resource_id="rid-b")
+
+        session = _FakeAsyncSession(
+            gets={
+                ("Module", "module-id"): module,
+                ("Course", "course-id"): course,
+            },
+            execute_queue=[
+                _scalar_result([pdf_a, pdf_b]),
+                _row_result([chunk_row]),
+            ],
+        )
+        sources = [f"{_UUID} Ch.1, p.5"]
+        out = await rewrite_uuid_citations_for_module(sources, "module-id", session, "fr")
+        assert out == ["Beta Ch.1, p.5"]
+
+    async def test_null_fk_falls_back_to_fingerprint(self):
+        # Chunk content matches PDF A uniquely; FK is NULL → fingerprint
+        # path resolves it to A.
+        pdf_a = _make_resource(
+            "alpha.pdf",
+            raw_text="alpha-content " + "fingerprint-A " * 30,
+            rid="rid-a",
+        )
+        pdf_b = _make_resource(
+            "beta.pdf",
+            raw_text="beta-content " + "fingerprint-B " * 30,
+            rid="rid-b",
+        )
+        course = _make_course()
+        module = _make_module()
+        chunk_content = "alpha-content " + "fingerprint-A " * 15
+        chunk_row = _make_chunk_row("1", 5, chunk_content, course_resource_id=None)
+
+        session = _FakeAsyncSession(
+            gets={
+                ("Module", "module-id"): module,
+                ("Course", "course-id"): course,
+            },
+            execute_queue=[
+                _scalar_result([pdf_a, pdf_b]),
+                _row_result([chunk_row]),
+            ],
+        )
+        sources = [f"{_UUID} Ch.1, p.5"]
+        out = await rewrite_uuid_citations_for_module(sources, "module-id", session, "fr")
+        assert out == ["Alpha Ch.1, p.5"]
+
+    async def test_fk_dangling_falls_back_to_fingerprint(self):
+        # FK references a resource id that's no longer in the loaded list
+        # (ON DELETE SET NULL would normally NULL the column, but defend
+        # against the transient state). Multi-resource course so the chunk
+        # SELECT still runs.
+        pdf_a = _make_resource(
+            "alpha.pdf",
+            raw_text="alpha-content " + "fingerprint-A " * 30,
+            rid="rid-a",
+        )
+        pdf_b = _make_resource(
+            "beta.pdf",
+            raw_text="beta-content " + "fingerprint-B " * 30,
+            rid="rid-b",
+        )
+        course = _make_course()
+        module = _make_module()
+        chunk_content = "alpha-content " + "fingerprint-A " * 15
+
+        session = _FakeAsyncSession(
+            gets={
+                ("Module", "module-id"): module,
+                ("Course", "course-id"): course,
+            },
+            execute_queue=[
+                _scalar_result([pdf_a, pdf_b]),
+                _row_result(
+                    [
+                        _make_chunk_row(
+                            "1", 5, chunk_content, course_resource_id="rid-deleted"
+                        )
+                    ]
+                ),
+            ],
+        )
+        sources = [f"{_UUID} Ch.1, p.5"]
+        out = await rewrite_uuid_citations_for_module(sources, "module-id", session, "fr")
+        # FK is dangling → falls through to fingerprint vote → resolves to A.
+        assert out == ["Alpha Ch.1, p.5"]
+
+
+@pytest.mark.asyncio
 class TestImageTiebreaker:
     """When chunk content matches multiple resources, ``SourceImage.surrounding_text``
     breaks ties (#2181)."""
@@ -499,7 +609,7 @@ class TestImageTiebreaker:
 
         chunk_id = "chunk-1"
         # Chunk content == boilerplate, so it matches BOTH resources.
-        chunk_row = (chunk_id, "1", 5, boilerplate)
+        chunk_row = (chunk_id, "1", 5, boilerplate, None)
         # Linked surrounding_text contains alpha-specific marker → unique to A.
         img_row = (chunk_id, "alpha-only specific marker " * 5)
 
@@ -527,7 +637,7 @@ class TestImageTiebreaker:
         course = _make_course()
         module = _make_module()
 
-        chunk_row = ("chunk-1", "1", 5, boilerplate)
+        chunk_row = ("chunk-1", "1", 5, boilerplate, None)
 
         session = _FakeAsyncSession(
             gets={
@@ -553,7 +663,7 @@ class TestImageTiebreaker:
         course = _make_course()
         module = _make_module()
 
-        chunk_row = ("chunk-1", "1", 5, boilerplate)
+        chunk_row = ("chunk-1", "1", 5, boilerplate, None)
         img_row = ("chunk-1", boilerplate)  # surrounding_text is also shared
 
         session = _FakeAsyncSession(

--- a/backend/tests/test_citation_formatter.py
+++ b/backend/tests/test_citation_formatter.py
@@ -568,11 +568,7 @@ class TestFKFastPath:
             execute_queue=[
                 _scalar_result([pdf_a, pdf_b]),
                 _row_result(
-                    [
-                        _make_chunk_row(
-                            "1", 5, chunk_content, course_resource_id="rid-deleted"
-                        )
-                    ]
+                    [_make_chunk_row("1", 5, chunk_content, course_resource_id="rid-deleted")]
                 ),
             ],
         )


### PR DESCRIPTION
## Summary

Resolves #2186. Stops the bleed at the ingest source — chunks now know which PDF they came from, instead of forcing the read-side rewriter to back-derive it.

- Migration 089: nullable \`course_resource_id\` FK on \`document_chunks\`. Reversible (\`ON DELETE SET NULL\`).
- Chunker, pipeline, and both \`rag_indexation.py\` paths plumb the FK through to \`_store_chunks\`.
- \`citation_formatter._resolve_per_citation_map\` checks the FK first; falls back to fingerprint vote + image-text tiebreaker for legacy NULL rows.

New chunks resolve to ~100% accuracy in a single indexed lookup. Legacy chunks (NULL FK) degrade gracefully to today's heuristic. No re-indexation, no API spend, no regen of cached lessons.

## Backfill (separate, optional)

Existing courses can be backfilled by running the same fingerprint-match logic as a one-shot SQL/Python script post-deploy. Not in this PR — filed as follow-up.

## Test plan

- [x] 53 unit tests including FK fast path, FK + multi-resource, dangling FK falls back, NULL FK falls back to existing vote, single-resource path unchanged.
- [x] Adjacent suites green: \`test_indexation_lifecycle\`, \`test_resource_extraction\`, \`test_rag_pipeline_images\`.
- [ ] Staging migration applies cleanly, then re-index a small test course and confirm new \`document_chunks\` rows have \`course_resource_id\` populated.