### PR TITLE
fix(quiz): per-attempt option shuffle to neutralize position bias (#2263)

### DIFF
--- a/frontend/components/quiz/quiz-interface.tsx
+++ b/frontend/components/quiz/quiz-interface.tsx
@@ -16,6 +16,12 @@ import type { Quiz, QuizAnswerSubmission, QuizAttemptResponse } from '@/lib/api'
 import { ApiError, submitQuizAttempt } from '@/lib/api';
 import { scoreQuizOffline } from '@/lib/offline/offline-quiz-scorer';
 import { loadQuizState, saveQuizState, clearQuizState } from '@/lib/quiz-state-persistence';
+import {
+  buildQuizDisplayOrders,
+  displayToOriginal,
+  displayedOptions,
+  isValidPermutation,
+} from '@/lib/quiz-shuffle';
 
 interface QuizInterfaceProps {
   quiz: Quiz;
@@ -33,6 +39,10 @@ interface PersistedQuizState {
   currentQuestionIndex: number;
   questionStates: QuestionState[];
   startTime: number;
+  // Per-question permutation. Each entry maps display position -> original
+  // index. Persisted so a mid-attempt refresh keeps the same shuffle and the
+  // already-stored selectedOption indices stay valid.
+  displayOrders: number[][];
 }
 
 export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps) {
@@ -40,7 +50,22 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
 
   // Quiz IDs are unique per generation, so a regenerate auto-invalidates this key.
   const storageKey = `quiz-state:v1:${quiz.id}`;
-  const [restored] = useState(() => loadQuizState<PersistedQuizState>(storageKey));
+  const [restored] = useState<PersistedQuizState | null>(() => {
+    const raw = loadQuizState<PersistedQuizState>(storageKey);
+    if (!raw) return null;
+    // Pre-shuffle entries lack displayOrders. Discard the whole restored
+    // attempt rather than rebuilding orders alongside stale selectedOption
+    // indices — the latter would silently mis-grade.
+    if (!Array.isArray(raw.displayOrders) || raw.displayOrders.length !== quiz.content.questions.length) {
+      return null;
+    }
+    for (let i = 0; i < raw.displayOrders.length; i++) {
+      if (!isValidPermutation(raw.displayOrders[i], quiz.content.questions[i].options.length)) {
+        return null;
+      }
+    }
+    return raw;
+  });
 
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(
     restored?.currentQuestionIndex ?? 0,
@@ -54,6 +79,9 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
       })),
   );
   const [startTime] = useState(restored?.startTime ?? Date.now());
+  const [displayOrders] = useState<number[][]>(
+    () => restored?.displayOrders ?? buildQuizDisplayOrders(quiz.content.questions),
+  );
   // Reconstruct questionStartTime so the per-second tick keeps adding to the
   // already-recorded time on the current question instead of resetting to 0.
   const [questionStartTime, setQuestionStartTime] = useState(() => {
@@ -69,8 +97,9 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
       currentQuestionIndex,
       questionStates,
       startTime,
+      displayOrders,
     });
-  }, [storageKey, currentQuestionIndex, questionStates, startTime]);
+  }, [storageKey, currentQuestionIndex, questionStates, startTime, displayOrders]);
   
   const currentQuestion = quiz.content.questions[currentQuestionIndex];
   const currentState = questionStates[currentQuestionIndex];
@@ -259,14 +288,15 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
         <CardContent className="space-y-4">
           {/* Answer Options */}
           <div className="space-y-3">
