### PR TITLE
merge dev → main: i18n keys (#2128) (#2201)

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -222,7 +222,8 @@
     "hours": "{count, plural, one {# hour} other {# hours}}",
     "prerequisitesRequired": "Prerequisites required",
     "continue": "Continue",
-    "start": "Start"
+    "start": "Start",
+    "review": "Review"
   },
   "ModuleMap": {
     "title": "Learning Modules",
@@ -452,6 +453,7 @@
   },
   "Flashcards": {
     "title": "Flashcards",
+    "cards": "cards",
     "loading": "Loading flashcards...",
     "generating": "Generating your flashcards...",
     "noCardsToday": "No cards due today!",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -222,7 +222,8 @@
     "hours": "{count, plural, one {# heure} other {# heures}}",
     "prerequisitesRequired": "Prérequis nécessaires",
     "continue": "Continuer",
-    "start": "Commencer"
+    "start": "Commencer",
+    "review": "Réviser"
   },
   "ModuleMap": {
     "title": "Modules d'apprentissage",
@@ -452,6 +453,7 @@
   },
   "Flashcards": {
     "title": "Flashcards",
+    "cards": "cartes",
     "loading": "Chargement des flashcards...",
     "generating": "Génération de vos flashcards...",
     "noCardsToday": "Aucune carte due aujourd'hui !",


### PR DESCRIPTION
## Summary
Promotes #2201 (merged to dev as 30ec4b7a) to main via the cherry-pick-on-sync-branch pattern.

Adds `Flashcards.cards` + `ModuleCard.review` to FR + EN locale files.

Partially addresses #2128.

## Test plan
- [x] CI green on the dev-side PR (#2201).
- [ ] Post-deploy on staging: no `MISSING_MESSAGE` for either key on `/fr/flashcards` or `/fr/modules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)