### PR TITLE
fix(i18n): add missing Flashcards.cards + ModuleCard.review keys (#2128)

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -222,7 +222,8 @@
     "hours": "{count, plural, one {# hour} other {# hours}}",
     "prerequisitesRequired": "Prerequisites required",
     "continue": "Continue",
-    "start": "Start"
+    "start": "Start",
+    "review": "Review"
   },
   "ModuleMap": {
     "title": "Learning Modules",
@@ -452,6 +453,7 @@
   },
   "Flashcards": {
     "title": "Flashcards",
+    "cards": "cards",
     "loading": "Loading flashcards...",
     "generating": "Generating your flashcards...",
     "noCardsToday": "No cards due today!",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -222,7 +222,8 @@
     "hours": "{count, plural, one {# heure} other {# heures}}",
     "prerequisitesRequired": "Prérequis nécessaires",
     "continue": "Continuer",
-    "start": "Commencer"
+    "start": "Commencer",
+    "review": "Réviser"
   },
   "ModuleMap": {
     "title": "Modules d'apprentissage",
@@ -452,6 +453,7 @@
   },
   "Flashcards": {
     "title": "Flashcards",
+    "cards": "cartes",
     "loading": "Chargement des flashcards...",
     "generating": "Génération de vos flashcards...",
     "noCardsToday": "Aucune carte due aujourd'hui !",


### PR DESCRIPTION
## Summary
Two raw i18n keys were rendering into the FR + EN UI as plain text:

- `Flashcards.cards` — leaks on `/fr/flashcards` as `Objectif: 20 Flashcards.cards`. Referenced at [`flashcards-container.tsx:325`](frontend/app/[locale]/(app)/flashcards/flashcards-container.tsx#L325).
- `ModuleCard.review` — leaks on `/fr/modules` for completed modules. Referenced at [`module-card.tsx:106`](frontend/components/learning/module-card.tsx#L106).

Adds:

| Key | FR | EN |
|---|---|---|
| `Flashcards.cards` | cartes | cards |
| `ModuleCard.review` | Réviser | Review |

Partially addresses #2128. The broader FR/EN locale-completeness audit (lowercase admin-settings category labels, Bloom-verb chips, raw event-type chart labels, EN parity sweep) remains.

Part of the production-readiness epic #2123.

## Test plan
- [x] JSON validates on both locale files; new keys present.
- [ ] Post-deploy on staging: `/fr/flashcards` shows "Objectif: 20 cartes"; `/fr/modules` completed-module button shows "Réviser"; no `MISSING_MESSAGE` console errors for either key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)