### PR TITLE
merge dev → main: SW eval fix (#2113) (#2199)

### DIFF
--- a/frontend/sw.ts
+++ b/frontend/sw.ts
@@ -28,10 +28,11 @@ const CACHE_VERSION = "v7-status-no-cache";
 const OFFLINE_FALLBACK_URL = "/offline.html";
 
 const serwist = new Serwist({
-  precacheEntries: [
-    ...(self.__SW_MANIFEST || []),
-    { url: OFFLINE_FALLBACK_URL, revision: "1" },
-  ],
+  // `/offline.html` is auto-injected into __SW_MANIFEST by @serwist/next from
+  // public/. Re-adding it here with a different revision throws
+  // `add-to-cache-list-conflicting-entries` at SW eval, which broke
+  // registration end-to-end (see #2113).
+  precacheEntries: self.__SW_MANIFEST || [],
   skipWaiting: true,
   clientsClaim: true,
   navigationPreload: false,


### PR DESCRIPTION
## Summary
- Promotes #2199 (merged to dev as e1d4ef13) to main via the cherry-pick-on-sync-branch pattern to avoid phantom conflicts.
- Single commit: `fix(pwa): remove duplicate offline.html precache entry that broke SW eval (#2113)`.

Fixes #2113

## Test plan
- [x] CI green on the dev-side PR (#2199).
- [ ] Post-deploy on staging: `navigator.serviceWorker.getRegistrations()` returns one active registration; no `ServiceWorker script evaluation failed` console error on any page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)