### PR TITLE
feat(quality): per-course review dashboard (#2249, step 2)

### DIFF
--- a/frontend/app/[locale]/admin/courses/[courseId]/quality/page.tsx
+++ b/frontend/app/[locale]/admin/courses/[courseId]/quality/page.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+import { QualityClient } from "@/components/admin/quality/quality-client";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string; courseId: string }>;
+}) {
+  await params;
+  const t = await getTranslations("Admin.qualityAgent");
+  return {
+    title: t("pageTitle"),
+    description: t("pageDescription"),
+  };
+}
+
+export default async function AdminCourseQualityPage({
+  params,
+}: {
+  params: Promise<{ locale: string; courseId: string }>;
+}) {
+  const { courseId } = await params;
+  const t = await getTranslations("Admin.qualityAgent");
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <div className="border-b bg-background p-4 shrink-0">
+        <Link
+          href="/admin/courses"
+          className="mb-2 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="size-4" />
+          {t("backToCourses")}
+        </Link>
+        <h1 className="text-2xl font-bold">{t("pageTitle")}</h1>
+        <p className="text-muted-foreground mt-1">{t("pageDescription")}</p>
+      </div>
+      <QualityClient courseId={courseId} />
+    </div>
+  );
+}

--- a/frontend/components/admin/courses-client.tsx
+++ b/frontend/components/admin/courses-client.tsx
@@ -12,6 +12,7 @@ import {
   Sparkles,
   Loader2,
   AlertCircle,
+  Activity,
   BookOpen,
   Database,
   ImageOff,
@@ -408,6 +409,7 @@ export function CoursesClient() {
                 onDelete={(c) => setPendingAction({ type: 'delete', course: c })}
                 onGenerateStructure={(c) => setPendingAction({ type: 'generate', course: c })}
                 onEdit={(c) => { setEditingCourse(c); setFormOpen(true); }}
+                onReviewQuality={(c) => router.push(`/admin/courses/${c.id}/quality`)}
                 onResumeWizard={() => openWizardResume(course)}
               />
             ))}
