### PR TITLE
feat(quality): unit-detail review page (#2249, step 3)

### DIFF
--- a/frontend/app/[locale]/admin/courses/[courseId]/quality/runs/[runId]/units/[contentId]/page.tsx
+++ b/frontend/app/[locale]/admin/courses/[courseId]/quality/runs/[runId]/units/[contentId]/page.tsx
@@ -1,0 +1,44 @@
+import { getTranslations } from "next-intl/server";
+import { UnitQualityClient } from "@/components/admin/quality/unit-quality-client";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{
+    locale: string;
+    courseId: string;
+    runId: string;
+    contentId: string;
+  }>;
+}) {
+  await params;
+  const t = await getTranslations("Admin.qualityAgent");
+  return {
+    title: t("unit.pageTitle"),
+    description: t("unit.pageDescription"),
+  };
+}
+
+export default async function AdminUnitQualityPage({
+  params,
+}: {
+  params: Promise<{
+    locale: string;
+    courseId: string;
+    runId: string;
+    contentId: string;
+  }>;
+}) {
+  const { courseId, contentId } = await params;
+  const t = await getTranslations("Admin.qualityAgent");
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <div className="border-b bg-background p-4 shrink-0">
+        <h1 className="text-2xl font-bold">{t("unit.pageTitle")}</h1>
+        <p className="text-muted-foreground mt-1">{t("unit.pageDescription")}</p>
+      </div>
+      <UnitQualityClient courseId={courseId} contentId={contentId} />
+    </div>
+  );
+}

