### PR TITLE
fix(pwa): remove duplicate offline.html precache entry that broke SW eval (#2113)

### DIFF
--- a/frontend/sw.ts
+++ b/frontend/sw.ts
@@ -28,10 +28,11 @@ const CACHE_VERSION = "v7-status-no-cache";
 const OFFLINE_FALLBACK_URL = "/offline.html";
 
 const serwist = new Serwist({
-  precacheEntries: [
-    ...(self.__SW_MANIFEST || []),
-    { url: OFFLINE_FALLBACK_URL, revision: "1" },
-  ],
+  // `/offline.html` is auto-injected into __SW_MANIFEST by @serwist/next from
+  // public/. Re-adding it here with a different revision throws
+  // `add-to-cache-list-conflicting-entries` at SW eval, which broke
+  // registration end-to-end (see #2113).
+  precacheEntries: self.__SW_MANIFEST || [],
   skipWaiting: true,
   clientsClaim: true,
   navigationPreload: false,


### PR DESCRIPTION
## Summary
PWA service worker registration was failing on every page load with `ServiceWorker script evaluation failed`. The 2026-04-30 sweep finding F-005 was originally filed as a 404 (which has since been fixed — `/sw.js` now serves 200 with the bundled script), but registration still threw — different failure mode.

## Root cause
`@serwist/next` auto-injects every file under `public/` into the precache manifest. `public/offline.html` was therefore already in `__SW_MANIFEST` with a real content-hash revision (`8660dc96…`). [`sw.ts:33`](frontend/sw.ts#L33) then *also* added it manually with `revision: "1"`, producing two entries with the same URL but different revisions. Serwist's `addToPrecacheList()` rejects that synchronously with `add-to-cache-list-conflicting-entries`, so `new Serwist({...})` threw during SW global-scope evaluation.

Found by re-running the deployed `sw.js` through a sandboxed `ServiceWorkerGlobalScope`-like eval, which surfaced the exact error message that the browser elides behind the generic registration error.

## Fix
Drop the manual entry. The auto-manifest still contains `offline.html`, and the `fallbacks.entries[0].url` reference only requires the URL to be in the precache (revision-agnostic) — verified in the sandbox eval.

Fixes #2113

Part of the production-readiness epic #2123 (sweep finding F-005).

## Test plan
- [x] Local sandbox eval of the rebuilt SW no longer throws.
- [x] `npx tsc --noEmit` introduces no new errors (pre-existing `html5-qrcode` error in unrelated file).
- [ ] Post-deploy on staging: `navigator.serviceWorker.getRegistrations()` returns one active registration; no `ServiceWorker script evaluation failed` console error on any page; offline navigation falls back to `/offline.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)