### PR TITLE
fix(modules): use unit_number not 0-indexed order_index in module overlay (#2132 F-020)

### DIFF
--- a/frontend/components/learning/module-progress-overlay.tsx
+++ b/frontend/components/learning/module-progress-overlay.tsx
@@ -199,7 +199,7 @@ export function ModuleProgressOverlay({
                             <div className="flex items-center gap-1 text-stone-600 shrink-0">
                               {getTypeIcon(unit)}
                               <span className="text-sm font-medium">
-                                {t('unitNumber', { number: unit.order_index })}
+                                {t('unitNumber', { number: unit.unit_number })}
                               </span>
                             </div>
                             <div className="flex items-center gap-1 text-sm text-stone-500 shrink-0">


### PR DESCRIPTION
## Summary
Sweep finding F-020 reported \`Unité 015 min de lecture\` on the module overview as a 'collapsed whitespace' issue. Investigating live, the visible rendering is actually \`Unité 0\` and \`15 min de lecture\` on separate lines (flex-wrap parent works correctly — the snapshot's \`textContent\` extract just loses the line break, similar to the F-019 false positive).

The **actual bug** is the \`0\`: 'Unité 0' rendered for the first unit because the \`unitNumber\` i18n template was fed \`unit.order_index\` (a 0-based array index from the API) instead of \`unit.unit_number\` (the canonical '1.1', '1.2', '1.3' identifier already used by:

- the URL pattern \`/modules/{id}/units/1.1\`
- the lesson viewer header \`Unité 1.1\`
- the unit-quiz-viewer header — fixed in #2211 to use \`ModuleOverview.unitNumber\`).

## Fix
One-character path change at [\`module-progress-overlay.tsx:202\`](frontend/components/learning/module-progress-overlay.tsx#L202): \`unit.order_index\` → \`unit.unit_number\`. Now renders \`Unité 1.1\`, \`Unité 1.2\`, … consistent with the rest of the app.

The rare static-fallback path (\`staticUnitsFallback\` at line 127-137) already populates \`unit_number\` (line 129), so it stays correct under that path too.

Partially addresses #2132. F-020 is reframed: snapshot artifact (no real whitespace bug) + adjacent 0-indexing bug fixed.

Part of the production-readiness epic #2123.

## Test plan
- [x] \`tsc --noEmit\` clean.
- [x] \`eslint\` clean.
- [ ] Post-deploy: \`/fr/modules/{id}\` (module overview) shows \`Unité 1.1\`, \`Unité 1.2\`, … instead of \`Unité 0\`, \`Unité 1\`, …

🤖 Generated with [Claude Code](https://claude.com/claude-code)