### PR TITLE
fix(auth): show invitation-only banner when registration disabled (#2110)

### DIFF
--- a/frontend/app/[locale]/about/page.tsx
+++ b/frontend/app/[locale]/about/page.tsx
@@ -27,6 +27,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
+import { useSettings } from '@/lib/settings-context';
 
 const FEATURES = [
   { titleKey: 'featureSmartCourseTitle', descKey: 'featureSmartCourseDesc', icon: Upload },
@@ -55,8 +56,14 @@ const TRUST = [
 
 export default function AboutPage() {
   const t = useTranslations('About');
+  const tAuth = useTranslations('Auth');
   const pathname = usePathname();
   const locale = pathname.split('/')[1] || 'fr';
+  // When self-registration is disabled, swap the secondary CTA from
+  // 'Become an expert' (which routes to /register and dead-ends at /login)
+  // to 'I have a code' (which routes to /activate). See #2110.
+  const { getSetting } = useSettings();
+  const registrationEnabled = getSetting<boolean>('auth-self-registration-enabled', false);
 
   return (
     <div className="min-h-dvh bg-white">
@@ -99,9 +106,9 @@ export default function AboutPage() {
                 {t('ctaBrowse')}
               </Button>
             </Link>
-            <Link href={`/${locale}/register`}>
+            <Link href={`/${locale}/${registrationEnabled ? 'register' : 'activate'}`}>
               <Button size="lg" variant="outline" className="px-8">
-                {t('ctaExpert')}
+                {registrationEnabled ? t('ctaExpert') : tAuth('invitationOnlyHaveCode')}
               </Button>
             </Link>
           </div>
@@ -237,9 +244,9 @@ export default function AboutPage() {
                 {t('ctaBrowse')}
               </Button>
             </Link>
-            <Link href={`/${locale}/register`}>
+            <Link href={`/${locale}/${registrationEnabled ? 'register' : 'activate'}`}>
               <Button size="lg" variant="outline" className="px-8">
-                {t('ctaExpert')}
+                {registrationEnabled ? t('ctaExpert') : tAuth('invitationOnlyHaveCode')}
               </Button>
             </Link>
           </div>

--- a/frontend/components/auth/password-login-form.tsx
+++ b/frontend/components/auth/password-login-form.tsx
@@ -158,11 +158,18 @@ export function PasswordLoginForm({ redirectTo }: { redirectTo?: string }) {
             {isLoading ? tCommon('loading') : t('signIn')}
           </Button>
 
-          {registrationEnabled && (
+          {registrationEnabled ? (
             <div className="text-center text-sm">
               <span className="text-muted-foreground">{t('noAccount')} </span>
               <Link href="/register-options" className="font-medium text-primary hover:underline">
                 {t('signUp')}
+              </Link>
+            </div>
+          ) : (
+            <div className="rounded-md border border-stone-200 bg-stone-50 p-3 text-center text-sm text-stone-600">
+              {t('invitationOnlyBanner')}{' '}
+              <Link href="/activate" className="font-medium text-primary hover:underline">
+                {t('invitationOnlyHaveCode')}
               </Link>
             </div>
           )}

--- a/frontend/components/auth/totp-login-form.tsx
+++ b/frontend/components/auth/totp-login-form.tsx
@@ -275,8 +275,8 @@ export function TOTPLoginForm({ redirectTo }: { redirectTo?: string }) {
             </button>
           </div>
 
-          {/* Registration Link */}
-          {registrationEnabled && (
+          {/* Registration Link or invitation-only banner (#2110) */}
+          {registrationEnabled ? (
             <div className="text-center text-sm">
               <span className="text-muted-foreground">{t('noAccount')} </span>
               <Link
@@ -284,6 +284,16 @@ export function TOTPLoginForm({ redirectTo }: { redirectTo?: string }) {
                 className="font-medium text-primary hover:underline"
               >
                 {t('signUp')}
+              </Link>
+            </div>
+          ) : (
+            <div className="rounded-md border border-stone-200 bg-stone-50 p-3 text-center text-sm text-stone-600">
+              {t('invitationOnlyBanner')}{' '}
+              <Link
+                href="/activate"
+                className="font-medium text-primary hover:underline"
+              >
+                {t('invitationOnlyHaveCode')}
               </Link>
             </div>
           )}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -87,6 +87,8 @@
     "video_summary": "Video Summaries"
   },
   "Auth": {
+    "invitationOnlyBanner": "Registration is currently invitation-only. Have a code? Redeem it here.",
+    "invitationOnlyHaveCode": "I have a code",
     "login": "Sign in",
     "register": "Create account",
     "email": "Email address",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -87,6 +87,8 @@
     "video_summary": "Résumés vidéo"
   },
   "Auth": {
+    "invitationOnlyBanner": "Les inscriptions sont actuellement sur invitation. Vous avez un code ? Activez-le ici.",
+    "invitationOnlyHaveCode": "J'ai un code",
     "login": "Se connecter",
     "register": "Créer un compte",
     "email": "Adresse email",


### PR DESCRIPTION
## Summary
When \`auth-self-registration-enabled = false\` the platform was leaving new visitors at a dead end:
- /fr/about's 'Become an expert' CTA routes to \`/register\` → 302 to \`/login\` (correct — the route is server-gated).
- \`/login\` then hides its 'Sign up' link via [`registrationEnabled = getSetting('auth-self-registration-enabled', false)`](frontend/components/auth/password-login-form.tsx#L37) — but with no replacement copy.
- Net: a code-less visitor sees a login form with no signal that registration is invitation-only or how to redeem an activation code.

Sweep finding F-001 (reframed) in #2110.

## Fix
Two i18n keys (FR + EN) + 3 file edits. No backend, no flag flip.

| Key | FR | EN |
|---|---|---|
| Auth.invitationOnlyBanner | Les inscriptions sont actuellement sur invitation. Vous avez un code ? Activez-le ici. | Registration is currently invitation-only. Have a code? Redeem it here. |
| Auth.invitationOnlyHaveCode | J'ai un code | I have a code |

- [\`password-login-form.tsx\`](frontend/components/auth/password-login-form.tsx) — swap the hidden 'Sign up' link for a bordered banner when \`registrationEnabled\` is false.
- [\`totp-login-form.tsx\`](frontend/components/auth/totp-login-form.tsx) — same pattern, same banner.
- [\`/fr/about\`](frontend/app/[locale]/about/page.tsx) — wire \`useSettings\` and swap both 'Become an expert' CTAs (hero + closing section) for 'I have a code' / \`/activate\` when the flag is off.

When the flag is true, every existing UI element is unchanged.

Fixes #2110

Part of the production-readiness epic #2123.

## Test plan
- [x] \`tsc --noEmit\` clean.
- [x] \`eslint\` clean.
- [ ] Post-deploy on staging with \`auth-self-registration-enabled=false\`:
  - \`/fr/login\` shows the banner with a working 'J'ai un code' link to \`/activate\`.
  - \`/fr/about\` hero + closing CTAs read 'J'ai un code' linking to \`/activate\`.
  - Same for \`/en/login\` + \`/en/about\`.
- [ ] When admin flips \`auth-self-registration-enabled\` to \`true\`, banner disappears and 'Sign up' link returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)