### PR TITLE
feat(quality): course-glossary review page (#2249, step 5)

### DIFF
--- a/frontend/app/[locale]/admin/courses/[courseId]/quality/glossary/page.tsx
+++ b/frontend/app/[locale]/admin/courses/[courseId]/quality/glossary/page.tsx
@@ -1,0 +1,34 @@
+import { getTranslations } from "next-intl/server";
+import { GlossaryClient } from "@/components/admin/quality/glossary-client";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string; courseId: string }>;
+}) {
+  await params;
+  const t = await getTranslations("Admin.qualityAgent.glossary");
+  return {
+    title: t("pageTitle"),
+    description: t("pageDescription"),
+  };
+}
+
+export default async function AdminGlossaryPage({
+  params,
+}: {
+  params: Promise<{ locale: string; courseId: string }>;
+}) {
+  const { courseId } = await params;
+  const t = await getTranslations("Admin.qualityAgent.glossary");
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <div className="border-b bg-background p-4 shrink-0">
+        <h1 className="text-2xl font-bold">{t("pageTitle")}</h1>
+        <p className="text-muted-foreground mt-1">{t("pageDescription")}</p>
+      </div>
+      <GlossaryClient courseId={courseId} />
+    </div>
+  );
+}

--- a/frontend/components/admin/quality/glossary-client.tsx
+++ b/frontend/components/admin/quality/glossary-client.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { ArrowLeft, AlertTriangle } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useQuery } from "@tanstack/react-query";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { type GlossaryEntryResponse, getCourseGlossary } from "@/lib/api-quality";
+
+type Language = "fr" | "en";
+
+const CONSISTENCY_VARIANT: Record<
+  GlossaryEntryResponse["consistency_status"],
+  "default" | "secondary" | "destructive" | "outline"
+> = {
+  consistent: "default",
+  drift_detected: "destructive",
+  unsourced: "secondary",
+};
+
+export function GlossaryClient({ courseId }: { courseId: string }) {
+  const t = useTranslations("Admin.qualityAgent.glossary");
+  const tConsistency = useTranslations("Admin.qualityAgent.glossary.consistency");
+  const [language, setLanguage] = useState<Language>("fr");
+
+  const glossaryQ = useQuery<GlossaryEntryResponse[]>({
+    queryKey: ["admin", "quality", courseId, "glossary", language],
+    queryFn: () => getCourseGlossary(courseId, language),
+  });
+
+  const entries = glossaryQ.data ?? [];
+  const driftCount = entries.filter((e) => e.consistency_status === "drift_detected").length;
+
+  return (
+    <div className="flex flex-col gap-6 p-4">
+      <div className="flex flex-col gap-2">
+        <Link
+          href={`/admin/courses/${courseId}/quality`}
+          className="inline-flex w-fit items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="size-4" />
+          {t("backToCourseQuality")}
+        </Link>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-sm">
+          <span className="text-muted-foreground">{t("language")}:</span>
+          <div className="inline-flex rounded-md border" role="group" aria-label={t("language")}>
+            {(["fr", "en"] as Language[]).map((lang) => (
+              <button
+                key={lang}
+                type="button"
+                onClick={() => setLanguage(lang)}
+                aria-pressed={language === lang}
+                className={cn(
+                  "px-3 py-1 text-sm font-medium first:rounded-l-md last:rounded-r-md",
+                  language === lang
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-background text-muted-foreground hover:bg-muted",
+                )}
+              >
+                {lang.toUpperCase()}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {driftCount > 0 && (
+          <div className="inline-flex items-center gap-1 rounded-md border border-amber-200 bg-amber-50 px-2 py-1 text-xs text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200">
+            <AlertTriangle className="size-3" aria-hidden="true" />
+            {t("driftSummary", { count: driftCount })}
+          </div>
+        )}
+      </div>
+
+      {glossaryQ.isLoading && (
+        <p className="py-12 text-center text-sm text-muted-foreground">{t("loading")}</p>
+      )}
+
+      {glossaryQ.error && (
+        <p className="py-12 text-center text-sm text-destructive" role="alert">
+          {glossaryQ.error instanceof Error ? glossaryQ.error.message : t("error")}
+        </p>
+      )}
+
+      {!glossaryQ.isLoading && !glossaryQ.error && entries.length === 0 && (
+        <div className="rounded-md border bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+          {t("empty")}
+        </div>
+      )}
+
+      {!glossaryQ.isLoading && !glossaryQ.error && entries.length > 0 && (
+        <div className="overflow-x-auto rounded-md border">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-muted/30 text-left text-muted-foreground">
+                <th className="px-3 py-2">{t("col.term")}</th>
+                <th className="px-3 py-2">{t("col.definition")}</th>
+                <th className="px-3 py-2">{t("col.firstUnit")}</th>
+                <th className="px-3 py-2">{t("col.occurrences")}</th>
+                <th className="px-3 py-2">{t("col.status")}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((e) => {
+                const isDrift = e.consistency_status === "drift_detected";
+                return (
+                  <tr
+                    key={e.id}
+                    className={cn(
+                      "border-b last:border-0 align-top",
+                      isDrift
+                        ? "bg-amber-50/60 hover:bg-amber-100/60 dark:bg-amber-950/20"
+                        : "hover:bg-muted/20",
+                    )}
+                  >
+                    <td className="px-3 py-2 font-medium">{e.term_display}</td>
+                    <td className="px-3 py-2 max-w-md">
+                      <div className="text-sm">{e.canonical_definition}</div>
+                      {e.drift_details && (
+                        <div className="mt-1 text-xs text-amber-800 dark:text-amber-300">
+                          <span className="font-medium">{t("driftDetailsLabel")}:</span>{" "}
+                          {e.drift_details}
+                        </div>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">
+                      {e.first_unit_number ?? "—"}
+                    </td>
+                    <td className="px-3 py-2 tabular-nums text-muted-foreground">
+                      {e.occurrences_count}
+                    </td>
+                    <td className="px-3 py-2">
+                      <Badge variant={CONSISTENCY_VARIANT[e.consistency_status]}>
+                        {tConsistency(e.consistency_status)}
+                      </Badge>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/admin/quality/quality-client.tsx
+++ b/frontend/components/admin/quality/quality-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -89,16 +90,24 @@ export function QualityClient({ courseId }: { courseId: string }) {
         <NeedsReviewQueue courseId={courseId} latestRun={runDetailQ.data ?? null} />
       </section>
 
-      {summary.glossary_drift_count > 0 && (
-        <section>
-          <h2 className="mb-3 text-lg font-semibold">{t("sections.glossaryDrift")}</h2>
-          <div className="rounded-md border bg-muted/20 p-4 text-sm">
-            <p className="text-muted-foreground">
+      <section>
+        <h2 className="mb-3 text-lg font-semibold">{t("sections.glossary")}</h2>
+        <div className="rounded-md border bg-muted/20 p-4 text-sm">
+          {summary.glossary_drift_count > 0 ? (
+            <p className="mb-2 text-amber-900 dark:text-amber-300">
               {t("glossaryDriftBody", { count: summary.glossary_drift_count })}
             </p>
-          </div>
-        </section>
-      )}
+          ) : (
+            <p className="mb-2 text-muted-foreground">{t("glossaryNoDrift")}</p>
+          )}
+          <Link
+            href={`/admin/courses/${courseId}/quality/glossary`}
+            className="text-sm text-primary hover:underline"
+          >
+            {t("viewGlossary")} →
+          </Link>
+        </div>
+      </section>
 
       <section>
         <h2 className="mb-3 text-lg font-semibold">{t("sections.runsLog")}</h2>

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1336,7 +1336,8 @@
       "sections": {
         "needsReview": "Units needing review",
         "glossaryDrift": "Glossary drift",
-        "runsLog": "Recent runs"
+        "runsLog": "Recent runs",
+        "glossary": "Glossary"
       },
       "needsReview": {
         "noRun": "The agent has not assessed this course yet — units will appear here after the next lesson generation.",
@@ -1468,7 +1469,32 @@
           "attempts": "Retries",
           "lastAssessed": "Last assessed"
         }
-      }
+      },
+      "glossary": {
+        "pageTitle": "Course glossary",
+        "pageDescription": "Canonical terms the autonomous quality agent uses to detect terminology drift across this course.",
+        "backToCourseQuality": "Back to course quality",
+        "loading": "Loading glossary…",
+        "error": "Could not load glossary.",
+        "empty": "No glossary terms have been extracted for this language yet.",
+        "language": "Language",
+        "driftSummary": "{count, plural, one {# term with drift} other {# terms with drift}}",
+        "driftDetailsLabel": "Drift details",
+        "col": {
+          "term": "Term",
+          "definition": "Canonical definition",
+          "firstUnit": "First unit",
+          "occurrences": "Occurrences",
+          "status": "Status"
+        },
+        "consistency": {
+          "consistent": "Consistent",
+          "drift_detected": "Drift",
+          "unsourced": "Unsourced"
+        }
+      },
+      "glossaryNoDrift": "No glossary drift detected for this course.",
+      "viewGlossary": "View full glossary"
     }
   },
   "Courses": {

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1336,7 +1336,8 @@
       "sections": {
         "needsReview": "Unités à examiner",
         "glossaryDrift": "Dérive de glossaire",
-        "runsLog": "Analyses récentes"
+        "runsLog": "Analyses récentes",
+        "glossary": "Glossaire"
       },
       "needsReview": {
         "noRun": "L'agent n'a pas encore évalué ce cours — les unités apparaîtront ici après la prochaine génération de leçon.",
@@ -1468,7 +1469,32 @@
           "attempts": "Reprises",
           "lastAssessed": "Dernière éval."
         }
-      }
+      },
+      "glossary": {
+        "pageTitle": "Glossaire du cours",
+        "pageDescription": "Termes canoniques que l'agent qualité autonome utilise pour détecter la dérive terminologique dans ce cours.",
+        "backToCourseQuality": "Retour à la qualité du cours",
+        "loading": "Chargement du glossaire…",
+        "error": "Impossible de charger le glossaire.",
+        "empty": "Aucun terme de glossaire n'a encore été extrait pour cette langue.",
+        "language": "Langue",
+        "driftSummary": "{count, plural, one {# terme avec dérive} other {# termes avec dérive}}",
+        "driftDetailsLabel": "Détails de la dérive",
+        "col": {
+          "term": "Terme",
+          "definition": "Définition canonique",
+          "firstUnit": "Première unité",
+          "occurrences": "Occurrences",
+          "status": "Statut"
+        },
+        "consistency": {
+          "consistent": "Cohérent",
+          "drift_detected": "Dérive",
+          "unsourced": "Non sourcé"
+        }
+      },
+      "glossaryNoDrift": "Aucune dérive terminologique détectée pour ce cours.",
+      "viewGlossary": "Voir le glossaire complet"
     }
   },
   "Courses": {


### PR DESCRIPTION
Cherry-pick sync of #2266 onto main.

## Summary
Adds `/admin/courses/[id]/quality/glossary` — read-only glossary view with FR/EN toggle and drift highlighting. Per-course dashboard now always renders a glossary section with a "View full glossary →" link.

Builds on #2265 (run-detail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)