### PR TITLE
merge dev → main: invitation-only banner + activate CTA (#2110) (#2247)

### DIFF
--- a/frontend/app/[locale]/about/page.tsx
+++ b/frontend/app/[locale]/about/page.tsx
@@ -27,6 +27,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
+import { useSettings } from '@/lib/settings-context';
 
 const FEATURES = [
   { titleKey: 'featureSmartCourseTitle', descKey: 'featureSmartCourseDesc', icon: Upload },
@@ -55,8 +56,14 @@ const TRUST = [
 
 export default function AboutPage() {
   const t = useTranslations('About');
+  const tAuth = useTranslations('Auth');
   const pathname = usePathname();
   const locale = pathname.split('/')[1] || 'fr';
+  // When self-registration is disabled, swap the secondary CTA from
+  // 'Become an expert' (which routes to /register and dead-ends at /login)
+  // to 'I have a code' (which routes to /activate). See #2110.
+  const { getSetting } = useSettings();
+  const registrationEnabled = getSetting<boolean>('auth-self-registration-enabled', false);
 
   return (
     <div className="min-h-dvh bg-white">
@@ -99,9 +106,9 @@ export default function AboutPage() {
                 {t('ctaBrowse')}
               </Button>
             </Link>
-            <Link href={`/${locale}/register`}>
+            <Link href={`/${locale}/${registrationEnabled ? 'register' : 'activate'}`}>
               <Button size="lg" variant="outline" className="px-8">
-                {t('ctaExpert')}
+                {registrationEnabled ? t('ctaExpert') : tAuth('invitationOnlyHaveCode')}
               </Button>
             </Link>
           </div>
@@ -237,9 +244,9 @@ export default function AboutPage() {
                 {t('ctaBrowse')}
               </Button>
             </Link>
-            <Link href={`/${locale}/register`}>
+            <Link href={`/${locale}/${registrationEnabled ? 'register' : 'activate'}`}>
               <Button size="lg" variant="outline" className="px-8">
-                {t('ctaExpert')}
+                {registrationEnabled ? t('ctaExpert') : tAuth('invitationOnlyHaveCode')}
               </Button>
             </Link>
           </div>

--- a/frontend/components/auth/password-login-form.tsx
+++ b/frontend/components/auth/password-login-form.tsx
@@ -158,11 +158,18 @@ export function PasswordLoginForm({ redirectTo }: { redirectTo?: string }) {
             {isLoading ? tCommon('loading') : t('signIn')}
           </Button>
 
-          {registrationEnabled && (
+          {registrationEnabled ? (
             <div className="text-center text-sm">
               <span className="text-muted-foreground">{t('noAccount')} </span>
               <Link href="/register-options" className="font-medium text-primary hover:underline">
                 {t('signUp')}
+              </Link>
+            </div>
+          ) : (
+            <div className="rounded-md border border-stone-200 bg-stone-50 p-3 text-center text-sm text-stone-600">
+              {t('invitationOnlyBanner')}{' '}
+              <Link href="/activate" className="font-medium text-primary hover:underline">
+                {t('invitationOnlyHaveCode')}
               </Link>
             </div>
           )}

--- a/frontend/components/auth/totp-login-form.tsx
+++ b/frontend/components/auth/totp-login-form.tsx
@@ -275,8 +275,8 @@ export function TOTPLoginForm({ redirectTo }: { redirectTo?: string }) {
             </button>
           </div>
 
-          {/* Registration Link */}
-          {registrationEnabled && (
+          {/* Registration Link or invitation-only banner (#2110) */}
+          {registrationEnabled ? (
             <div className="text-center text-sm">
               <span className="text-muted-foreground">{t('noAccount')} </span>
               <Link
@@ -284,6 +284,16 @@ export function TOTPLoginForm({ redirectTo }: { redirectTo?: string }) {
                 className="font-medium text-primary hover:underline"
               >
                 {t('signUp')}
+              </Link>
+            </div>
+          ) : (
+            <div className="rounded-md border border-stone-200 bg-stone-50 p-3 text-center text-sm text-stone-600">
+              {t('invitationOnlyBanner')}{' '}
+              <Link
+                href="/activate"
+                className="font-medium text-primary hover:underline"
+              >
+                {t('invitationOnlyHaveCode')}
               </Link>
             </div>
           )}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -87,6 +87,8 @@
     "video_summary": "Video Summaries"
   },
   "Auth": {
+    "invitationOnlyBanner": "Registration is currently invitation-only. Have a code? Redeem it here.",
+    "invitationOnlyHaveCode": "I have a code",
     "login": "Sign in",
     "register": "Create account",
     "email": "Email address",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -87,6 +87,8 @@
     "video_summary": "Résumés vidéo"
   },
   "Auth": {
+    "invitationOnlyBanner": "Les inscriptions sont actuellement sur invitation. Vous avez un code ? Activez-le ici.",
+    "invitationOnlyHaveCode": "J'ai un code",
     "login": "Se connecter",
     "register": "Créer un compte",
     "email": "Adresse email",


### PR DESCRIPTION
Promotes #2247 (merged to dev as fd795d06) to main via cherry-pick. UX fix only — fills the dead-end gap when self-registration is off. Fixes #2110. CI green on dev-side PR.%n%n🤖 Generated with [Claude Code](https://claude.com/claude-code)