### PR TITLE
merge dev → main: deploy runbook (#2122) (#2160)

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,98 @@
+# Production environment template — copy to /home/deploy/etutor/.env on the
+# prod server (deploy@94.250.201.110) and fill in the secret values.
+#
+# Source of truth for the *shape* is .env.example (dev template). This file
+# differs by:
+#   - APP_ENV=production
+#   - all *_URL pointing at internal Docker DNS (postgres, redis, etc.)
+#   - real secrets (rotated regularly per security/key-management policy)
+#   - SMTP via the real relay (not localhost:25 stub)
+#   - WhatsApp + Sentry + PostHog DSNs filled in
+#
+# Never commit a populated copy of this file. The CI does NOT push env files
+# to the server — env management is a manual operator step.
+
+# Database (in-cluster Docker DNS)
+DATABASE_URL=postgresql+asyncpg://postgres:CHANGE_ME@postgres:5432/santepublique_aof
+DATABASE_URL_SYNC=postgresql://postgres:CHANGE_ME@postgres:5432/santepublique_aof
+POSTGRES_PASSWORD=CHANGE_ME
+
+# Redis
+REDIS_URL=redis://redis:6379/0
+
+# Local JWT Auth — rotate quarterly. Compromise = forced sign-out for all users.
+JWT_SECRET=CHANGE_ME_64_BYTES_HEX
+
+# Anthropic Claude API — burn protection: monitor /admin/usage daily.
+ANTHROPIC_API_KEY=sk-ant-prod-XXXX
+
+# OpenAI Embeddings
+OPENAI_API_KEY=sk-prod-XXXX
+
+# HeyGen (lesson video generation) + Google APIs (analytics)
+HEYGEN_API_KEY=hg-prod-XXXX
+GOOGLE_API_KEY=AIza-prod-XXXX
+
+# Embeddings
+EMBEDDING_MODEL=text-embedding-3-small
+EMBEDDING_DIMENSIONS=1536
+
+# App
+APP_ENV=production
+CORS_ORIGINS=https://app.sira-donnia.org
+API_V1_PREFIX=/api/v1
+
+# Frontend
+NEXT_PUBLIC_API_URL=https://api.sira-donnia.org
+FRONTEND_URL=https://app.sira-donnia.org
+
+# Email Service — real SMTP relay
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USE_TLS=true
+SMTP_USERNAME=noreply@sira-donnia.org
+SMTP_PASSWORD=CHANGE_ME
+FROM_EMAIL=noreply@sira-donnia.org
+FROM_NAME=Sira
+
+# WhatsApp Cloud API
+WHATSAPP_PHONE_NUMBER_ID=CHANGE_ME
+WHATSAPP_ACCESS_TOKEN=CHANGE_ME
+WHATSAPP_OTP_TEMPLATE_NAME=sira_otp
+WHATSAPP_API_VERSION=v20.0
+WHATSAPP_STUB_MODE=false
+
+# Sentry — separate DSNs for FE + BE so error attribution is clean
+SENTRY_DSN=https://...@sentry.io/...
+NEXT_PUBLIC_SENTRY_DSN=https://...@sentry.io/...
+SENTRY_ORG=sira
+SENTRY_PROJECT=sira-prod
+SENTRY_AUTH_TOKEN=sntrys_CHANGE_ME
+
+# PostHog (EU instance for GDPR)
+NEXT_PUBLIC_POSTHOG_KEY=phc_CHANGE_ME
+NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
+
+# MinIO — prod creds rotate quarterly
+MINIO_ACCESS_KEY=CHANGE_ME
+MINIO_SECRET_KEY=CHANGE_ME
+MINIO_ENDPOINT=http://minio:9000
+MINIO_PUBLIC_URL=https://media.sira-donnia.org
+MINIO_BUCKET_MEDIA=sira-media
+
+# Sidecar URLs — fixed, internal Docker DNS
+MMS_TTS_URL=http://mms-tts:5050
+NLLB_URL=http://nllb:5060
+
+# SMS relay (subscription billing via Orange Money / Wave)
+SMS_RELAY_API_KEY=CHANGE_ME
+SMS_RELAY_TRUSTED_SENDERS=CHANGE_ME
+
+# Cost kill-switch for Vision-backed figure tasks (#1928).
+# true = allow Claude Vision spend; false = block. Default false in prod
+# until a manual operator decision per backfill batch.
+ENABLE_FIGURE_VISION=false
+
+# Rate Limiting
+RATE_LIMIT_REQUESTS_PER_MINUTE=100
+RATE_LIMIT_TUTOR_MESSAGES_PER_DAY=200

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Auth:** Local FastAPI auth — passwordless TOTP MFA (Microsoft/Google Authenticator) + email magic link recovery. JWTs issued by backend (pyotp + python-jose).
 - **AI/RAG:** Anthropic Claude API, Claude Agent SDK, Anthropic Python SDK, pgvector (PostgreSQL), OpenAI text-embedding-3-small (1536 dims)
 - **Payments:** Credit system (in-app currency), Paystack (mobile money, cards), SMS-based subscriptions (Orange Money, Wave)
-- **Deploy:** GitHub Actions → Docker images → ghcr.io → VPS (Traefik reverse proxy), Sentry + PostHog
+- **Deploy:** GitHub Actions → Docker images → ghcr.io → VPS (Traefik reverse proxy), Sentry + PostHog. See [DEPLOY.md](DEPLOY.md) for the full runbook.
 
 ## Architecture (3-layer)
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,227 @@
+# Deploy runbook
+
+Operational reference for staging + production. Closes #2122 (supersedes the older #1744).
+
+This document covers **how Sira gets built, where it runs, and what to do when things break**. Read this whole file before your first prod deploy. Emergency-mode skim: jump straight to ["Smoke is RED, what now?"](#smoke-is-red-what-now).
+
+---
+
+## TL;DR
+
+- **Staging** auto-deploys on every `push` to `main`. URL: `https://etutor.elearning.portfolio2.kimbetien.com` (FE) + `https://api.elearning.portfolio2.kimbetien.com` (BE). Server: `deploy@167.86.115.58`.
+- **Production** deploys only via manual `workflow_dispatch` with `environment=production`. URL: `https://app.sira-donnia.org` + `https://api.sira-donnia.org`. Server: `deploy@94.250.201.110`.
+- **Build pipeline**: GH Actions → `ghcr.io/benidrissa/etutor-digital-ph/{backend,frontend,mms-tts,nllb}` → server pulls changed layers (replaces SCP since 2026-04-05).
+- **Hourly prod smoke** runs from `.github/workflows/prod-smoke.yml` (#2118). On failure it auto-opens / comments a tracking issue.
+- **Persona E2E suite** runs in PR CI (#2117); `e2e` job in `.github/workflows/ci.yml` against staging.
+
+---
+
+## Topology
+
+### Staging
+
+| Component | Where | Deployed via |
+|---|---|---|
+| FE | `etutor.elearning.portfolio2.kimbetien.com` | GH Actions → ghcr.io image, pulled by `docker compose` on `167.86.115.58` |
+| BE | `api.elearning.portfolio2.kimbetien.com` | Same |
+| Postgres / Redis / MinIO / mms-tts / nllb | Same Docker Compose stack on `167.86.115.58:/home/deploy/etutor/` | Static images, rebuilt only on infra changes |
+
+Trigger: any `push` to `main` runs `.github/workflows/deploy.yml` with default `environment=staging`.
+
+### Production
+
+| Component | Where | Deployed via |
+|---|---|---|
+| FE | `app.sira-donnia.org` | GH Actions → ghcr.io image, pulled by `docker compose` on `94.250.201.110` |
+| BE | `api.sira-donnia.org` | Same |
+| Shared infra (postgres/redis/minio for *all* tenants + console) | `/home/deploy/etutor/` on `94.250.201.110` — see memory `prod_etutor_shared_infra` for why this is shared | Manual; never stop the shared trio |
+| App tier (backend/frontend/celery/mms-tts) | Same host, separate compose | Deployed via `workflow_dispatch` with `environment=production` |
+
+Bare `sira-donnia.org` is a **parked domain** (root → `/lander` → search-network redirect). Never use it as a target. Staging path uses a different domain entirely.
+
+---
+
+## How to deploy
+
+### Staging (automatic)
+
+```bash
+git push origin main      # triggers .github/workflows/deploy.yml on main
+```
+
+CI runs: lint + test + build → push images to ghcr.io → SSH to staging → `docker compose pull && docker compose up -d`. Watch the run: `gh run watch` (per memory `feedback_deploy_speed.md`: don't block on it; check status once and move on).
+
+### Production (manual)
+
+```bash
+gh workflow run deploy.yml -f environment=production
+```
+
+Per memory `feedback_never_prod_without_green_staging.md`: only invoke production deploy when:
+1. The change has been on staging for at least one validated test cycle,
+2. An authenticated smoke against staging has passed (the persona suite at minimum),
+3. Someone explicitly typed the word "prod" — `deploy` alone always means staging.
+
+Or use `make prod-deploy` (a thin wrapper, see [Makefile prod-* targets](#makefile-prod--targets)).
+
+### What CI does NOT do (yet)
+
+- **No SHA pinning** — images use `:latest` tag. A subsequent deploy can silently move `:latest`. **#2119 will fix this** by digest-pinning.
+- **No pre-deploy DB backup** — if a migration drops a column wrongly, restoring is a manual restore-from-yesterday's pgdump. **#2119 will add a pre-deploy snapshot.**
+- **No post-deploy smoke gate** — once images deploy, CI considers the job done. The hourly prod smoke (#2118) catches breakage but with up to 60-minute latency. **#2119 will add a post-deploy synchronous smoke that gates the deploy.**
+
+Until #2119 lands, the operator is the safety net: watch the prod-smoke channel after every deploy.
+
+---
+
+## Rollback
+
+Today (pre-#2119): manual.
+
+```bash
+ssh deploy@94.250.201.110
+cd /home/deploy/etutor
+# Identify the previous good image digest from your local notes / Slack:
+# the deploy.yml workflow log lists `docker pull ghcr.io/.../backend@sha256:...`
+docker compose pull backend:<previous-tag>     # if you know the tag
+docker compose up -d backend
+# Or the nuclear option: pull a specific known-good ghcr.io tag for ALL services
+# and recreate the whole compose stack.
+```
+
+After #2119 lands: `make prod-rollback` will fetch the previously-pinned digest from a recorded artifact and redeploy that.
+
+---
+
+## Backup + restore
+
+Today (pre-#2119): on the prod host, a manual pgdump:
+
+```bash
+ssh deploy@94.250.201.110
+cd /home/deploy/etutor
+docker compose exec -T postgres pg_dump -U postgres santepublique_aof | \
+  gzip > backups/pre-manual-$(date +%Y%m%d-%H%M).sql.gz
+```
+
+After #2119 lands:
+- Pre-deploy snapshot is automatic (workflow step).
+- Daily cron snapshot to off-host storage.
+- `make prod-backup` for ad-hoc; `make prod-restore-drill` for verification.
+
+Until then, **before any DB-mutating PR ships to prod**, run the manual pgdump above and copy it off-host (e.g. `scp deploy@94.250.201.110:.../*.sql.gz ./local/`).
+
+---
+
+## Smoke is RED, what now?
+
+The hourly cron (`.github/workflows/prod-smoke.yml`) will have already opened or commented on a tracking issue titled `[prod-smoke] Hourly smoke is RED on app.sira-donnia.org`. Each red run downloads the Playwright HTML report + traces as a workflow artifact (30-day retention).
+
+**Triage order** (5-minute time budget; escalate if exceeded):
+
+1. **Open the workflow run** linked from the tracking issue.
+2. **Check Sentry** — `https://sentry.io/organizations/sira/projects/sira-prod/` (DSN in `.env.prod.example`). Spike in 5xx? Auth-bypass spike? That's the headline cause.
+3. **Check PostHog** — top-of-funnel events still firing? If `/dashboard` traffic dropped to zero, the FE is broken at routing level, not at the smoked endpoint.
+4. **Check Traefik logs**:
+   ```bash
+   ssh deploy@94.250.201.110
+   docker logs etutor-traefik --tail 200
+   ```
+   404 storms = a service container down. Connection refused = a backend container down.
+5. **Check service container status**:
+   ```bash
+   docker compose ps
+   docker logs etutor-backend --tail 200
+   docker logs etutor-frontend --tail 200
+   ```
+6. **If a recent deploy is the suspect**: rollback (see above). Don't waste time forensics on a known-failing release; restore service first, dig later.
+
+Categories:
+- **Real prod regression** → file a fix issue, link to the tracking issue, **leave the tracking issue open** until the smoke is green for 24h.
+- **Transient (network blip, GH Actions runner flake)** → close with a `transient` label.
+- **Known fixme** (currently `/sw.js` 404 pending #2113 deploy) — mentioned in the smoke spec; don't open a new tracking issue for these.
+
+---
+
+## Makefile prod-* targets
+
+Thin wrappers around `gh workflow run` + SSH. Run from the repo root.
+
+```bash
+make prod-deploy           # gh workflow run deploy.yml -f environment=production
+make prod-status           # SSH to prod, docker compose ps + recent logs
+make prod-rollback         # (pending #2119) — restore previous-pinned image digest
+make prod-backup           # (pending #2119) — manual pgdump + scp off-host
+make prod-restore-drill    # (pending #2119) — restore latest backup into a side schema
+make prod-smoke            # gh workflow run prod-smoke.yml --ref main (manual smoke)
+```
+
+`prod-rollback`, `prod-backup`, `prod-restore-drill` print a `# TODO(#2119)` notice today; #2119 fills them in.
+
+---
+
+## Required GitHub Actions secrets
+
+These must be set on the repo for CI + deploy to work. Verify with `gh secret list`.
+
+| Secret | Used by | Purpose |
+|---|---|---|
+| `GHCR_TOKEN` | `deploy.yml` | Push images to `ghcr.io` |
+| `DEPLOY_KEY_STAGING` | `deploy.yml` | SSH key to `deploy@167.86.115.58` |
+| `DEPLOY_KEY_PRODUCTION` | `deploy.yml` | SSH key to `deploy@94.250.201.110` |
+| `E2E_LEARNER_PASSWORD` | `ci.yml` (#2117) | Persona suite — staging fixture (set 2026-05-01) |
+| `E2E_ORG_OWNER_PASSWORD` | `ci.yml` (#2117) | Same |
+| `E2E_SUB_ADMIN_PASSWORD` | `ci.yml` (#2117) | Same |
+| `E2E_ADMIN_PASSWORD` | `ci.yml` (#2117) | Same |
+
+Tokens for paid APIs (Anthropic, OpenAI, HeyGen) are managed *on the server's `.env`*, not as GH Actions secrets — CI never touches them.
+
+---
+
+## Common operations
+
+### Tail prod backend logs
+```bash
+ssh deploy@94.250.201.110 'cd /home/deploy/etutor && docker compose logs -f --tail=100 backend'
+```
+
+### Restart a stuck container
+```bash
+ssh deploy@94.250.201.110 'cd /home/deploy/etutor && docker compose restart celery-worker'
+```
+
+### Run an Alembic migration manually on prod
+```bash
+ssh deploy@94.250.201.110 'cd /home/deploy/etutor && docker compose exec backend uv run alembic upgrade head'
+```
+Per memory `feedback_never_prod_without_green_staging`: don't do this without staging-validation first.
+
+### One-off Python in the backend container
+```bash
+ssh deploy@94.250.201.110 \
+  'cd /home/deploy/etutor && docker compose exec backend /app/.venv/bin/python -c "..."'
+```
+
+---
+
+## Memory references
+
+The following memory entries are load-bearing for prod operations — read them before deviating from the patterns above:
+
+- `production_server.md` — IP, domains, Traefik routing
+- `deployment_server.md` — staging server details
+- `server_architecture.md` — CI/CD pipeline shape
+- `prod_etutor_shared_infra.md` — never stop the shared infra trio
+- `feedback_never_prod_without_green_staging.md` — prod-deploy gate
+- `feedback_paid_external_apis.md` — don't burn HeyGen/Anthropic/OpenAI on validation re-runs
+- `feedback_no_main_branch.md` — never `git checkout main`; let automation handle main
+- `feedback_no_manual_merge.md` — never `gh pr merge` from CLI
+- `repo_merge_methods.md` — main requires `--squash`, dev uses `--merge`
+
+---
+
+## What's next (out of scope for this PR)
+
+- **#2119** — deploy hardening (SHA pinning, pre-deploy backup, post-deploy smoke gate, auto-rollback). Will fill in the `# TODO(#2119)` placeholders in this doc + Makefile.
+- **#2120** — observability audit (Sentry/PostHog instrumentation gaps). Will add explicit alert thresholds to this doc.
+- **#2121** — Lighthouse CI gate. Will add `make perf-baseline` and threshold reference.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .PHONY: dev-infra dev-infra-down backend-install backend-dev backend-lint backend-test \
        backend-celery-worker backend-celery-beat backend-celery-flower \
        frontend-install frontend-dev frontend-lint frontend-test \
-       db-migrate db-revision lint test
+       db-migrate db-revision lint test \
+       prod-deploy prod-status prod-rollback prod-backup prod-restore-drill prod-smoke
 
 # Infrastructure
 dev-infra:
@@ -56,3 +57,37 @@ db-revision:
 lint: backend-lint frontend-lint
 
 test: backend-test frontend-test
+
+# Production operations — see DEPLOY.md for full context.
+PROD_HOST=deploy@94.250.201.110
+PROD_DIR=/home/deploy/etutor
+
+prod-deploy:
+	gh workflow run deploy.yml -f environment=production
+	@echo "Dispatched. Watch with: gh run watch  (or check the Actions tab)"
+
+prod-status:
+	ssh $(PROD_HOST) 'cd $(PROD_DIR) && docker compose ps && echo "---" && docker compose logs --tail=20'
+
+prod-smoke:
+	gh workflow run prod-smoke.yml --ref main
+	@echo "Manual smoke dispatched. Tail with: gh run watch"
+
+prod-rollback:
+	@echo "TODO(#2119): record previous-pinned digest in deploy.yml, fetch + redeploy here."
+	@echo "  Today: ssh $(PROD_HOST), docker compose pull <previous-tag>, docker compose up -d."
+	@echo "  See DEPLOY.md > Rollback section."
+	@false
+
+prod-backup:
+	@echo "TODO(#2119): automated pgdump + scp off-host. For now do it manually:"
+	@echo "  ssh $(PROD_HOST)"
+	@echo "  cd $(PROD_DIR)"
+	@echo "  docker compose exec -T postgres pg_dump -U postgres santepublique_aof | gzip > backups/manual-\$$(date +%Y%m%d-%H%M).sql.gz"
+	@echo "  scp deploy@host:.../*.sql.gz off-host-storage/"
+	@false
+
+prod-restore-drill:
+	@echo "TODO(#2119): restore the latest backup into a side schema and validate."
+	@echo "  See DEPLOY.md > Backup + restore."
+	@false


### PR DESCRIPTION
Promotes #2160 (merged to dev as 06f108e7) to main via cherry-pick of the runbook commit. 4 files: DEPLOY.md (new, +227), .env.prod.example (new, +98), Makefile (+34/-1, six prod-* targets), CLAUDE.md (+1/-1, link to DEPLOY.md). Fixes #2122. Closes #1744 as superseded.%n%n🤖 Generated with [Claude Code](https://claude.com/claude-code)