### PR TITLE
merge dev → main: localize Bloom verbs (#2128 F-024) (#2237)

### DIFF
--- a/frontend/app/[locale]/(app)/courses/[courseSlug]/page.tsx
+++ b/frontend/app/[locale]/(app)/courses/[courseSlug]/page.tsx
@@ -90,6 +90,7 @@ const LEVEL_COLORS: Record<string, string> = {
 export default function CourseDetailPage() {
   const t = useTranslations("Courses");
   const tDetail = useTranslations("CourseDetail");
+  const tBloom = useTranslations("BloomTaxonomy");
   const locale = useLocale() as "fr" | "en";
   const params = useParams();
   const router = useRouter();
@@ -343,7 +344,9 @@ export default function CourseDetailPage() {
                         <span>{mod.units.length} {tDetail("units")}</span>
                         {mod.bloom_level && (
                           <Badge variant="outline" className="text-[10px] py-0">
-                            {mod.bloom_level}
+                            {tBloom.has(mod.bloom_level)
+                              ? tBloom(mod.bloom_level)
+                              : mod.bloom_level}
                           </Badge>
                         )}
                       </div>

--- a/frontend/components/admin/module-card.tsx
+++ b/frontend/components/admin/module-card.tsx
@@ -43,6 +43,7 @@ const LEVEL_LABELS: Record<number, { fr: string; en: string; color: string }> = 
 
 export function AdminModuleCard({ module, onEdit }: AdminModuleCardProps) {
   const t = useTranslations('AdminSyllabus');
+  const tBloom = useTranslations('BloomTaxonomy');
   const locale = useLocale() as 'fr' | 'en';
 
   const title = locale === 'fr' ? module.title_fr : module.title_en;
@@ -64,8 +65,10 @@ export function AdminModuleCard({ module, onEdit }: AdminModuleCardProps) {
               {locale === 'fr' ? levelLabel.fr : levelLabel.en}
             </Badge>
             {module.bloom_level && (
-              <Badge variant="secondary" className="text-xs shrink-0 capitalize">
-                {module.bloom_level}
+              <Badge variant="secondary" className="text-xs shrink-0">
+                {tBloom.has(module.bloom_level)
+                  ? tBloom(module.bloom_level)
+                  : module.bloom_level}
               </Badge>
             )}
           </div>

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -55,6 +55,14 @@
     "qbankTests": "Practice tests",
     "qbankTestsDescription": "Jump straight into an available test"
   },
+  "BloomTaxonomy": {
+    "remember": "Remember",
+    "understand": "Understand",
+    "apply": "Apply",
+    "analyze": "Analyze",
+    "evaluate": "Evaluate",
+    "create": "Create"
+  },
   "Auth": {
     "login": "Sign in",
     "register": "Create account",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -55,6 +55,14 @@
     "qbankTests": "Tests de révision",
     "qbankTestsDescription": "Lancez directement un test depuis la liste disponible"
   },
+  "BloomTaxonomy": {
+    "remember": "Mémoriser",
+    "understand": "Comprendre",
+    "apply": "Appliquer",
+    "analyze": "Analyser",
+    "evaluate": "Évaluer",
+    "create": "Créer"
+  },
   "Auth": {
     "login": "Se connecter",
     "register": "Créer un compte",


### PR DESCRIPTION
Promotes #2237 (merged to dev as 0c324c46) to main via cherry-pick. Adds BloomTaxonomy namespace + uses it on public course detail and admin module-card. Partially addresses #2128. CI green on dev-side PR.%n%n🤖 Generated with [Claude Code](https://claude.com/claude-code)