### PR TITLE
merge dev → main: Playwright suite scaffolding (#2116-1) (#2153)

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -43,3 +43,4 @@ next-env.d.ts
 # Playwright
 test-results/
 playwright-report/
+e2e/.auth/

--- a/frontend/e2e/auth.setup.ts
+++ b/frontend/e2e/auth.setup.ts
@@ -1,0 +1,87 @@
+/**
+ * Setup project — runs once before persona projects to populate
+ * `e2e/.auth/{persona}.json` storage states. Each persona project then loads
+ * its file via `storageState` so specs start pre-authed without per-test login
+ * round-trips.
+ *
+ * Strategy:
+ *   1. POST /api/v1/auth/login-password (verified working on staging
+ *      against e2e-* fixtures from issue #2109).
+ *   2. Open the app once so localStorage gets origin-bound.
+ *   3. Inject access_token + refresh_token + user object into localStorage
+ *      (the FE expects them there per its current auth client).
+ *   4. Save context state (cookies + localStorage) to .auth/{persona}.json.
+ *
+ * Future TOTP variant: replace step 1 with the speakeasy.totp pattern proven
+ * in production-uat.spec.ts. Out of scope for #2116-1 (password-only).
+ */
+
+import { test as setup } from '@playwright/test';
+import path from 'node:path';
+
+import { applyAuthToLocalStorage, loginViaApi, PERSONAS, type Persona } from './fixtures/auth';
+
+const STAGING_URL =
+  process.env.STAGING_URL ?? 'https://etutor.elearning.portfolio2.kimbetien.com';
+
+const AUTH_DIR = path.resolve(__dirname, '.auth');
+
+async function authenticatePersona(
+  page: Parameters<Parameters<typeof setup>[1]>[0]['page'],
+  persona: Persona,
+): Promise<void> {
+  // Establish the origin context FIRST so localStorage can be bound to it.
+  await page.goto(`${STAGING_URL}/fr/login`, { waitUntil: 'domcontentloaded' });
+
+  // Login via the *page's* request context — Set-Cookie headers populate
+  // the same context the browser uses, so the HttpOnly refresh cookie
+  // carries through. Using the standalone `request` fixture would create a
+  // separate cookie jar and the page would see no auth.
+  const login = await loginViaApi(page.request, STAGING_URL, persona);
+
+  // The FE's apiFetch reads access_token from localStorage too — set both.
+  await applyAuthToLocalStorage(page, login);
+
+  await page.context().storageState({ path: path.join(AUTH_DIR, `${persona}.json`) });
+}
+
+// One setup test per persona — Playwright runs them in parallel within the
+// `setup` project, then any project that depends on `setup` runs after all
+// of them succeed.
+//
+// 2116-1 only consumes the `learner` storageState (canary spec). Future PRs
+// (2116-2..2116-4) consume the others. Generating all 4 here keeps the
+// setup self-contained.
+
+setup('authenticate as learner', async ({ page }) => {
+  await authenticatePersona(page, 'learner');
+});
+
+setup('authenticate as org-owner', async ({ page }) => {
+  await authenticatePersona(page, 'org-owner');
+});
+
+setup('authenticate as sub-admin', async ({ page }) => {
+  await authenticatePersona(page, 'sub-admin');
+});
+
+setup('authenticate as admin', async ({ page }) => {
+  await authenticatePersona(page, 'admin');
+});
+
+// Smoke check: env vars present for at least the persona we exercise in this
+// PR's canary. Throwing here early (rather than mid-test) gives a clearer
+// failure message about missing GH Actions secrets.
+setup('env vars present', () => {
+  const required = ['E2E_LEARNER_PASSWORD'];
+  for (const name of required) {
+    if (!process.env[name]) {
+      throw new Error(
+        `${name} is not set. For local runs: export it before running. ` +
+          `For CI: add it to GitHub Actions secrets (already done 2026-05-01 — verify with \`gh secret list\`).`,
+      );
+    }
+  }
+  // Touch PERSONAS so unused-import warnings don't fire on this single setup.
+  void PERSONAS;
+});

--- a/frontend/e2e/auth.setup.ts
+++ b/frontend/e2e/auth.setup.ts
@@ -16,7 +16,7 @@
  * in production-uat.spec.ts. Out of scope for #2116-1 (password-only).
  */
 
-import { test as setup } from '@playwright/test';
+import { test as setup, type Page } from '@playwright/test';
 import path from 'node:path';
 
 import { applyAuthToLocalStorage, loginViaApi, PERSONAS, type Persona } from './fixtures/auth';
@@ -26,10 +26,7 @@ const STAGING_URL =
 
 const AUTH_DIR = path.resolve(__dirname, '.auth');
 
-async function authenticatePersona(
-  page: Parameters<Parameters<typeof setup>[1]>[0]['page'],
-  persona: Persona,
-): Promise<void> {
+async function authenticatePersona(page: Page, persona: Persona): Promise<void> {
   // Establish the origin context FIRST so localStorage can be bound to it.
   await page.goto(`${STAGING_URL}/fr/login`, { waitUntil: 'domcontentloaded' });
 

--- a/frontend/e2e/fixtures/auth.ts
+++ b/frontend/e2e/fixtures/auth.ts
@@ -1,0 +1,106 @@
+/**
+ * Auth helpers for the persona-based Playwright suite.
+ *
+ * The setup project (e2e/auth.setup.ts) calls `loginAndSaveState()` once per
+ * persona to populate `e2e/.auth/{persona}.json` with cookies + localStorage.
+ * Each persona's project loads that storage state so specs start pre-authed.
+ *
+ * Auth endpoint: POST /api/v1/auth/login-password
+ * Request:  { identifier: string, password: string }
+ * Response: { access_token, refresh_token, token_type, expires_in, user }
+ *
+ * Verified against staging on 2026-05-01 with the e2e-* fixture accounts
+ * seeded by backend/scripts/seed_e2e_users.py (issue #2109).
+ */
+
+import type { Page, APIRequestContext } from '@playwright/test';
+
+export type Persona = 'learner' | 'org-owner' | 'sub-admin' | 'admin';
+
+export interface PersonaCredentials {
+  email: string;
+  passwordEnvVar: string;
+}
+
+export const PERSONAS: Record<Persona, PersonaCredentials> = {
+  'learner': {
+    email: 'e2e-learner@sira-test.local',
+    passwordEnvVar: 'E2E_LEARNER_PASSWORD',
+  },
+  'org-owner': {
+    email: 'e2e-org-owner@sira-test.local',
+    passwordEnvVar: 'E2E_ORG_OWNER_PASSWORD',
+  },
+  'sub-admin': {
+    email: 'e2e-sub-admin@sira-test.local',
+    passwordEnvVar: 'E2E_SUB_ADMIN_PASSWORD',
+  },
+  'admin': {
+    email: 'e2e-admin@sira-test.local',
+    passwordEnvVar: 'E2E_ADMIN_PASSWORD',
+  },
+};
+
+export function getPasswordForPersona(persona: Persona): string {
+  const { passwordEnvVar, email } = PERSONAS[persona];
+  const pwd = process.env[passwordEnvVar];
+  if (!pwd) {
+    throw new Error(
+      `Missing env var ${passwordEnvVar}. Set it locally before running, or in GitHub Actions secrets for CI. ` +
+        `Account: ${email}. See backend/scripts/seed_e2e_users.py manifest (issue #2109).`,
+    );
+  }
+  return pwd;
+}
+
+export interface LoginResponse {
+  access_token: string;
+  refresh_token: string;
+  token_type: string;
+  expires_in: number;
+  user: {
+    id: string;
+    email: string;
+    name: string;
+    role: string;
+    preferred_language: string;
+    country: string | null;
+    current_level: number;
+  };
+}
+
+/**
+ * POST credentials to the staging auth endpoint and return the JSON body.
+ * Throws on any non-2xx response.
+ */
+export async function loginViaApi(
+  request: APIRequestContext,
+  baseURL: string,
+  persona: Persona,
+): Promise<LoginResponse> {
+  const { email } = PERSONAS[persona];
+  const password = getPasswordForPersona(persona);
+  const res = await request.post(`${baseURL}/api/v1/auth/login-password`, {
+    data: { identifier: email, password },
+  });
+  if (!res.ok()) {
+    const body = await res.text();
+    throw new Error(
+      `login-password failed for ${persona} (${email}): ${res.status()} ${body.slice(0, 200)}`,
+    );
+  }
+  return (await res.json()) as LoginResponse;
+}
+
+/**
+ * Populate localStorage with the tokens + user object the FE expects after
+ * password login. Idempotent — overwrites any existing keys.
+ */
+export async function applyAuthToLocalStorage(page: Page, login: LoginResponse): Promise<void> {
+  await page.evaluate((data) => {
+    localStorage.setItem('access_token', data.access_token);
+    localStorage.setItem('refresh_token', data.refresh_token);
+    localStorage.setItem('user', JSON.stringify(data.user));
+    localStorage.setItem('preferred-locale', data.user.preferred_language ?? 'fr');
+  }, login);
+}

--- a/frontend/e2e/fixtures/seed-data.ts
+++ b/frontend/e2e/fixtures/seed-data.ts
@@ -1,0 +1,67 @@
+/**
+ * Known fixture IDs and slugs from the staging seed.
+ *
+ * Source of truth: backend/scripts/seed_e2e_users.py (issue #2109).
+ * UUIDs captured from the staging dry-run on 2026-05-01.
+ *
+ * If the seed is re-run on a fresh DB, IDs change — but slugs/codes are stable.
+ * Specs should prefer slug/code matching over UUID matching where possible.
+ */
+
+export const SEED_ORG = {
+  slug: 'e2e-test-org',
+  name: 'E2E Test Org',
+  // staging UUID (captured 2026-05-01) — informational, prefer slug
+  id: '9a25da22-f4a3-44a6-aa3c-40a533e0bf51',
+} as const;
+
+export const SEED_COURSES = {
+  published: {
+    slug: 'e2e-published-course',
+    id: 'a611148d-cf61-4262-9282-e47eb81fcb16',
+  },
+  draft: {
+    slug: 'e2e-draft-course',
+    id: '849fac54-0a23-4702-bf1f-0236d9d65bd0',
+  },
+} as const;
+
+export const SEED_CURRICULA = {
+  public: {
+    slug: 'e2e-public-curriculum',
+    id: 'a1ac32e1-0897-4b4b-aabe-816b7ad9578a',
+  },
+  private: {
+    slug: 'e2e-private-curriculum',
+    id: 'edc4b664-8e72-4be0-bfdb-f6a45082fdea',
+  },
+} as const;
+
+export const SEED_ACTIVATION_CODE = 'E2E-FIXTURE-CODE';
+
+/**
+ * The 9 sidebar links a plain `role=user` learner with no org membership
+ * should see. Used by 02-learner/dashboard.spec.ts as the canary assertion
+ * for role-scoped navigation.
+ *
+ * NOTE: localized labels — these are the FR strings. EN counterparts live
+ * in messages/en.json under the same Navigation namespace.
+ */
+export const LEARNER_SIDEBAR_LINKS_FR = [
+  'Dashboard',
+  'Formations',
+  'Modules',
+  'Flashcards',
+  'Tests de révision',
+  'Certificats',
+  'Tuteur IA',
+  'Profil',
+  'Abonnement',
+] as const;
+
+/** Links that must NOT appear for a plain learner (role-scoped UI gating). */
+export const LEARNER_HIDDEN_LINKS_FR = [
+  'Administration',
+  'Organisations',
+  'Banques de questions',
+] as const;

--- a/frontend/e2e/pages/dashboard-page.ts
+++ b/frontend/e2e/pages/dashboard-page.ts
@@ -1,0 +1,47 @@
+/**
+ * Page object for /[locale]/dashboard.
+ *
+ * Thin wrapper — locators only for the elements canary specs need to assert on.
+ */
+
+import type { Locator, Page } from '@playwright/test';
+
+export class DashboardPage {
+  constructor(public readonly page: Page) {}
+
+  async goto(locale: 'fr' | 'en' = 'fr'): Promise<void> {
+    await this.page.goto(`/${locale}/dashboard`);
+  }
+
+  heading(): Locator {
+    return this.page.getByRole('heading', { name: /^dashboard$/i, level: 1 });
+  }
+
+  /** Desktop sidebar — the primary nav role on this page. */
+  sidebar(): Locator {
+    return this.page.getByRole('navigation', { name: /navigation de bureau|desktop navigation/i });
+  }
+
+  /**
+   * Returns a locator for a sidebar link by its visible label text.
+   *
+   * NOTE: cannot use `getByRole('link', { name })` here — the sidebar links
+   * have descriptive aria-labels (e.g. "Accéder à votre tableau de bord
+   * d'apprentissage" for the Dashboard link) whose role-name doesn't match
+   * the visible label "Dashboard". Match by visible text instead.
+   */
+  sidebarLink(text: string): Locator {
+    return this.sidebar().locator('a', { hasText: new RegExp(`^${escapeRegex(text)}$`) });
+  }
+
+  /** Returns the visible link texts in order, deduped, empty strings filtered. */
+  async sidebarLinkTexts(): Promise<string[]> {
+    const links = await this.sidebar().locator('a').all();
+    const texts = await Promise.all(links.map((l) => l.textContent()));
+    return texts.map((t) => (t ?? '').trim()).filter((t) => t.length > 0);
+  }
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/frontend/e2e/pages/login-page.ts
+++ b/frontend/e2e/pages/login-page.ts
@@ -1,0 +1,42 @@
+/**
+ * Page object for /[locale]/login.
+ *
+ * Thin wrapper — exposes locators + a couple of high-level actions.
+ * No service-layer abstraction.
+ */
+
+import type { Locator, Page } from '@playwright/test';
+
+export class LoginPage {
+  constructor(public readonly page: Page) {}
+
+  async goto(locale: 'fr' | 'en' = 'fr'): Promise<void> {
+    await this.page.goto(`/${locale}/login`);
+  }
+
+  identifierInput(): Locator {
+    return this.page.locator('input[name="identifier"]');
+  }
+
+  passwordInput(): Locator {
+    return this.page.locator('input[name="password"]');
+  }
+
+  submitButton(): Locator {
+    return this.page.locator('button[type="submit"]', { hasText: /se connecter|sign in/i });
+  }
+
+  forgotPasswordLink(): Locator {
+    return this.page.getByRole('link', { name: /mot de passe oublié|forgot password/i });
+  }
+
+  /** "S'inscrire" / "Sign up" link — only renders when registration is enabled. */
+  signupLink(): Locator {
+    return this.page.getByRole('link', { name: /^s'inscrire$|^sign up$/i });
+  }
+
+  /** Toggle to the TOTP-only login view. */
+  totpModeButton(): Locator {
+    return this.page.getByRole('button', { name: /application d'authentification|authenticator/i });
+  }
+}

--- a/frontend/e2e/specs/01-anonymous/login-form.spec.ts
+++ b/frontend/e2e/specs/01-anonymous/login-form.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Anonymous canary — verifies the login page renders correctly without auth.
+ *
+ * This is the one anonymous-persona spec in #2116-1. Other anonymous flows
+ * (catalog browse, curricula, about page, register flow end-to-end) come in
+ * follow-up PRs.
+ *
+ * The "S'inscrire" link assertion is a regression sentinel for the
+ * `auth-self-registration-enabled` setting flag (verified TRUE on staging
+ * 2026-04-30). If the flag flips to false on staging, this spec fails —
+ * intentional drift detection per F-001 in the sweep doc.
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { LoginPage } from '../../pages/login-page';
+
+test.describe('@anonymous login form', () => {
+  test('renders identifier + password fields and submit button', async ({ page }) => {
+    const login = new LoginPage(page);
+    await login.goto('fr');
+
+    await expect(login.identifierInput()).toBeVisible();
+    await expect(login.passwordInput()).toBeVisible();
+    await expect(login.submitButton()).toBeVisible();
+  });
+
+  test('shows "Mot de passe oublié ?" link to /fr/magic-link', async ({ page }) => {
+    const login = new LoginPage(page);
+    await login.goto('fr');
+
+    const forgot = login.forgotPasswordLink();
+    await expect(forgot).toBeVisible();
+    await expect(forgot).toHaveAttribute('href', '/fr/magic-link');
+  });
+
+  test('shows "S\'inscrire" link when self-registration is enabled (drift sentinel)', async ({
+    page,
+  }) => {
+    const login = new LoginPage(page);
+    await login.goto('fr');
+
+    // Gated by `auth-self-registration-enabled` setting on the backend.
+    // Verified TRUE on staging 2026-04-30. If staging flips it off, this
+    // spec fails by design — see F-001 in docs/qa/sweep-2026-04-28.md.
+    await expect(login.signupLink()).toBeVisible();
+    await expect(login.signupLink()).toHaveAttribute('href', /\/register-options$/);
+  });
+
+  test('toggles into TOTP-only mode when authenticator button clicked', async ({ page }) => {
+    const login = new LoginPage(page);
+    await login.goto('fr');
+
+    await login.totpModeButton().click();
+
+    // TOTP mode shows email + 6-digit code fields, no password field.
+    await expect(page.getByLabel(/code d'authentification|authentication code/i)).toBeVisible();
+    await expect(login.passwordInput()).toHaveCount(0);
+  });
+});

--- a/frontend/e2e/specs/02-learner/dashboard.spec.ts
+++ b/frontend/e2e/specs/02-learner/dashboard.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * Learner canary — verifies the dashboard renders with role-scoped sidebar.
+ *
+ * Pre-authed via the `setup` project (e2e/auth.setup.ts) which writes
+ * `e2e/.auth/learner.json` with the e2e-learner@sira-test.local fixture's
+ * tokens. The 02-learner project loads that storageState.
+ *
+ * Critical regression bar: the sidebar should hide admin/orgs/qbank-author
+ * links for `role=user`. Server-side RBAC was independently verified during
+ * the 2026-04-30 sweep — this spec catches frontend nav-gating regressions
+ * specifically.
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { DashboardPage } from '../../pages/dashboard-page';
+import { LEARNER_HIDDEN_LINKS_FR, LEARNER_SIDEBAR_LINKS_FR } from '../../fixtures/seed-data';
+
+test.describe('@learner dashboard', () => {
+  test('renders the Dashboard heading', async ({ page }) => {
+    const dashboard = new DashboardPage(page);
+    await dashboard.goto('fr');
+
+    await expect(dashboard.heading()).toBeVisible();
+  });
+
+  test('sidebar shows the 9 learner links and hides admin/orgs/qbank-author', async ({ page }) => {
+    const dashboard = new DashboardPage(page);
+    await dashboard.goto('fr');
+
+    // Each expected link must be visible.
+    for (const label of LEARNER_SIDEBAR_LINKS_FR) {
+      await expect(
+        dashboard.sidebarLink(label),
+        `expected sidebar link "${label}" to be visible for a role=user learner`,
+      ).toBeVisible();
+    }
+
+    // Each hidden link must NOT exist.
+    for (const label of LEARNER_HIDDEN_LINKS_FR) {
+      await expect(
+        dashboard.sidebarLink(label),
+        `expected sidebar link "${label}" to be hidden for a role=user learner (RBAC regression)`,
+      ).toHaveCount(0);
+    }
+  });
+
+  test('sidebar link count matches the expected learner set exactly', async ({ page }) => {
+    const dashboard = new DashboardPage(page);
+    await dashboard.goto('fr');
+
+    const visibleLinks = await dashboard.sidebarLinkTexts();
+    // Filter to only the LEARNER_SIDEBAR_LINKS_FR expected set + any others —
+    // we don't want to fail on incidental nav additions, but we do want to
+    // catch role-leak (e.g., "Administration" silently appearing).
+    const unexpectedRoleScopedLinks = visibleLinks.filter((label) =>
+      (LEARNER_HIDDEN_LINKS_FR as readonly string[]).includes(label),
+    );
+    expect(
+      unexpectedRoleScopedLinks,
+      `unexpected role-scoped links visible to learner: ${unexpectedRoleScopedLinks.join(', ')}`,
+    ).toEqual([]);
+  });
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,6 +1,27 @@
 import { defineConfig, devices } from '@playwright/test';
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+const STAGING_URL =
+  process.env.STAGING_URL || 'https://etutor.elearning.portfolio2.kimbetien.com';
+
+// Persona projects (#2116) authenticate via auth.setup.ts and load the saved
+// storageState file. New specs go under e2e/specs/{persona}/. Old flat specs
+// in e2e/*.spec.ts continue to run under chromium/mobile-chrome projects below.
+const personaProject = (name: string) => ({
+  name,
+  testDir: `./e2e/specs/${name}`,
+  use: {
+    ...devices['Desktop Chrome'],
+    baseURL: STAGING_URL,
+    storageState: name === '01-anonymous' ? undefined : `./e2e/.auth/${personaToFile(name)}`,
+  },
+  dependencies: name === '01-anonymous' ? [] : ['setup'],
+});
+
+function personaToFile(projectName: string): string {
+  // '02-learner' → 'learner.json'; '03-org-owner' → 'org-owner.json'
+  return `${projectName.replace(/^\d+-/, '')}.json`;
+}
 
 export default defineConfig({
   testDir: './e2e',
@@ -19,14 +40,32 @@ export default defineConfig({
   },
 
   projects: [
+    // Existing flat specs — unchanged. Keep running against BASE_URL until
+    // they're migrated or retired (cleanup follow-up to #2116).
     {
       name: 'chromium',
+      testIgnore: ['**/specs/**', '**/auth.setup.ts'],
       use: { ...devices['Desktop Chrome'] },
     },
     {
       name: 'mobile-chrome',
+      testIgnore: ['**/specs/**', '**/auth.setup.ts'],
       use: { ...devices['Pixel 5'] },
     },
+
+    // Persona-based suite (#2116). The setup project authenticates each
+    // persona via /api/v1/auth/login-password and saves storageState files
+    // under e2e/.auth/. Each persona project loads its file so specs start
+    // pre-authed. .auth/ is gitignored.
+    {
+      name: 'setup',
+      testMatch: /auth\.setup\.ts$/,
+      use: { baseURL: STAGING_URL },
+    },
+    personaProject('01-anonymous'),
+    personaProject('02-learner'),
+    // 03-org-owner / 04-sub-admin / 05-admin: declared in follow-up PRs
+    // (2116-2..2116-4) once their spec dirs exist.
   ],
 
   webServer:


### PR DESCRIPTION
Promotes #2153 (merged to dev as 44ea8ba7) to main via cherry-pick of the 2 content commits onto a fresh sync branch. 9 files: playwright.config + auth.setup + auth/seed-data fixtures + login/dashboard page objects + 2 canary spec files. PR 1 of 5 for issue #2116. CI green on dev-side PR.%n%n🤖 Generated with [Claude Code](https://claude.com/claude-code)