### PR TITLE
fix(routing): add units/ redirect page to silence RSC prefetch 404 (#2132 F-023)

### DIFF
--- a/frontend/app/[locale]/(app)/modules/[moduleId]/units/page.tsx
+++ b/frontend/app/[locale]/(app)/modules/[moduleId]/units/page.tsx
@@ -1,0 +1,16 @@
+import { redirect } from '@/i18n/routing';
+
+// `/modules/{moduleId}/units` is not a real user-facing route — only
+// `/modules/{moduleId}/units/{unit}` is. Without a `page.tsx` here,
+// Next.js's RSC prefetcher 404s when it walks up the route tree
+// during navigation, polluting the console and Sentry. Redirecting
+// to the parent module overview turns that into a 200 + clean
+// fallback. See sweep finding F-023 in #2132.
+export default async function UnitsIndexRedirectPage({
+  params,
+}: {
+  params: Promise<{ locale: string; moduleId: string }>;
+}) {
+  const { locale, moduleId } = await params;
+  redirect({ href: `/modules/${moduleId}`, locale });
+}


### PR DESCRIPTION
## Summary
\`/fr/modules/{moduleId}/units\` was not a real user-facing route — only \`/fr/modules/{moduleId}/units/{unit}\` is. Without a \`page.tsx\` at the intermediate segment, Next.js's RSC prefetcher 404'd when it walked up the route tree during navigation prefetch, polluting the console with:

\`\`\`
Failed to load resource: 404 ()
/fr/modules/{moduleId}/units?_rsc=...
\`\`\`

on every lesson page load and breadcrumb hover.

## Fix
Adds a tiny server \`page.tsx\` at the missing segment that redirects to the parent module overview using the locale-aware \`redirect()\` from \`@/i18n/routing\` (matches the pattern in [\`app/[locale]/(auth)/register/page.tsx\`](frontend/app/[locale]/(auth)/register/page.tsx)). Now the prefetch returns a clean 200 + redirect instead of a noisy 404.

The sibling case in F-023 (\`/fr/curricula?_rsc=...\`) was already resolved by PR #2197 which created the \`curricula/page.tsx\` index.

Partially addresses #2132 (F-023 — last sub-finding from this polish cluster).

Part of the production-readiness epic #2123.

## Test plan
- [x] \`tsc --noEmit\` clean.
- [x] \`eslint\` clean.
- [ ] Post-deploy on staging: \`/fr/modules/{id}/units\` redirects to \`/fr/modules/{id}\` (200, not 404). Lesson page console no longer shows \`?_rsc=...\` 404 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)