### PR TITLE
merge dev → main: units/ redirect page (#2132 F-023) (#2233)

### DIFF
--- a/frontend/app/[locale]/(app)/modules/[moduleId]/units/page.tsx
+++ b/frontend/app/[locale]/(app)/modules/[moduleId]/units/page.tsx
@@ -1,0 +1,16 @@
+import { redirect } from '@/i18n/routing';
+
+// `/modules/{moduleId}/units` is not a real user-facing route — only
+// `/modules/{moduleId}/units/{unit}` is. Without a `page.tsx` here,
+// Next.js's RSC prefetcher 404s when it walks up the route tree
+// during navigation, polluting the console and Sentry. Redirecting
+// to the parent module overview turns that into a 200 + clean
+// fallback. See sweep finding F-023 in #2132.
+export default async function UnitsIndexRedirectPage({
+  params,
+}: {
+  params: Promise<{ locale: string; moduleId: string }>;
+}) {
+  const { locale, moduleId } = await params;
+  redirect({ href: `/modules/${moduleId}`, locale });
+}


### PR DESCRIPTION
Promotes #2233 (merged to dev as cdf88600) to main via cherry-pick. Adds the missing units/page.tsx to silence the RSC prefetch 404. Partially addresses #2132. CI green on dev-side PR.%n%n🤖 Generated with [Claude Code](https://claude.com/claude-code)