### PR TITLE
fix(i18n): localize taxonomy chips on /fr/admin/courses (#2128 F-013)

### DIFF
--- a/frontend/components/admin/courses-client.tsx
+++ b/frontend/components/admin/courses-client.tsx
@@ -35,7 +35,7 @@ import {
   AlertDialogAction,
   AlertDialogCancel,
 } from '@/components/ui/alert-dialog';
-import { apiFetch, ApiError, API_BASE } from '@/lib/api';
+import { apiFetch, ApiError, API_BASE, getCourseTaxonomy, type TaxonomyResponse } from '@/lib/api';
 import { authClient, AuthError } from '@/lib/auth';
 import { CourseForm } from '@/components/admin/course-form';
 import { CourseWizardClient } from '@/components/admin/course-wizard-client';
@@ -75,6 +75,29 @@ function useAdminCourses() {
     queryKey: ['admin', 'courses'],
     queryFn: () => apiFetch<AdminCourse[]>('/api/v1/admin/courses'),
   });
+}
+
+// Admin courses API returns taxonomy as raw `string[]` of values (e.g.
+// "health_sciences"); the public courses API returns labeled objects.
+// Fetch the taxonomy once and build a value→label lookup so admin chips
+// localize correctly. See sweep finding F-013/F-024 in #2128.
+function useTaxonomyLookup(locale: string) {
+  const { data } = useQuery<TaxonomyResponse>({
+    queryKey: ['admin', 'taxonomy'],
+    queryFn: getCourseTaxonomy,
+    staleTime: 5 * 60 * 1000, // 5 min — taxonomy rarely changes
+  });
+  return useCallback(
+    (kind: 'domain' | 'level' | 'audience', value: string) => {
+      if (!data) return value.replace(/_/g, ' ');
+      const list =
+        kind === 'domain' ? data.domains : kind === 'level' ? data.levels : data.audience_types;
+      const item = list.find((i) => i.value === value);
+      if (!item) return value.replace(/_/g, ' ');
+      return locale === 'fr' ? item.label_fr : item.label_en;
+    },
+    [data, locale],
+  );
 }
 
 export function CoursesClient() {
@@ -549,6 +572,7 @@ function CourseRow({
 }) {
   const t = useTranslations('AdminCourses');
   const locale = useLocale();
+  const taxonomyLabel = useTaxonomyLookup(locale);
 
   const title = locale === 'fr' ? course.title_fr : course.title_en;
 
@@ -586,12 +610,12 @@ function CourseRow({
             <div className="flex gap-1 flex-wrap">
               {course.course_domain?.map((d) => (
                 <span key={d} className="text-[10px] font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded-full px-1.5 py-0.5">
-                  {d.replace(/_/g, ' ')}
+                  {taxonomyLabel('domain', d)}
                 </span>
               ))}
               {course.course_level?.map((l) => (
                 <span key={l} className="text-[10px] font-medium text-teal-700 bg-teal-50 border border-teal-200 rounded-full px-1.5 py-0.5">
-                  {l}
+                  {taxonomyLabel('level', l)}
                 </span>
               ))}
             </div>


### PR DESCRIPTION
## Summary
Admin courses chips rendered raw English values like \`health sciences\`, \`intermediate\`, \`advanced\` even on FR locale because the admin API returns \`course_domain: list[str]\` (slug values) while the public courses API returns \`TaxonomyItem[]\` with \`label_fr\`/\`label_en\` already localized.

## Fix
Adds a \`useTaxonomyLookup(locale)\` hook that fetches the taxonomy table once via the existing [\`getCourseTaxonomy()\`](frontend/lib/api.ts) helper (5-min staleTime) and returns a value→label resolver. The hook is used inside \`CourseRow\` to translate domain and level slugs to localized labels at render time. Falls back to the existing \`value.replace(/_/g, ' ')\` formatting during the fetch window or for unknown values — visually indistinguishable.

[Public \`course-card.tsx\`](frontend/components/learning/course-card.tsx) already had the right pattern (it uses the labeled API directly); this brings admin to parity without changing the backend response shape.

Partially addresses #2128 (F-013). The Bloom-verb chips on FR course detail (F-024) and the analytics event-type labels (F-025) follow a similar pattern but live in different components — separate PRs.

Part of the production-readiness epic #2123.

## Test plan
- [x] \`tsc --noEmit\` clean.
- [x] \`eslint\` clean.
- [ ] Post-deploy on staging at \`/fr/admin/courses\`: chips read 'Sciences de la santé', 'Intermédiaire', 'Avancé' (instead of 'health sciences', 'intermediate', 'advanced').

🤖 Generated with [Claude Code](https://claude.com/claude-code)