### PR TITLE
fix(admin): give Recharts a numeric height so it stops warning width/height(-1) (#2131)

### DIFF
--- a/frontend/app/[locale]/admin/analytics/page.tsx
+++ b/frontend/app/[locale]/admin/analytics/page.tsx
@@ -135,8 +135,8 @@ export default function AnalyticsPage() {
                 <CardTitle className="text-base">{t("dailyActiveUsers")}</CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="h-64 w-full overflow-x-auto">
-                  <ResponsiveContainer width="100%" height="100%">
+                <div className="w-full">
+                  <ResponsiveContainer width="100%" height={256}>
                     <LineChart data={data.daily_active_users}>
                       <CartesianGrid strokeDasharray="3 3" />
                       <XAxis
@@ -170,8 +170,8 @@ export default function AnalyticsPage() {
                 <CardTitle className="text-base">{t("eventsByType")}</CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="h-64 w-full overflow-x-auto">
-                  <ResponsiveContainer width="100%" height="100%">
+                <div className="w-full">
+                  <ResponsiveContainer width="100%" height={256}>
                     <BarChart data={eventsByTypeData}>
                       <CartesianGrid strokeDasharray="3 3" />
                       <XAxis dataKey="name" tick={{ fontSize: 11 }} angle={-25} textAnchor="end" height={60} />


### PR DESCRIPTION
## Summary
Both charts on `/fr/admin/analytics` (DAU LineChart, events-by-type BarChart) emit a Recharts console warning on every render:

\`\`\`
The width(-1) and height(-1) of chart should be greater than 0, please check the style of container, or the props width(100%) and height(100%), or add a minWidth(0) or minHeight(undefined) or use aspect(undefined) to control the height and width.
\`\`\`

## Root cause
Each chart wrapper combined `h-64 w-full overflow-x-auto` with a `ResponsiveContainer` set to `height="100%"`. `overflow-x-auto` makes the inner `width: 100%` recursive against the *content* width, and during one of Recharts's measurement passes both dimensions resolved to -1 before settling.

## Fix
Matches the recommended Recharts pattern:
- Drop `overflow-x-auto` — the chart is already responsive (XAxis ticks rotate at -25° at narrow widths).
- Drop `h-64` on the wrapper; pass numeric `height={256}` (= `h-64`) to `ResponsiveContainer`.

Same change applied to both charts. Charts visually unchanged.

Fixes #2131

Part of the production-readiness epic #2123 (sweep finding F-010).

## Test plan
- [x] `tsc --noEmit` introduces no new errors.
- [x] `eslint` clean on the changed file.
- [ ] Post-deploy on staging: `/fr/admin/analytics` console no longer emits the `width(-1) and height(-1)` warning; charts still render at the same height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)