### PR TITLE
fix(i18n): localize admin/settings category labels (#2128 F-011)

### DIFF
--- a/frontend/components/admin/settings-client.tsx
+++ b/frontend/components/admin/settings-client.tsx
@@ -12,22 +12,20 @@ import {
 } from "@/lib/api";
 import { PromptEditor } from "./prompt-editor";
 
-const CATEGORY_LABELS: Record<string, string> = {
-  quiz: "Quiz & Assessment",
-  progress: "Progress & Unlocking",
-  flashcards: "Flashcards (FSRS)",
-  placement: "Placement Test",
-  auth: "Auth & Security",
-  rate_limiting: "Rate Limiting",
-  ai: "AI & Content Generation",
-  ai_prompts: "AI Prompt Templates",
-  tutor: "AI Tutor",
-  pagination: "Pagination",
-  payments: "Payments & Billing",
-};
+// Category labels for tabs + section headings. Localized via the
+// `AdminSettingsCategories` namespace; new categories emitted by the
+// backend (e.g. `marketplace`, `subscription`, `syllabus`,
+// `video_summary` observed during sweep #2128 F-011) fall back to a
+// space-replaced version of the slug until translations are added.
+function formatCategoryFallback(slug: string): string {
+  return slug.replace(/_/g, " ");
+}
 
 export function SettingsClient() {
   const t = useTranslations("Admin.settings");
+  const tCat = useTranslations("AdminSettingsCategories");
+  const categoryLabel = (slug: string) =>
+    tCat.has(slug) ? tCat(slug) : formatCategoryFallback(slug);
   const [categories, setCategories] = useState<SettingsByCategory[]>([]);
   const [activeTab, setActiveTab] = useState("");
   const [loading, setLoading] = useState(true);
@@ -100,7 +98,7 @@ export function SettingsClient() {
                 : "bg-muted text-muted-foreground hover:bg-muted/80"
             }`}
           >
-            {CATEGORY_LABELS[cat.category] || cat.category}
+            {categoryLabel(cat.category)}
           </button>
         ))}
       </div>
@@ -108,7 +106,7 @@ export function SettingsClient() {
         <div className="space-y-1">
           <div className="mb-4 flex items-center justify-between">
             <h2 className="text-lg font-semibold">
-              {CATEGORY_LABELS[activeCategory.category] || activeCategory.category}
+              {categoryLabel(activeCategory.category)}
             </h2>
             <button onClick={() => handleResetCategory(activeCategory.category)}
               className="rounded-md border border-destructive/30 px-3 py-1 text-xs text-destructive hover:bg-destructive/10"

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -69,6 +69,23 @@
     "flashcard_reviewed": "Flashcard reviewed",
     "tutor_message_sent": "Tutor message sent"
   },
+  "AdminSettingsCategories": {
+    "quiz": "Quiz & Assessment",
+    "progress": "Progress & Unlocking",
+    "flashcards": "Flashcards (FSRS)",
+    "placement": "Placement Test",
+    "auth": "Auth & Security",
+    "rate_limiting": "Rate Limiting",
+    "ai": "AI & Content Generation",
+    "ai_prompts": "AI Prompt Templates",
+    "tutor": "AI Tutor",
+    "pagination": "Pagination",
+    "payments": "Payments & Billing",
+    "marketplace": "Marketplace",
+    "subscription": "Subscriptions",
+    "syllabus": "Syllabus",
+    "video_summary": "Video Summaries"
+  },
   "Auth": {
     "login": "Sign in",
     "register": "Create account",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -69,6 +69,23 @@
     "flashcard_reviewed": "Flashcard révisée",
     "tutor_message_sent": "Message au tuteur"
   },
+  "AdminSettingsCategories": {
+    "quiz": "Quiz et évaluations",
+    "progress": "Progression et déverrouillage",
+    "flashcards": "Flashcards (FSRS)",
+    "placement": "Test de positionnement",
+    "auth": "Authentification et sécurité",
+    "rate_limiting": "Limitation de débit",
+    "ai": "IA et génération de contenu",
+    "ai_prompts": "Modèles de prompts IA",
+    "tutor": "Tuteur IA",
+    "pagination": "Pagination",
+    "payments": "Paiements et facturation",
+    "marketplace": "Place de marché",
+    "subscription": "Abonnements",
+    "syllabus": "Syllabus",
+    "video_summary": "Résumés vidéo"
+  },
   "Auth": {
     "login": "Se connecter",
     "register": "Créer un compte",


### PR DESCRIPTION
## Summary
Admin/settings tab labels + section headings rendered:
- English-only labels in FR locale (\`Quiz & Assessment\`, \`Auth & Security\`, etc.) because they came from a hardcoded \`CATEGORY_LABELS\` map in [\`settings-client.tsx\`](frontend/components/admin/settings-client.tsx).
- Lowercase raw slugs (\`marketplace\`, \`subscription\`, \`syllabus\`, \`video_summary\`) because those categories were missing from the hardcoded map and fell through to \`cat.category\`.

## Fix
- Replaces the hardcoded map with an \`AdminSettingsCategories\` i18n namespace covering all 15 known categories (11 from the original map + 4 newly observed in the sweep).
- Settings client uses \`tCat.has(slug) ? tCat(slug) : slug.replace(/_/g, ' ')\` — any future backend-emitted category gracefully falls back to a space-replaced slug.

## Closes the #2128 audit
With this PR, every sub-finding from the broader #2128 audit is addressed:

| Finding | Status |
|---|---|
| F-006 \`Flashcards.cards\` raw key | ✅ #2201/#2202 |
| F-007 \`Navigation.curricula\` raw key | ✅ #2197 |
| \`ModuleCard.review\` raw key | ✅ #2201/#2202 |
| F-013 admin courses taxonomy chips | ✅ #2235/#2236 |
| F-024 Bloom verbs | ✅ #2237/#2238 |
| F-025 analytics event-type labels | ✅ #2239/#2240 |
| F-011 admin/settings categories | this PR |

Part of the production-readiness epic #2123.

## Test plan
- [x] \`tsc --noEmit\` clean.
- [x] \`eslint\` clean (pre-existing exhaustive-deps warning unchanged).
- [ ] Post-deploy on staging at \`/fr/admin/settings\`: 15 tabs render in French; all section headings translated; no lowercase raw slugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)