### PR TITLE
chore(migrations): renumber backfill 090→091 to resolve Alembic head collision

### DIFF
--- a/backend/migrations/versions/091_relax_module_progress_locked_post_2125.py
+++ b/backend/migrations/versions/091_relax_module_progress_locked_post_2125.py
@@ -1,7 +1,7 @@
 """Backfill: relax 'locked' module progress rows to 'not_started' (#2218).
 
-Revision ID: 090
-Revises: 089
+Revision ID: 091
+Revises: 090
 Create Date: 2026-05-04
 
 Follow-up to migration 088. PR #2125 removed sequential module gating, and
@@ -25,8 +25,8 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "090"
-down_revision: str | None = "089"
+revision: str = "091"
+down_revision: str | None = "090"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
@@ -36,7 +36,7 @@ def upgrade() -> None:
     result = bind.execute(
         sa.text("UPDATE user_module_progress SET status = 'not_started' WHERE status = 'locked'")
     )
-    print(f"[090] Relaxed {result.rowcount} 'locked' module progress row(s) to 'not_started'")
+    print(f"[091] Relaxed {result.rowcount} 'locked' module progress row(s) to 'not_started'")
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Summary

PRs #2219 and #2220 each merged a migration with \`revision=\"090\"\` / \`down_revision=\"089\"\`, leaving dev with two Alembic heads. \`alembic upgrade head\` fails on multiple heads, which would block the next deploy.

This PR renumbers the smaller of the two (the \`UPDATE\`-only backfill from #2219) to \`091\` / \`down_revision=\"090\"\`, so the chain is linear:

\`\`\`
089 → 090 (course quality agent, #2220) → 091 (relax locked module rows, #2219)
\`\`\`

Course quality agent stays at \`090\` because it merged first and is structurally larger.

Refs #2218.

## Test plan

- [ ] \`cd backend && uv run alembic upgrade head\` runs cleanly on a fresh DB
- [ ] \`uv run alembic heads\` returns a single head (\`091\`)
- [ ] On staging deploy: log line \`[091] Relaxed N 'locked' module progress row(s) to 'not_started'\` appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)