### PR TITLE
fix(a11y): refresh-content buttons meet 44×44 touch target on mobile (#2132 F-022)

### DIFF
--- a/frontend/components/learning/case-study-viewer.tsx
+++ b/frontend/components/learning/case-study-viewer.tsx
@@ -397,8 +397,9 @@ export function CaseStudyViewer({
             size="sm"
             onClick={handleRefresh}
             disabled={isRefreshing || isLoading || isGenerating || !isOnline}
-            className="min-h-11 gap-1.5 text-gray-500 hover:text-gray-900"
+            className="min-h-11 min-w-11 gap-1.5 text-gray-500 hover:text-gray-900"
             title={t('refreshContent')}
+            aria-label={t('refreshContent')}
           >
             <RefreshCw className={`w-4 h-4 ${isRefreshing ? 'animate-spin' : ''}`} />
             <span className="hidden sm:inline">{t('refreshContent')}</span>

--- a/frontend/components/learning/lesson-viewer.tsx
+++ b/frontend/components/learning/lesson-viewer.tsx
@@ -494,8 +494,9 @@ export function LessonViewer({
               size="sm"
               onClick={handleRefresh}
               disabled={isRefreshing || isLoading || isGenerating || !isOnline}
-              className="min-h-11 gap-1.5 text-gray-500 hover:text-gray-900"
+              className="min-h-11 min-w-11 gap-1.5 text-gray-500 hover:text-gray-900"
               title={t('refreshContent')}
+              aria-label={t('refreshContent')}
             >
               <RefreshCw className={`w-4 h-4 ${isRefreshing ? 'animate-spin' : ''}`} />
               <span className="hidden sm:inline">{t('refreshContent')}</span>

--- a/frontend/components/quiz/quiz-container.tsx
+++ b/frontend/components/quiz/quiz-container.tsx
@@ -411,7 +411,9 @@ export function QuizContainer({
                 size="sm"
                 onClick={handleRefreshContent}
                 disabled={!isOnline}
-                className="min-h-11 gap-1.5 text-stone-500 hover:text-stone-900"
+                className="min-h-11 min-w-11 gap-1.5 text-stone-500 hover:text-stone-900"
+                title={t('refreshContent')}
+                aria-label={t('refreshContent')}
               >
                 <RefreshCw className="w-4 h-4" />
                 <span className="hidden sm:inline">{t('refreshContent')}</span>


### PR DESCRIPTION
## Summary
Three icon-only "Actualiser le contenu" / "Refresh content" buttons (lesson, case-study, quiz pages) collapsed to **36×44** on the 375×667 mobile viewport. Visible label is gated behind `hidden sm:inline`; wrapper had `min-h-11` but no `min-w-11`. WCAG 2.1 AA target size is 44×44.

## Fix
- Add `min-w-11` to all three buttons.
- Add explicit `aria-label={t('refreshContent')}` (relying on `title` alone is not best practice — `aria-label` is what most ATs use).
- Add the missing `title` to the quiz-container button (it had neither).

## F-019 — verified false positive (no code change)
While investigating, the next/prev unit-nav button "concatenation" reported as F-019 was checked against the deployed component (`components/learning/unit-nav.tsx`). The `flex-col` styling renders the prev-label and the title on separate visual lines (verified via screenshot on staging — see attached). The sweep snapshot's `textContent` extraction loses the line break, but the accessibility tree shows a proper space-separated accessible name (`"Suivant Parties Prenantes…"`). No code change needed.

Partially addresses #2132. Remaining sub-findings: F-008 (page metadata), F-014 (login a11y h1), F-020 (unit-list whitespace), F-023 (RSC prefetch 404).

Part of the production-readiness epic #2123.

## Test plan
- [x] `tsc --noEmit` introduces no new errors.
- [x] `eslint` clean on all 3 changed files (pre-existing unused-import warning unchanged).
- [ ] Post-deploy on staging at viewport 375×667: button measures ≥44×44 on lesson, case-study, and quiz pages; screen reader announces "Actualiser le contenu" / "Refresh content".

🤖 Generated with [Claude Code](https://claude.com/claude-code)