### PR TITLE
merge dev → main: refresh-content button touch target (#2132 F-022) (#2207)

### DIFF
--- a/frontend/components/learning/case-study-viewer.tsx
+++ b/frontend/components/learning/case-study-viewer.tsx
@@ -397,8 +397,9 @@ export function CaseStudyViewer({
             size="sm"
             onClick={handleRefresh}
             disabled={isRefreshing || isLoading || isGenerating || !isOnline}
-            className="min-h-11 gap-1.5 text-gray-500 hover:text-gray-900"
+            className="min-h-11 min-w-11 gap-1.5 text-gray-500 hover:text-gray-900"
             title={t('refreshContent')}
+            aria-label={t('refreshContent')}
           >
             <RefreshCw className={`w-4 h-4 ${isRefreshing ? 'animate-spin' : ''}`} />
             <span className="hidden sm:inline">{t('refreshContent')}</span>

--- a/frontend/components/learning/lesson-viewer.tsx
+++ b/frontend/components/learning/lesson-viewer.tsx
@@ -494,8 +494,9 @@ export function LessonViewer({
               size="sm"
               onClick={handleRefresh}
               disabled={isRefreshing || isLoading || isGenerating || !isOnline}
-              className="min-h-11 gap-1.5 text-gray-500 hover:text-gray-900"
+              className="min-h-11 min-w-11 gap-1.5 text-gray-500 hover:text-gray-900"
               title={t('refreshContent')}
+              aria-label={t('refreshContent')}
             >
               <RefreshCw className={`w-4 h-4 ${isRefreshing ? 'animate-spin' : ''}`} />
               <span className="hidden sm:inline">{t('refreshContent')}</span>

--- a/frontend/components/quiz/quiz-container.tsx
+++ b/frontend/components/quiz/quiz-container.tsx
@@ -411,7 +411,9 @@ export function QuizContainer({
                 size="sm"
                 onClick={handleRefreshContent}
                 disabled={!isOnline}
-                className="min-h-11 gap-1.5 text-stone-500 hover:text-stone-900"
+                className="min-h-11 min-w-11 gap-1.5 text-stone-500 hover:text-stone-900"
+                title={t('refreshContent')}
+                aria-label={t('refreshContent')}
               >
                 <RefreshCw className="w-4 h-4" />
                 <span className="hidden sm:inline">{t('refreshContent')}</span>


### PR DESCRIPTION
Promotes #2207 (merged to dev as eaaf1ad1) to main via cherry-pick. Single commit: `fix(a11y): refresh-content buttons meet 44×44 touch target on mobile (#2132 F-022)`. Partially addresses #2132. CI green on dev-side PR.%n%n🤖 Generated with [Claude Code](https://claude.com/claude-code)