### PR TITLE
fix(a11y): add sr-only h1 to /fr/login (#2132 F-014)

### DIFF
--- a/frontend/app/[locale]/(auth)/login/page.tsx
+++ b/frontend/app/[locale]/(auth)/login/page.tsx
@@ -17,6 +17,7 @@ export default function LoginPage() {
   return (
     <div className="flex min-h-screen items-center justify-center p-4">
       <div className="w-full max-w-md space-y-3">
+        <h1 className="sr-only">{t('signIn')}</h1>
         {useAuthenticator ? (
           <>
             <TOTPLoginForm redirectTo={redirectTo} />


### PR DESCRIPTION
## Summary
\`/fr/login\` had no \`<h1>\` because the visual title comes from \`<CardTitle>\`, which renders as a \`<div>\` (see [\`components/ui/card.tsx\`](frontend/components/ui/card.tsx)). Screen readers had no top-level page heading and the hierarchy started at h2 inside the card. WCAG 2.4.6 expects a clear page-level heading.

## Fix
Single-line addition: an \`sr-only\` \`<h1>\` using the existing \`Auth.signIn\` key (\`Se connecter\` / \`Sign in\`). Visually hidden but in the accessibility tree, so screen readers announce the page heading without altering the centered-Card visual design.

Partially addresses #2132 (F-014). Remaining sub-findings: F-008 (page metadata), F-020 (unit-list whitespace), F-023 (RSC prefetch 404).

Part of the production-readiness epic #2123.

## Test plan
- [x] \`tsc --noEmit\` clean.
- [x] \`eslint\` clean.
- [ ] Post-deploy on staging: \`/fr/login\` page exposes an \`<h1>\` to the accessibility tree (\`Se connecter\`); visual layout unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)