-            {currentQuestion.options.map((option, index) => {
-              const isSelected = currentState.selectedOption === index;
+            {displayedOptions(currentQuestion, displayOrders[currentQuestionIndex]).map((option, displayIdx) => {
+              const originalIdx = displayToOriginal(displayOrders[currentQuestionIndex], displayIdx);
+              const isSelected = currentState.selectedOption === originalIdx;
               const showResult = currentState.showFeedback;
-              const isCorrectOption = index === currentQuestion.correct_answer;
-              
+              const isCorrectOption = originalIdx === currentQuestion.correct_answer;
+
               let buttonVariant: "default" | "outline" | "secondary" = "outline";
               let className = "min-h-11 h-auto p-4 text-left justify-start";
-              
+
               if (showResult) {
                 if (isSelected && isCorrectOption) {
                   className += " bg-green-50 border-green-500 text-green-900";
@@ -278,21 +308,21 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
               } else if (isSelected) {
                 buttonVariant = "default";
               }
-              
+
               return (
                 <Button
-                  key={index}
+                  key={originalIdx}
                   variant={buttonVariant}
-                  onClick={() => handleOptionSelect(index)}
+                  onClick={() => handleOptionSelect(originalIdx)}
                   disabled={showResult}
                   className={`w-full ${className}`}
                 >
                   <div className="flex items-center gap-3 w-full">
                     <div className="w-6 h-6 rounded-full border-2 flex-shrink-0 flex items-center justify-center text-xs font-medium">
-                      {String.fromCharCode(65 + index)}
+                      {String.fromCharCode(65 + displayIdx)}
                     </div>
                     <span className="flex-1 text-wrap">{option}</span>
-                    
+
                     {showResult && isSelected && (
                       <div className="flex-shrink-0">
                         {isCorrectOption ? (
@@ -302,7 +332,7 @@ export function QuizInterface({ quiz, onComplete, onError }: QuizInterfaceProps)
                         )}
                       </div>
                     )}
-                    
+
                     {showResult && !isSelected && isCorrectOption && (
                       <div className="flex-shrink-0">
                         <CheckCircle className="w-5 h-5 text-green-600" />

--- a/frontend/components/quiz/summative-assessment-interface.tsx
+++ b/frontend/components/quiz/summative-assessment-interface.tsx
@@ -12,6 +12,12 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import type { Quiz, QuizAnswerSubmission, SummativeAssessmentResponse } from '@/lib/api';
 import { submitSummativeAssessmentAttempt } from '@/lib/api';
 import { loadQuizState, saveQuizState, clearQuizState } from '@/lib/quiz-state-persistence';
+import {
+  buildQuizDisplayOrders,
+  displayToOriginal,
+  displayedOptions,
+  isValidPermutation,
+} from '@/lib/quiz-shuffle';
 
 interface SummativeAssessmentInterfaceProps {
   assessment: Quiz;
@@ -32,6 +38,10 @@ interface PersistedSummativeState {
   // Persist remaining time so a reload can't be exploited to reset the clock
   // back to a full timeLimit window.
   timeRemaining: number;
+  // Per-question permutation. Each entry maps display position -> original
+  // index. Persisted so a mid-attempt refresh keeps the same shuffle and the
+  // already-stored selectedOption indices stay valid.
+  displayOrders: number[][];
 }
 
 const TIMER_WARNING_MINUTES = 5; // Show warning when 5 minutes left
@@ -46,7 +56,19 @@ export function SummativeAssessmentInterface({
 
   // Assessment IDs are unique per generation, so a regenerate auto-invalidates this key.
   const storageKey = `summative-state:v1:${assessment.id}`;
-  const [restored] = useState(() => loadQuizState<PersistedSummativeState>(storageKey));
+  const [restored] = useState<PersistedSummativeState | null>(() => {
+    const raw = loadQuizState<PersistedSummativeState>(storageKey);
+    if (!raw) return null;
+    if (!Array.isArray(raw.displayOrders) || raw.displayOrders.length !== assessment.content.questions.length) {
+      return null;
+    }
+    for (let i = 0; i < raw.displayOrders.length; i++) {
+      if (!isValidPermutation(raw.displayOrders[i], assessment.content.questions[i].options.length)) {
+        return null;
+      }
+    }
+    return raw;
+  });
 
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(
     restored?.currentQuestionIndex ?? 0,
@@ -59,6 +81,9 @@ export function SummativeAssessmentInterface({
       })),
   );
   const [startTime] = useState(restored?.startTime ?? Date.now());
+  const [displayOrders] = useState<number[][]>(
+    () => restored?.displayOrders ?? buildQuizDisplayOrders(assessment.content.questions),
+  );
   // Reconstruct questionStartTime so the per-second tick keeps adding to the
   // already-recorded time on the current question instead of resetting to 0.
   const [questionStartTime, setQuestionStartTime] = useState(() => {
@@ -81,8 +106,9 @@ export function SummativeAssessmentInterface({
       questionStates,
       startTime,
       timeRemaining,
+      displayOrders,
     });
-  }, [storageKey, currentQuestionIndex, questionStates, startTime, timeRemaining]);
+  }, [storageKey, currentQuestionIndex, questionStates, startTime, timeRemaining, displayOrders]);
   
   const currentQuestion = assessment.content.questions[currentQuestionIndex];
   const currentState = questionStates[currentQuestionIndex];
@@ -303,19 +329,20 @@ export function SummativeAssessmentInterface({
         <CardContent className="space-y-4">
           {/* Answer Options */}
           <div className="space-y-3">
-            {currentQuestion.options.map((option, index) => {
-              const isSelected = currentState.selectedOption === index;
-              
+            {displayedOptions(currentQuestion, displayOrders[currentQuestionIndex]).map((option, displayIdx) => {
+              const originalIdx = displayToOriginal(displayOrders[currentQuestionIndex], displayIdx);
+              const isSelected = currentState.selectedOption === originalIdx;
+
               return (
                 <Button
-                  key={index}
+                  key={originalIdx}
                   variant={isSelected ? "default" : "outline"}
-                  onClick={() => handleOptionSelect(index)}
+                  onClick={() => handleOptionSelect(originalIdx)}
                   className="w-full min-h-11 h-auto p-4 text-left justify-start"
                 >
                   <div className="flex items-center gap-3 w-full">
                     <div className="w-6 h-6 rounded-full border-2 flex-shrink-0 flex items-center justify-center text-xs font-medium">
-                      {String.fromCharCode(65 + index)}
+                      {String.fromCharCode(65 + displayIdx)}
                     </div>
                     <span className="flex-1 text-wrap">{option}</span>
                   </div>

--- a/frontend/lib/quiz-shuffle.test.ts
+++ b/frontend/lib/quiz-shuffle.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  buildDisplayOrder,
+  buildQuizDisplayOrders,
+  displayToOriginal,
+  displayedOptions,
+  isValidPermutation,
+  originalToDisplay,
+} from "./quiz-shuffle";
+
+// Deterministic seeded RNG so reproducibility tests don't depend on Math.random.
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+describe("buildDisplayOrder", () => {
+  it("returns a permutation of [0..n-1]", () => {
+    const order = buildDisplayOrder(4);
+    expect(order).toHaveLength(4);
+    expect([...order].sort((a, b) => a - b)).toEqual([0, 1, 2, 3]);
+  });
+
+  it("is deterministic with an injected RNG", () => {
+    const a = buildDisplayOrder(4, mulberry32(42));
+    const b = buildDisplayOrder(4, mulberry32(42));
+    expect(a).toEqual(b);
+  });
+
+  it("handles n=1 as identity", () => {
+    expect(buildDisplayOrder(1)).toEqual([0]);
+  });
+
+  it("distributes index 1 across positions roughly uniformly", () => {
+    const counts = [0, 0, 0, 0];
+    const N = 10_000;
+    for (let i = 0; i < N; i++) {
+      const order = buildDisplayOrder(4);
+      counts[order.indexOf(1)]++;
+    }
+    // Identity permutation would put index 1 at position 1 100% of the time;
+    // this guards against accidental regression to identity. Loose tolerance
+    // (20–30%) makes the test deterministically pass for a real shuffle.
+    for (const c of counts) {
+      expect(c / N).toBeGreaterThan(0.2);
+      expect(c / N).toBeLessThan(0.3);
+    }
+  });
+});
+
+describe("displayToOriginal / originalToDisplay", () => {
+  it("are inverses across all positions", () => {
+    const order = [2, 0, 3, 1];
+    for (let original = 0; original < 4; original++) {
+      expect(displayToOriginal(order, originalToDisplay(order, original))).toBe(
+        original,
+      );
+    }
+    for (let display = 0; display < 4; display++) {
+      expect(originalToDisplay(order, displayToOriginal(order, display))).toBe(
+        display,
+      );
+    }
+  });
+});
+
+describe("displayedOptions", () => {
+  it("returns options in shuffled order", () => {
+    const q = { options: ["A-text", "B-text", "C-text", "D-text"] };
+    expect(displayedOptions(q, [2, 0, 3, 1])).toEqual([
+      "C-text",
+      "A-text",
+      "D-text",
+      "B-text",
+    ]);
+  });
+});
+
+describe("buildQuizDisplayOrders", () => {
+  it("returns one valid permutation per question, sized to that question", () => {
+    const questions = [
+      { options: ["a", "b", "c", "d"] },
+      { options: ["x", "y", "z"] },
+    ];
+    const orders = buildQuizDisplayOrders(questions);
+    expect(orders).toHaveLength(2);
+    expect(isValidPermutation(orders[0], 4)).toBe(true);
+    expect(isValidPermutation(orders[1], 3)).toBe(true);
+  });
+});
+
+describe("isValidPermutation", () => {
+  it("accepts a valid permutation", () => {
+    expect(isValidPermutation([2, 0, 3, 1], 4)).toBe(true);
+  });
+
+  it("rejects duplicates", () => {
+    expect(isValidPermutation([0, 1, 1, 3], 4)).toBe(false);
+  });
+
+  it("rejects wrong length", () => {
+    expect(isValidPermutation([0, 1, 2], 4)).toBe(false);
+  });
+
+  it("rejects out-of-range values", () => {
+    expect(isValidPermutation([0, 1, 2, 5], 4)).toBe(false);
+  });
+
+  it("rejects non-arrays", () => {
+    expect(isValidPermutation(null, 4)).toBe(false);
+    expect(isValidPermutation(undefined, 4)).toBe(false);
+    expect(isValidPermutation("0,1,2,3", 4)).toBe(false);
+  });
+
+  it("rejects non-integer values", () => {
+    expect(isValidPermutation([0, 1.5, 2, 3], 4)).toBe(false);
+  });
+});

--- a/frontend/lib/quiz-shuffle.ts
+++ b/frontend/lib/quiz-shuffle.ts
@@ -1,0 +1,64 @@
+// Per-attempt shuffle for quiz answer options.
+//
+// Claude's structured output places the correct answer at index 1 (option B)
+// roughly 99% of the time, and the generated quiz JSON is permanently cached
+// in `generated_content`, so every learner sees the same biased order.
+// Shuffling on the client per attempt fixes the bias for both existing and
+// future quizzes without touching backend storage or grading.
+//
+// Convention: a `displayOrder` is a permutation of [0..n-1] where
+// `displayOrder[displayIdx] = originalIdx`. Renderers iterate display indices,
+// click handlers translate to original indices before storing them, so the
+// rest of the pipeline (server grading, offline scoring, results UI) keeps
+// operating in the original index space.
+
+export function buildDisplayOrder(
+  n: number,
+  rng: () => number = Math.random,
+): number[] {
+  const order = Array.from({ length: n }, (_, i) => i);
+  for (let i = order.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [order[i], order[j]] = [order[j], order[i]];
+  }
+  return order;
+}
+
+export function buildQuizDisplayOrders(
+  questions: ReadonlyArray<{ options: ReadonlyArray<unknown> }>,
+  rng: () => number = Math.random,
+): number[][] {
+  return questions.map((q) => buildDisplayOrder(q.options.length, rng));
+}
+
+export function displayedOptions<T>(
+  question: { options: ReadonlyArray<T> },
+  order: ReadonlyArray<number>,
+): T[] {
+  return order.map((i) => question.options[i]);
+}
+
+export function displayToOriginal(
+  order: ReadonlyArray<number>,
+  displayIdx: number,
+): number {
+  return order[displayIdx];
+}
+
+export function originalToDisplay(
+  order: ReadonlyArray<number>,
+  originalIdx: number,
+): number {
+  return order.indexOf(originalIdx);
+}
+
+export function isValidPermutation(value: unknown, n: number): value is number[] {
+  if (!Array.isArray(value) || value.length !== n) return false;
+  const seen = new Set<number>();
+  for (const v of value) {
+    if (!Number.isInteger(v) || v < 0 || v >= n) return false;
+    if (seen.has(v)) return false;
+    seen.add(v);
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary

- Adds `frontend/lib/quiz-shuffle.ts` (Fisher-Yates helper + permutation utils with unit tests).
- Wires per-attempt option shuffle into `quiz-interface.tsx` and `summative-assessment-interface.tsx`. Permutations are persisted in the existing sessionStorage entry so a mid-attempt refresh keeps the same order; new attempts get a fresh shuffle automatically because `clearQuizState` is already called on submit/retry.
- `selectedOption` stays in original-index space — clicks translate display→original at the call site — so server grading (`backend/app/api/v1/quiz.py:437` and `:876`), the offline scorer (`scoreQuizOffline`), and the results UI keep working unchanged.

Fixes #2263.

## Test plan

- [x] `npm run test:run -- lib/quiz-shuffle.test.ts` — 13/13 passing (permutation validity, RNG determinism, inverse round-trip, statistical distribution check).
- [x] `npm run lint` on changed files — clean.
- [ ] Manual: open a quiz unit, confirm option order varies across reloads of new attempts; mid-attempt refresh preserves order; submit grades correctly; toggle offline → cached quiz still grades right; repeat for summative assessment.

## Notes

- Pre-shuffle sessionStorage entries (in-progress at deploy time) are discarded entirely rather than mixing a fresh shuffle with stale `selectedOption` indices — the latter would silently mis-grade.
- `tsc --noEmit` surfaces 7 pre-existing errors in `app/[locale]/(app)/activate/page.tsx` and `e2e/production-uat.spec.ts`. None are in files this PR touches; reporting and not chasing per scope discipline.
- Out of scope: backend prompt update / post-gen redistribution helper, Alembic migration to shuffle at-rest data, signed-token shuffle-on-read. Once the frontend shuffles per attempt the at-rest bias is invisible to users; revisit if a non-frontend consumer (analytics export, native client) starts reading the JSON directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)