### PR TITLE
fix(i18n): localize analytics event-type chart labels (#2128 F-025)

### DIFF
--- a/frontend/app/[locale]/admin/analytics/page.tsx
+++ b/frontend/app/[locale]/admin/analytics/page.tsx
@@ -30,6 +30,7 @@ const PERIODS = [7, 30, 90] as const;
 
 export default function AnalyticsPage() {
   const t = useTranslations("Admin.analytics");
+  const tEvent = useTranslations("AnalyticsEventTypes");
   const [period, setPeriod] = useState<number>(7);
   const [data, setData] = useState<AnalyticsSummary | null>(null);
   const [loading, setLoading] = useState(true);
@@ -61,7 +62,7 @@ export default function AnalyticsPage() {
 
   const eventsByTypeData = data
     ? Object.entries(data.events_by_type).map(([name, count]) => ({
-        name: name.replace(/_/g, " "),
+        name: tEvent.has(name) ? tEvent(name) : name.replace(/_/g, " "),
         count,
       }))
     : [];

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -63,6 +63,12 @@
     "evaluate": "Evaluate",
     "create": "Create"
   },
+  "AnalyticsEventTypes": {
+    "lesson_viewed": "Lesson viewed",
+    "quiz_completed": "Quiz completed",
+    "flashcard_reviewed": "Flashcard reviewed",
+    "tutor_message_sent": "Tutor message sent"
+  },
   "Auth": {
     "login": "Sign in",
     "register": "Create account",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -63,6 +63,12 @@
     "evaluate": "Évaluer",
     "create": "Créer"
   },
+  "AnalyticsEventTypes": {
+    "lesson_viewed": "Leçon consultée",
+    "quiz_completed": "Quiz terminé",
+    "flashcard_reviewed": "Flashcard révisée",
+    "tutor_message_sent": "Message au tuteur"
+  },
   "Auth": {
     "login": "Se connecter",
     "register": "Créer un compte",


### PR DESCRIPTION
## Summary
The events-by-type bar chart on \`/fr/admin/analytics\` rendered raw English event slugs (\`tutor message sent\`, \`lesson viewed\`, \`quiz completed\`, \`flashcard reviewed\`) with underscores stripped — the BE emits canonical slugs and the FE only did \`name.replace(/_/g, ' ')\` without translating.

## Fix
- Adds \`AnalyticsEventTypes\` namespace to both locale files with the 4 event types currently emitted by the backend (grep'd \`event_name=\"...\"\` in \`backend/app/api/\`):

| Slug | FR | EN |
|---|---|---|
| lesson_viewed | Leçon consultée | Lesson viewed |
| quiz_completed | Quiz terminé | Quiz completed |
| flashcard_reviewed | Flashcard révisée | Flashcard reviewed |
| tutor_message_sent | Message au tuteur | Tutor message sent |

- Updates \`analytics/page.tsx\` to use \`tEvent.has(name) ? tEvent(name) : name.replace(/_/g, ' ')\`. Falls back to the prior space-replacement behaviour for any future event types added to the backend.

Partially addresses #2128 (F-025). Remaining: F-011 (admin/settings category labels).

Part of the production-readiness epic #2123.

## Test plan
- [x] \`tsc --noEmit\` clean.
- [x] \`eslint\` clean.
- [ ] Post-deploy on staging at \`/fr/admin/analytics\`: events-by-type chart x-axis shows French labels for all 4 known event types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)