### PR TITLE
fix(quality): drop redundant headerLine wrapper on run-detail (#2249)

### DIFF
--- a/frontend/components/admin/quality/run-detail-client.tsx
+++ b/frontend/components/admin/quality/run-detail-client.tsx
@@ -112,7 +112,7 @@ export function RunDetailClient({
           {t("backToCourseQuality")}
         </Link>
         <div className="flex flex-wrap items-center gap-3">
-          <h2 className="text-xl font-bold">{t("headerLine", { kind: tKind(run.run_kind) })}</h2>
+          <h2 className="text-xl font-bold">{tKind(run.run_kind)}</h2>
           <RunStatusBadge status={run.status} />
           <ScorePill score={run.overall_score} />
         </div>

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1442,7 +1442,6 @@
       "runDetail": {
         "pageTitle": "Run detail",
         "pageDescription": "Audit trail of one quality run for this course.",
-        "headerLine": "{kind} run",
         "backToCourseQuality": "Back to course quality",
         "loading": "Loading run detail…",
         "error": "Could not load run detail.",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1442,7 +1442,6 @@
       "runDetail": {
         "pageTitle": "Détail d'une analyse",
         "pageDescription": "Trace d'audit d'une analyse qualité de ce cours.",
-        "headerLine": "Analyse {kind}",
         "backToCourseQuality": "Retour à la qualité du cours",
         "loading": "Chargement du détail de l'analyse…",
         "error": "Impossible de charger le détail de l'analyse.",


### PR DESCRIPTION
Caught while browse-testing #2261 on staging.

## The bug
Run-detail page heading shipped with a noun-stacking redundancy:
- **FR:** "Analyse Analyse complète" (the `headerLine` wrapper said "Analyse {kind}" and `runKind.full` already said "Analyse complète")
- **EN:** "Full sweep run" ("sweep" and "run" mean the same thing)

## The fix
Drop the `headerLine` wrapper. Use the localized run-kind directly as the heading. The page metadata grid + status badge below already provide the surrounding context.

After this change:
- **EN:** "Full sweep" / "Targeted" / "Glossary only"
- **FR:** "Analyse complète" / "Ciblée" / "Glossaire seul"

3-line change: 1 line in the component, 1 key removed from each locale file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)