--- a/frontend/components/admin/quality/dimension-bars.tsx
+++ b/frontend/components/admin/quality/dimension-bars.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { cn } from "@/lib/utils";
+import {
+  DIMENSION_KEYS,
+  DIMENSION_WEIGHTS,
+  type DimensionKey,
+  type DimensionScores,
+} from "@/lib/api-quality";
+
+function fillFor(score: number) {
+  if (score >= 90) return "bg-green-500 dark:bg-green-500/80";
+  if (score >= 70) return "bg-amber-500 dark:bg-amber-500/80";
+  return "bg-red-500 dark:bg-red-500/80";
+}
+
+export function DimensionBars({
+  scores,
+}: {
+  scores: DimensionScores | null;
+}) {
+  const t = useTranslations("Admin.qualityAgent");
+  const tDim = useTranslations("Admin.qualityAgent.dimensions");
+
+  if (!scores) {
+    return (
+      <div
+        className="rounded-md border bg-muted/20 p-6 text-center text-sm text-muted-foreground"
+        role="note"
+      >
+        {t("unit.notAssessed")}
+      </div>
+    );
+  }
+
+  return (
+    <ul className="space-y-3">
+      {DIMENSION_KEYS.map((key: DimensionKey) => {
+        const score = scores[key];
+        const weight = DIMENSION_WEIGHTS[key];
+        const clamped = Math.max(0, Math.min(100, score));
+        return (
+          <li key={key} className="flex flex-col gap-1">
+            <div className="flex items-baseline justify-between gap-3 text-sm">
+              <span className="font-medium">{tDim(key)}</span>
+              <span className="text-xs text-muted-foreground tabular-nums">
+                {t("unit.weight", { weight })} · {Math.round(score)}
+              </span>
+            </div>
+            <div
+              className="h-2 w-full overflow-hidden rounded-full bg-muted"
+              role="progressbar"
+              aria-valuenow={clamped}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={tDim(key)}
+            >
+              <div
+                className={cn("h-full rounded-full transition-all", fillFor(clamped))}
+                style={{ width: `${clamped}%` }}
+              />
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/frontend/components/admin/quality/flag-list.tsx
+++ b/frontend/components/admin/quality/flag-list.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import type { FlagSeverity, QualityFlag } from "@/lib/api-quality";
+
+const SEVERITY_ORDER: FlagSeverity[] = ["blocking", "high", "medium", "low"];
+
+const SEVERITY_VARIANT: Record<
+  FlagSeverity,
+  "default" | "secondary" | "destructive" | "outline"
+> = {
+  blocking: "destructive",
+  high: "destructive",
+  medium: "secondary",
+  low: "outline",
+};
+
+function groupBySeverity(flags: QualityFlag[]): Map<FlagSeverity, QualityFlag[]> {
+  const out = new Map<FlagSeverity, QualityFlag[]>();
+  for (const f of flags) {
+    const list = out.get(f.severity) ?? [];
+    list.push(f);
+    out.set(f.severity, list);
+  }
+  return out;
+}
+
+export function FlagList({ flags }: { flags: QualityFlag[] }) {
+  const t = useTranslations("Admin.qualityAgent");
+  const tCat = useTranslations("Admin.qualityAgent.flagCategory");
+  const tSev = useTranslations("Admin.qualityAgent.severity");
+
+  if (flags.length === 0) {
+    return (
+      <div className="rounded-md border bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+        {t("unit.noFlags")}
+      </div>
+    );
+  }
+
+  const grouped = groupBySeverity(flags);
+
+  return (
+    <div className="space-y-4">
+      {SEVERITY_ORDER.flatMap((sev) => {
+        const items = grouped.get(sev);
+        if (!items || items.length === 0) return [];
+        return [
+          <section key={sev} className="space-y-2">
+            <h3 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              <Badge variant={SEVERITY_VARIANT[sev]}>{tSev(sev)}</Badge>
+              <span>· {items.length}</span>
+            </h3>
+            <ul className="space-y-2">
+              {items.map((f, i) => (
+                <li key={`${sev}-${i}`}>
+                  <Card className="p-4">
+                    <div className="flex flex-wrap items-baseline justify-between gap-2">
+                      <span className="text-sm font-semibold">{tCat(f.category)}</span>
+                      <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
+                        {f.location}
+                      </code>
+                    </div>
+                    {f.evidence_unit_id && (
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {t("unit.crossUnitRef", { unit: f.evidence_unit_id })}
+                      </p>
+                    )}
+                    <p className="mt-2 text-sm">{f.description}</p>
+                    <pre className="mt-2 max-h-40 overflow-auto rounded bg-muted/50 p-2 font-mono text-xs whitespace-pre-wrap break-words">
+                      {f.evidence}
+                    </pre>
+                    <p className="mt-2 text-sm italic text-muted-foreground">
+                      <span className="font-medium not-italic">{t("unit.suggestedFix")}:</span>{" "}
+                      {f.suggested_fix}
+                    </p>
+                  </Card>
+                </li>
+              ))}
+            </ul>
+          </section>,
+        ];
+      })}
+    </div>
+  );
+}

--- a/frontend/components/admin/quality/unit-action-row.tsx
+++ b/frontend/components/admin/quality/unit-action-row.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import { resolveUnit, unlockUnit } from "@/lib/api-quality";
+
+export function UnitActionRow({
+  courseId,
+  contentId,
+  isLocked,
+  onResolved,
+  onUnlocked,
+}: {
+  courseId: string;
+  contentId: string;
+  isLocked: boolean;
+  onResolved?: () => void;
+  onUnlocked?: () => void;
+}) {
+  const t = useTranslations("Admin.qualityAgent");
+  const queryClient = useQueryClient();
+
+  const [resolveOpen, setResolveOpen] = useState(false);
+  const [note, setNote] = useState("");
+
+  const invalidateTree = () => {
+    queryClient.invalidateQueries({
+      queryKey: ["admin", "quality", courseId],
+    });
+  };
+
+  const resolveMut = useMutation({
+    mutationFn: () =>
+      resolveUnit(courseId, contentId, { note: note.trim() || null }),
+    onSuccess: () => {
+      invalidateTree();
+      setResolveOpen(false);
+      setNote("");
+      onResolved?.();
+    },
+  });
+
+  const unlockMut = useMutation({
+    mutationFn: () => unlockUnit(courseId, contentId),
+    onSuccess: () => {
+      invalidateTree();
+      onUnlocked?.();
+    },
+  });
+
+  const error = resolveMut.error ?? unlockMut.error;
+  const errorMessage =
+    error instanceof Error ? error.message : error ? String(error) : null;
+
+  return (
+    <div className="space-y-3 rounded-md border p-4">
+      <h3 className="text-sm font-semibold">{t("unit.actions.title")}</h3>
+
+      <div className="flex flex-wrap items-start gap-2">
+        {!resolveOpen ? (
+          <Button
+            type="button"
+            variant="default"
+            onClick={() => setResolveOpen(true)}
+            disabled={resolveMut.isPending}
+          >
+            {t("unit.actions.resolve")}
+          </Button>
+        ) : (
+          <div className="flex w-full max-w-xl flex-col gap-2">
+            <label htmlFor="resolve-note" className="text-sm font-medium">
+              {t("unit.actions.note")}
+            </label>
+            <textarea
+              id="resolve-note"
+              className="min-h-20 rounded-md border bg-background p-2 text-sm"
+              placeholder={t("unit.actions.notePlaceholder")}
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              maxLength={500}
+              disabled={resolveMut.isPending}
+            />
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                onClick={() => resolveMut.mutate()}
+                disabled={resolveMut.isPending}
+              >
+                {resolveMut.isPending ? (
+                  <>
+                    <Loader2 className="mr-2 size-4 animate-spin" />
+                    {t("unit.actions.submitting")}
+                  </>
+                ) : (
+                  t("unit.actions.resolveSubmit")
+                )}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setResolveOpen(false);
+                  setNote("");
+                  resolveMut.reset();
+                }}
+                disabled={resolveMut.isPending}
+              >
+                {t("unit.actions.cancel")}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {isLocked && !resolveOpen && (
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => unlockMut.mutate()}
+            disabled={unlockMut.isPending}
+          >
+            {unlockMut.isPending ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" />
+                {t("unit.actions.submitting")}
+              </>
+            ) : (
+              t("unit.actions.unlock")
+            )}
+          </Button>
+        )}
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        {isLocked ? t("unit.actions.helpLocked") : t("unit.actions.help")}
+      </p>
+
+      {errorMessage && (
+        <p className="text-sm text-destructive" role="alert">
+          {t("unit.actions.error")}: {errorMessage}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/admin/quality/unit-quality-client.tsx
+++ b/frontend/components/admin/quality/unit-quality-client.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft, Lock } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
+import { useQuery } from "@tanstack/react-query";
+import {
+  type UnitQualityDetail,
+  getUnitQualityDetail,
+} from "@/lib/api-quality";
+import { DimensionBars } from "./dimension-bars";
+import { FlagList } from "./flag-list";
+import { QualityStatusBadge } from "./quality-status-badge";
+import { ScorePill } from "./score-pill";
+import { UnitActionRow } from "./unit-action-row";
+
+function fmtDate(iso: string | null, locale: string): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString(locale, {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function UnitQualityClient({
+  courseId,
+  contentId,
+}: {
+  courseId: string;
+  contentId: string;
+}) {
+  const t = useTranslations("Admin.qualityAgent");
+  const locale = useLocale();
+
+  const detailQ = useQuery<UnitQualityDetail>({
+    queryKey: ["admin", "quality", courseId, "unit", contentId],
+    queryFn: () => getUnitQualityDetail(courseId, contentId),
+  });
+
+  if (detailQ.isLoading) {
+    return (
+      <p className="py-12 text-center text-sm text-muted-foreground">
+        {t("loading")}
+      </p>
+    );
+  }
+
+  if (detailQ.error) {
+    const msg =
+      detailQ.error instanceof Error ? detailQ.error.message : t("error");
+    return (
+      <p className="py-12 text-center text-sm text-destructive" role="alert">
+        {msg}
+      </p>
+    );
+  }
+
+  const detail = detailQ.data;
+  if (!detail) {
+    return (
+      <p className="py-12 text-center text-sm text-muted-foreground">
+        {t("noData")}
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-4">
+      <div className="flex flex-col gap-2">
+        <Link
+          href={`/admin/courses/${courseId}/quality`}
+          className="inline-flex w-fit items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="size-4" />
+          {t("unit.backToCourseQuality")}
+        </Link>
+        <div className="flex flex-wrap items-center gap-3">
+          <h2 className="text-xl font-bold">
+            {t("unit.headerLine", {
+              unit_number: detail.unit_number ?? "—",
+              type: detail.content_type,
+              language: detail.language.toUpperCase(),
+            })}
+          </h2>
+          <QualityStatusBadge status={detail.quality_status} />
+          <ScorePill score={detail.quality_score} />
+          {detail.regeneration_attempts > 0 && (
+            <span className="text-xs text-muted-foreground">
+              {t("unit.attempts", { count: detail.regeneration_attempts })}
+            </span>
+          )}
+          {detail.is_manually_edited && (
+            <span className="inline-flex items-center gap-1 rounded-md border border-amber-200 bg-amber-50 px-2 py-0.5 text-xs text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200">
+              <Lock className="size-3" aria-hidden="true" />
+              {t("unit.lockedShort")}
+            </span>
+          )}
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {t("unit.lastAssessed")}: {fmtDate(detail.quality_assessed_at, locale)}
+        </p>
+        {detail.is_manually_edited && (
+          <p className="text-sm text-amber-700 dark:text-amber-300" role="note">
+            {t("unit.locked")}
+          </p>
+        )}
+      </div>
+
+      <section>
+        <h3 className="mb-3 text-lg font-semibold">{t("unit.sections.dimensions")}</h3>
+        <DimensionBars scores={detail.dimension_scores} />
+      </section>
+
+      <section>
+        <h3 className="mb-3 text-lg font-semibold">
+          {t("unit.sections.flags", { count: detail.flag_count })}
+        </h3>
+        <FlagList flags={detail.quality_flags} />
+      </section>
+
+      <section>
+        <UnitActionRow
+          courseId={courseId}
+          contentId={contentId}
+          isLocked={detail.is_manually_edited}
+        />
+      </section>
+    </div>
+  );
+}

--- a/frontend/lib/api-quality.ts
+++ b/frontend/lib/api-quality.ts
@@ -220,6 +220,48 @@ export function getReviewQueue(opts?: {
   );
 }
 
+// ---- override mutations (admin/sub_admin/expert-owner only) ----
+
+export interface ResolveUnitResponse {
+  content_id: string;
+  quality_status: "passing";
+  note: string | null;
+}
+
+export interface UnlockUnitResponse {
+  content_id: string;
+  is_manually_edited: false;
+}
+
+export function resolveUnit(
+  courseId: string,
+  contentId: string,
+  body: { note: string | null },
+): Promise<ResolveUnitResponse> {
+  return apiFetch<ResolveUnitResponse>(
+    `/api/v1/admin/courses/${courseId}/units/${contentId}/quality/resolve`,
+    {
+      method: "POST",
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+export function unlockUnit(
+  courseId: string,
+  contentId: string,
+): Promise<UnlockUnitResponse> {
+  return apiFetch<UnlockUnitResponse>(
+    `/api/v1/admin/courses/${courseId}/units/${contentId}/quality/unlock`,
+    { method: "POST" },
+  );
+}
+
+// Note: Regenerate is intentionally NOT exposed in the UI. Assessment is
+// autonomous (`assess_unit_task` runs after every lesson generation), and
+// surfacing a "regenerate this unit" button on the review page would
+// reframe the agent as something humans drive.
+
 // ---- run-state helpers ----
 
 const ACTIVE_RUN_STATUSES: ReadonlySet<RunStatus> = new Set([

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1383,7 +1383,61 @@
         "manual_override": "Manual override",
         "failed": "Failed"
       },
-      "glossaryDriftBody": "{count, plural, one {# term has divergent definitions across units.} other {# terms have divergent definitions across units.}}"
+      "glossaryDriftBody": "{count, plural, one {# term has divergent definitions across units.} other {# terms have divergent definitions across units.}}",
+      "unit": {
+        "pageTitle": "Unit quality detail",
+        "pageDescription": "What the autonomous quality agent flagged on this specific unit, and the override actions you can take.",
+        "backToCourseQuality": "Back to course quality",
+        "headerLine": "Unit {unit_number} · {type} · {language}",
+        "lastAssessed": "Last assessed",
+        "attempts": "{count, plural, one {# retry} other {# retries}}",
+        "lockedShort": "Manually edited",
+        "locked": "This unit is manually edited — the agent will skip it on future runs until you unlock it.",
+        "weight": "{weight}%",
+        "notAssessed": "The agent has not assessed this unit yet — it will appear here after the next lesson generation.",
+        "noFlags": "No flags recorded for this assessment.",
+        "crossUnitRef": "Cross-unit reference: unit {unit}",
+        "suggestedFix": "Suggested fix",
+        "sections": {
+          "dimensions": "Rubric dimensions",
+          "flags": "{count, plural, =0 {No flags} one {# flag} other {# flags}}"
+        },
+        "actions": {
+          "title": "Override the agent's verdict",
+          "help": "Resolve marks the unit as passing without re-running the agent.",
+          "helpLocked": "Resolve marks the unit as passing. Unlock clears the manual-edit lock so the agent can re-evaluate on its next run.",
+          "resolve": "Resolve",
+          "resolveSubmit": "Mark passing",
+          "unlock": "Unlock for re-evaluation",
+          "note": "Note (optional)",
+          "notePlaceholder": "Why are you marking this unit as passing?",
+          "submitting": "Submitting…",
+          "cancel": "Cancel",
+          "error": "Action failed"
+        }
+      },
+      "dimensions": {
+        "terminology_consistency": "Terminology consistency",
+        "source_grounding": "Source grounding",
+        "syllabus_alignment": "Syllabus alignment",
+        "internal_contradictions": "Internal contradictions",
+        "pedagogical_fit": "Pedagogical fit",
+        "structural_completeness": "Structural completeness"
+      },
+      "flagCategory": {
+        "terminology_drift": "Terminology drift",
+        "ungrounded_claim": "Ungrounded claim",
+        "syllabus_scope_drift": "Syllabus scope drift",
+        "internal_contradiction": "Internal contradiction",
+        "pedagogical_mismatch": "Pedagogical mismatch",
+        "structural_gap": "Structural gap"
+      },
+      "severity": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "blocking": "Blocking"
+      }
     }
   },
   "Courses": {

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1383,7 +1383,61 @@
         "manual_override": "Validation manuelle",
         "failed": "Échec"
       },
-      "glossaryDriftBody": "{count, plural, one {# terme a des définitions divergentes entre les unités.} other {# termes ont des définitions divergentes entre les unités.}}"
+      "glossaryDriftBody": "{count, plural, one {# terme a des définitions divergentes entre les unités.} other {# termes ont des définitions divergentes entre les unités.}}",
+      "unit": {
+        "pageTitle": "Détail qualité d'une unité",
+        "pageDescription": "Ce que l'agent qualité autonome a signalé sur cette unité, et les actions de validation manuelle disponibles.",
+        "backToCourseQuality": "Retour à la qualité du cours",
+        "headerLine": "Unité {unit_number} · {type} · {language}",
+        "lastAssessed": "Dernière évaluation",
+        "attempts": "{count, plural, one {# reprise} other {# reprises}}",
+        "lockedShort": "Modifiée manuellement",
+        "locked": "Cette unité est modifiée manuellement — l'agent l'ignorera lors des prochaines analyses jusqu'à ce que vous la déverrouilliez.",
+        "weight": "{weight} %",
+        "notAssessed": "L'agent n'a pas encore évalué cette unité — elle apparaîtra ici après la prochaine génération de leçon.",
+        "noFlags": "Aucun signalement pour cette évaluation.",
+        "crossUnitRef": "Référence inter-unités : unité {unit}",
+        "suggestedFix": "Correction suggérée",
+        "sections": {
+          "dimensions": "Dimensions du barème",
+          "flags": "{count, plural, =0 {Aucun signalement} one {# signalement} other {# signalements}}"
+        },
+        "actions": {
+          "title": "Valider la décision de l'agent",
+          "help": "Valider marque l'unité comme conforme sans relancer l'agent.",
+          "helpLocked": "Valider marque l'unité comme conforme. Déverrouiller libère le verrou manuel afin que l'agent puisse la réévaluer lors de sa prochaine analyse.",
+          "resolve": "Valider",
+          "resolveSubmit": "Marquer comme conforme",
+          "unlock": "Déverrouiller pour réévaluation",
+          "note": "Note (optionnel)",
+          "notePlaceholder": "Pourquoi marquez-vous cette unité comme conforme ?",
+          "submitting": "Envoi…",
+          "cancel": "Annuler",
+          "error": "Action échouée"
+        }
+      },
+      "dimensions": {
+        "terminology_consistency": "Cohérence terminologique",
+        "source_grounding": "Ancrage dans les sources",
+        "syllabus_alignment": "Alignement avec le syllabus",
+        "internal_contradictions": "Contradictions internes",
+        "pedagogical_fit": "Adéquation pédagogique",
+        "structural_completeness": "Complétude structurelle"
+      },
+      "flagCategory": {
+        "terminology_drift": "Dérive terminologique",
+        "ungrounded_claim": "Affirmation non sourcée",
+        "syllabus_scope_drift": "Hors-scope du syllabus",
+        "internal_contradiction": "Contradiction interne",
+        "pedagogical_mismatch": "Inadéquation pédagogique",
+        "structural_gap": "Lacune structurelle"
+      },
+      "severity": {
+        "low": "Faible",
+        "medium": "Moyen",
+        "high": "Élevé",
+        "blocking": "Bloquant"
+      }
     }
   },
   "Courses": {


### PR DESCRIPTION
Cherry-pick sync of #2255 onto main.

## Summary
Per-unit review surface for the autonomous Quality Agent: dimension bars, severity-grouped flag list, and two override actions (Resolve + Unlock). **No Regenerate UX** — assessment is autonomous and triggering re-assessment from a per-unit page would reframe the agent.

Builds on #2254 (Step 2 dashboard).

## Test plan
- [ ] CI green
- [ ] After staging deploy: navigate from a course's needs-review queue → click a flagged unit → page renders with bars + flags. FR/EN switch works.
- [ ] Resolve flow updates parent dashboard counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)