### PR TITLE
fix(seo): per-page <title> for top static routes (#2132 F-008)

### DIFF
--- a/frontend/app/[locale]/(app)/courses/layout.tsx
+++ b/frontend/app/[locale]/(app)/courses/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "Courses" });
+  return { title: t("title") };
+}
+
+export default function CoursesLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/app/[locale]/(app)/dashboard/page.tsx
+++ b/frontend/app/[locale]/(app)/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { DashboardClient } from "./dashboard-client";
 import { DashboardStats } from "@/components/dashboard/dashboard-stats";
@@ -7,6 +8,16 @@ import { ClearCurriculumContext } from "@/components/shared/clear-curriculum-con
 
 interface DashboardPageProps {
   searchParams: Promise<{ curriculum?: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "Dashboard" });
+  return { title: t("title") };
 }
 
 export default async function DashboardPage({ searchParams }: DashboardPageProps) {

--- a/frontend/app/[locale]/(app)/profile/page.tsx
+++ b/frontend/app/[locale]/(app)/profile/page.tsx
@@ -1,5 +1,16 @@
+import type { Metadata } from "next";
 import { ProfileClient } from "./profile-client";
 import { getTranslations } from "next-intl/server";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "Profile" });
+  return { title: t("title"), description: t("description") };
+}
 
 export default async function ProfilePage() {
   const t = await getTranslations("Profile");

--- a/frontend/app/[locale]/(auth)/login/layout.tsx
+++ b/frontend/app/[locale]/(auth)/login/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "Auth" });
+  return { title: t("signIn") };
+}
+
+export default function LoginLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/app/[locale]/about/layout.tsx
+++ b/frontend/app/[locale]/about/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "About" });
+  return { title: t("title") };
+}
+
+export default function AboutLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
Five high-traffic pages were rendering generic \`Sira\` as the browser tab title because they had no \`metadata\` / \`generateMetadata\` export. The locale layout's title template (\`%s · Sira\`) only applies when a child page provides a value. Sweep finding F-008.

## Pages addressed (5 of 12)
| Route | Title | Source |
|---|---|---|
| \`/fr/dashboard\` | Dashboard · Sira | Dashboard.title |
| \`/fr/profile\` | Profil · Sira | Profile.title + description |
| \`/fr/courses\` | Catalogue des formations · Sira | Courses.title |
| \`/fr/about\` | À propos de Sira · Sira | About.title |
| \`/fr/login\` | Se connecter · Sira | Auth.signIn |

## Implementation
- **dashboard + profile** are server pages — \`generateMetadata\` added directly.
- **courses, about, login** are \`'use client'\` pages — added thin \`layout.tsx\` siblings that render \`{children}\` and export \`generateMetadata\`. No existing client code touched.

All titles use existing i18n keys (no new strings added). Implementation matches the established pattern in [\`flashcards/page.tsx\`](frontend/app/[locale]/(app)/flashcards/page.tsx) (server wrapper) for the server cases.

## Deferred to follow-ups
- \`/fr/admin/analytics\`, \`/fr/admin/settings\`, \`/fr/admin/syllabus\` — lower priority (admin-only) + need new \`AdminPage\` namespace.
- \`/fr/qbank\`, \`/fr/qbank/tests\` — need new \`QBank\` namespace.
- Dynamic \`/fr/courses/{id}\` and \`/fr/curricula/{slug}\` — need per-resource personalization (bigger change).

Partially addresses #2132 (F-008).

Part of the production-readiness epic #2123.

## Test plan
- [x] \`tsc --noEmit\` clean.
- [x] \`eslint\` clean.
- [ ] Post-deploy on staging: each of the 5 pages shows the expected title in the browser tab and \`<head><title>\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)