### PR TITLE
feat(quality): top-level cross-course review queue + nav badge (#2249, step 6)

### DIFF
--- a/frontend/app/[locale]/admin/quality/page.tsx
+++ b/frontend/app/[locale]/admin/quality/page.tsx
@@ -1,0 +1,23 @@
+import { getTranslations } from "next-intl/server";
+import { ReviewQueueClient } from "@/components/admin/quality/review-queue-client";
+
+export async function generateMetadata() {
+  const t = await getTranslations("Admin.qualityAgent.reviewQueue");
+  return {
+    title: t("pageTitle"),
+    description: t("pageDescription"),
+  };
+}
+
+export default async function AdminQualityReviewQueuePage() {
+  const t = await getTranslations("Admin.qualityAgent.reviewQueue");
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <div className="border-b bg-background p-4 shrink-0">
+        <h1 className="text-2xl font-bold">{t("pageTitle")}</h1>
+        <p className="text-muted-foreground mt-1">{t("pageDescription")}</p>
+      </div>
+      <ReviewQueueClient />
+    </div>
+  );
+}

--- a/frontend/components/admin/admin-nav.tsx
+++ b/frontend/components/admin/admin-nav.tsx
@@ -4,7 +4,9 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useTranslations, useLocale } from "next-intl";
 import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { cn } from "@/lib/utils";
+import { getReviewQueue } from "@/lib/api-quality";
 
 function getRole(): string | null {
   if (typeof window === "undefined") return null;
@@ -21,23 +23,41 @@ function getRole(): string | null {
   }
 }
 
