### PR TITLE
fix(api): GET /api/v1/organizations lists current user's orgs (#2129)

### DIFF
--- a/backend/app/api/v1/organizations.py
+++ b/backend/app/api/v1/organizations.py
@@ -118,13 +118,8 @@ async def create_organization(
     return _org_to_response(org)
 
 
-@router.get("/me", response_model=list[OrgWithRoleResponse])
-async def list_my_organizations(
-    current_user: AuthenticatedUser = Depends(get_current_user),
-    db=Depends(get_db_session),
-) -> list[OrgWithRoleResponse]:
-    """List all organizations where the current user is a member."""
-    memberships = await _svc.list_user_organizations(db, uuid.UUID(current_user.id))
+async def _list_user_orgs(db, user_id: uuid.UUID) -> list[OrgWithRoleResponse]:
+    memberships = await _svc.list_user_organizations(db, user_id)
     return [
         OrgWithRoleResponse(
             organization=_org_to_response(m["organization"]),
@@ -133,6 +128,27 @@ async def list_my_organizations(
         )
         for m in memberships
     ]
+
+
+@router.get("", response_model=list[OrgWithRoleResponse])
+async def list_organizations(
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+) -> list[OrgWithRoleResponse]:
+    """List all organizations where the current user is a member.
+
+    Default RESTful endpoint — equivalent to ``GET /organizations/me``.
+    """
+    return await _list_user_orgs(db, uuid.UUID(current_user.id))
+
+
+@router.get("/me", response_model=list[OrgWithRoleResponse])
+async def list_my_organizations(
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db=Depends(get_db_session),
+) -> list[OrgWithRoleResponse]:
+    """List all organizations where the current user is a member."""
+    return await _list_user_orgs(db, uuid.UUID(current_user.id))
 
 
 @router.get("/{org_id}", response_model=OrgResponse)

--- a/backend/tests/test_organizations_endpoints.py
+++ b/backend/tests/test_organizations_endpoints.py
@@ -1,0 +1,111 @@
+"""Tests for the GET /api/v1/organizations endpoint added in #2129.
+
+Asserts the canonical RESTful path returns the same payload as ``/me`` and
+covers the unauthenticated case.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.api.deps import get_db_session
+from app.api.deps_local_auth import AuthenticatedUser, get_current_user
+from app.main import app
+
+
+def _membership(role: str = "owner") -> dict:
+    org = MagicMock()
+    org.id = uuid.uuid4()
+    org.name = "Acme"
+    org.slug = "acme"
+    org.description = None
+    org.logo_url = None
+    org.contact_email = None
+    org.is_active = True
+    org.created_at = datetime(2026, 1, 1, 12, 0, 0)
+    return {
+        "organization": org,
+        "role": role,
+        "joined_at": datetime(2026, 2, 1, 12, 0, 0),
+    }
+
+
+@pytest.fixture
+def override_user():
+    user = AuthenticatedUser(
+        {
+            "sub": str(uuid.uuid4()),
+            "email": "learner@example.com",
+            "role": "user",
+            "preferred_language": "fr",
+            "current_level": 1,
+        }
+    )
+    app.dependency_overrides[get_current_user] = lambda: user
+    yield user
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture
+def override_db():
+    mock_db = AsyncMock()
+    app.dependency_overrides[get_db_session] = lambda: mock_db
+    yield mock_db
+    app.dependency_overrides.pop(get_db_session, None)
+
+
+async def test_list_organizations_unauthenticated_is_rejected() -> None:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/v1/organizations")
+    assert resp.status_code in (401, 403)
+    assert resp.status_code != 405
+
+
+async def test_list_organizations_returns_user_memberships(
+    override_user, override_db, monkeypatch
+) -> None:
+    rows = [_membership("owner"), _membership("viewer")]
+    monkeypatch.setattr(
+        "app.api.v1.organizations._svc.list_user_organizations",
+        AsyncMock(return_value=rows),
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/v1/organizations")
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert isinstance(payload, list)
+    assert len(payload) == 2
+    assert {p["role"] for p in payload} == {"owner", "viewer"}
+    first = payload[0]
+    assert first["organization"]["slug"] == "acme"
+    assert first["organization"]["name"] == "Acme"
+    assert first["organization"]["is_active"] is True
+    assert first["joined_at"].startswith("2026-02-01")
+
+
+async def test_list_organizations_matches_me_endpoint(
+    override_user, override_db, monkeypatch
+) -> None:
+    rows = [_membership("admin")]
+    monkeypatch.setattr(
+        "app.api.v1.organizations._svc.list_user_organizations",
+        AsyncMock(return_value=rows),
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        root = await ac.get("/api/v1/organizations")
+        me = await ac.get("/api/v1/organizations/me")
+
+    assert root.status_code == 200
+    assert me.status_code == 200
+    assert root.json() == me.json()


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/organizations` returning the same payload as `GET /api/v1/organizations/me` (list of memberships with role).
- Refactors the shared response shape into a private helper so both routes stay in lockstep.
- Frontend already calls `/me`; this is a non-breaking addition that fixes the 405 surfaced in the production-readiness sweep.

The canonical RESTful path was returning `405 Method Not Allowed` because only `POST ""` (create) was registered at the prefix root.

Fixes #2129

Part of the production-readiness epic #2123 (sweep finding F-016).

## Test plan
- [x] `pytest tests/test_organizations_endpoints.py -v` — 3 tests added covering: unauthenticated rejection, response shape (memberships with role + joined_at), and parity with `/me`.
- [x] `pytest tests/test_organization_service.py` — existing service tests still pass.
- [x] `ruff check` + `ruff format --check` clean on the two changed files.
- [ ] Post-deploy on staging: `curl -H "Authorization: Bearer …" https://api.elearning.portfolio2.kimbetien.com/api/v1/organizations` returns 200 with a JSON array (was 405).

🤖 Generated with [Claude Code](https://claude.com/claude-code)