### PR TITLE
fix(lesson): video lesson preflight returns 200+empty list, not 404 (#2130)

### DIFF
--- a/backend/app/api/v1/lesson_video.py
+++ b/backend/app/api/v1/lesson_video.py
@@ -188,14 +188,20 @@ async def generate_lesson_video(
     "/lesson/{lesson_id}",
     response_model=LessonVideoListResponse,
     status_code=status.HTTP_200_OK,
-    responses={404: {"description": "No video for this lesson"}},
+    responses={404: {"description": "Lesson not found"}},
 )
 async def get_lesson_video(
     lesson_id: UUID,
     _current_user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db_session),
 ) -> LessonVideoListResponse:
-    """Return video rows for a lesson, shared across countries."""
+    """Return video rows for a lesson, shared across countries.
+
+    Returns 200 with ``video: []`` when the lesson exists but no video
+    has been generated yet. (The 404 was previously surfaced as a
+    console error on every lesson page load — see #2130.) Reserves
+    404 for the genuine "lesson not found" case.
+    """
     from app.domain.models.content import GeneratedContent
 
     lesson_row = await db.execute(
@@ -225,28 +231,17 @@ async def get_lesson_video(
     )
     rows = result.scalars().all()
 
-    video_responses = []
-    for row in rows:
-        row_status: VideoStatus = row.status  # type: ignore[assignment]
-        video_responses.append(
-            LessonVideoResponse(
-                video_id=row.id,
-                lesson_id=lesson_id,
-                status=row_status,
-                video_url=_resolve_video_url(row),
-                duration_seconds=row.duration_seconds if row.status == "ready" else None,
-                file_size_bytes=row.file_size_bytes if row.status == "ready" else None,
-            )
+    video_responses = [
+        LessonVideoResponse(
+            video_id=row.id,
+            lesson_id=lesson_id,
+            status=row.status,  # type: ignore[arg-type]
+            video_url=_resolve_video_url(row),
+            duration_seconds=row.duration_seconds if row.status == "ready" else None,
+            file_size_bytes=row.file_size_bytes if row.status == "ready" else None,
         )
-
-    if not video_responses:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "error": "lesson_video_not_found",
-                "message": f"No video for lesson {lesson_id}",
-            },
-        )
+        for row in rows
+    ]
 
     return LessonVideoListResponse(
         lesson_id=lesson_id,

--- a/backend/tests/test_lesson_video_endpoint.py
+++ b/backend/tests/test_lesson_video_endpoint.py
@@ -1,0 +1,116 @@
+"""Tests for GET /api/v1/video/lesson/{lesson_id} (#2130).
+
+Asserts the endpoint distinguishes "lesson does not exist" (404) from
+"lesson exists but no video generated yet" (200 with empty list). The
+former keeps the original semantics; the latter previously also returned
+404 and surfaced as a console error on every lesson page load.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.api.deps import get_db_session
+from app.api.deps_local_auth import AuthenticatedUser, get_current_user
+from app.main import app
+
+
+@pytest.fixture
+def override_user():
+    user = AuthenticatedUser(
+        {
+            "sub": str(uuid.uuid4()),
+            "email": "learner@example.com",
+            "role": "user",
+            "preferred_language": "fr",
+            "current_level": 1,
+        }
+    )
+    app.dependency_overrides[get_current_user] = lambda: user
+    yield user
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def _make_lesson_row(language: str = "fr") -> MagicMock:
+    row = MagicMock()
+    row.module_id = uuid.uuid4()
+    row.unit_id = "1.1"
+    row.language = language
+    return row
+
+
+def _override_db(*, lesson_meta, video_rows):
+    """Build a mock DB whose two execute() calls return the lesson lookup
+    then the video lookup.
+    """
+    lesson_first = MagicMock()
+    lesson_first.first = MagicMock(return_value=lesson_meta)
+    video_scalars = MagicMock()
+    video_scalars.all = MagicMock(return_value=video_rows)
+    video_result = MagicMock()
+    video_result.scalars = MagicMock(return_value=video_scalars)
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(side_effect=[lesson_first, video_result])
+    app.dependency_overrides[get_db_session] = lambda: mock_db
+    return mock_db
+
+
+async def test_lesson_not_found_returns_404(override_user) -> None:
+    _override_db(lesson_meta=None, video_rows=[])
+    transport = ASGITransport(app=app)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(f"/api/v1/video/lesson/{uuid.uuid4()}")
+        assert resp.status_code == 404
+        assert resp.json()["detail"]["error"] == "lesson_not_found"
+    finally:
+        app.dependency_overrides.pop(get_db_session, None)
+
+
+async def test_lesson_with_no_video_returns_200_empty_list(override_user) -> None:
+    """The fix for #2130: previously this returned 404 and polluted the
+    browser console on every lesson page load. Now returns 200 with an
+    empty `video` list so the FE can render the Generate button without
+    a network error.
+    """
+    _override_db(lesson_meta=_make_lesson_row(), video_rows=[])
+    lesson_id = uuid.uuid4()
+    transport = ASGITransport(app=app)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(f"/api/v1/video/lesson/{lesson_id}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["lesson_id"] == str(lesson_id)
+        assert body["video"] == []
+        assert body["total"] == 0
+    finally:
+        app.dependency_overrides.pop(get_db_session, None)
+
+
+async def test_lesson_with_video_returns_video_list(override_user) -> None:
+    video_row = MagicMock()
+    video_row.id = uuid.uuid4()
+    video_row.status = "ready"
+    video_row.duration_seconds = 90
+    video_row.file_size_bytes = 12345
+    _override_db(lesson_meta=_make_lesson_row(), video_rows=[video_row])
+    lesson_id = uuid.uuid4()
+    transport = ASGITransport(app=app)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(f"/api/v1/video/lesson/{lesson_id}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 1
+        first = body["video"][0]
+        assert first["status"] == "ready"
+        assert first["duration_seconds"] == 90
+        assert first["video_url"] == f"/api/v1/video/{video_row.id}/data"
+    finally:
+        app.dependency_overrides.pop(get_db_session, None)

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -781,7 +781,10 @@ export async function getLessonVideoStatus(
     );
     const first = data.video[0];
     if (!first) {
-      return { lesson_id: lessonId, status: "pending" };
+      // BE returns 200 with `video: []` when the lesson exists but has
+      // no video row yet. Map to `absent` so the UI shows Generate
+      // instead of auto-starting the poll loop (#1824, #2130).
+      return { lesson_id: lessonId, status: "absent" };
     }
     return {
       lesson_id: first.lesson_id,
@@ -791,10 +794,11 @@ export async function getLessonVideoStatus(
       duration_seconds: first.duration_seconds ?? undefined,
     };
   } catch (err: unknown) {
-    // 404 means "no video row exists yet". Return the synthetic
-    // ``absent`` status so the UI can tell this apart from a real
-    // ``pending`` row and show the Generate button instead of
-    // auto-starting the poll loop. See #1824.
+    // Older BE deployments return 404 for "no video yet". Treat it as
+    // `absent` for cross-deploy compat; once #2130 ships everywhere
+    // this branch becomes dead code (will surface only on real 404 —
+    // i.e. lesson-not-found — at which point letting it bubble would
+    // be more honest, but `absent` keeps the UI rendering).
     const status = (err as { status?: number })?.status;
     if (status === 404) {
       return { lesson_id: lessonId, status: "absent" };


### PR DESCRIPTION
## Summary
Lesson pages preflight `GET /api/v1/video/lesson/{id}` to decide whether to render the "Générer la vidéo" button vs the player. When no video had been generated yet, the BE 404'd, surfacing a console error and Sentry noise on every lesson page load. The 404 was conveying "you can ask for one" — a state, not a missing resource.

### Backend ([`lesson_video.py`](backend/app/api/v1/lesson_video.py))
- Drop the `if not video_responses: raise 404` branch. Return `{lesson_id, video: [], total: 0}` when the lesson exists but has no video row.
- 404 reserved for the genuine "lesson not found" case (the upstream `GeneratedContent` lookup miss).

### Frontend ([`lib/api.ts`](frontend/lib/api.ts))
- Map empty `data.video` to `status: "absent"` (not `"pending"`, which would auto-start the poll loop and break the Generate-button affordance documented at #1824).
- Keep the 404 catch as a cross-deploy compatibility shim while the old BE is still rolling.

### Tests
3 new endpoint tests covering: lesson-not-found 404, lesson-with-no-video 200+empty, lesson-with-video 200+populated.

Fixes #2130

Part of the production-readiness epic #2123 (sweep finding F-017).

## Test plan
- [x] `pytest tests/test_lesson_video_endpoint.py -v` — 3/3 pass.
- [x] `ruff check` + `ruff format --check` clean on the BE file + tests.
- [x] `tsc --noEmit` introduces no new errors on the FE file (pre-existing `html5-qrcode` error in unrelated file).
- [ ] Post-deploy on staging: lesson page no longer logs `404` in the console for `GET /api/v1/video/lesson/{id}`; "Générer la vidéo" button still visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)