### PR TITLE
fix(i18n): correct namespace for quiz unit number — ModuleOverview not Navigation (#2132 F-021 follow-up)

### DIFF
--- a/frontend/components/learning/unit-quiz-viewer.tsx
+++ b/frontend/components/learning/unit-quiz-viewer.tsx
@@ -22,7 +22,7 @@ export function UnitQuizViewer({
   unitDescription,
 }: UnitQuizViewerProps) {
   const router = useRouter();
-  const tNav = useTranslations('Navigation');
+  const t = useTranslations('ModuleOverview');
 
   return (
     <div>
@@ -31,7 +31,7 @@ export function UnitQuizViewer({
           <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-1">
             {unitTitle}
           </h1>
-          <p className="text-sm text-gray-500">{tNav('unitNumber', { number: unitId })}</p>
+          <p className="text-sm text-gray-500">{t('unitNumber', { number: unitId })}</p>
           {unitDescription && (
             <p className="text-base text-gray-700 mt-2">{unitDescription}</p>
           )}


### PR DESCRIPTION
## Summary
PR #2209 used \`Navigation.unitNumber\` which does not exist — the actual key is \`ModuleOverview.unitNumber\` (sibling of \`units\`, \`progress\`, \`level\`, etc.). The 22:30 deploy surfaced \`MISSING_MESSAGE: Navigation.unitNumber (fr)\` and rendered \`Navigation.unitNumber\` as raw text on \`/fr/modules/{id}/units/{quiz}\`.

I'd misread the \`grep\` output as \`Navigation.unitNumber\` because the \`module-progress-overlay\` consumer is the only call-site and the namespace wasn't visible in the search line. Verified via JSON parse this time:
\`\`\`
fr.json: ModuleOverview.unitNumber = "Unité {number}"
en.json: ModuleOverview.unitNumber = "Unit {number}"
\`\`\`

## Fix
Two-character change: \`'Navigation'\` → \`'ModuleOverview'\`, plus rename the binding from \`tNav\` → \`t\` since it's no longer a navigation namespace.

## Test plan
- [x] \`tsc --noEmit\` clean.
- [x] \`eslint\` clean.
- [ ] Post-deploy: \`/fr/modules/{id}/units/{quiz-unit}\` renders \`Unité X.Y\` under the title; no \`MISSING_MESSAGE\` console error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)