### PR TITLE
fix(pwa): stop reloadOnOnline + persist quiz/summative/case-study state (#2226)

### DIFF
--- a/frontend/app/[locale]/(app)/modules/[moduleId]/summative/summative-page-client.tsx
+++ b/frontend/app/[locale]/(app)/modules/[moduleId]/summative/summative-page-client.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
 import { SummativeAssessmentContainer } from '@/components/quiz/summative-assessment-container';
 
 interface SummativePageClientProps {
@@ -17,19 +20,26 @@ export function SummativePageClient({
   country,
   level,
 }: SummativePageClientProps) {
+  const router = useRouter();
+  // Bumping the key remounts the container with fresh state — used to reset
+  // a failed attempt without a hard page reload that would also blow away
+  // unrelated client state (issue #2226).
+  const [retryKey, setRetryKey] = useState(0);
+
   return (
     <main className="min-h-screen bg-stone-50">
       <div className="py-8">
         <SummativeAssessmentContainer
+          key={retryKey}
           moduleId={moduleId}
           language={language}
           country={country}
           level={level}
           onComplete={() => {
-            window.location.href = `/${locale}/modules`;
+            router.push(`/${locale}/modules`);
           }}
           onRetry={() => {
-            window.location.reload();
+            setRetryKey((k) => k + 1);
           }}
         />
       </div>

--- a/frontend/components/learning/case-study-viewer.tsx
+++ b/frontend/components/learning/case-study-viewer.tsx
@@ -20,6 +20,7 @@ import { useCurrentUser } from '@/lib/hooks/use-current-user';
 import { loadCaseStudy, OfflineContentNotAvailable } from '@/lib/offline/content-loader';
 import { OfflineBadge } from '@/components/shared/offline-badge';
 import { useNetworkStatus } from '@/lib/hooks/use-network-status';
+import { loadQuizState, saveQuizState, clearQuizState } from '@/lib/quiz-state-persistence';
 
 const COUNTRY_NAMES: Record<string, { en: string; fr: string }> = {
   BF: { en: 'Burkina Faso', fr: 'Burkina Faso' },
@@ -117,6 +118,21 @@ export function CaseStudyViewer({
   const { isOnline } = useNetworkStatus();
 
   const t = useTranslations('CaseStudyViewer');
+
+  // Restore the "show correction" flag once the case study has loaded so a
+  // refresh / network blip doesn't force the user to re-click the button.
+  // Keyed on the case-study id so a regenerate auto-invalidates.
+  const storageKey = caseStudyData ? `case-study-state:v1:${caseStudyData.id}` : null;
+  useEffect(() => {
+    if (!storageKey) return;
+    const restored = loadQuizState<{ correctionVisible: boolean }>(storageKey);
+    if (restored?.correctionVisible) setCorrectionVisible(true);
+  }, [storageKey]);
+
+  useEffect(() => {
+    if (!storageKey) return;
+    saveQuizState(storageKey, { correctionVisible });
+  }, [storageKey, correctionVisible]);
 
   useEffect(() => {
     if (!isHydrated || !moduleId || !unitId) return;
@@ -258,6 +274,7 @@ export function CaseStudyViewer({
   }, [moduleId, unitId, language, level, country, forceRegenerate, isHydrated]);
 
   const handleRefresh = () => {
+    if (storageKey) clearQuizState(storageKey);
     setCaseStudyData(null);
     setIsRefreshing(true);
     setForceRegenerate(true);
@@ -273,6 +290,7 @@ export function CaseStudyViewer({
           unit_id: unitId,
         }),
       });
+      if (storageKey) clearQuizState(storageKey);
       setIsCompleted(true);
       onComplete?.();
     } catch (err) {

--- a/frontend/components/quiz/quiz-interface.tsx
+++ b/frontend/components/quiz/quiz-interface.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useTranslations } from 'next-intl';
 import { Clock, ChevronLeft, ChevronRight, CheckCircle, XCircle, AlertCircle } from 'lucide-react';
 
@@ -15,6 +15,7 @@ import { Badge } from '@/components/ui/badge';
 import type { Quiz, QuizAnswerSubmission, QuizAttemptResponse } from '@/lib/api';
 import { ApiError, submitQuizAttempt } from '@/lib/api';
 import { scoreQuizOffline } from '@/lib/offline/offline-quiz-scorer';
+import { loadQuizState, saveQuizState, clearQuizState } from '@/lib/quiz-state-persistence';
 
 interface QuizInterfaceProps {
   quiz: Quiz;
@@ -28,20 +29,48 @@ interface QuestionState {
   showFeedback: boolean;
 }
 
+interface PersistedQuizState {
+  currentQuestionIndex: number;
+  questionStates: QuestionState[];
+  startTime: number;
+}
+
 export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps) {
   const t = useTranslations('Quiz');
-  
-  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
-  const [questionStates, setQuestionStates] = useState<QuestionState[]>(
-    quiz.content.questions.map(() => ({
-      selectedOption: null,
-      timeSpentSeconds: 0,
-      showFeedback: false,
-    }))
+
+  // Quiz IDs are unique per generation, so a regenerate auto-invalidates this key.
+  const storageKey = `quiz-state:v1:${quiz.id}`;
+  const [restored] = useState(() => loadQuizState<PersistedQuizState>(storageKey));
+
+  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(
+    restored?.currentQuestionIndex ?? 0,
   );
-  const [startTime] = useState(Date.now());
-  const [questionStartTime, setQuestionStartTime] = useState(Date.now());
+  const [questionStates, setQuestionStates] = useState<QuestionState[]>(
+    restored?.questionStates ??
+      quiz.content.questions.map(() => ({
+        selectedOption: null,
+        timeSpentSeconds: 0,
+        showFeedback: false,
+      })),
+  );
+  const [startTime] = useState(restored?.startTime ?? Date.now());
+  // Reconstruct questionStartTime so the per-second tick keeps adding to the
+  // already-recorded time on the current question instead of resetting to 0.
+  const [questionStartTime, setQuestionStartTime] = useState(() => {
+    const seconds = restored?.questionStates[restored.currentQuestionIndex]?.timeSpentSeconds ?? 0;
+    return Date.now() - seconds * 1000;
+  });
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Persist on every meaningful state change. State is small (<10 questions),
+  // so writing on every keystroke-equivalent is cheap.
+  useEffect(() => {
+    saveQuizState<PersistedQuizState>(storageKey, {
+      currentQuestionIndex,
+      questionStates,
+      startTime,
+    });
+  }, [storageKey, currentQuestionIndex, questionStates, startTime]);
   
   const currentQuestion = quiz.content.questions[currentQuestionIndex];
   const currentState = questionStates[currentQuestionIndex];
@@ -63,8 +92,15 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
     return () => clearInterval(interval);
   }, [currentQuestionIndex, questionStartTime, currentState.showFeedback]);
   
-  // Reset question start time when question changes
+  // Reset question start time when question changes. Skip the first run so
+  // the reconstructed questionStartTime (which preserves already-recorded
+  // time on a restored attempt) isn't clobbered on mount.
+  const didMountRef = useRef(false);
   useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
     setQuestionStartTime(Date.now());
   }, [currentQuestionIndex]);
   
@@ -118,6 +154,7 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
             answers,
             total_time_seconds: totalTimeSeconds,
           });
+          clearQuizState(storageKey);
           onComplete(result);
           return;
         } catch (serverErr) {
@@ -136,6 +173,7 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
         answersMap[a.question_id] = a.selected_option;
       }
       const offlineResult = await scoreQuizOffline(quiz, answersMap, totalTimeSeconds);
+      clearQuizState(storageKey);
       onComplete(offlineResult);
     } catch (error) {
       console.error('Quiz submission failed:', error);
@@ -153,7 +191,7 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
     } finally {
       setIsSubmitting(false);
     }
-  }, [quiz, questionStates, startTime, isSubmitting, onComplete, onError, t]);
+  }, [quiz, questionStates, startTime, isSubmitting, onComplete, onError, t, storageKey]);
 
   const handleNextQuestion = useCallback(() => {
     if (currentQuestionIndex < totalQuestions - 1) {

--- a/frontend/components/quiz/summative-assessment-interface.tsx
+++ b/frontend/components/quiz/summative-assessment-interface.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useTranslations } from 'next-intl';
 import { Clock, ChevronLeft, ChevronRight, AlertCircle, Timer } from 'lucide-react';
 
@@ -11,6 +11,7 @@ import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import type { Quiz, QuizAnswerSubmission, SummativeAssessmentResponse } from '@/lib/api';
 import { submitSummativeAssessmentAttempt } from '@/lib/api';
+import { loadQuizState, saveQuizState, clearQuizState } from '@/lib/quiz-state-persistence';
 
 interface SummativeAssessmentInterfaceProps {
   assessment: Quiz;
@@ -24,28 +25,64 @@ interface QuestionState {
   timeSpentSeconds: number;
 }
 
+interface PersistedSummativeState {
+  currentQuestionIndex: number;
+  questionStates: QuestionState[];
+  startTime: number;
+  // Persist remaining time so a reload can't be exploited to reset the clock
+  // back to a full timeLimit window.
+  timeRemaining: number;
+}
+
 const TIMER_WARNING_MINUTES = 5; // Show warning when 5 minutes left
 
-export function SummativeAssessmentInterface({ 
-  assessment, 
-  onComplete, 
+export function SummativeAssessmentInterface({
+  assessment,
+  onComplete,
   onError,
-  timeLimit = 30 
+  timeLimit = 30
 }: SummativeAssessmentInterfaceProps) {
   const t = useTranslations('SummativeAssessment');
-  
-  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
-  const [questionStates, setQuestionStates] = useState<QuestionState[]>(
-    assessment.content.questions.map(() => ({
-      selectedOption: null,
-      timeSpentSeconds: 0,
-    }))
+
+  // Assessment IDs are unique per generation, so a regenerate auto-invalidates this key.
+  const storageKey = `summative-state:v1:${assessment.id}`;
+  const [restored] = useState(() => loadQuizState<PersistedSummativeState>(storageKey));
+
+  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(
+    restored?.currentQuestionIndex ?? 0,
   );
-  const [startTime] = useState(Date.now());
-  const [questionStartTime, setQuestionStartTime] = useState(Date.now());
-  const [timeRemaining, setTimeRemaining] = useState(timeLimit * 60); // Convert to seconds
+  const [questionStates, setQuestionStates] = useState<QuestionState[]>(
+    restored?.questionStates ??
+      assessment.content.questions.map(() => ({
+        selectedOption: null,
+        timeSpentSeconds: 0,
+      })),
+  );
+  const [startTime] = useState(restored?.startTime ?? Date.now());
+  // Reconstruct questionStartTime so the per-second tick keeps adding to the
+  // already-recorded time on the current question instead of resetting to 0.
+  const [questionStartTime, setQuestionStartTime] = useState(() => {
+    const seconds = restored?.questionStates[restored.currentQuestionIndex]?.timeSpentSeconds ?? 0;
+    return Date.now() - seconds * 1000;
+  });
+  const [timeRemaining, setTimeRemaining] = useState(
+    restored?.timeRemaining ?? timeLimit * 60,
+  );
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [showTimeWarning, setShowTimeWarning] = useState(false);
+  const [showTimeWarning, setShowTimeWarning] = useState(
+    (restored?.timeRemaining ?? timeLimit * 60) <= TIMER_WARNING_MINUTES * 60,
+  );
+
+  // Persist on every meaningful state change. Question-state writes are debounced
+  // by the 1Hz tick; timeRemaining writes once per second is fine for ~30 min sessions.
+  useEffect(() => {
+    saveQuizState<PersistedSummativeState>(storageKey, {
+      currentQuestionIndex,
+      questionStates,
+      startTime,
+      timeRemaining,
+    });
+  }, [storageKey, currentQuestionIndex, questionStates, startTime, timeRemaining]);
   
   const currentQuestion = assessment.content.questions[currentQuestionIndex];
   const currentState = questionStates[currentQuestionIndex];
@@ -72,6 +109,7 @@ export function SummativeAssessmentInterface({
         total_time_seconds: totalTimeSeconds,
       });
 
+      clearQuizState(storageKey);
       onComplete(result);
     } catch (error) {
       console.error('Auto-submit failed:', error);
@@ -79,7 +117,7 @@ export function SummativeAssessmentInterface({
     } finally {
       setIsSubmitting(false);
     }
-  }, [assessment, questionStates, startTime, isSubmitting, onComplete, onError, t]);
+  }, [assessment, questionStates, startTime, isSubmitting, onComplete, onError, t, storageKey]);
 
   // Timer countdown effect
   useEffect(() => {
@@ -123,8 +161,15 @@ export function SummativeAssessmentInterface({
     return () => clearInterval(interval);
   }, [currentQuestionIndex, questionStartTime]);
   
-  // Reset question start time when question changes
+  // Reset question start time when question changes. Skip the first run so
+  // the reconstructed questionStartTime (which preserves already-recorded
+  // time on a restored attempt) isn't clobbered on mount.
+  const didMountRef = useRef(false);
   useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
     setQuestionStartTime(Date.now());
   }, [currentQuestionIndex]);
   
@@ -174,7 +219,8 @@ export function SummativeAssessmentInterface({
         answers,
         total_time_seconds: totalTimeSeconds,
       });
-      
+
+      clearQuizState(storageKey);
       onComplete(result);
     } catch (error) {
       console.error('Assessment submission failed:', error);
@@ -182,8 +228,8 @@ export function SummativeAssessmentInterface({
     } finally {
       setIsSubmitting(false);
     }
-  }, [assessment, questionStates, startTime, isSubmitting, onComplete, onError, t]);
-  
+  }, [assessment, questionStates, startTime, isSubmitting, onComplete, onError, t, storageKey]);
+
   const formatTime = (seconds: number): string => {
     const minutes = Math.floor(seconds / 60);
     const remainingSeconds = seconds % 60;

--- a/frontend/lib/quiz-state-persistence.ts
+++ b/frontend/lib/quiz-state-persistence.ts
@@ -1,0 +1,41 @@
+// SSR-safe wrapper around sessionStorage. Used by the quiz, summative, and
+// case-study UIs to recover from unexpected page reloads (network blips,
+// accidental refresh, browser crash). sessionStorage — not localStorage —
+// because progress should survive a reload but not outlive the browser
+// session, and shouldn't leak across users on a shared device.
+
+type Persisted<S> = { v: 1; state: S };
+
+function isBrowser(): boolean {
+  return typeof window !== "undefined" && !!window.sessionStorage;
+}
+
+export function loadQuizState<S>(key: string): S | null {
+  if (!isBrowser()) return null;
+  try {
+    const raw = sessionStorage.getItem(key);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Persisted<S>;
+    return parsed.v === 1 ? parsed.state : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveQuizState<S>(key: string, state: S): void {
+  if (!isBrowser()) return;
+  try {
+    sessionStorage.setItem(key, JSON.stringify({ v: 1, state } as Persisted<S>));
+  } catch {
+    // Quota exceeded / Safari private mode — degrade silently to in-memory state.
+  }
+}
+
+export function clearQuizState(key: string): void {
+  if (!isBrowser()) return;
+  try {
+    sessionStorage.removeItem(key);
+  } catch {
+    // Ignore: storage failures here are not actionable.
+  }
+}

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -15,7 +15,9 @@ const withBundleAnalyzer = createBundleAnalyzer({
 const withSerwist = withSerwistInit({
   swSrc: "sw.ts",
   swDest: "public/sw.js",
-  reloadOnOnline: true,
+  // Offline-first PWA on flaky 3G networks: a hard reload on every `online`
+  // event destroys in-progress quiz/case-study state (issue #2226).
+  reloadOnOnline: false,
   disable: process.env.NODE_ENV === "development",
 });
 


### PR DESCRIPTION
## Summary
- Disables `reloadOnOnline` in `next.config.ts`. Serwist was injecting a `window.online` listener that hard-reloaded the page on every reconnect, wiping in-progress quiz state on flaky mobile networks.
- Adds `frontend/lib/quiz-state-persistence.ts`, a small SSR-safe sessionStorage wrapper.
- Persists per-attempt state in three places so an unexpected reload (or any future remount) recovers cleanly: unit quiz (`{currentQuestionIndex, questionStates, startTime}`), summative (same plus `timeRemaining` to prevent timer reset), case study (`correctionVisible` only — content is already cached, completion is server-authoritative).
- Replaces `window.location.reload()` / `window.location.href` in summative-page-client.tsx with a `retryKey` remount + `router.push`.

Fixes #2226

## Test plan
- [ ] `npm run build && npm run start` (Serwist SW only runs in prod), start a unit quiz, answer 2 questions, toggle DevTools Network offline → online: page does NOT reload, quiz state intact.
- [ ] Mid-quiz, refresh (Ctrl-R): quiz resumes on the same question with prior answers and accurate elapsed time. After submit, sessionStorage key `quiz-state:v1:<uuid>` is removed.
- [ ] Same for summative assessment; verify `timeRemaining` survives the refresh (no free-time exploit).
- [ ] Open a case study, click "Show correction", refresh: correction stays visible. After mark-complete, `case-study-state:v1:<uuid>` is removed.
- [ ] Summative retry after fail → no full reload (no `document` request in Network); state resets via key bump.
- [ ] Summative complete → URL changes to `/{locale}/modules` via client navigation, no full reload.