### PR TITLE
fix(modules): create module progress as 'not_started' on enrollment (follow-up to #2125)

### DIFF
--- a/backend/app/domain/services/enrollment_helper.py
+++ b/backend/app/domain/services/enrollment_helper.py
@@ -60,7 +60,7 @@ async def enroll_user_in_course(
                 UserModuleProgress(
                     user_id=user_id,
                     module_id=module.id,
-                    status="in_progress" if module.id == first_module_id else "locked",
+                    status="in_progress" if module.id == first_module_id else "not_started",
                     completion_pct=0.0,
                     time_spent_minutes=0,
                 )

--- a/backend/migrations/versions/090_relax_module_progress_locked_post_2125.py
+++ b/backend/migrations/versions/090_relax_module_progress_locked_post_2125.py
@@ -1,0 +1,43 @@
+"""Backfill: relax 'locked' module progress rows to 'not_started' (#2218).
+
+Revision ID: 090
+Revises: 089
+Create Date: 2026-05-04
+
+Follow-up to migration 088. PR #2125 removed sequential module gating, and
+088 backfilled legacy ``'locked'`` rows to ``'not_started'``. However,
+``enrollment_helper.enroll_user_in_course()`` was missed and continued to
+write ``status='locked'`` for every non-first module at enrollment time,
+re-introducing the same locked rows that 088 had just cleaned up.
+
+PR #2219 fixes the write path. This migration relaxes any ``'locked'``
+rows that the buggy enrollment path persisted between the deploy of #2125
+(2026-04-30) and the deploy of #2219, so the database matches the new
+"every module accessible after enrollment" semantics.
+
+Forward-only: downgrade is a no-op. Reversing ``'not_started'`` →
+``'locked'`` would require knowing which rows had been buggy-locked vs.
+intentionally locked, and that distinction is no longer meaningful.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "090"
+down_revision: str | None = "089"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    result = bind.execute(
+        sa.text("UPDATE user_module_progress SET status = 'not_started' WHERE status = 'locked'")
+    )
+    print(f"[090] Relaxed {result.rowcount} 'locked' module progress row(s) to 'not_started'")
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary

- One-line fix in [`backend/app/domain/services/enrollment_helper.py:63`](https://github.com/Benidrissa/etutor-digital-ph/blob/fix/2125-followup-enrollment-locked/backend/app/domain/services/enrollment_helper.py#L63): `"locked"` → `"not_started"` for non-first modules.
- Backfill migration `090_relax_module_progress_locked_post_2125.py` — mirrors migration 088 — relaxes any `'locked'` rows the buggy enrollment path persisted between the #2125 deploy and this fix.
- PR #2125 / migration 088 removed sequential gating on the read side and backfilled legacy rows, but the **enrollment write path** kept persisting `"locked"`. Every fresh enrollment re-introduced locked rows the migration had just cleaned up.
- Affects manual, API, and activation-code-driven enrollments (all use `enroll_user_in_course()`).

Fixes #2218.

## Test plan

- [ ] Backend unit tests: `cd backend && uv run pytest tests/ -k enroll -v`
- [ ] `alembic upgrade head` runs cleanly on staging; check log line `[090] Relaxed N 'locked' module progress row(s) to 'not_started'`
- [ ] Manual E2E on staging: create a new course with multiple modules → enroll a fresh learner → verify all modules render without the lock gate
- [ ] SQL spot-check post-migration: `SELECT COUNT(*) FROM user_module_progress WHERE status = 'locked';` should return `0`
- [ ] Activation-code enrollment also produces accessible modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)