### PR TITLE
merge dev → main: admin + qbank page titles (#2132 F-008 follow-up) (#2243)

### DIFF
--- a/frontend/app/[locale]/(app)/qbank/tests/page.tsx
+++ b/frontend/app/[locale]/(app)/qbank/tests/page.tsx
@@ -1,4 +1,16 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { QBankTestsDiscoveryClient } from "./client";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "qbank" });
+  return { title: t("testsDiscoveryTitle") };
+}
 
 export default function QBankTestsDiscoveryPage() {
   return <QBankTestsDiscoveryClient />;

--- a/frontend/app/[locale]/admin/analytics/layout.tsx
+++ b/frontend/app/[locale]/admin/analytics/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
-import { QBankDiscoveryClient } from "./client";
 
 export async function generateMetadata({
   params,
@@ -8,10 +7,14 @@ export async function generateMetadata({
   params: Promise<{ locale: string }>;
 }): Promise<Metadata> {
   const { locale } = await params;
-  const t = await getTranslations({ locale, namespace: "qbank" });
-  return { title: t("banksTitle") };
+  const t = await getTranslations({ locale, namespace: "Admin.analytics" });
+  return { title: t("title") };
 }
 
-export default function QBankDiscoveryPage() {
-  return <QBankDiscoveryClient />;
+export default function AdminAnalyticsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
 }

--- a/frontend/app/[locale]/admin/audit-logs/page.tsx
+++ b/frontend/app/[locale]/admin/audit-logs/page.tsx
@@ -1,5 +1,16 @@
+import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { AuditLogClient } from "@/components/admin/audit-log-client";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "Admin.auditLog" });
+  return { title: t("title") };
+}
 
 export default async function AdminAuditLogsPage() {
   const t = await getTranslations("Admin.auditLog");

--- a/frontend/app/[locale]/admin/payments/layout.tsx
+++ b/frontend/app/[locale]/admin/payments/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
-import { QBankDiscoveryClient } from "./client";
 
 export async function generateMetadata({
   params,
@@ -8,10 +7,14 @@ export async function generateMetadata({
   params: Promise<{ locale: string }>;
 }): Promise<Metadata> {
   const { locale } = await params;
-  const t = await getTranslations({ locale, namespace: "qbank" });
-  return { title: t("banksTitle") };
+  const t = await getTranslations({ locale, namespace: "Admin.payments" });
+  return { title: t("title") };
 }
 
-export default function QBankDiscoveryPage() {
-  return <QBankDiscoveryClient />;
+export default function AdminPaymentsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
 }

--- a/frontend/app/[locale]/admin/settings/layout.tsx
+++ b/frontend/app/[locale]/admin/settings/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
-import { QBankDiscoveryClient } from "./client";
 
 export async function generateMetadata({
   params,
@@ -8,10 +7,14 @@ export async function generateMetadata({
   params: Promise<{ locale: string }>;
 }): Promise<Metadata> {
   const { locale } = await params;
-  const t = await getTranslations({ locale, namespace: "qbank" });
-  return { title: t("banksTitle") };
+  const t = await getTranslations({ locale, namespace: "Admin.settings" });
+  return { title: t("title") };
 }
 
-export default function QBankDiscoveryPage() {
-  return <QBankDiscoveryClient />;
+export default function AdminSettingsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
 }

--- a/frontend/app/[locale]/admin/taxonomy/page.tsx
+++ b/frontend/app/[locale]/admin/taxonomy/page.tsx
@@ -1,5 +1,16 @@
+import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { TaxonomyClient } from '@/components/admin/taxonomy-client';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'Admin.taxonomy' });
+  return { title: t('title') };
+}
 
 export default async function TaxonomyPage() {
   const t = await getTranslations('Admin.taxonomy');

--- a/frontend/app/[locale]/admin/users/page.tsx
+++ b/frontend/app/[locale]/admin/users/page.tsx
@@ -1,5 +1,16 @@
+import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { UserListClient } from "@/components/admin/user-list-client";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "Admin.users" });
+  return { title: t("title") };
+}
 
 export default async function AdminUsersPage() {
   const t = await getTranslations("Admin.users");


### PR DESCRIPTION
Promotes #2243 (merged to dev as 0f74fc31) to main via cherry-pick. Adds metadata to 8 admin+qbank pages (5 server, 3 client+layout). Partially addresses #2132. CI green on dev-side PR.%n%n🤖 Generated with [Claude Code](https://claude.com/claude-code)