### PR TITLE
fix(i18n): localize quiz unit header — Unit X → Unité X in FR (#2132 F-021)

### DIFF
--- a/frontend/components/learning/unit-quiz-viewer.tsx
+++ b/frontend/components/learning/unit-quiz-viewer.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useTranslations } from 'next-intl';
 import { useRouter } from '@/i18n/routing';
 import { QuizContainer } from '@/components/quiz/quiz-container';
 
@@ -21,6 +22,7 @@ export function UnitQuizViewer({
   unitDescription,
 }: UnitQuizViewerProps) {
   const router = useRouter();
+  const tNav = useTranslations('Navigation');
 
   return (
     <div>
@@ -29,7 +31,7 @@ export function UnitQuizViewer({
           <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-1">
             {unitTitle}
           </h1>
-          <p className="text-sm text-gray-500">{`Unit ${unitId}`}</p>
+          <p className="text-sm text-gray-500">{tNav('unitNumber', { number: unitId })}</p>
           {unitDescription && (
             <p className="text-base text-gray-700 mt-2">{unitDescription}</p>
           )}


### PR DESCRIPTION
## Summary
Lesson units render \`Unité 1.1\` in FR; quiz units rendered \`Unit 1.4\` — string inconsistency between unit-type renderers, flagged by sweep finding F-021.

## Root cause
[\`unit-quiz-viewer.tsx:32\`](frontend/components/learning/unit-quiz-viewer.tsx#L32) hardcoded:
\`\`\`tsx
<p>{\`Unit \${unitId}\`}</p>
\`\`\`

## Fix
Replaced with \`tNav('unitNumber', { number: unitId })\` using the existing \`Navigation.unitNumber\` key (\`Unité {number}\` / \`Unit {number}\`), which already ships in both locales and is used by \`module-progress-overlay.tsx\` for the same purpose. No new i18n keys needed.

Partially addresses #2132 (F-021).

Part of the production-readiness epic #2123.

## Test plan
- [x] \`tsc --noEmit\` clean on the changed file.
- [x] \`eslint\` clean.
- [ ] Post-deploy on staging at \`/fr/modules/{id}/units/{quiz-unit}\`: header sub-text reads \`Unité X.Y\` (was \`Unit X.Y\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)