### PR TITLE
fix(citations): embedding-centroid tiebreaker (#2187)

### DIFF
--- a/backend/app/domain/services/citation_formatter.py
+++ b/backend/app/domain/services/citation_formatter.py
@@ -26,7 +26,7 @@ import re
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import and_, or_, select
+from sqlalchemy import and_, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.domain.models.course import Course
@@ -147,6 +147,95 @@ def _pick_display_name(
     return _course_title(course, language)
 
 
+def _cosine_distance(a: list[float], b: list[float]) -> float:
+    """Pure-Python cosine distance for 1536-dim embedding vectors.
+
+    Returns 1 - cosine_similarity. Defends against zero norms by returning
+    1.0 (maximum distance) when either vector has zero magnitude.
+    """
+    if not a or not b or len(a) != len(b):
+        return 1.0
+    dot = 0.0
+    norm_a = 0.0
+    norm_b = 0.0
+    for x, y in zip(a, b, strict=False):
+        dot += x * y
+        norm_a += x * x
+        norm_b += y * y
+    if norm_a <= 0.0 or norm_b <= 0.0:
+        return 1.0
+    similarity = dot / ((norm_a**0.5) * (norm_b**0.5))
+    return 1.0 - similarity
+
+
+def _vector_mean(vectors: list[list[float]]) -> list[float] | None:
+    """Component-wise mean of equal-length vectors. None if input is empty."""
+    if not vectors:
+        return None
+    dim = len(vectors[0])
+    if any(len(v) != dim for v in vectors):
+        return None
+    sums = [0.0] * dim
+    for v in vectors:
+        for i, x in enumerate(v):
+            sums[i] += x
+    n = len(vectors)
+    return [s / n for s in sums]
+
+
+_CENTROID_SAMPLE_PER_RESOURCE = 50
+_CENTROID_MARGIN = 0.05
+
+
+async def _build_resource_centroids(
+    session: AsyncSession,
+    rag_id: str,
+) -> dict[Any, list[float]]:
+    """Per-resource embedding centroids derived from FK-populated chunks.
+
+    Samples up to ``_CENTROID_SAMPLE_PER_RESOURCE`` chunks per resource that
+    already have ``course_resource_id`` set (from ingest #2186 or backfill
+    #2190). Returns ``{resource_id: centroid_vector}``. Returns an empty dict
+    if no FK-populated rows exist (e.g. course never re-indexed AND backfill
+    never ran), in which case the caller falls back to existing behavior.
+    """
+    stmt = text(
+        """
+        SELECT course_resource_id, embedding
+        FROM (
+            SELECT course_resource_id, embedding,
+                ROW_NUMBER() OVER (
+                    PARTITION BY course_resource_id ORDER BY created_at
+                ) AS rn
+            FROM document_chunks
+            WHERE source = :rag_id
+              AND course_resource_id IS NOT NULL
+              AND embedding IS NOT NULL
+        ) t
+        WHERE rn <= :sample_size
+        """
+    )
+    rows = (
+        await session.execute(
+            stmt,
+            {"rag_id": rag_id, "sample_size": _CENTROID_SAMPLE_PER_RESOURCE},
+        )
+    ).all()
+    if not rows:
+        return {}
+    by_resource: dict[Any, list[list[float]]] = {}
+    for resource_id, embedding in rows:
+        if not embedding:
+            continue
+        by_resource.setdefault(resource_id, []).append(list(embedding))
+    centroids: dict[Any, list[float]] = {}
+    for rid, vectors in by_resource.items():
+        c = _vector_mean(vectors)
+        if c is not None:
+            centroids[rid] = c
+    return centroids
+
+
 async def _resolve_per_citation_map(
     course: Course,
     resources: list[CourseResource],
@@ -164,6 +253,9 @@ async def _resolve_per_citation_map(
     3. **SourceImage.surrounding_text tiebreaker** (#2181): for chunks where
        step 2 matched multiple resources, look up linked figures and use
        the surrounding paragraph as a second fingerprint.
+    4. **Embedding-centroid tiebreaker** (#2187): for chunks still ambiguous
+       after step 3, compute per-resource centroids from FK-populated chunks
+       and pick the closest by cosine distance, gated by a margin threshold.
 
     Pairs that don't yield a unique resource are simply omitted from the map.
     """
@@ -190,6 +282,7 @@ async def _resolve_per_citation_map(
             DocumentChunk.page,
             DocumentChunk.content,
             DocumentChunk.course_resource_id,
+            DocumentChunk.embedding,
         )
         .where(or_(*conditions))
         .limit(200)
@@ -207,8 +300,10 @@ async def _resolve_per_citation_map(
     AMBIGUOUS: object = object()
     seen: dict[tuple[str | None, int | None], CourseResource | object] = {}
     # Chunks whose content matched 2+ resources — defer to the image-text
-    # tiebreaker pass below.
-    deferred: list[tuple[Any, str | None, int | None, list[CourseResource]]] = []
+    # tiebreaker pass below, then the embedding centroid pass.
+    deferred: list[
+        tuple[Any, str | None, int | None, list[CourseResource], list[float] | None]
+    ] = []
 
     # Build resource-by-id lookup once for the FK fast path.
     resource_by_id = {r.id: r for r in resources}
@@ -228,6 +323,7 @@ async def _resolve_per_citation_map(
         chunk_page = row[2]
         chunk_content = row[3] or ""
         chunk_resource_id = row[4]
+        chunk_embedding = row[5]
 
         # Fast path (#2186): chunks ingested after migration 089 carry a
         # direct FK to their originating CourseResource. Skip all the
@@ -249,10 +345,13 @@ async def _resolve_per_citation_map(
         if len(matches) == 1:
             _record((chunk_chapter, chunk_page), matches[0])
         elif len(matches) > 1:
-            deferred.append((chunk_id, chunk_chapter, chunk_page, matches))
+            deferred.append((chunk_id, chunk_chapter, chunk_page, matches, chunk_embedding))
 
     if deferred:
         chunk_ids = list({d[0] for d in deferred if d[0] is not None})
+        # Track which deferred chunks the image tiebreaker resolves so the
+        # centroid pass only runs on the still-ambiguous remainder.
+        resolved_by_image: set[Any] = set()
         if chunk_ids:
             img_stmt = (
                 select(SourceImageChunk.document_chunk_id, SourceImage.surrounding_text)
@@ -266,7 +365,7 @@ async def _resolve_per_citation_map(
                     continue
                 surrounding_by_chunk.setdefault(cid, []).append(st)
 
-            for chunk_id, chunk_chapter, chunk_page, candidates in deferred:
+            for chunk_id, chunk_chapter, chunk_page, candidates, _emb in deferred:
                 sts = surrounding_by_chunk.get(chunk_id, [])
                 if not sts:
                     continue
@@ -286,6 +385,39 @@ async def _resolve_per_citation_map(
                         break
                 if tiebreaker_winner is not None:
                     _record((chunk_chapter, chunk_page), tiebreaker_winner)
+                    resolved_by_image.add(chunk_id)
+
+        # Centroid tiebreaker (#2187): for chunks the image pass couldn't
+        # resolve, compare the chunk's embedding against per-resource
+        # centroids derived from already-FK-populated chunks. Margin gate
+        # prevents wrong-attribution when two centroids are similarly close.
+        unresolved = [
+            d
+            for d in deferred
+            if d[0] not in resolved_by_image and d[4]  # has an embedding
+        ]
+        if unresolved:
+            centroids = await _build_resource_centroids(session, rag_id)
+            if centroids:
+                for _chunk_id, chunk_chapter, chunk_page, candidates, embedding in unresolved:
+                    candidate_centroids = [
+                        (r, centroids[r.id]) for r in candidates if r.id in centroids
+                    ]
+                    if len(candidate_centroids) < 2:
+                        # Need at least two candidates with centroids to
+                        # measure margin meaningfully.
+                        continue
+                    distances = sorted(
+                        (
+                            (_cosine_distance(list(embedding), c), r)
+                            for (r, c) in candidate_centroids
+                        ),
+                        key=lambda t: t[0],
+                    )
+                    best_distance, best_resource = distances[0]
+                    second_distance = distances[1][0]
+                    if (second_distance - best_distance) >= _CENTROID_MARGIN:
+                        _record((chunk_chapter, chunk_page), best_resource)
 
     out: dict[tuple[str | None, int | None], str] = {}
     for key, winner in seen.items():

--- a/backend/tests/test_citation_formatter.py
+++ b/backend/tests/test_citation_formatter.py
@@ -6,10 +6,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from app.domain.services.citation_formatter import (
+    _cosine_distance,
     _normalize_for_match,
     _parse_chapter_page,
     _replace_uuid_prefix,
     _starts_with_uuid,
+    _vector_mean,
     humanize_filename,
     rewrite_uuid_citations_for_module,
     rewrite_uuid_citations_with_context,
@@ -58,14 +60,17 @@ def _make_chunk_row(
     content: str,
     chunk_id: str | None = None,
     course_resource_id: object | None = None,
+    embedding: list[float] | None = None,
 ) -> tuple:
-    """Mimic an SQLAlchemy Row for the (id, chapter, page, content, course_resource_id) projection."""
+    """Mimic an SQLAlchemy Row for the
+    (id, chapter, page, content, course_resource_id, embedding) projection."""
     return (
         chunk_id or f"chunk-{chapter}-{page}",
         chapter,
         page,
         content,
         course_resource_id,
+        embedding,
     )
 
 
@@ -88,7 +93,7 @@ class _FakeAsyncSession:
     async def get(self, model, key):
         return self._gets.get((model.__name__, str(key)))
 
-    async def execute(self, stmt):
+    async def execute(self, stmt, params=None):
         self.execute_calls.append(stmt)
         if not self._queue:
             raise AssertionError("Unexpected execute() call — queue empty")
@@ -447,7 +452,7 @@ class TestRewriteForModuleMultiResource:
             },
             execute_queue=[
                 _scalar_result([pdf_a, pdf_b]),
-                _row_result([("chunk-amb-1", "1", 1, boilerplate, None)]),
+                _row_result([("chunk-amb-1", "1", 1, boilerplate, None, None)]),
                 _row_result([]),  # no linked images for the deferred chunk
             ],
         )
@@ -605,7 +610,7 @@ class TestImageTiebreaker:
 
         chunk_id = "chunk-1"
         # Chunk content == boilerplate, so it matches BOTH resources.
-        chunk_row = (chunk_id, "1", 5, boilerplate, None)
+        chunk_row = (chunk_id, "1", 5, boilerplate, None, None)
         # Linked surrounding_text contains alpha-specific marker → unique to A.
         img_row = (chunk_id, "alpha-only specific marker " * 5)
 
@@ -633,7 +638,7 @@ class TestImageTiebreaker:
         course = _make_course()
         module = _make_module()
 
-        chunk_row = ("chunk-1", "1", 5, boilerplate, None)
+        chunk_row = ("chunk-1", "1", 5, boilerplate, None, None)
 
         session = _FakeAsyncSession(
             gets={
@@ -659,7 +664,7 @@ class TestImageTiebreaker:
         course = _make_course()
         module = _make_module()
 
-        chunk_row = ("chunk-1", "1", 5, boilerplate, None)
+        chunk_row = ("chunk-1", "1", 5, boilerplate, None, None)
         img_row = ("chunk-1", boilerplate)  # surrounding_text is also shared
 
         session = _FakeAsyncSession(
@@ -671,6 +676,180 @@ class TestImageTiebreaker:
                 _scalar_result([pdf_a, pdf_b]),
                 _row_result([chunk_row]),
                 _row_result([img_row]),
+            ],
+        )
+        sources = [f"{_UUID} Ch.1, p.5"]
+        out = await rewrite_uuid_citations_for_module(sources, "module-id", session, "fr")
+        assert out == ["Statistiques de Santé Publique Ch.1, p.5"]
+
+
+class TestVectorMath:
+    def test_cosine_distance_identical(self):
+        v = [1.0, 2.0, 3.0]
+        assert _cosine_distance(v, v) == pytest.approx(0.0)
+
+    def test_cosine_distance_orthogonal(self):
+        # Orthogonal vectors → cosine similarity 0 → distance 1
+        a = [1.0, 0.0, 0.0]
+        b = [0.0, 1.0, 0.0]
+        assert _cosine_distance(a, b) == pytest.approx(1.0)
+
+    def test_cosine_distance_zero_vector(self):
+        # Defends against div-by-zero on zero-norm vectors.
+        assert _cosine_distance([0.0, 0.0, 0.0], [1.0, 2.0, 3.0]) == 1.0
+
+    def test_cosine_distance_mismatched_dim(self):
+        assert _cosine_distance([1.0], [1.0, 1.0]) == 1.0
+
+    def test_vector_mean(self):
+        result = _vector_mean([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        assert result == [3.0, 4.0]
+
+    def test_vector_mean_empty(self):
+        assert _vector_mean([]) is None
+
+    def test_vector_mean_mismatched_dims(self):
+        assert _vector_mean([[1.0, 2.0], [3.0]]) is None
+
+
+@pytest.mark.asyncio
+class TestCentroidTiebreaker:
+    """Embedding-centroid tiebreaker fires when chunk content + image text
+    can't disambiguate (#2187)."""
+
+    async def test_centroid_breaks_tie_with_clear_margin(self):
+        # Both PDFs share boilerplate (so content + image both ambiguous),
+        # but the chunk's embedding is clearly closer to A's centroid.
+        boilerplate = "shared paragraph " * 30
+        pdf_a = _make_resource("alpha.pdf", raw_text=boilerplate, rid="rid-a")
+        pdf_b = _make_resource("beta.pdf", raw_text=boilerplate, rid="rid-b")
+        course = _make_course()
+        module = _make_module()
+
+        # Chunk embedding closer to A-shaped vectors.
+        chunk_embedding = [1.0, 0.0, 0.0]
+        chunk_row = (
+            "chunk-1",
+            "1",
+            5,
+            boilerplate,
+            None,  # course_resource_id NULL → falls through to vote
+            chunk_embedding,
+        )
+
+        # Per-resource centroid sample query rows.
+        # rid-a chunks point in direction [1, 0, 0]; rid-b in [0, 1, 0].
+        centroid_rows = [
+            ("rid-a", [1.0, 0.0, 0.0]),
+            ("rid-a", [0.9, 0.1, 0.0]),
+            ("rid-b", [0.0, 1.0, 0.0]),
+            ("rid-b", [0.1, 0.9, 0.0]),
+        ]
+
+        session = _FakeAsyncSession(
+            gets={
+                ("Module", "module-id"): module,
+                ("Course", "course-id"): course,
+            },
+            execute_queue=[
+                _scalar_result([pdf_a, pdf_b]),
+                _row_result([chunk_row]),
+                _row_result([]),  # no linked images
+                _row_result(centroid_rows),  # centroid sample SELECT
+            ],
+        )
+        sources = [f"{_UUID} Ch.1, p.5"]
+        out = await rewrite_uuid_citations_for_module(sources, "module-id", session, "fr")
+        assert out == ["Alpha Ch.1, p.5"]
+
+    async def test_centroid_margin_gate_blocks_close_call(self):
+        # Two centroids almost equidistant → margin gate refuses to assign,
+        # falls back to course title.
+        boilerplate = "shared paragraph " * 30
+        pdf_a = _make_resource("alpha.pdf", raw_text=boilerplate, rid="rid-a")
+        pdf_b = _make_resource("beta.pdf", raw_text=boilerplate, rid="rid-b")
+        course = _make_course()
+        module = _make_module()
+
+        chunk_embedding = [1.0, 1.0, 0.0]
+        chunk_row = (
+            "chunk-1",
+            "1",
+            5,
+            boilerplate,
+            None,
+            chunk_embedding,
+        )
+        # Centroids equidistant from the chunk → no clear winner.
+        centroid_rows = [
+            ("rid-a", [1.0, 1.0, 0.0]),
+            ("rid-b", [1.0, 1.0, 0.001]),  # ~equally close
+        ]
+
+        session = _FakeAsyncSession(
+            gets={
+                ("Module", "module-id"): module,
+                ("Course", "course-id"): course,
+            },
+            execute_queue=[
+                _scalar_result([pdf_a, pdf_b]),
+                _row_result([chunk_row]),
+                _row_result([]),
+                _row_result(centroid_rows),
+            ],
+        )
+        sources = [f"{_UUID} Ch.1, p.5"]
+        out = await rewrite_uuid_citations_for_module(sources, "module-id", session, "fr")
+        # Margin gate keeps it ambiguous → falls back to course title.
+        assert out == ["Statistiques de Santé Publique Ch.1, p.5"]
+
+    async def test_no_centroids_skips_pass(self):
+        # No FK-populated chunks for the course → centroid SELECT empty →
+        # tiebreaker no-ops → existing behavior (course title fallback).
+        boilerplate = "shared paragraph " * 30
+        pdf_a = _make_resource("alpha.pdf", raw_text=boilerplate, rid="rid-a")
+        pdf_b = _make_resource("beta.pdf", raw_text=boilerplate, rid="rid-b")
+        course = _make_course()
+        module = _make_module()
+
+        chunk_row = ("chunk-1", "1", 5, boilerplate, None, [1.0, 0.0, 0.0])
+
+        session = _FakeAsyncSession(
+            gets={
+                ("Module", "module-id"): module,
+                ("Course", "course-id"): course,
+            },
+            execute_queue=[
+                _scalar_result([pdf_a, pdf_b]),
+                _row_result([chunk_row]),
+                _row_result([]),
+                _row_result([]),  # centroid sample empty
+            ],
+        )
+        sources = [f"{_UUID} Ch.1, p.5"]
+        out = await rewrite_uuid_citations_for_module(sources, "module-id", session, "fr")
+        assert out == ["Statistiques de Santé Publique Ch.1, p.5"]
+
+    async def test_chunk_without_embedding_skips_centroid(self):
+        # Chunk has no embedding → centroid pass skipped for it.
+        boilerplate = "shared paragraph " * 30
+        pdf_a = _make_resource("alpha.pdf", raw_text=boilerplate, rid="rid-a")
+        pdf_b = _make_resource("beta.pdf", raw_text=boilerplate, rid="rid-b")
+        course = _make_course()
+        module = _make_module()
+
+        chunk_row = ("chunk-1", "1", 5, boilerplate, None, None)
+
+        session = _FakeAsyncSession(
+            gets={
+                ("Module", "module-id"): module,
+                ("Course", "course-id"): course,
+            },
+            execute_queue=[
+                _scalar_result([pdf_a, pdf_b]),
+                _row_result([chunk_row]),
+                _row_result([]),
+                # No centroid SELECT issued (filtered by `d[4]` truthy in _resolve_per_citation_map)
             ],
         )
         sources = [f"{_UUID} Ch.1, p.5"]


### PR DESCRIPTION
## Summary

Resolves #2187. Fourth resolution pass for citations still ambiguous after fingerprint + image-text tiebreakers. Uses existing pgvector embeddings — no new API spend.

For each unresolved chunk: sample up to 50 FK-populated chunks per candidate resource, compute centroid (component-wise mean), pick winner by cosine distance with a 0.05 margin gate.

## Test plan

- [x] 64 unit tests including: clear-margin centroid wins, tight-margin gate falls back, no centroids skips pass, missing embedding skips pass.
- [ ] Staging: re-hit known multi-PDF lessons, expect lift on courses where the centroids separate.