### PR TITLE
fix(i18n): localize Bloom-taxonomy chips on course detail (#2128 F-024)

### DIFF
--- a/frontend/app/[locale]/(app)/courses/[courseSlug]/page.tsx
+++ b/frontend/app/[locale]/(app)/courses/[courseSlug]/page.tsx
@@ -90,6 +90,7 @@ const LEVEL_COLORS: Record<string, string> = {
 export default function CourseDetailPage() {
   const t = useTranslations("Courses");
   const tDetail = useTranslations("CourseDetail");
+  const tBloom = useTranslations("BloomTaxonomy");
   const locale = useLocale() as "fr" | "en";
   const params = useParams();
   const router = useRouter();
@@ -343,7 +344,9 @@ export default function CourseDetailPage() {
                         <span>{mod.units.length} {tDetail("units")}</span>
                         {mod.bloom_level && (
                           <Badge variant="outline" className="text-[10px] py-0">
-                            {mod.bloom_level}
+                            {tBloom.has(mod.bloom_level)
+                              ? tBloom(mod.bloom_level)
+                              : mod.bloom_level}
                           </Badge>
                         )}
                       </div>

--- a/frontend/components/admin/module-card.tsx
+++ b/frontend/components/admin/module-card.tsx
@@ -43,6 +43,7 @@ const LEVEL_LABELS: Record<number, { fr: string; en: string; color: string }> = 
 
 export function AdminModuleCard({ module, onEdit }: AdminModuleCardProps) {
   const t = useTranslations('AdminSyllabus');
+  const tBloom = useTranslations('BloomTaxonomy');
   const locale = useLocale() as 'fr' | 'en';
 
   const title = locale === 'fr' ? module.title_fr : module.title_en;
@@ -64,8 +65,10 @@ export function AdminModuleCard({ module, onEdit }: AdminModuleCardProps) {
               {locale === 'fr' ? levelLabel.fr : levelLabel.en}
             </Badge>
             {module.bloom_level && (
-              <Badge variant="secondary" className="text-xs shrink-0 capitalize">
-                {module.bloom_level}
+              <Badge variant="secondary" className="text-xs shrink-0">
+                {tBloom.has(module.bloom_level)
+                  ? tBloom(module.bloom_level)
+                  : module.bloom_level}
               </Badge>
             )}
           </div>

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -55,6 +55,14 @@
     "qbankTests": "Practice tests",
     "qbankTestsDescription": "Jump straight into an available test"
   },
+  "BloomTaxonomy": {
+    "remember": "Remember",
+    "understand": "Understand",
+    "apply": "Apply",
+    "analyze": "Analyze",
+    "evaluate": "Evaluate",
+    "create": "Create"
+  },
   "Auth": {
     "login": "Sign in",
     "register": "Create account",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -55,6 +55,14 @@
     "qbankTests": "Tests de révision",
     "qbankTestsDescription": "Lancez directement un test depuis la liste disponible"
   },
+  "BloomTaxonomy": {
+    "remember": "Mémoriser",
+    "understand": "Comprendre",
+    "apply": "Appliquer",
+    "analyze": "Analyser",
+    "evaluate": "Évaluer",
+    "create": "Créer"
+  },
   "Auth": {
     "login": "Se connecter",
     "register": "Créer un compte",


### PR DESCRIPTION
## Summary
Module cards on \`/fr/courses/{slug}\` and \`/fr/admin/syllabus\` rendered raw English Bloom verbs (\`understand\`, \`apply\`, \`analyze\`, \`evaluate\`, \`remember\`, \`create\`) because the API returns the verb as a slug string and the chip components rendered it directly.

## Fix
- Adds \`BloomTaxonomy\` namespace to both locale files with all six verbs:

| Slug | FR | EN |
|---|---|---|
| remember | Mémoriser | Remember |
| understand | Comprendre | Understand |
| apply | Appliquer | Apply |
| analyze | Analyser | Analyze |
| evaluate | Évaluer | Evaluate |
| create | Créer | Create |

- Updates two chip render sites:
  - [\`app/[locale]/(app)/courses/[courseSlug]/page.tsx\`](frontend/app/[locale]/(app)/courses/[courseSlug]/page.tsx) (public course detail)
  - [\`components/admin/module-card.tsx\`](frontend/components/admin/module-card.tsx) (admin syllabus tile)

Both use \`tBloom.has(v) ? tBloom(v) : v\` so unknown slugs fall back to the raw value instead of throwing \`MISSING_MESSAGE\`.

Partially addresses #2128 (F-024). Remaining: F-025 (analytics event-type labels), F-011 (admin/settings category labels).

Part of the production-readiness epic #2123.

## Test plan
- [x] \`tsc --noEmit\` clean.
- [x] \`eslint\` clean (pre-existing \`<img>\` warning unchanged).
- [ ] Post-deploy on staging at \`/fr/courses/{slug}\`: module Bloom chips read \`Comprendre\`, \`Appliquer\`, etc.
- [ ] \`/fr/admin/syllabus\` admin module cards: same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)