+const QUALITY_ROLES = new Set(["admin", "sub_admin", "expert"]);
+
 export function AdminNav() {
   const t = useTranslations("Admin");
   const locale = useLocale();
   const pathname = usePathname();
   const role = useMemo(() => getRole(), []);
 
+  // Pull the cross-course attention count for the Quality nav badge.
+  // Refetches on focus and every 5 min; only fires for roles that can read.
+  const queueQ = useQuery({
+    queryKey: ["admin", "quality", "nav-badge"],
+    queryFn: () => getReviewQueue({ hasIssues: true, limit: 200 }),
+    enabled: role !== null && QUALITY_ROLES.has(role),
+    staleTime: 5 * 60 * 1000,
+    refetchInterval: false,
+  });
+  const attentionCount =
+    queueQ.data?.reduce(
+      (acc, c) => acc + c.units_needs_review_final + c.units_failed,
+      0,
+    ) ?? 0;
+
   const allItems = [
-    { href: `/${locale}/admin/users`, label: t("users.title"), adminOnly: false },
-    { href: `/${locale}/admin/courses`, label: t("courses.title"), adminOnly: false },
-    { href: `/${locale}/admin/curricula`, label: t("curricula.title"), adminOnly: false },
-    { href: `/${locale}/admin/groups`, label: t("groups.title"), adminOnly: false },
-    { href: `/${locale}/admin/taxonomy`, label: t("taxonomy.title"), adminOnly: false },
-    { href: `/${locale}/admin/syllabus`, label: t("syllabus.title"), adminOnly: false },
-    { href: `/${locale}/admin/settings`, label: t("settings.title"), adminOnly: true },
-    { href: `/${locale}/admin/analytics`, label: t("analytics.title"), adminOnly: false },
-    { href: `/${locale}/admin/audit-logs`, label: t("auditLog.title"), adminOnly: false },
-    { href: `/${locale}/admin/payments`, label: t("payments.title"), adminOnly: false },
+    { href: `/${locale}/admin/users`, label: t("users.title"), adminOnly: false, badge: 0 },
+    { href: `/${locale}/admin/courses`, label: t("courses.title"), adminOnly: false, badge: 0 },
+    { href: `/${locale}/admin/quality`, label: t("quality.title"), adminOnly: false, badge: attentionCount },
+    { href: `/${locale}/admin/curricula`, label: t("curricula.title"), adminOnly: false, badge: 0 },
+    { href: `/${locale}/admin/groups`, label: t("groups.title"), adminOnly: false, badge: 0 },
+    { href: `/${locale}/admin/taxonomy`, label: t("taxonomy.title"), adminOnly: false, badge: 0 },
+    { href: `/${locale}/admin/syllabus`, label: t("syllabus.title"), adminOnly: false, badge: 0 },
+    { href: `/${locale}/admin/settings`, label: t("settings.title"), adminOnly: true, badge: 0 },
+    { href: `/${locale}/admin/analytics`, label: t("analytics.title"), adminOnly: false, badge: 0 },
+    { href: `/${locale}/admin/audit-logs`, label: t("auditLog.title"), adminOnly: false, badge: 0 },
+    { href: `/${locale}/admin/payments`, label: t("payments.title"), adminOnly: false, badge: 0 },
   ];
 
   const items = allItems.filter((item) => !item.adminOnly || role === "admin");
@@ -51,7 +71,7 @@ export function AdminNav() {
             key={item.href}
             href={item.href}
             className={cn(
-              "shrink-0 border-b-2 px-3 py-3 text-sm font-medium transition-colors",
+              "shrink-0 inline-flex items-center gap-2 border-b-2 px-3 py-3 text-sm font-medium transition-colors",
               isActive
                 ? "border-primary text-foreground"
                 : "border-transparent text-muted-foreground hover:text-foreground"
@@ -59,6 +79,14 @@ export function AdminNav() {
             aria-current={isActive ? "page" : undefined}
           >
             {item.label}
+            {item.badge > 0 && (
+              <span
+                className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-red-500 px-1.5 text-xs font-semibold text-white"
+                aria-label={`${item.badge}`}
+              >
+                {item.badge}
+              </span>
+            )}
           </Link>
         );
       })}

--- a/frontend/components/admin/quality/review-queue-client.tsx
+++ b/frontend/components/admin/quality/review-queue-client.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import { useQuery } from "@tanstack/react-query";
+import { AlertTriangle } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { type ReviewQueueEntry, getReviewQueue } from "@/lib/api-quality";
+import { RunStatusBadge } from "./quality-status-badge";
+
+function fmtRel(iso: string | null, locale: string): string {
+  if (!iso) return "—";
+  const then = new Date(iso).getTime();
+  const now = Date.now();
+  const diffSec = Math.round((then - now) / 1000);
+  const abs = Math.abs(diffSec);
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
+  if (abs < 60) return rtf.format(diffSec, "second");
+  if (abs < 3600) return rtf.format(Math.round(diffSec / 60), "minute");
+  if (abs < 86400) return rtf.format(Math.round(diffSec / 3600), "hour");
+  return rtf.format(Math.round(diffSec / 86400), "day");
+}
+
+function attentionScore(e: ReviewQueueEntry): number {
+  return e.units_needs_review_final + e.units_failed;
+}
+
+export function ReviewQueueClient() {
+  const t = useTranslations("Admin.qualityAgent.reviewQueue");
+  const locale = useLocale();
+  const [hasIssues, setHasIssues] = useState(true);
+
+  const queueQ = useQuery<ReviewQueueEntry[]>({
+    queryKey: ["admin", "quality", "review-queue", hasIssues],
+    queryFn: () => getReviewQueue({ hasIssues, limit: 200 }),
+  });
+
+  const entries = queueQ.data ?? [];
+
+  return (
+    <div className="flex flex-col gap-6 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="text-sm text-muted-foreground">{t("intro")}</p>
+        <label className="inline-flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={hasIssues}
+            onChange={(e) => setHasIssues(e.target.checked)}
+            className="size-4"
+          />
+          {t("filterHasIssues")}
+        </label>
+      </div>
+
+      {queueQ.isLoading && (
+        <p className="py-12 text-center text-sm text-muted-foreground">{t("loading")}</p>
+      )}
+
+      {queueQ.error && (
+        <p className="py-12 text-center text-sm text-destructive" role="alert">
+          {queueQ.error instanceof Error ? queueQ.error.message : t("error")}
+        </p>
+      )}
+
+      {!queueQ.isLoading && !queueQ.error && entries.length === 0 && (
+        <div className="rounded-md border bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+          {hasIssues ? t("emptyClean") : t("emptyAll")}
+        </div>
+      )}
+
+      {!queueQ.isLoading && !queueQ.error && entries.length > 0 && (
+        <div className="overflow-x-auto rounded-md border">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-muted/30 text-left text-muted-foreground">
+                <th className="px-3 py-2">{t("col.course")}</th>
+                <th className="px-3 py-2">{t("col.attention")}</th>
+                <th className="px-3 py-2">{t("col.passing")}</th>
+                <th className="px-3 py-2">{t("col.drift")}</th>
+                <th className="px-3 py-2">{t("col.lastAssessed")}</th>
+                <th className="px-3 py-2">{t("col.lastRun")}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((e) => {
+                const attn = attentionScore(e);
+                const title = locale === "fr" ? e.course_title_fr : e.course_title_en;
+                return (
+                  <tr
+                    key={e.course_id}
+                    className={cn(
+                      "border-b last:border-0 align-top",
+                      attn > 0
+                        ? "bg-amber-50/40 hover:bg-amber-100/40 dark:bg-amber-950/20"
+                        : "hover:bg-muted/20",
+                    )}
+                  >
+                    <td className="px-3 py-2 font-medium max-w-md">
+                      <Link
+                        href={`/admin/courses/${e.course_id}/quality`}
+                        className="text-primary hover:underline"
+                      >
+                        {title}
+                      </Link>
+                    </td>
+                    <td className="px-3 py-2 tabular-nums">
+                      {attn > 0 ? (
+                        <span className="inline-flex items-center gap-1 font-semibold text-red-700 dark:text-red-300">
+                          <AlertTriangle className="size-3" aria-hidden="true" />
+                          {attn}
+                        </span>
+                      ) : e.units_needs_review > 0 ? (
+                        <span className="inline-flex items-center gap-1 text-amber-700 dark:text-amber-300">
+                          {e.units_needs_review}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground">0</span>
+                      )}
+                      {(e.units_needs_review_final > 0 || e.units_failed > 0) && (
+                        <span className="ml-2 text-xs text-muted-foreground">
+                          ({e.units_needs_review_final} · {e.units_failed})
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 tabular-nums text-muted-foreground">
+                      {e.units_passing}/{e.units_total}
+                    </td>
+                    <td className="px-3 py-2">
+                      {e.glossary_drift_count > 0 ? (
+                        <Badge variant="destructive">{e.glossary_drift_count}</Badge>
+                      ) : (
+                        <span className="text-muted-foreground">0</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 whitespace-nowrap text-xs text-muted-foreground">
+                      {fmtRel(e.last_assessed_at, locale)}
+                    </td>
+                    <td className="px-3 py-2">
+                      {e.last_run ? <RunStatusBadge status={e.last_run.status} /> : (
+                        <span className="text-xs text-muted-foreground">—</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1494,7 +1494,28 @@
         }
       },
       "glossaryNoDrift": "No glossary drift detected for this course.",
-      "viewGlossary": "View full glossary"
+      "viewGlossary": "View full glossary",
+      "reviewQueue": {
+        "pageTitle": "Quality review",
+        "pageDescription": "Cross-course triage of what the autonomous quality agent has flagged.",
+        "intro": "Courses sorted by attention needed: stalled units (final review), failed units, then needs-review units.",
+        "filterHasIssues": "Hide all-passing courses",
+        "loading": "Loading review queue…",
+        "error": "Could not load review queue.",
+        "emptyClean": "No courses currently need attention. The autonomous agent is happy.",
+        "emptyAll": "No courses to display.",
+        "col": {
+          "course": "Course",
+          "attention": "Attention",
+          "passing": "Passing/Total",
+          "drift": "Drift",
+          "lastAssessed": "Last assessed",
+          "lastRun": "Last run"
+        }
+      }
+    },
+    "quality": {
+      "title": "Quality"
     }
   },
   "Courses": {

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1494,7 +1494,28 @@
         }
       },
       "glossaryNoDrift": "Aucune dérive terminologique détectée pour ce cours.",
-      "viewGlossary": "Voir le glossaire complet"
+      "viewGlossary": "Voir le glossaire complet",
+      "reviewQueue": {
+        "pageTitle": "Revue qualité",
+        "pageDescription": "Triage transversal de ce que l'agent qualité autonome a signalé sur l'ensemble des cours.",
+        "intro": "Cours triés par attention nécessaire : unités bloquées (revue finale), unités en échec, puis unités à examiner.",
+        "filterHasIssues": "Masquer les cours sans signalement",
+        "loading": "Chargement de la file de revue…",
+        "error": "Impossible de charger la file de revue.",
+        "emptyClean": "Aucun cours ne nécessite d'attention pour le moment. L'agent autonome est satisfait.",
+        "emptyAll": "Aucun cours à afficher.",
+        "col": {
+          "course": "Cours",
+          "attention": "Attention",
+          "passing": "Réussies/Total",
+          "drift": "Dérive",
+          "lastAssessed": "Dernière éval.",
+          "lastRun": "Dernière analyse"
+        }
+      }
+    },
+    "quality": {
+      "title": "Qualité"
     }
   },
   "Courses": {


### PR DESCRIPTION
Cherry-pick sync of #2268 onto main.

## Summary
Adds `/admin/quality` cross-course review queue + admin-nav "Quality" tab with attention-count badge. The discoverability layer for the autonomous Quality Agent.

Builds on #2267 (Step 5 glossary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)