### PR TITLE
fix(citations): backfill course_resource_id on legacy chunks (#2190)

### DIFF
--- a/backend/scripts/backfill_chunk_resource_ids.py
+++ b/backend/scripts/backfill_chunk_resource_ids.py
@@ -1,0 +1,214 @@
+"""Backfill ``document_chunks.course_resource_id`` from chunk content (#2190).
+
+Migration 089 added ``course_resource_id`` (nullable FK to ``course_resources.id``)
+to ``document_chunks``. New chunks land with the FK populated by ingest. Existing
+chunks have NULL FK; this script populates them by fingerprint-matching each
+chunk's content against the originating course's ``CourseResource.raw_text``.
+
+No API spend — pure SQL + Python (same logic as ``citation_formatter._normalize_for_match``).
+Ambiguous chunks (content matches multiple resources, e.g. shared boilerplate)
+keep ``course_resource_id = NULL`` and continue to use the read-side tiebreaker.
+
+Usage:
+    cd backend && python scripts/backfill_chunk_resource_ids.py
+    cd backend && python scripts/backfill_chunk_resource_ids.py --course-id <UUID>
+    cd backend && python scripts/backfill_chunk_resource_ids.py --dry-run
+
+Idempotent. Re-running only acts on still-NULL rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import re
+import sys
+from collections import defaultdict
+from typing import Any
+from uuid import UUID
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+# Mirror citation_formatter._normalize_for_match — keep the two implementations
+# in sync if either changes.
+_PAGE_NUMBER_NOISE = re.compile(r"\b(?:Page|page)\s*\d+\b")
+_CHAPTER_HEADER_NOISE = re.compile(r"\b\d{1,3}\s*\|\s*Chapter\s*\d+")
+_CASE_BREAK = re.compile(r"([a-z])([A-Z])")
+_WHITESPACE = re.compile(r"\s+")
+_FINGERPRINT_LEN = 200
+
+
+def _normalize_for_match(text_in: str | None) -> str:
+    if not text_in:
+        return ""
+    text_in = _WHITESPACE.sub(" ", text_in)
+    text_in = _PAGE_NUMBER_NOISE.sub("", text_in)
+    text_in = _CHAPTER_HEADER_NOISE.sub("", text_in)
+    text_in = re.sub(r"\s*\n\s*", " ", text_in)
+    text_in = _CASE_BREAK.sub(r"\1. \2", text_in)
+    return text_in.lower()
+
+
+async def _backfill_course(
+    session: AsyncSession,
+    course_id: UUID,
+    rag_collection_id: str,
+    dry_run: bool,
+) -> tuple[int, int, int]:
+    """Backfill chunks for a single course.
+
+    Returns ``(scanned, updated, ambiguous)``.
+    """
+    # Load all resources with their raw_text once.
+    res_rows = (
+        await session.execute(
+            text(
+                "SELECT id, raw_text FROM course_resources "
+                "WHERE course_id = :cid AND raw_text IS NOT NULL"
+            ),
+            {"cid": str(course_id)},
+        )
+    ).all()
+    if len(res_rows) < 2:
+        # Single-resource: read-side already maps everything to the only PDF;
+        # nothing to disambiguate at the chunk level.
+        return 0, 0, 0
+
+    normalized_resources: list[tuple[Any, str]] = [
+        (r[0], _normalize_for_match(r[1])) for r in res_rows
+    ]
+
+    # Load chunks needing backfill.
+    chunk_rows = (
+        await session.execute(
+            text(
+                "SELECT id, content FROM document_chunks "
+                "WHERE source = :rag AND course_resource_id IS NULL"
+            ),
+            {"rag": rag_collection_id},
+        )
+    ).all()
+
+    scanned = len(chunk_rows)
+    if scanned == 0:
+        return 0, 0, 0
+
+    # Bucket chunks by their resolved resource id (if unique).
+    updates: dict[Any, list[Any]] = defaultdict(list)
+    ambiguous = 0
+    for chunk_id, content in chunk_rows:
+        normalized = _normalize_for_match(content)
+        fingerprint = normalized[:_FINGERPRINT_LEN]
+        if len(fingerprint) < 40:
+            ambiguous += 1
+            continue
+        matches = [rid for (rid, t) in normalized_resources if fingerprint in t]
+        if len(matches) == 1:
+            updates[matches[0]].append(chunk_id)
+        else:
+            ambiguous += 1
+
+    updated = sum(len(ids) for ids in updates.values())
+    if dry_run or not updates:
+        return scanned, updated, ambiguous
+
+    # Apply updates per-resource (single round-trip per resource).
+    for resource_id, chunk_ids in updates.items():
+        await session.execute(
+            text(
+                "UPDATE document_chunks SET course_resource_id = :rid "
+                "WHERE id = ANY(:ids) AND course_resource_id IS NULL"
+            ),
+            {"rid": resource_id, "ids": chunk_ids},
+        )
+    await session.commit()
+    return scanned, updated, ambiguous
+
+
+async def main(course_filter: UUID | None, dry_run: bool) -> int:
+    database_url = os.environ.get(
+        "DATABASE_URL",
+        "postgresql+asyncpg://postgres:postgres@localhost:5432/santepublique",
+    )
+    if database_url.startswith("postgresql://"):
+        database_url = database_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+
+    engine = create_async_engine(database_url)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    total_scanned = 0
+    total_updated = 0
+    total_ambiguous = 0
+    courses_processed = 0
+
+    async with async_session() as session:
+        # Find candidate courses: have rag_collection_id AND >1 CourseResource.
+        course_query = """
+            SELECT c.id, c.rag_collection_id
+            FROM courses c
+            WHERE c.rag_collection_id IS NOT NULL
+              AND (
+                  SELECT COUNT(*) FROM course_resources cr
+                  WHERE cr.course_id = c.id AND cr.raw_text IS NOT NULL
+              ) >= 2
+        """
+        params: dict[str, Any] = {}
+        if course_filter is not None:
+            course_query += " AND c.id = :cid"
+            params["cid"] = str(course_filter)
+
+        course_rows = (await session.execute(text(course_query), params)).all()
+        if not course_rows:
+            print(
+                "No multi-resource courses to backfill"
+                + (f" (course filter: {course_filter})" if course_filter else "")
+            )
+            return 0
+
+        for c_id, rag_id in course_rows:
+            scanned, updated, ambiguous = await _backfill_course(session, c_id, rag_id, dry_run)
+            if scanned == 0:
+                continue
+            courses_processed += 1
+            total_scanned += scanned
+            total_updated += updated
+            total_ambiguous += ambiguous
+            mode = "[dry-run]" if dry_run else "[applied]"
+            print(
+                f"{mode} course={c_id}  scanned={scanned}  updated={updated}  ambiguous={ambiguous}"
+            )
+
+    await engine.dispose()
+
+    print(
+        f"\nDone. courses_processed={courses_processed}  "
+        f"chunks_scanned={total_scanned}  chunks_updated={total_updated}  "
+        f"ambiguous_left_null={total_ambiguous}  dry_run={dry_run}"
+    )
+    return 0
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--course-id",
+        type=UUID,
+        default=None,
+        help="Restrict backfill to a single course UUID. Default: all multi-resource courses.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be updated without writing.",
+    )
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    sys.exit(asyncio.run(main(args.course_id, args.dry_run)))

--- a/backend/tests/test_backfill_chunk_resource_ids.py
+++ b/backend/tests/test_backfill_chunk_resource_ids.py
@@ -1,0 +1,158 @@
+"""Tests for the backfill helpers in ``scripts/backfill_chunk_resource_ids.py`` (#2190).
+
+We exercise the resolution logic via ``_backfill_course``'s normalization +
+fingerprint-match path with a fake async session that scripts the SQL
+results. No real DB needed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Load the script as a module since it lives outside ``tests/``.
+_SCRIPT_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "scripts", "backfill_chunk_resource_ids.py"
+)
+spec = importlib.util.spec_from_file_location("backfill_chunk_resource_ids", _SCRIPT_PATH)
+backfill_module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(backfill_module)
+
+
+_normalize_for_match = backfill_module._normalize_for_match
+_backfill_course = backfill_module._backfill_course
+
+
+def _result(rows: list[tuple]) -> MagicMock:
+    out = MagicMock()
+    out.all.return_value = rows
+    return out
+
+
+@pytest.mark.asyncio
+async def test_normalize_matches_chunk_against_raw_text():
+    raw_text = "Quick brown fox the cat sat on the mat. " + ("alpha " * 100)
+    chunk = "Quick brown fox the cat sat on the mat. " + ("alpha " * 50)
+    fingerprint = _normalize_for_match(chunk)[:200]
+    assert fingerprint in _normalize_for_match(raw_text)
+
+
+@pytest.mark.asyncio
+async def test_skips_single_resource_courses():
+    # Single resource → nothing to disambiguate; script returns immediately.
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_result([("rid-a", "any text")]))
+    scanned, updated, ambiguous = await _backfill_course(
+        session, "course-1", "rag-1", dry_run=False
+    )
+    assert (scanned, updated, ambiguous) == (0, 0, 0)
+
+
+@pytest.mark.asyncio
+async def test_unique_match_updates_chunk():
+    pdf_a_text = "alpha-only specific text " * 30
+    pdf_b_text = "beta-only specific text " * 30
+    chunk_id = "chunk-1"
+    chunk_content = "alpha-only specific text " * 15
+
+    session = MagicMock()
+    # Sequence of execute() calls:
+    #   1. SELECT resources
+    #   2. SELECT chunks
+    #   3. UPDATE for the resolved resource (only when not dry_run)
+    update_call: list[Any] = []
+
+    async def fake_execute(stmt, params=None):
+        sql_str = str(stmt)
+        if "FROM course_resources" in sql_str:
+            return _result([("rid-a", pdf_a_text), ("rid-b", pdf_b_text)])
+        if "FROM document_chunks" in sql_str:
+            return _result([(chunk_id, chunk_content)])
+        if sql_str.startswith("UPDATE") or "UPDATE" in sql_str:
+            update_call.append(params)
+            return MagicMock()
+        raise AssertionError(f"unexpected SQL: {sql_str}")
+
+    session.execute = AsyncMock(side_effect=fake_execute)
+    session.commit = AsyncMock()
+
+    scanned, updated, ambiguous = await _backfill_course(
+        session, "course-1", "rag-1", dry_run=False
+    )
+    assert scanned == 1
+    assert updated == 1
+    assert ambiguous == 0
+    assert len(update_call) == 1
+    assert update_call[0]["rid"] == "rid-a"
+    assert update_call[0]["ids"] == [chunk_id]
+    session.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_chunk_left_null():
+    # Chunk content is shared boilerplate that appears in BOTH resources.
+    boilerplate = "shared header paragraph " * 30
+    pdf_a_text = boilerplate + "alpha unique " * 20
+    pdf_b_text = boilerplate + "beta unique " * 20
+
+    session = MagicMock()
+    update_call: list[Any] = []
+
+    async def fake_execute(stmt, params=None):
+        sql_str = str(stmt)
+        if "FROM course_resources" in sql_str:
+            return _result([("rid-a", pdf_a_text), ("rid-b", pdf_b_text)])
+        if "FROM document_chunks" in sql_str:
+            return _result([("chunk-amb", boilerplate)])
+        if "UPDATE" in sql_str:
+            update_call.append(params)
+            return MagicMock()
+        raise AssertionError(f"unexpected SQL: {sql_str}")
+
+    session.execute = AsyncMock(side_effect=fake_execute)
+    session.commit = AsyncMock()
+
+    scanned, updated, ambiguous = await _backfill_course(
+        session, "course-1", "rag-1", dry_run=False
+    )
+    assert scanned == 1
+    assert updated == 0
+    assert ambiguous == 1
+    assert update_call == []  # no UPDATE issued
+    session.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dry_run_does_not_write():
+    pdf_a_text = "alpha-only specific text " * 30
+    pdf_b_text = "beta-only specific text " * 30
+    chunk_content = "alpha-only specific text " * 15
+
+    session = MagicMock()
+    update_call: list[Any] = []
+
+    async def fake_execute(stmt, params=None):
+        sql_str = str(stmt)
+        if "FROM course_resources" in sql_str:
+            return _result([("rid-a", pdf_a_text), ("rid-b", pdf_b_text)])
+        if "FROM document_chunks" in sql_str:
+            return _result([("chunk-1", chunk_content)])
+        if "UPDATE" in sql_str:
+            update_call.append(params)
+            return MagicMock()
+        raise AssertionError(f"unexpected SQL: {sql_str}")
+
+    session.execute = AsyncMock(side_effect=fake_execute)
+    session.commit = AsyncMock()
+
+    scanned, updated, ambiguous = await _backfill_course(session, "course-1", "rag-1", dry_run=True)
+    assert scanned == 1
+    assert updated == 1  # would update
+    assert ambiguous == 0
+    assert update_call == []  # but didn't actually
+    session.commit.assert_not_awaited()


### PR DESCRIPTION
## Summary

Resolves #2190. One-shot script to populate \`document_chunks.course_resource_id\` (added by migration 089) for chunks ingested before #2186 landed.

- Pure SQL + Python; no embedding/LLM API spend.
- Idempotent (\`WHERE course_resource_id IS NULL\`).
- CLI: \`--course-id <UUID>\` to scope, \`--dry-run\` to preview.
- Single-resource courses skip immediately (nothing to disambiguate).
- Ambiguous chunks (shared boilerplate) keep NULL FK; the read-side tiebreaker continues to handle them.

After this merges, run on staging:

\`\`\`
docker exec etutor-backend bash -c 'cd /app && PYTHONPATH=/app uv run python scripts/backfill_chunk_resource_ids.py --dry-run'
\`\`\`

Then drop \`--dry-run\` to apply.

## Test plan

- [x] 5 unit tests: normalize match, single-resource skip, unique-match update, ambiguous-stay-null, dry-run no-op.
- [ ] Staging dry-run reports plausible numbers per multi-PDF course.
- [ ] Staging apply: pre/post counts of \`document_chunks.course_resource_id IS NOT NULL\` jump.
- [ ] Existing API responses for previously-failed lessons now resolve more citations per-PDF.