### PR TITLE
merge dev → main: correct namespace for quiz unit number (#2132 F-021 follow-up) (#2211)

### DIFF
--- a/frontend/components/learning/unit-quiz-viewer.tsx
+++ b/frontend/components/learning/unit-quiz-viewer.tsx
@@ -22,7 +22,7 @@ export function UnitQuizViewer({
   unitDescription,
 }: UnitQuizViewerProps) {
   const router = useRouter();
-  const tNav = useTranslations('Navigation');
+  const t = useTranslations('ModuleOverview');
 
   return (
     <div>
@@ -31,7 +31,7 @@ export function UnitQuizViewer({
           <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-1">
             {unitTitle}
           </h1>
-          <p className="text-sm text-gray-500">{tNav('unitNumber', { number: unitId })}</p>
+          <p className="text-sm text-gray-500">{t('unitNumber', { number: unitId })}</p>
           {unitDescription && (
             <p className="text-base text-gray-700 mt-2">{unitDescription}</p>
           )}


### PR DESCRIPTION
Promotes #2211 (merged to dev as cc9e2803) to main via cherry-pick. Fixes the broken `Navigation.unitNumber` reference from PR #2210 — the actual key lives under `ModuleOverview`. CI green on dev-side PR.%n%n🤖 Generated with [Claude Code](https://claude.com/claude-code)