@@ -559,6 +561,7 @@ function CourseRow({
   onDelete,
   onGenerateStructure,
   onEdit,
+  onReviewQuality,
   onResumeWizard,
 }: {
   course: AdminCourse;
@@ -568,6 +571,7 @@ function CourseRow({
   onDelete: (c: AdminCourse) => void;
   onGenerateStructure: (c: AdminCourse) => void;
   onEdit: (c: AdminCourse) => void;
+  onReviewQuality: (c: AdminCourse) => void;
   onResumeWizard: () => void;
 }) {
   const t = useTranslations('AdminCourses');
@@ -668,6 +672,10 @@ function CourseRow({
               <DropdownMenuItem onClick={() => onEdit(course)}>
                 <BookOpen className="mr-2 h-4 w-4" />
                 {t('editCourse')}
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onReviewQuality(course)}>
+                <Activity className="mr-2 h-4 w-4" />
+                {t('reviewQuality')}
               </DropdownMenuItem>
               {!isPublished && (
                 <DropdownMenuItem

--- a/frontend/components/admin/quality/needs-review-queue.tsx
+++ b/frontend/components/admin/quality/needs-review-queue.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import Link from "next/link";
+import { useLocale, useTranslations } from "next-intl";
+import type { CourseQualityRunDetail, UnitQualitySummary } from "@/lib/api-quality";
+import { FLAGGED_STATUSES } from "@/lib/api-quality";
+import { QualityStatusBadge } from "./quality-status-badge";
+import { ScorePill } from "./score-pill";
+
+function fmtDate(iso: string | null, locale: string): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString(locale, {
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function NeedsReviewQueue({
+  courseId,
+  latestRun,
+}: {
+  courseId: string;
+  latestRun: CourseQualityRunDetail | null;
+}) {
+  const t = useTranslations("Admin.qualityAgent.needsReview");
+  const locale = useLocale();
+
+  const flagged: UnitQualitySummary[] = (latestRun?.units ?? []).filter((u) =>
+    FLAGGED_STATUSES.has(u.quality_status),
+  );
+
+  if (!latestRun) {
+    return (
+      <div className="rounded-md border bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+        {t("noRun")}
+      </div>
+    );
+  }
+
+  if (flagged.length === 0) {
+    return (
+      <div className="rounded-md border bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+        {t("allClear")}
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-md border">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b bg-muted/30 text-left text-muted-foreground">
+            <th className="px-3 py-2">{t("unit")}</th>
+            <th className="px-3 py-2">{t("type")}</th>
+            <th className="px-3 py-2">{t("language")}</th>
+            <th className="px-3 py-2">{t("status")}</th>
+            <th className="px-3 py-2">{t("score")}</th>
+            <th className="px-3 py-2">{t("flags")}</th>
+            <th className="px-3 py-2">{t("attempts")}</th>
+            <th className="px-3 py-2">{t("lastAssessed")}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {flagged.map((u) => (
+            <tr key={u.generated_content_id} className="border-b last:border-0 hover:bg-muted/20">
+              <td className="px-3 py-2 font-medium">
+                <Link
+                  href={`/admin/courses/${courseId}/quality/runs/${latestRun.id}/units/${u.generated_content_id}`}
+                  className="text-primary hover:underline"
+                >
+                  {u.unit_number ?? "—"}
+                </Link>
+              </td>
+              <td className="px-3 py-2 text-muted-foreground">{u.content_type}</td>
+              <td className="px-3 py-2 text-muted-foreground uppercase">{u.language}</td>
+              <td className="px-3 py-2">
+                <QualityStatusBadge status={u.quality_status} />
+              </td>
+              <td className="px-3 py-2">
+                <ScorePill score={u.quality_score} />
+              </td>
+              <td className="px-3 py-2 tabular-nums">{u.flag_count}</td>
+              <td className="px-3 py-2 tabular-nums text-muted-foreground">
+                {u.regeneration_attempts}
+              </td>
+              <td className="px-3 py-2 whitespace-nowrap text-xs text-muted-foreground">
+                {fmtDate(u.last_assessed_at, locale)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/components/admin/quality/quality-client.tsx
+++ b/frontend/components/admin/quality/quality-client.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useQuery } from "@tanstack/react-query";
+import {
+  type CourseQualityRunDetail,
+  type CourseQualityRunSummary,
+  type QualitySummary,
+  getQualityRun,
+  getQualitySummary,
+  isRunInProgress,
+  listQualityRuns,
+} from "@/lib/api-quality";
+import { NeedsReviewQueue } from "./needs-review-queue";
+import { QualitySummaryTiles } from "./quality-summary-tiles";
+import { RunsLog } from "./runs-log";
+
+const POLL_MS = 10_000;
+
+export function QualityClient({ courseId }: { courseId: string }) {
+  const t = useTranslations("Admin.qualityAgent");
+
+  const summaryQ = useQuery<QualitySummary>({
+    queryKey: ["admin", "quality", courseId, "summary"],
+    queryFn: () => getQualitySummary(courseId),
+    refetchInterval: (q) =>
+      isRunInProgress(q.state.data?.last_run?.status) ? POLL_MS : false,
+  });
+
+  const runsQ = useQuery<CourseQualityRunSummary[]>({
+    queryKey: ["admin", "quality", courseId, "runs"],
+    queryFn: () => listQualityRuns(courseId, 10),
+    refetchInterval: (q) =>
+      (q.state.data ?? []).some((r) => isRunInProgress(r.status)) ? POLL_MS : false,
+  });
+
+  // Latest *completed* run drives the needs-review queue. If the only runs
+  // are in-progress, fall back to the most recent overall — its `units` will
+  // be empty until the worker scores them, but the empty-state message is
+  // truthful then.
+  const latestCompleted =
+    runsQ.data?.find((r) => r.status === "completed") ?? runsQ.data?.[0] ?? null;
+
+  const runDetailQ = useQuery<CourseQualityRunDetail>({
+    queryKey: ["admin", "quality", courseId, "run", latestCompleted?.id ?? "none"],
+    queryFn: () => getQualityRun(courseId, latestCompleted!.id),
+    enabled: !!latestCompleted,
+    refetchInterval: () =>
+      latestCompleted && isRunInProgress(latestCompleted.status) ? POLL_MS : false,
+  });
+
+  if (summaryQ.isLoading || runsQ.isLoading) {
+    return (
+      <p className="py-12 text-center text-sm text-muted-foreground">{t("loading")}</p>
+    );
+  }
+
+  if (summaryQ.error) {
+    return (
+      <p className="py-12 text-center text-sm text-destructive" role="alert">
+        {summaryQ.error instanceof Error ? summaryQ.error.message : t("error")}
+      </p>
+    );
+  }
+
+  const summary = summaryQ.data;
+  if (!summary) {
+    return <p className="py-12 text-center text-sm text-muted-foreground">{t("noData")}</p>;
+  }
+
+  const inProgress = (runsQ.data ?? []).find((r) => isRunInProgress(r.status));
+
+  return (
+    <div className="flex flex-col gap-6 p-4">
+      {inProgress && (
+        <div
+          className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200"
+          role="status"
+        >
+          <span className="font-medium">{t("runInProgress.title")}</span>{" "}
+          <span>{t("runInProgress.body")}</span>
+        </div>
+      )}
+
+      <QualitySummaryTiles summary={summary} />
+
+      <section>
+        <h2 className="mb-3 text-lg font-semibold">{t("sections.needsReview")}</h2>
+        <NeedsReviewQueue courseId={courseId} latestRun={runDetailQ.data ?? null} />
+      </section>
+
+      {summary.glossary_drift_count > 0 && (
+        <section>
+          <h2 className="mb-3 text-lg font-semibold">{t("sections.glossaryDrift")}</h2>
+          <div className="rounded-md border bg-muted/20 p-4 text-sm">
+            <p className="text-muted-foreground">
+              {t("glossaryDriftBody", { count: summary.glossary_drift_count })}
+            </p>
+          </div>
+        </section>
+      )}
+
+      <section>
+        <h2 className="mb-3 text-lg font-semibold">{t("sections.runsLog")}</h2>
+        <RunsLog courseId={courseId} runs={runsQ.data ?? []} />
+      </section>
+    </div>
+  );
+}

--- a/frontend/components/admin/quality/quality-status-badge.tsx
+++ b/frontend/components/admin/quality/quality-status-badge.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Badge } from "@/components/ui/badge";
+import type { QualityStatus, RunStatus } from "@/lib/api-quality";
+
+const UNIT_STATUS_VARIANT: Record<
+  QualityStatus,
+  "default" | "secondary" | "destructive" | "outline" | "ghost"
+> = {
+  pending: "outline",
+  scoring: "secondary",
+  passing: "default",
+  needs_review: "secondary",
+  regenerating: "secondary",
+  needs_review_final: "destructive",
+  manual_override: "ghost",
+  failed: "destructive",
+};
+
+const RUN_STATUS_VARIANT: Record<
+  RunStatus,
+  "default" | "secondary" | "destructive" | "outline"
+> = {
+  queued: "outline",
+  scoring: "secondary",
+  regenerating: "secondary",
+  completed: "default",
+  failed: "destructive",
+  cancelled: "outline",
+};
+
+export function QualityStatusBadge({ status }: { status: QualityStatus }) {
+  const t = useTranslations("Admin.qualityAgent.unitStatus");
+  return <Badge variant={UNIT_STATUS_VARIANT[status]}>{t(status)}</Badge>;
+}
+
+export function RunStatusBadge({ status }: { status: RunStatus }) {
+  const t = useTranslations("Admin.qualityAgent.runStatus");
+  return <Badge variant={RUN_STATUS_VARIANT[status]}>{t(status)}</Badge>;
+}

--- a/frontend/components/admin/quality/quality-summary-tiles.tsx
+++ b/frontend/components/admin/quality/quality-summary-tiles.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useLocale, useTranslations } from "next-intl";
+import { Card } from "@/components/ui/card";
+import type { QualitySummary } from "@/lib/api-quality";
+import { FLAGGED_STATUSES } from "@/lib/api-quality";
+import { RunStatusBadge } from "./quality-status-badge";
+import { ScorePill } from "./score-pill";
+
+function relativeTime(isoOrNull: string | null | undefined, locale: string) {
+  if (!isoOrNull) return null;
+  const then = new Date(isoOrNull).getTime();
+  const now = Date.now();
+  const diffSec = Math.round((then - now) / 1000);
+  const abs = Math.abs(diffSec);
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
+  if (abs < 60) return rtf.format(diffSec, "second");
+  if (abs < 3600) return rtf.format(Math.round(diffSec / 60), "minute");
+  if (abs < 86400) return rtf.format(Math.round(diffSec / 3600), "hour");
+  return rtf.format(Math.round(diffSec / 86400), "day");
+}
+
+function flaggedCount(summary: QualitySummary): number {
+  let count = 0;
+  for (const s of FLAGGED_STATUSES) {
+    count += summary.units_by_status[s] ?? 0;
+  }
+  return count;
+}
+
+export function QualitySummaryTiles({ summary }: { summary: QualitySummary }) {
+  const t = useTranslations("Admin.qualityAgent.tiles");
+  const locale = useLocale();
+  const flagged = flaggedCount(summary);
+  const lastRun = summary.last_run;
+  const lastRunRel = relativeTime(lastRun?.finished_at ?? lastRun?.started_at, locale);
+
+  return (
+    <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+      <Card className="p-4">
+        <div className="text-sm text-muted-foreground">{t("unitsTotal")}</div>
+        <div className="mt-1 text-2xl font-bold tabular-nums">{summary.units_total}</div>
+      </Card>
+
+      <Card className="p-4">
+        <div className="text-sm text-muted-foreground">{t("needsReview")}</div>
+        <div className="mt-1 flex items-baseline gap-2">
+          <span className="text-2xl font-bold tabular-nums">{flagged}</span>
+          {flagged > 0 && (
+            <span className="text-xs text-amber-700 dark:text-amber-300">{t("needsReviewHint")}</span>
+          )}
+        </div>
+      </Card>
+
+      <Card className="p-4">
+        <div className="text-sm text-muted-foreground">{t("glossaryDrift")}</div>
+        <div className="mt-1 flex items-baseline gap-2">
+          <span className="text-2xl font-bold tabular-nums">{summary.glossary_drift_count}</span>
+          {summary.glossary_drift_count > 0 && (
+            <span className="text-xs text-amber-700 dark:text-amber-300">{t("driftHint")}</span>
+          )}
+        </div>
+      </Card>
+
+      <Card className="p-4">
+        <div className="text-sm text-muted-foreground">{t("lastRun")}</div>
+        {lastRun ? (
+          <div className="mt-1 flex flex-col gap-1">
+            <div className="flex items-center gap-2">
+              <RunStatusBadge status={lastRun.status} />
+              <ScorePill score={lastRun.overall_score} />
+            </div>
+            {lastRunRel && (
+              <div className="text-xs text-muted-foreground">{lastRunRel}</div>
+            )}
+          </div>
+        ) : (
+          <div className="mt-1 text-sm text-muted-foreground">{t("noRun")}</div>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/frontend/components/admin/quality/runs-log.tsx
+++ b/frontend/components/admin/quality/runs-log.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import Link from "next/link";
+import { useLocale, useTranslations } from "next-intl";
+import type { CourseQualityRunSummary } from "@/lib/api-quality";
+import { RunStatusBadge } from "./quality-status-badge";
+import { ScorePill } from "./score-pill";
+
+function fmtDate(iso: string | null, locale: string): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString(locale, {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function RunsLog({
+  courseId,
+  runs,
+}: {
+  courseId: string;
+  runs: CourseQualityRunSummary[];
+}) {
+  const t = useTranslations("Admin.qualityAgent.runsLog");
+  const tKind = useTranslations("Admin.qualityAgent.runKind");
+  const locale = useLocale();
+
+  if (runs.length === 0) {
+    return (
+      <div className="rounded-md border bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+        {t("empty")}
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-md border">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b bg-muted/30 text-left text-muted-foreground">
+            <th className="px-3 py-2">{t("status")}</th>
+            <th className="px-3 py-2">{t("kind")}</th>
+            <th className="px-3 py-2">{t("started")}</th>
+            <th className="px-3 py-2">{t("score")}</th>
+            <th className="px-3 py-2">{t("units")}</th>
+            <th className="px-3 py-2">{t("credits")}</th>
+            <th className="px-3 py-2"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {runs.map((r) => (
+            <tr key={r.id} className="border-b last:border-0 hover:bg-muted/20">
+              <td className="px-3 py-2">
+                <RunStatusBadge status={r.status} />
+              </td>
+              <td className="px-3 py-2 text-muted-foreground">{tKind(r.run_kind)}</td>
+              <td className="px-3 py-2 whitespace-nowrap text-xs text-muted-foreground">
+                {fmtDate(r.started_at ?? r.created_at, locale)}
+              </td>
+              <td className="px-3 py-2">
+                <ScorePill score={r.overall_score} />
+              </td>
+              <td className="px-3 py-2 tabular-nums text-muted-foreground">
+                {r.units_passing}/{r.units_total}
+              </td>
+              <td className="px-3 py-2 tabular-nums text-muted-foreground">
+                {r.spent_credits}/{r.budget_credits}
+              </td>
+              <td className="px-3 py-2 text-right">
+                <Link
+                  href={`/admin/courses/${courseId}/quality/runs/${r.id}`}
+                  className="text-xs text-primary hover:underline"
+                >
+                  {t("open")}
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/components/admin/quality/score-pill.tsx
+++ b/frontend/components/admin/quality/score-pill.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+function colorFor(score: number) {
+  if (score >= 90) return "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200";
+  if (score >= 70) return "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200";
+  return "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200";
+}
+
+export function ScorePill({
+  score,
+  className,
+}: {
+  score: number | null | undefined;
+  className?: string;
+}) {
+  if (score === null || score === undefined) {
+    return <span className={cn("text-muted-foreground text-xs", className)}>—</span>;
+  }
+  const rounded = Math.round(score);
+  return (
+    <span
+      className={cn(
+        "inline-flex h-5 items-center rounded-md px-1.5 text-xs font-medium tabular-nums",
+        colorFor(rounded),
+        className,
+      )}
+    >
+      {rounded}
+    </span>
+  );
+}

--- a/frontend/lib/api-quality.ts
+++ b/frontend/lib/api-quality.ts
@@ -1,0 +1,239 @@
+import { apiFetch } from "./api";
+
+export type QualityStatus =
+  | "pending"
+  | "scoring"
+  | "passing"
+  | "needs_review"
+  | "regenerating"
+  | "needs_review_final"
+  | "manual_override"
+  | "failed";
+
+export type RunStatus =
+  | "queued"
+  | "scoring"
+  | "regenerating"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export type RunKind = "full" | "targeted" | "glossary_only";
+
+export type FlagCategory =
+  | "terminology_drift"
+  | "ungrounded_claim"
+  | "syllabus_scope_drift"
+  | "internal_contradiction"
+  | "pedagogical_mismatch"
+  | "structural_gap";
+
+export type FlagSeverity = "low" | "medium" | "high" | "blocking";
+
+export type DimensionKey =
+  | "terminology_consistency"
+  | "source_grounding"
+  | "syllabus_alignment"
+  | "internal_contradictions"
+  | "pedagogical_fit"
+  | "structural_completeness";
+
+export const DIMENSION_KEYS: DimensionKey[] = [
+  "terminology_consistency",
+  "source_grounding",
+  "syllabus_alignment",
+  "internal_contradictions",
+  "pedagogical_fit",
+  "structural_completeness",
+];
+
+export const DIMENSION_WEIGHTS: Record<DimensionKey, number> = {
+  terminology_consistency: 25,
+  source_grounding: 20,
+  syllabus_alignment: 20,
+  internal_contradictions: 15,
+  pedagogical_fit: 10,
+  structural_completeness: 10,
+};
+
+export interface QualityFlag {
+  category: FlagCategory;
+  severity: FlagSeverity;
+  location: string;
+  description: string;
+  evidence: string;
+  suggested_fix: string;
+  evidence_unit_id: string | null;
+}
+
+export type DimensionScores = Record<DimensionKey, number>;
+
+export interface CourseQualityRunSummary {
+  id: string;
+  course_id: string;
+  run_kind: RunKind;
+  status: RunStatus;
+  started_at: string | null;
+  finished_at: string | null;
+  overall_score: number | null;
+  units_total: number;
+  units_passing: number;
+  units_regenerated: number;
+  budget_credits: number;
+  spent_credits: number;
+  triggered_by_user_id: string | null;
+  notes: string | null;
+  created_at: string;
+}
+
+export interface UnitQualitySummary {
+  generated_content_id: string;
+  unit_number: string | null;
+  content_type: string;
+  language: string;
+  quality_score: number | null;
+  quality_status: QualityStatus;
+  flag_count: number;
+  regeneration_attempts: number;
+  is_manually_edited: boolean;
+  last_assessed_at: string | null;
+}
+
+export interface CourseQualityRunDetail extends CourseQualityRunSummary {
+  units: UnitQualitySummary[];
+}
+
+export interface UnitQualityDetail {
+  generated_content_id: string;
+  unit_number: string | null;
+  content_type: string;
+  language: string;
+  quality_score: number | null;
+  quality_status: QualityStatus;
+  flag_count: number;
+  regeneration_attempts: number;
+  is_manually_edited: boolean;
+  validated: boolean;
+  quality_assessed_at: string | null;
+  last_quality_run_id: string | null;
+  quality_flags: QualityFlag[];
+  dimension_scores: DimensionScores | null;
+  latest_attempt_id: string | null;
+  latest_attempt_number: number | null;
+  latest_attempt_score: number | null;
+}
+
+export interface GlossaryEntryResponse {
+  id: string;
+  term_display: string;
+  language: string;
+  canonical_definition: string;
+  first_unit_number: string | null;
+  consistency_status: "consistent" | "drift_detected" | "unsourced";
+  drift_details: string | null;
+  occurrences_count: number;
+  status: string;
+}
+
+export interface QualitySummary {
+  course_id: string;
+  units_total: number;
+  units_by_status: Partial<Record<QualityStatus, number>>;
+  glossary_drift_count: number;
+  last_run: CourseQualityRunSummary | null;
+}
+
+export interface ReviewQueueEntry {
+  course_id: string;
+  course_title_fr: string;
+  course_title_en: string;
+  owner_id: string | null;
+  units_total: number;
+  units_passing: number;
+  units_needs_review: number;
+  units_needs_review_final: number;
+  units_failed: number;
+  glossary_drift_count: number;
+  last_assessed_at: string | null;
+  last_run: CourseQualityRunSummary | null;
+}
+
+// ---- read endpoints ----
+
+export function getQualitySummary(courseId: string): Promise<QualitySummary> {
+  return apiFetch<QualitySummary>(
+    `/api/v1/admin/courses/${courseId}/quality/summary`,
+  );
+}
+
+export function listQualityRuns(
+  courseId: string,
+  limit = 20,
+): Promise<CourseQualityRunSummary[]> {
+  return apiFetch<CourseQualityRunSummary[]>(
+    `/api/v1/admin/courses/${courseId}/quality/runs?limit=${limit}`,
+  );
+}
+
+export function getQualityRun(
+  courseId: string,
+  runId: string,
+): Promise<CourseQualityRunDetail> {
+  return apiFetch<CourseQualityRunDetail>(
+    `/api/v1/admin/courses/${courseId}/quality/runs/${runId}`,
+  );
+}
+
+export function getCourseGlossary(
+  courseId: string,
+  language?: string,
+): Promise<GlossaryEntryResponse[]> {
+  const qs = language ? `?language=${encodeURIComponent(language)}` : "";
+  return apiFetch<GlossaryEntryResponse[]>(
+    `/api/v1/admin/courses/${courseId}/quality/glossary${qs}`,
+  );
+}
+
+export function getUnitQualityDetail(
+  courseId: string,
+  contentId: string,
+): Promise<UnitQualityDetail> {
+  return apiFetch<UnitQualityDetail>(
+    `/api/v1/admin/courses/${courseId}/units/${contentId}/quality`,
+  );
+}
+
+export function getReviewQueue(opts?: {
+  hasIssues?: boolean;
+  limit?: number;
+}): Promise<ReviewQueueEntry[]> {
+  const params = new URLSearchParams();
+  if (opts?.hasIssues !== undefined) {
+    params.set("has_issues", String(opts.hasIssues));
+  }
+  if (opts?.limit !== undefined) {
+    params.set("limit", String(opts.limit));
+  }
+  const qs = params.toString();
+  return apiFetch<ReviewQueueEntry[]>(
+    `/api/v1/admin/quality/review-queue${qs ? `?${qs}` : ""}`,
+  );
+}
+
+// ---- run-state helpers ----
+
+const ACTIVE_RUN_STATUSES: ReadonlySet<RunStatus> = new Set([
+  "queued",
+  "scoring",
+  "regenerating",
+]);
+
+export function isRunInProgress(status: RunStatus | null | undefined): boolean {
+  return status !== null && status !== undefined && ACTIVE_RUN_STATUSES.has(status);
+}
+
+export const FLAGGED_STATUSES: ReadonlySet<QualityStatus> = new Set([
+  "needs_review",
+  "needs_review_final",
+  "failed",
+]);

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1312,6 +1312,78 @@
       "removeMember": "Remove member",
       "confirmDelete": "Delete this group?",
       "confirmDeleteDesc": "This will remove the group and revoke any curriculum access granted via this group."
+    },
+    "qualityAgent": {
+      "pageTitle": "Quality review",
+      "pageDescription": "Review what the autonomous quality agent has flagged for this course.",
+      "backToCourses": "Back to courses",
+      "loading": "Loading quality data…",
+      "error": "Could not load quality data.",
+      "noData": "No quality data yet.",
+      "runInProgress": {
+        "title": "A quality run is in progress.",
+        "body": "Counts and unit statuses below will refresh automatically."
+      },
+      "tiles": {
+        "unitsTotal": "Total units",
+        "needsReview": "Needs review",
+        "needsReviewHint": "flagged",
+        "glossaryDrift": "Glossary drift",
+        "driftHint": "terms diverge",
+        "lastRun": "Latest run",
+        "noRun": "No run yet"
+      },
+      "sections": {
+        "needsReview": "Units needing review",
+        "glossaryDrift": "Glossary drift",
+        "runsLog": "Recent runs"
+      },
+      "needsReview": {
+        "noRun": "The agent has not assessed this course yet — units will appear here after the next lesson generation.",
+        "allClear": "Nothing flagged in the latest run. The agent is happy with this course.",
+        "unit": "Unit",
+        "type": "Type",
+        "language": "Lang",
+        "status": "Status",
+        "score": "Score",
+        "flags": "Flags",
+        "attempts": "Retries",
+        "lastAssessed": "Last assessed"
+      },
+      "runsLog": {
+        "empty": "No runs yet for this course.",
+        "status": "Status",
+        "kind": "Kind",
+        "started": "Started",
+        "score": "Score",
+        "units": "Units (passing/total)",
+        "credits": "Credits (spent/budget)",
+        "open": "Open"
+      },
+      "runStatus": {
+        "queued": "Queued",
+        "scoring": "Scoring",
+        "regenerating": "Regenerating",
+        "completed": "Completed",
+        "failed": "Failed",
+        "cancelled": "Cancelled"
+      },
+      "runKind": {
+        "full": "Full sweep",
+        "targeted": "Targeted",
+        "glossary_only": "Glossary only"
+      },
+      "unitStatus": {
+        "pending": "Pending",
+        "scoring": "Scoring",
+        "passing": "Passing",
+        "needs_review": "Needs review",
+        "regenerating": "Regenerating",
+        "needs_review_final": "Final review",
+        "manual_override": "Manual override",
+        "failed": "Failed"
+      },
+      "glossaryDriftBody": "{count, plural, one {# term has divergent definitions across units.} other {# terms have divergent definitions across units.}}"
     }
   },
   "Courses": {
@@ -1718,7 +1790,8 @@
       "lockHint": "Saved lessons are locked and will never be regenerated.",
       "generateError": "Failed to generate lesson preview.",
       "noModules": "No modules found. Generate a syllabus first."
-    }
+    },
+    "reviewQuality": "Review quality"
   },
   "AdminSyllabus": {
     "pageTitle": "Syllabus Management",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1312,6 +1312,78 @@
       "removeMember": "Retirer le membre",
       "confirmDelete": "Supprimer ce groupe ?",
       "confirmDeleteDesc": "Cela supprimera le groupe et révoquera tout accès aux curricula accordé via ce groupe."
+    },
+    "qualityAgent": {
+      "pageTitle": "Revue qualité",
+      "pageDescription": "Examinez ce que l'agent qualité autonome a signalé pour ce cours.",
+      "backToCourses": "Retour aux cours",
+      "loading": "Chargement des données qualité…",
+      "error": "Impossible de charger les données qualité.",
+      "noData": "Aucune donnée qualité pour l'instant.",
+      "runInProgress": {
+        "title": "Une analyse qualité est en cours.",
+        "body": "Les compteurs et statuts ci-dessous se rafraîchiront automatiquement."
+      },
+      "tiles": {
+        "unitsTotal": "Unités totales",
+        "needsReview": "À examiner",
+        "needsReviewHint": "signalées",
+        "glossaryDrift": "Dérive de glossaire",
+        "driftHint": "termes divergents",
+        "lastRun": "Dernière analyse",
+        "noRun": "Aucune analyse"
+      },
+      "sections": {
+        "needsReview": "Unités à examiner",
+        "glossaryDrift": "Dérive de glossaire",
+        "runsLog": "Analyses récentes"
+      },
+      "needsReview": {
+        "noRun": "L'agent n'a pas encore évalué ce cours — les unités apparaîtront ici après la prochaine génération de leçon.",
+        "allClear": "Rien à signaler dans la dernière analyse. L'agent est satisfait de ce cours.",
+        "unit": "Unité",
+        "type": "Type",
+        "language": "Langue",
+        "status": "Statut",
+        "score": "Score",
+        "flags": "Signalements",
+        "attempts": "Reprises",
+        "lastAssessed": "Dernière éval."
+      },
+      "runsLog": {
+        "empty": "Aucune analyse pour ce cours.",
+        "status": "Statut",
+        "kind": "Type",
+        "started": "Démarrée",
+        "score": "Score",
+        "units": "Unités (réussies/total)",
+        "credits": "Crédits (dépensés/budget)",
+        "open": "Ouvrir"
+      },
+      "runStatus": {
+        "queued": "En attente",
+        "scoring": "Évaluation",
+        "regenerating": "Régénération",
+        "completed": "Terminée",
+        "failed": "Échec",
+        "cancelled": "Annulée"
+      },
+      "runKind": {
+        "full": "Analyse complète",
+        "targeted": "Ciblée",
+        "glossary_only": "Glossaire seul"
+      },
+      "unitStatus": {
+        "pending": "En attente",
+        "scoring": "Évaluation",
+        "passing": "Validée",
+        "needs_review": "À examiner",
+        "regenerating": "Régénération",
+        "needs_review_final": "Examen final",
+        "manual_override": "Validation manuelle",
+        "failed": "Échec"
+      },
+      "glossaryDriftBody": "{count, plural, one {# terme a des définitions divergentes entre les unités.} other {# termes ont des définitions divergentes entre les unités.}}"
     }
   },
   "Courses": {
@@ -1718,7 +1790,8 @@
       "lockHint": "Les leçons enregistrées sont verrouillées et ne seront jamais régénérées.",
       "generateError": "Échec de la génération de l'aperçu de la leçon.",
       "noModules": "Aucun module trouvé. Générez d'abord un programme."
-    }
+    },
+    "reviewQuality": "Revue qualité"
   },
   "AdminSyllabus": {
     "pageTitle": "Gestion du syllabus",


### PR DESCRIPTION
Refs #2249, builds on #2250.

## Summary
Per-course review surface for the **autonomous** Quality Agent. Admin/sub_admin/expert (own courses) can navigate to `/admin/courses/{id}/quality` from the courses dropdown menu and see what the agent has flagged. **Read-only in this PR**; write actions (Regenerate / Resolve / Unlock) and the unit-detail drill-in arrive in step 3.

## Layout
Top → bottom on the page:
1. **Run-in-progress banner** when `last_run.status ∈ {queued, scoring, regenerating}`.
2. **4 summary tiles** — units_total, needs_review count (sum of `needs_review + needs_review_final + failed`), glossary drift, last run (status pill + score + relative time).
3. **Needs-review queue** — flagged units from the latest completed run, with status pill, score pill, flag count, retries, last-assessed time. Each row links to the unit-detail page (step 3 — placeholder route for now).
4. **Glossary drift card** — only when drift count > 0; just a body line for now (full glossary page is step 5).
5. **Recent runs log** — read-only audit table.

## Roles
Backend (#2250) gates expert to own courses via `_assert_course_access`; frontend `<AdminGuard>` already permits `admin | sub_admin | expert`. No extra frontend gating — non-owner experts hit a 403 from `apiFetch`.

## Polling
TanStack Query with `refetchInterval=10s` *only* when the latest run is in `{queued, scoring, regenerating}`. Otherwise static. Three keyed queries: summary, runs list, latest-run detail.

## Bundle
- No charting library (CSS-only `ScorePill` for color-coded numbers).
- New components live under `components/admin/quality/`.

## Files
**New:**
- `frontend/lib/api-quality.ts` — types + wrappers for all 9 backend endpoints.
- `frontend/components/admin/quality/` — 6 components (`quality-client`, `quality-summary-tiles`, `needs-review-queue`, `runs-log`, `quality-status-badge`, `score-pill`).
- `frontend/app/[locale]/admin/courses/[courseId]/quality/page.tsx` — server shell.

**Modified:**
- `frontend/components/admin/courses-client.tsx` — adds "Quality" dropdown item (with `Activity` icon) routing to the new page.
- `frontend/messages/en.json` + `fr.json` — `Admin.qualityAgent` namespace (~75 keys) + `AdminCourses.reviewQuality`.

## Test plan
- [ ] CI: ESLint + TypeScript pass (verified locally; only pre-existing warnings remain).
- [ ] Manual on staging after deploy: navigate to `/fr/admin/courses` → click ⋮ on a course → "Revue qualité" → page loads, tiles populated, "needs review" empty-state copy when no flagged units.
- [ ] FR/EN i18n switch: tile/section labels swap correctly.
- [ ] Mobile (375px): tiles stack 2 wide, tables scroll horizontally.
- [ ] In-progress smoke: trigger lesson generation on staging → land on the quality page → confirm the in-progress banner shows + counts refetch every 10s.

## Out of scope (next PRs)
- Step 3: unit-detail page with dimension bars, flag list, and Regenerate / Resolve / Unlock buttons.
- Step 4: full run-detail page (audit trail of one run).
- Step 5: glossary page.
- Step 6: top-level `/admin/quality` cross-course review queue + dashboard tile.
- Step 7: "Re-run full sweep" disclosure (secondary affordance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)