### PR TITLE
merge dev → main: logout reads refresh_token cookie (#2112) (#2245)

### DIFF
--- a/backend/app/api/v1/local_auth.py
+++ b/backend/app/api/v1/local_auth.py
@@ -109,9 +109,15 @@ class VerifyMagicLinkRequest(BaseModel):
 
 
 class LogoutRequest(BaseModel):
-    """Logout request."""
+    """Logout request.
 
-    refresh_token: str
+    `refresh_token` is optional in the body — the handler reads it from the
+    HttpOnly `refresh_token` cookie when absent (the canonical path). Body
+    is kept as a fallback so older clients that still send it keep working
+    during the cross-deploy migration window. See #2112.
+    """
+
+    refresh_token: str | None = None
 
 
 class RegisterPasswordRequest(BaseModel):
@@ -515,35 +521,43 @@ async def verify_magic_link(
 
 @router.post("/logout")
 async def logout(
-    request: LogoutRequest, response: Response, db=Depends(get_db_session)
+    http_request: Request,
+    response: Response,
+    payload: LogoutRequest | None = None,
+    db=Depends(get_db_session),
 ) -> dict[str, str]:
     """Logout user by invalidating refresh token.
 
-    Args:
-        request: Refresh token to invalidate
+    Reads the token from the request body, falling back to the
+    `refresh_token` HttpOnly cookie. The cookie path is the canonical
+    one — clients should call this with no body and let the browser
+    attach the cookie automatically. The body fallback is kept for
+    cross-deploy compatibility with older clients (see #2112).
 
-    Returns:
-        Logout confirmation
+    Returns logout confirmation. Always 200 — failures are logged and
+    swallowed so the cookie still gets cleared on the client.
     """
+    token = (payload.refresh_token if payload else None) or http_request.cookies.get(
+        "refresh_token"
+    )
+
     try:
-        auth_service = LocalAuthService(db)
-        success = await auth_service.logout(request.refresh_token)
-
-        # Clear refresh token cookie
-        response.delete_cookie(key="refresh_token", httponly=True, secure=True, samesite="lax")
-
-        if success:
-            logger.info("User logged out successfully")
-            return {"message": "Logged out successfully"}
-        else:
-            logger.warning("Logout failed")
-            return {"message": "Logout failed"}
-
+        if token:
+            auth_service = LocalAuthService(db)
+            success = await auth_service.logout(token)
+            if success:
+                logger.info("User logged out successfully")
+            else:
+                logger.warning("Logout: token invalidation returned False")
     except Exception as e:
         logger.error("Logout error", error=str(e))
-        # Don't raise error for logout, just clear cookie
+    finally:
+        # Always clear the refresh-token cookie on the client, even if the
+        # server-side invalidation failed (best-effort logout — the cookie
+        # being gone is what actually logs the user out from this device).
         response.delete_cookie(key="refresh_token", httponly=True, secure=True, samesite="lax")
-        return {"message": "Logged out"}
+
+    return {"message": "Logged out"}
 
 
 # =============================================================================

--- a/backend/tests/test_logout_cookie.py
+++ b/backend/tests/test_logout_cookie.py
@@ -1,0 +1,101 @@
+"""Tests for POST /api/v1/auth/logout cookie-mode handling (#2112).
+
+The endpoint must accept an empty body and read the `refresh_token` from
+the HttpOnly cookie. The body fallback is kept for cross-deploy
+compatibility but is no longer required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+async def test_logout_with_cookie_no_body() -> None:
+    """Empty-body logout succeeds when the refresh_token cookie is present.
+
+    The pre-#2112 behaviour returned 422 here ("missing field
+    refresh_token in body"). With the cookie fallback, the handler reads
+    from cookie and the call returns 200.
+    """
+    with patch(
+        "app.api.v1.local_auth.LocalAuthService.logout",
+        new=AsyncMock(return_value=True),
+    ) as mock:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.post(
+                "/api/v1/auth/logout",
+                cookies={"refresh_token": "fake-cookie-token"},
+            )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["message"] == "Logged out"
+    # Service should have been called with the cookie value, not None.
+    mock.assert_awaited_once_with("fake-cookie-token")
+    # Set-Cookie should clear the refresh_token cookie.
+    set_cookie_headers = [v for k, v in resp.headers.multi_items() if k.lower() == "set-cookie"]
+    refresh_clears = [c for c in set_cookie_headers if c.startswith("refresh_token=")]
+    assert refresh_clears, f"expected refresh_token clear cookie, got {set_cookie_headers}"
+    # Must clear with Max-Age=0 (or expires) and HttpOnly.
+    assert any(
+        "Max-Age=0" in c or "max-age=0" in c.lower() or "expires=" in c.lower()
+        for c in refresh_clears
+    )
+    assert any("httponly" in c.lower() for c in refresh_clears)
+
+
+async def test_logout_with_body_still_works() -> None:
+    """Cross-deploy compatibility: the body path still works when
+    older clients send `{"refresh_token": "..."}`.
+    """
+    with patch(
+        "app.api.v1.local_auth.LocalAuthService.logout",
+        new=AsyncMock(return_value=True),
+    ) as mock:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.post(
+                "/api/v1/auth/logout",
+                json={"refresh_token": "body-token"},
+            )
+
+    assert resp.status_code == 200
+    mock.assert_awaited_once_with("body-token")
+
+
+async def test_logout_with_no_token_at_all_still_clears_cookie() -> None:
+    """If neither body nor cookie is present, logout must still 200 and
+    clear the cookie (best-effort logout — never strands the user).
+    """
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post("/api/v1/auth/logout")
+
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "Logged out"
+    set_cookie_headers = [v for k, v in resp.headers.multi_items() if k.lower() == "set-cookie"]
+    refresh_clears = [c for c in set_cookie_headers if c.startswith("refresh_token=")]
+    assert refresh_clears, "cookie should still be cleared even with no token"
+
+
+async def test_logout_body_takes_precedence_over_cookie() -> None:
+    """When both are present, body wins (matches the /refresh handler)."""
+    with patch(
+        "app.api.v1.local_auth.LocalAuthService.logout",
+        new=AsyncMock(return_value=True),
+    ) as mock:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.post(
+                "/api/v1/auth/logout",
+                json={"refresh_token": "from-body"},
+                cookies={"refresh_token": "from-cookie"},
+            )
+
+    assert resp.status_code == 200
+    mock.assert_awaited_once_with("from-body")

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -178,11 +178,18 @@ class AuthClient {
 
   private setTokens(authResponse: AuthResponse): void {
     this.accessToken = authResponse.access_token;
+    // refresh_token is held in memory for the lifetime of this tab only.
+    // It is NOT persisted to localStorage anymore (#2112) — the HttpOnly
+    // `refresh_token` cookie set by the backend is the canonical store, and
+    // duplicating it in JS-readable storage defeats the HttpOnly protection.
+    // Subsequent /refresh + /logout calls rely on the browser auto-attaching
+    // the cookie; the backend reads from cookie when body is absent.
     this.refreshToken = authResponse.refresh_token;
 
     if (typeof window !== 'undefined') {
       localStorage.setItem('access_token', authResponse.access_token);
-      localStorage.setItem('refresh_token', authResponse.refresh_token);
+      // Migration: clear any pre-#2112 persisted refresh_token on next login.
+      localStorage.removeItem('refresh_token');
       localStorage.setItem('user', JSON.stringify(authResponse.user));
       // Set cookie for server-side middleware auth check
       const maxAge = authResponse.expires_in || 900;
@@ -263,18 +270,15 @@ class AuthClient {
   }
 
   /**
-   * Refresh access token using refresh token.
-   * Sends the localStorage token if present; otherwise relies on the
-   * HttpOnly refresh_token cookie (backend reads cookie when body omitted).
+   * Refresh access token using the HttpOnly refresh_token cookie.
+   * No body is sent — the backend reads the token from the cookie that
+   * the browser auto-attaches. (Pre-#2112 this also forwarded a body
+   * copy from localStorage; that path is retired.)
    */
   async refreshAccessToken(): Promise<void> {
-    const body = this.refreshToken
-      ? JSON.stringify({ refresh_token: this.refreshToken })
-      : JSON.stringify({});
-
     const response = await this.apiCall<RefreshTokenResponse>('/refresh', {
       method: 'POST',
-      body,
+      body: JSON.stringify({}),
     });
 
     this.accessToken = response.access_token;
@@ -287,21 +291,20 @@ class AuthClient {
   }
 
   /**
-   * Logout user and clear tokens
+   * Logout user and clear tokens.
+   * Calls the backend with no body — the HttpOnly refresh_token cookie
+   * is the source of truth, the server reads it from there and clears
+   * it via Set-Cookie. (#2112)
    */
   async logout(): Promise<void> {
-    if (this.refreshToken) {
-      try {
-        await this.apiCall('/logout', {
-          method: 'POST',
-          body: JSON.stringify({
-            refresh_token: this.refreshToken,
-          }),
-        });
-      } catch (error) {
-        // Don't throw on logout errors, just clear tokens
-        console.warn('Logout request failed:', error);
-      }
+    try {
+      await this.apiCall('/logout', {
+        method: 'POST',
+        body: JSON.stringify({}),
+      });
+    } catch (error) {
+      // Don't throw on logout errors, just clear tokens locally.
+      console.warn('Logout request failed:', error);
     }
 
     this.clearTokens();


### PR DESCRIPTION
Promotes #2245 (merged to dev as 49463c17) to main via cherry-pick. P1 security fix — eliminates the localStorage refresh_token persistence that defeated HttpOnly protection. Fixes #2112. CI green on dev-side PR.%n%n🤖 Generated with [Claude Code](https://claude.com/claude-code)