### PR TITLE
merge dev → main: localize analytics event types (#2128 F-025) (#2239)

### DIFF
--- a/frontend/app/[locale]/admin/analytics/page.tsx
+++ b/frontend/app/[locale]/admin/analytics/page.tsx
@@ -30,6 +30,7 @@ const PERIODS = [7, 30, 90] as const;
 
 export default function AnalyticsPage() {
   const t = useTranslations("Admin.analytics");
+  const tEvent = useTranslations("AnalyticsEventTypes");
   const [period, setPeriod] = useState<number>(7);
   const [data, setData] = useState<AnalyticsSummary | null>(null);
   const [loading, setLoading] = useState(true);
@@ -61,7 +62,7 @@ export default function AnalyticsPage() {
 
   const eventsByTypeData = data
     ? Object.entries(data.events_by_type).map(([name, count]) => ({
-        name: name.replace(/_/g, " "),
+        name: tEvent.has(name) ? tEvent(name) : name.replace(/_/g, " "),
         count,
       }))
     : [];

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -63,6 +63,12 @@
     "evaluate": "Evaluate",
     "create": "Create"
   },
+  "AnalyticsEventTypes": {
+    "lesson_viewed": "Lesson viewed",
+    "quiz_completed": "Quiz completed",
+    "flashcard_reviewed": "Flashcard reviewed",
+    "tutor_message_sent": "Tutor message sent"
+  },
   "Auth": {
     "login": "Sign in",
     "register": "Create account",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -63,6 +63,12 @@
     "evaluate": "Évaluer",
     "create": "Créer"
   },
+  "AnalyticsEventTypes": {
+    "lesson_viewed": "Leçon consultée",
+    "quiz_completed": "Quiz terminé",
+    "flashcard_reviewed": "Flashcard révisée",
+    "tutor_message_sent": "Message au tuteur"
+  },
   "Auth": {
     "login": "Se connecter",
     "register": "Créer un compte",


### PR DESCRIPTION
Promotes #2239 (merged to dev as c4ce8fa0) to main via cherry-pick. Adds AnalyticsEventTypes namespace + uses it on /fr/admin/analytics. Partially addresses #2128. CI green on dev-side PR.%n%n🤖 Generated with [Claude Code](https://claude.com/claude-code)