### PR TITLE
fix(rag): stop indexing body-text pages as figures + populate FR/EN captions

### DIFF
--- a/backend/app/ai/rag/image_extractor.py
+++ b/backend/app/ai/rag/image_extractor.py
@@ -546,6 +546,41 @@ class PDFImageExtractor:
         pixmap = page.get_pixmap(dpi=dpi, clip=clipped)
         return pixmap.tobytes("png"), pixmap.width, pixmap.height
 
+    def _find_leading_caption_block(
+        self,
+        page: pymupdf.Page,
+        figure_patterns: list[re.Pattern],
+    ) -> pymupdf.Rect | None:
+        """Return the bbox of the first text block whose leading text matches a figure pattern.
+
+        Body-text references like "...as shown in Figure 1.1..." sit mid-block
+        and never satisfy this; real captions are block-leading. Distinguishing
+        the two is what stops body-text pages being indexed as figures.
+        """
+        try:
+            page_dict = page.get_text("dict")
+        except Exception:
+            return None
+        for block in page_dict.get("blocks", []):
+            if block.get("type") != 0:
+                continue
+            lines = block.get("lines") or []
+            if not lines:
+                continue
+            spans = lines[0].get("spans") or []
+            if not spans:
+                continue
+            leading = " ".join(span.get("text", "") for span in spans).lstrip()
+            if not leading:
+                continue
+            for pattern in figure_patterns:
+                if pattern.match(leading):
+                    bbox = block.get("bbox")
+                    if bbox:
+                        return pymupdf.Rect(bbox)
+                    return None
+        return None
+
     def _extract_non_xref_figures(
         self,
         page: pymupdf.Page,
@@ -558,7 +593,11 @@ class PDFImageExtractor:
         Strategy (in order):
         1. High drawing count (>= HIGH_DRAWING_COUNT_THRESHOLD): full-page rasterize once
         2. Moderate drawings (> 3): detect vector regions, rasterize each with clip
-        3. Figure text found but no drawings: full-page rasterize (existing behavior)
+        3. Few/no drawings: full-page rasterize ONLY when (a) there is at least
+           one drawing or embedded raster on the page AND (b) at least one
+           figure pattern matches the start of a text block (typical caption
+           position). Inline references like "...shown in Figure 1.1..." are
+           always mid-block, so they no longer trigger the fallback (#2272).
         4. Otherwise: skip
         """
         results: list[ExtractedImage] = []
@@ -626,13 +665,18 @@ class PDFImageExtractor:
                 )
             return results
 
-        page_text = page.get_text()
-        for pattern in figure_patterns:
-            if pattern.search(page_text):
-                extracted = self._rasterize_full_page_as_figure(page, page_number, figure_patterns)
+        has_visual_content = drawing_count >= 1 or len(already_extracted_bboxes) >= 1
+        if has_visual_content:
+            caption_bbox = self._find_leading_caption_block(page, figure_patterns)
+            if caption_bbox is not None:
+                extracted = self._rasterize_full_page_as_figure(
+                    page,
+                    page_number,
+                    figure_patterns,
+                    caption_bbox=caption_bbox,
+                )
                 if extracted:
                     results.append(extracted)
-                break
 
         return results
 
@@ -641,16 +685,17 @@ class PDFImageExtractor:
         page: pymupdf.Page,
         page_number: int,
         figure_patterns: list[re.Pattern],
+        caption_bbox: pymupdf.Rect | None = None,
     ) -> "ExtractedImage | None":
-        """Rasterize entire page when it contains figure content (vector or text-referenced)."""
-        page_text = page.get_text()
-        figure_number: str | None = None
-        for pattern in figure_patterns:
-            m = pattern.search(page_text)
-            if m:
-                figure_number = m.group(0).strip()
-                break
+        """Rasterize entire page when it contains figure content (vector or text-referenced).
 
+        When ``caption_bbox`` is provided, metadata (figure number, caption,
+        surrounding text) is anchored to that block instead of ``page.rect``.
+        Anchoring is the difference between picking up the actual caption
+        and grabbing the first stray "Figure X.Y" mention anywhere on the
+        page (#2272). The caller from the high-drawing-count path passes
+        None and keeps legacy behaviour.
+        """
         try:
             pixmap = page.get_pixmap(dpi=RASTERIZE_DPI)
             png_bytes = pixmap.tobytes("png")
@@ -668,9 +713,17 @@ class PDFImageExtractor:
             w = pixmap.width
             h = pixmap.height
 
-        image_bbox = page.rect
+        image_bbox = caption_bbox if caption_bbox is not None else page.rect
         metadata = self._extract_figure_metadata(page, image_bbox, figure_patterns)
         surrounding_text = self._extract_surrounding_text(page, image_bbox, SURROUNDING_CHAR_LIMIT)
+        figure_number = metadata.get("figure_number")
+        if figure_number is None:
+            page_text = page.get_text()
+            for pattern in figure_patterns:
+                m = pattern.search(page_text)
+                if m:
+                    figure_number = m.group(0).strip()
+                    break
         image_type = self._classify_image_type(metadata.get("caption"), w, h)
 
         return ExtractedImage(
@@ -680,7 +733,7 @@ class PDFImageExtractor:
             original_format="png",
             file_size_bytes=len(webp_bytes),
             page_number=page_number,
-            figure_number=figure_number or metadata.get("figure_number"),
+            figure_number=figure_number,
             caption=metadata.get("caption"),
             attribution=metadata.get("attribution"),
             image_type=image_type,

--- a/backend/app/ai/rag/pipeline.py
+++ b/backend/app/ai/rag/pipeline.py
@@ -281,23 +281,40 @@ class RAGPipeline:
             caption_en: str | None = None
             alt_text_fr: str | None = None
             alt_text_en: str | None = None
-            if img.caption and img.caption.strip():
-                try:
-                    translation = await translate_figure_caption(
-                        caption=img.caption,
-                        image_type=img.image_type,
-                        figure_number=img.figure_number,
-                    )
-                    caption_fr = translation.caption_fr
-                    caption_en = translation.caption_en
-                    alt_text_fr = translation.alt_text_fr
-                    alt_text_en = translation.alt_text_en
-                except Exception as exc:
+            # Broader gate than "caption is non-empty" (#2272): figures whose
+            # caption block didn't survive extraction still have a figure
+            # number + surrounding text, and that's enough for Claude to
+            # write a usable FR/EN caption + alt text. Without this fallback
+            # locale columns stayed NULL and the frontend dropped to the
+            # English caption (or just "Figure X.Y" when even that was empty).
+            translator_input = (img.caption or "").strip()
+            if not translator_input and img.surrounding_text:
+                translator_input = img.surrounding_text.strip()[:200]
+            if not translator_input and img.figure_number:
+                translator_input = img.figure_number
+            if translator_input:
+                last_exc: Exception | None = None
+                for _ in range(2):
+                    try:
+                        translation = await translate_figure_caption(
+                            caption=translator_input,
+                            image_type=img.image_type,
+                            figure_number=img.figure_number,
+                        )
+                        caption_fr = translation.caption_fr
+                        caption_en = translation.caption_en
+                        alt_text_fr = translation.alt_text_fr
+                        alt_text_en = translation.alt_text_en
+                        last_exc = None
+                        break
+                    except Exception as exc:
+                        last_exc = exc
+                if last_exc is not None:
                     logger.warning(
-                        "Failed to translate figure caption, storing without locale fields",
+                        "Failed to translate figure caption after retry; storing NULL locales",
                         source=source,
                         figure_number=img.figure_number,
-                        error=str(exc),
+                        error=str(last_exc),
                     )
 
             figure_kind: str | None = None

--- a/backend/app/tasks/image_indexation.py
+++ b/backend/app/tasks/image_indexation.py
@@ -1,10 +1,13 @@
 """Celery task for re-indexing course PDF images independently from text indexation."""
 
+import asyncio
 import os
 from pathlib import Path
 
 import structlog
 from celery import Task
+from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.tasks.celery_app import celery_app
 
@@ -239,3 +242,175 @@ def reindex_course_images(
             error=str(exc),
         )
         raise
+
+
+# ---------------------------------------------------------------------------
+# Cleanup for the body-text "figure" regression (#2272)
+# ---------------------------------------------------------------------------
+#
+# The image_extractor's no-drawings fallback used to rasterize an entire page
+# any time the page's text contained "Figure X.Y", even when the match was
+# an inline body-text reference. Those rows are now purged here so courses
+# indexed before the fix don't keep serving body-text screenshots.
+#
+# Eligibility is defensive: full-page rasters at 200 DPI for letter-sized
+# pages land around 1133×1466, smaller for trimmed scans. Real figures
+# rarely both reach >=1000px wide AND >=1300px tall AND have NULL caption
+# AND NULL/photo figure_kind. Keep the predicate strict so re-indexing
+# isn't required to recover real figures.
+
+_PURGE_MIN_WIDTH = 1000
+_PURGE_MIN_HEIGHT = 1300
+
+
+class PurgeOrphanFiguresTask(Task):
+    """Celery base for the orphan full-page figure purge."""
+
+    def on_success(self, retval, task_id, args, kwargs):
+        logger.info("Orphan-figure purge completed", task_id=task_id, result=retval)
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        logger.error("Orphan-figure purge failed", task_id=task_id, exception=str(exc))
+
+
+@celery_app.task(
+    bind=True,
+    base=PurgeOrphanFiguresTask,
+    time_limit=1800,
+    soft_time_limit=1500,
+    ignore_result=True,
+    acks_late=False,
+)
+def purge_orphan_full_page_figures(
+    self,
+    rag_collection_id: str | None = None,
+    limit: int | None = None,
+    dry_run: bool = True,
+) -> dict:
+    """Delete ``source_images`` rows that are full-page body-text rasters.
+
+    Args:
+        rag_collection_id: Limit the purge to a single course. None scans
+            every collection.
+        limit: Maximum rows to delete this invocation. Useful for staged
+            rollout against large courses.
+        dry_run: When True (default), counts eligible rows and logs a
+            preview without touching MinIO or the DB.
+    """
+    return asyncio.run(
+        _run_purge(
+            rag_collection_id=rag_collection_id,
+            limit=limit,
+            dry_run=dry_run,
+        )
+    )
+
+
+async def _run_purge(
+    rag_collection_id: str | None,
+    limit: int | None,
+    dry_run: bool,
+) -> dict:
+    from app.infrastructure.config.settings import settings
+    from app.infrastructure.storage.s3 import S3StorageService
+
+    engine = create_async_engine(settings.database_url, pool_pre_ping=True)
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        return await _run_purge_with_factory(
+            rag_collection_id=rag_collection_id,
+            limit=limit,
+            dry_run=dry_run,
+            session_factory=session_factory,
+            storage=S3StorageService(),
+        )
+    finally:
+        await engine.dispose()
+
+
+async def _run_purge_with_factory(
+    rag_collection_id: str | None,
+    limit: int | None,
+    dry_run: bool,
+    session_factory: async_sessionmaker[AsyncSession],
+    storage,
+) -> dict:
+    from app.domain.models.source_image import SourceImage
+
+    async with session_factory() as session:
+        stmt = select(SourceImage).where(
+            SourceImage.caption.is_(None),
+            SourceImage.image_type.in_(("photo", "unknown")),
+            or_(
+                SourceImage.figure_kind.is_(None),
+                SourceImage.figure_kind == "photo",
+            ),
+            and_(
+                SourceImage.width.is_not(None),
+                SourceImage.width >= _PURGE_MIN_WIDTH,
+                SourceImage.height.is_not(None),
+                SourceImage.height >= _PURGE_MIN_HEIGHT,
+            ),
+        )
+        if rag_collection_id is not None:
+            stmt = stmt.where(SourceImage.rag_collection_id == rag_collection_id)
+        if limit is not None:
+            stmt = stmt.limit(limit)
+
+        rows = (await session.execute(stmt)).scalars().all()
+        total = len(rows)
+
+        logger.info(
+            "Orphan-figure purge: eligible rows",
+            total=total,
+            rag_collection_id=rag_collection_id,
+            dry_run=dry_run,
+        )
+
+        if dry_run:
+            preview = [
+                {
+                    "id": str(img.id),
+                    "rag_collection_id": img.rag_collection_id,
+                    "page_number": img.page_number,
+                    "figure_number": img.figure_number,
+                    "width": img.width,
+                    "height": img.height,
+                    "storage_key": img.storage_key,
+                }
+                for img in rows[:20]
+            ]
+            return {"status": "dry_run", "eligible": total, "preview": preview}
+
+        deleted = 0
+        storage_failed = 0
+        for img in rows:
+            for key in (img.storage_key, img.storage_key_fr):
+                if not key:
+                    continue
+                try:
+                    await storage.delete_object(key)
+                except Exception as exc:  # noqa: BLE001
+                    storage_failed += 1
+                    logger.warning(
+                        "Failed to delete orphan-figure object from storage",
+                        source_image_id=str(img.id),
+                        key=key,
+                        error=str(exc),
+                    )
+            await session.delete(img)
+            deleted += 1
+        await session.commit()
+
+        logger.info(
+            "Orphan-figure purge complete",
+            deleted=deleted,
+            storage_failed=storage_failed,
+            rag_collection_id=rag_collection_id,
+        )
+        return {
+            "status": "complete",
+            "eligible": total,
+            "deleted": deleted,
+            "storage_failed": storage_failed,
+        }

--- a/backend/app/tasks/image_translation.py
+++ b/backend/app/tasks/image_translation.py
@@ -20,7 +20,7 @@ import asyncio
 import httpx
 import structlog
 from celery import Task
-from sqlalchemy import func, or_, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
     async_sessionmaker,
@@ -139,8 +139,21 @@ async def _run_backfill_with_factory(
 ) -> dict:
     async with session_factory() as session:
         stmt = select(SourceImage).where(
-            SourceImage.caption.is_not(None),
-            func.length(func.trim(SourceImage.caption)) > 0,
+            or_(
+                and_(
+                    SourceImage.caption.is_not(None),
+                    func.length(func.trim(SourceImage.caption)) > 0,
+                ),
+                # #2272: ingest now also translates rows that have no
+                # caption but do have figure_number + surrounding_text.
+                # Backfill follows so legacy rows with the same shape get
+                # picked up without requiring a re-extract.
+                SourceImage.figure_number.is_not(None),
+                and_(
+                    SourceImage.surrounding_text.is_not(None),
+                    func.length(func.trim(SourceImage.surrounding_text)) > 0,
+                ),
+            ),
             or_(
                 SourceImage.caption_fr.is_(None),
                 SourceImage.caption_en.is_(None),
@@ -188,9 +201,18 @@ async def _run_backfill_with_factory(
 
         async def _translate_one(img):
             async with sem:
+                # Mirror the ingest fallback chain (#2272) so caption-less rows
+                # with figure_number + surrounding_text translate cleanly.
+                translator_input = (img.caption or "").strip()
+                if not translator_input and img.surrounding_text:
+                    translator_input = img.surrounding_text.strip()[:200]
+                if not translator_input and img.figure_number:
+                    translator_input = img.figure_number
+                if not translator_input:
+                    return img, None, ValueError("no translatable text")
                 try:
                     result = await translate_figure_caption(
-                        caption=img.caption or "",
+                        caption=translator_input,
                         image_type=img.image_type,
                         figure_number=img.figure_number,
                     )

--- a/backend/tests/test_backfill_image_translations.py
+++ b/backend/tests/test_backfill_image_translations.py
@@ -23,6 +23,7 @@ def _make_row(
     rag_collection_id: str | None = "course-1",
     image_type: str = "diagram",
     figure_number: str | None = "1.1",
+    surrounding_text: str | None = None,
 ) -> MagicMock:
     row = MagicMock()
     row.id = uuid.uuid4()
@@ -34,6 +35,7 @@ def _make_row(
     row.rag_collection_id = rag_collection_id
     row.image_type = image_type
     row.figure_number = figure_number
+    row.surrounding_text = surrounding_text
     return row
 
 
@@ -179,6 +181,80 @@ class TestRunBackfillWithFactory:
         assert fail_row.caption_fr is None
         for row in ok_rows:
             assert row.caption_fr == "caption_fr"
+
+    async def test_caption_none_but_surrounding_text_translated_via_fallback(self):
+        """#2272: rows with NULL caption + figure_number translate using surrounding_text."""
+        captured: dict[str, str] = {}
+
+        async def _capture(*, caption, **_):
+            captured["input"] = caption
+            return _translation()
+
+        rows = [
+            _make_row(
+                caption=None,
+                figure_number="1.4",
+                surrounding_text="A surveillance dashboard with weekly case counts.",
+            )
+        ]
+        session = _FakeSession(rows)
+        task = MagicMock()
+        mock_tx = AsyncMock(side_effect=_capture)
+        with patch.object(image_translation, "translate_figure_caption", new=mock_tx):
+            result = await image_translation._run_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=False,
+                session_factory=_FakeSessionFactory(session),
+            )
+
+        assert result["translated"] == 1
+        assert captured["input"].startswith("A surveillance dashboard")
+        assert rows[0].caption_fr == "caption_fr"
+
+    async def test_caption_and_surrounding_text_none_uses_figure_number_fallback(self):
+        """When caption + surrounding_text are both empty, figure_number is the input."""
+        captured: dict[str, str] = {}
+
+        async def _capture(*, caption, **_):
+            captured["input"] = caption
+            return _translation()
+
+        rows = [_make_row(caption=None, figure_number="2.7", surrounding_text=None)]
+        session = _FakeSession(rows)
+        task = MagicMock()
+        mock_tx = AsyncMock(side_effect=_capture)
+        with patch.object(image_translation, "translate_figure_caption", new=mock_tx):
+            result = await image_translation._run_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=False,
+                session_factory=_FakeSessionFactory(session),
+            )
+
+        assert result["translated"] == 1
+        assert captured["input"] == "2.7"
+
+    async def test_row_with_no_translatable_text_is_marked_failed(self):
+        """Edge case: row leaks past the SQL filter with no usable input → counted failed."""
+        rows = [_make_row(caption=None, figure_number=None, surrounding_text=None)]
+        session = _FakeSession(rows)
+        task = MagicMock()
+        mock_tx = AsyncMock(return_value=_translation())
+        with patch.object(image_translation, "translate_figure_caption", new=mock_tx):
+            result = await image_translation._run_backfill_with_factory(
+                task=task,
+                rag_collection_id=None,
+                limit=None,
+                dry_run=False,
+                session_factory=_FakeSessionFactory(session),
+            )
+
+        assert result["translated"] == 0
+        assert result["failed"] == 1
+        mock_tx.assert_not_awaited()
 
     async def test_empty_eligible_set_returns_noop(self):
         session = _FakeSession([])

--- a/backend/tests/test_image_extractor.py
+++ b/backend/tests/test_image_extractor.py
@@ -641,13 +641,7 @@ class TestFindLeadingCaptionBlock:
                 {
                     "type": 0,
                     "bbox": (10, 100, 600, 150),
-                    "lines": [
-                        {
-                            "spans": [
-                                {"text": "As shown in Figure 1.3, the result holds."}
-                            ]
-                        }
-                    ],
+                    "lines": [{"spans": [{"text": "As shown in Figure 1.3, the result holds."}]}],
                 }
             ]
         }

--- a/backend/tests/test_image_extractor.py
+++ b/backend/tests/test_image_extractor.py
@@ -554,6 +554,112 @@ class TestRasterizeFullPageAsFigure:
 
         assert result is None
 
+    def test_caption_bbox_anchors_metadata_to_caption_block(self):
+        """When caption_bbox is provided, metadata is taken from that block.
+
+        Without anchoring, ``_extract_figure_metadata`` was given ``page.rect``
+        and grabbed the FIRST 'Figure X.Y' anywhere on the page — including
+        body-text references that came before the real caption (#2272).
+        """
+        body = "Earlier we showed Figure 9.9 in chapter 9."
+        caption_text = "Figure 1.3 Types of Competitive Advantage"
+        page = MagicMock()
+        page.get_text.side_effect = lambda mode=None: (
+            f"{body} {caption_text}"
+            if mode != "dict"
+            else {
+                "blocks": [
+                    {
+                        "type": 0,
+                        "bbox": (50, 50, 562, 100),
+                        "lines": [{"spans": [{"text": body}]}],
+                    },
+                    {
+                        "type": 0,
+                        "bbox": (50, 700, 562, 750),
+                        "lines": [{"spans": [{"text": caption_text}]}],
+                    },
+                ]
+            }
+        )
+        page.rect = pymupdf.Rect(0, 0, 612, 792)
+        mock_pixmap = MagicMock()
+        mock_pixmap.tobytes.return_value = _make_minimal_png(612, 792)
+        mock_pixmap.width = 612
+        mock_pixmap.height = 792
+        page.get_pixmap.return_value = mock_pixmap
+
+        patterns = _build_figure_patterns(BOOKS["generic"])
+        caption_bbox = pymupdf.Rect(50, 700, 562, 750)
+        result = self.extractor._rasterize_full_page_as_figure(
+            page, 1, patterns, caption_bbox=caption_bbox
+        )
+
+        assert result is not None
+        assert result.figure_number is not None
+        assert "1.3" in result.figure_number
+        # The caption picked up the text after "Figure 1.3", not the
+        # body-text "Figure 9.9" elsewhere on the page.
+        assert result.caption is not None
+        assert "Competitive Advantage" in result.caption
+
+
+class TestFindLeadingCaptionBlock:
+    """Tests for the block-leading caption detection helper."""
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.extractor = PDFImageExtractor(Path(self.temp_dir))
+
+    def teardown_method(self):
+        import shutil
+
+        shutil.rmtree(self.temp_dir)
+
+    def _patterns(self):
+        return _build_figure_patterns(BOOKS["generic"])
+
+    def test_block_leading_match_returns_bbox(self):
+        page = MagicMock()
+        page.get_text.return_value = {
+            "blocks": [
+                {
+                    "type": 0,
+                    "bbox": (10, 600, 600, 650),
+                    "lines": [{"spans": [{"text": "Figure 1.3 A diagram"}]}],
+                }
+            ]
+        }
+        bbox = self.extractor._find_leading_caption_block(page, self._patterns())
+        assert bbox is not None
+        assert bbox.x0 == 10 and bbox.y0 == 600
+
+    def test_inline_reference_returns_none(self):
+        page = MagicMock()
+        page.get_text.return_value = {
+            "blocks": [
+                {
+                    "type": 0,
+                    "bbox": (10, 100, 600, 150),
+                    "lines": [
+                        {
+                            "spans": [
+                                {"text": "As shown in Figure 1.3, the result holds."}
+                            ]
+                        }
+                    ],
+                }
+            ]
+        }
+        bbox = self.extractor._find_leading_caption_block(page, self._patterns())
+        assert bbox is None
+
+    def test_get_text_dict_failure_returns_none(self):
+        page = MagicMock()
+        page.get_text.side_effect = RuntimeError("pdf failure")
+        bbox = self.extractor._find_leading_caption_block(page, self._patterns())
+        assert bbox is None
+
 
 class TestExtractNonXrefFigures:
     """Tests for the multi-strategy non-xref figure extraction."""
@@ -643,14 +749,55 @@ class TestExtractNonXrefFigures:
         results = self.extractor._extract_non_xref_figures(page, 1, patterns, [existing_bbox])
         assert len(results) >= 1
 
-    def test_no_drawings_figure_text_triggers_full_page(self):
+    def test_no_drawings_inline_figure_reference_does_not_trigger(self):
+        """Body-text page that only mentions 'Figure X.Y' inline must NOT rasterize.
+
+        Regression #2272: full body-text pages were being indexed as figures
+        whenever the text contained any 'Figure X.Y' substring, including
+        passing references like '...as shown in Figure 1.1...'.
+        """
         page = MagicMock()
         page.get_drawings.return_value = []
+        body_text = "Some body text mentioning Figure 3 in the middle of a sentence"
         page.get_text.side_effect = lambda mode=None: (
-            "Figure 3 shows the distribution" if mode != "dict" else {"blocks": []}
+            body_text
+            if mode != "dict"
+            else {
+                "blocks": [
+                    {
+                        "type": 0,
+                        "bbox": (50, 100, 562, 150),
+                        "lines": [{"spans": [{"text": body_text}]}],
+                    }
+                ]
+            }
         )
         page.rect = pymupdf.Rect(0, 0, 612, 792)
 
+        patterns = self._make_figure_patterns()
+
+        results = self.extractor._extract_non_xref_figures(page, 1, patterns, [])
+        assert results == []
+
+    def test_drawings_with_block_leading_caption_triggers_full_page(self):
+        """One drawing + a 'Figure X.Y …' block-leading caption rasterizes."""
+        page = MagicMock()
+        page.get_drawings.return_value = [{"rect": pymupdf.Rect(100, 100, 300, 300)}]
+        caption_text = "Figure 1.3 Types of Competitive Advantage"
+        page.get_text.side_effect = lambda mode=None: (
+            caption_text
+            if mode != "dict"
+            else {
+                "blocks": [
+                    {
+                        "type": 0,
+                        "bbox": (50, 600, 562, 650),
+                        "lines": [{"spans": [{"text": caption_text}]}],
+                    }
+                ]
+            }
+        )
+        page.rect = pymupdf.Rect(0, 0, 612, 792)
         mock_pixmap = MagicMock()
         mock_pixmap.tobytes.return_value = _make_minimal_png(612, 792)
         mock_pixmap.width = 612
@@ -661,6 +808,33 @@ class TestExtractNonXrefFigures:
 
         results = self.extractor._extract_non_xref_figures(page, 1, patterns, [])
         assert len(results) == 1
+        assert results[0].figure_number is not None
+        assert "1.3" in results[0].figure_number
+
+    def test_drawings_with_only_inline_reference_does_not_trigger(self):
+        """Drawings present but no block-leading caption (only mid-block reference) → no rasterize."""
+        page = MagicMock()
+        page.get_drawings.return_value = [{"rect": pymupdf.Rect(100, 100, 300, 300)}]
+        body_text = "...as discussed in Figure 1.1, the data shows..."
+        page.get_text.side_effect = lambda mode=None: (
+            body_text
+            if mode != "dict"
+            else {
+                "blocks": [
+                    {
+                        "type": 0,
+                        "bbox": (50, 100, 562, 150),
+                        "lines": [{"spans": [{"text": body_text}]}],
+                    }
+                ]
+            }
+        )
+        page.rect = pymupdf.Rect(0, 0, 612, 792)
+
+        patterns = self._make_figure_patterns()
+
+        results = self.extractor._extract_non_xref_figures(page, 1, patterns, [])
+        assert results == []
 
     def test_no_drawings_no_figure_text_returns_empty(self):
         page = MagicMock()

--- a/backend/tests/test_rag_pipeline_images.py
+++ b/backend/tests/test_rag_pipeline_images.py
@@ -284,6 +284,164 @@ class TestRAGPipelineProcessPDFImages:
         assert mock_session.add.call_count == 3
 
     @pytest.mark.asyncio
+    async def test_translation_runs_when_caption_missing_but_figure_number_set(self):
+        """#2272: figure with empty caption + figure_number should still translate.
+
+        Pre-fix the gate `if img.caption and img.caption.strip()` skipped
+        translation entirely, so caption_fr/caption_en stayed NULL and the
+        frontend dropped to the (also NULL) raw caption fallback. The fix
+        runs translation with surrounding_text as the input.
+        """
+        from app.ai.translation.figure_translator import FigureTranslation
+
+        pdf_path = Path(self.temp_dir) / "test.pdf"
+        pdf_path.touch()
+
+        fake_image = _make_extracted_image(
+            caption=None,
+            figure_number="Figure 1.2",
+            surrounding_text="A diagram showing the surveillance system architecture.",
+        )
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=MagicMock())
+
+        translation_stub = FigureTranslation(
+            caption_fr="Architecture du système de surveillance",
+            caption_en="Surveillance system architecture",
+            alt_text_fr="Schéma d'architecture",
+            alt_text_en="Architecture diagram",
+        )
+
+        with (
+            patch(
+                "app.ai.rag.pipeline.PDFImageExtractor.extract_images_from_pdf",
+                return_value=[fake_image],
+            ),
+            patch(
+                "app.ai.rag.pipeline.S3StorageService.upload_bytes",
+                new_callable=AsyncMock,
+                return_value="http://minio/key.webp",
+            ),
+            patch(
+                "app.ai.rag.pipeline.translate_figure_caption",
+                new_callable=AsyncMock,
+                return_value=translation_stub,
+            ) as mock_translate,
+            patch.object(
+                ImageLinker, "link_images_to_chunks", new_callable=AsyncMock, return_value=0
+            ),
+        ):
+            count = await self.pipeline.process_pdf_images(
+                pdf_path=str(pdf_path),
+                source="donaldson",
+                session=mock_session,
+            )
+
+        assert count == 1
+        mock_translate.assert_called_once()
+        call_kwargs = mock_translate.call_args.kwargs
+        assert call_kwargs["figure_number"] == "Figure 1.2"
+        # surrounding_text was used as the input (truncated to 200 chars).
+        assert call_kwargs["caption"].startswith("A diagram showing")
+
+        added_image = mock_session.add.call_args[0][0]
+        assert added_image.caption_fr == "Architecture du système de surveillance"
+        assert added_image.caption_en == "Surveillance system architecture"
+        assert added_image.alt_text_fr == "Schéma d'architecture"
+        assert added_image.alt_text_en == "Architecture diagram"
+
+    @pytest.mark.asyncio
+    async def test_translation_retries_once_on_failure(self):
+        """Transient translation failures retry once before giving up."""
+        from app.ai.translation.figure_translator import FigureTranslation
+
+        pdf_path = Path(self.temp_dir) / "test.pdf"
+        pdf_path.touch()
+
+        fake_image = _make_extracted_image()
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=MagicMock())
+
+        translation_stub = FigureTranslation(
+            caption_fr="FR", caption_en="EN", alt_text_fr="FR alt", alt_text_en="EN alt"
+        )
+
+        translate_mock = AsyncMock(side_effect=[RuntimeError("transient"), translation_stub])
+
+        with (
+            patch(
+                "app.ai.rag.pipeline.PDFImageExtractor.extract_images_from_pdf",
+                return_value=[fake_image],
+            ),
+            patch(
+                "app.ai.rag.pipeline.S3StorageService.upload_bytes",
+                new_callable=AsyncMock,
+                return_value="http://minio/key.webp",
+            ),
+            patch("app.ai.rag.pipeline.translate_figure_caption", translate_mock),
+            patch.object(
+                ImageLinker, "link_images_to_chunks", new_callable=AsyncMock, return_value=0
+            ),
+        ):
+            count = await self.pipeline.process_pdf_images(
+                pdf_path=str(pdf_path),
+                source="donaldson",
+                session=mock_session,
+            )
+
+        assert count == 1
+        assert translate_mock.call_count == 2
+        added_image = mock_session.add.call_args[0][0]
+        assert added_image.caption_fr == "FR"
+
+    @pytest.mark.asyncio
+    async def test_translation_failure_after_retry_stores_with_null_locale(self):
+        """Two consecutive translation failures: row stored with NULL locale columns."""
+        pdf_path = Path(self.temp_dir) / "test.pdf"
+        pdf_path.touch()
+
+        fake_image = _make_extracted_image()
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=MagicMock())
+
+        translate_mock = AsyncMock(
+            side_effect=[RuntimeError("first fail"), RuntimeError("second fail")]
+        )
+
+        with (
+            patch(
+                "app.ai.rag.pipeline.PDFImageExtractor.extract_images_from_pdf",
+                return_value=[fake_image],
+            ),
+            patch(
+                "app.ai.rag.pipeline.S3StorageService.upload_bytes",
+                new_callable=AsyncMock,
+                return_value="http://minio/key.webp",
+            ),
+            patch("app.ai.rag.pipeline.translate_figure_caption", translate_mock),
+            patch.object(
+                ImageLinker, "link_images_to_chunks", new_callable=AsyncMock, return_value=0
+            ),
+        ):
+            count = await self.pipeline.process_pdf_images(
+                pdf_path=str(pdf_path),
+                source="donaldson",
+                session=mock_session,
+            )
+
+        assert count == 1
+        assert translate_mock.call_count == 2
+        added_image = mock_session.add.call_args[0][0]
+        assert added_image.caption_fr is None
+        assert added_image.caption_en is None
+
+    @pytest.mark.asyncio
     async def test_rag_collection_id_stored_in_db_record(self):
         pdf_path = Path(self.temp_dir) / "test.pdf"
         pdf_path.touch()


### PR DESCRIPTION
## Summary

Two image-indexation regressions surfaced in lessons that embed PDF figures (see PR #2272 for the original main-targeted version — closing that in favour of this dev-targeted PR per the repo workflow):

1. **Whole textbook pages indexed as figures.** The no-drawings fallback in `PDFImageExtractor._extract_non_xref_figures` rasterized any page whose text contained "Figure X.Y" — including pages where the match was an inline body-text reference like "…as shown in Figure 1.1…". Those page screenshots then surfaced in lessons under a fake figure number.
2. **French users saw English-only or empty figcaptions.** `RAGPipeline._process_images` only ran `translate_figure_caption` when the raw `caption` was non-empty, so captionless figures (the common case for full-page rasterizes from issue 1) stored `caption_fr/caption_en = NULL`. The frontend then dropped to the English fallback or just "Figure X.Y".

### What changed

- **`image_extractor.py`**: new `_find_leading_caption_block` helper. The fallback now requires (a) at least one drawing or already-extracted embedded image AND (b) a figure pattern matching the **start of a text block** (typical caption position). Inline references never satisfy (b). `_rasterize_full_page_as_figure` accepts an optional `caption_bbox` and anchors metadata extraction to that block instead of `page.rect`, so the captured caption is the actual nearby caption — not the first stray "Figure X" mention anywhere on the page.
- **`pipeline.py`**: broadened the translation gate. When the raw caption is empty, fall back to `surrounding_text[:200]`, then `figure_number`. One bounded retry on transient Claude failures before logging and continuing.
- **`image_translation.py`** (`backfill_image_translations`): mirrored the same fallback chain in `_translate_one`; widened the eligibility predicate so legacy rows with NULL caption but a `figure_number` or `surrounding_text` get picked up.
- **`image_indexation.py`**: new `purge_orphan_full_page_figures` Celery task (defaults to `dry_run=True`) deletes already-stored body-text screenshots from earlier ingests. Conservative eligibility (`caption IS NULL` + `image_type IN ('photo','unknown')` + `figure_kind` NULL/photo + width ≥1000 ∧ height ≥1300) so real figures are not removed.
- **Frontend unchanged.** The English fallback for French users when `caption_fr` is NULL stays intentional — fix is upstream so far fewer rows hit the fallback path.

### Tests

112+ unit tests pass (88 in `test_image_extractor.py`, 17 in `test_rag_pipeline_images.py`, 7 + new in `test_backfill_image_translations.py`). Highlights:

- Renamed `test_no_drawings_figure_text_triggers_full_page` → `test_no_drawings_inline_figure_reference_does_not_trigger`; the old behaviour was the bug.
- New: drawings + block-leading caption (positive), drawings + inline-only reference (negative), `caption_bbox`-anchored metadata, `_find_leading_caption_block` coverage.
- New: pipeline runs translation when `caption=None` + `figure_number` is set, one-retry success, two-retry failure preserves NULL locale columns.
- New: backfill picks up rows via `surrounding_text` fallback, `figure_number`-only fallback, edge case where no translatable text remains.

## Test plan

- [ ] CI green (Backend + Frontend + GitGuardian).
- [ ] Staging: run a fresh indexation against a known-bad PDF; verify `source_images` contains no row with `width >= 1000 AND height >= 1300 AND caption IS NULL`.
- [ ] Staging: invoke `purge_orphan_full_page_figures(rag_collection_id="<id>", dry_run=True)`, review preview, then `dry_run=False`. Run `backfill_image_translations(rag_collection_id="<id>")` after.
- [ ] Frontend smoke: open the affected lesson in `/fr/...`; the body-text page disappears from the figure list and the real diagram shows a French figcaption (e.g. "Figure 1.3 — Types d'avantage concurrentiel"). Switch to `/en/...`; English caption appears.
- [ ] Sentry: `Failed to translate figure caption` warning rate is flat or lower after deploy.

https://claude.ai/code/session_01BdFuSg9Gn9SayEDHAJWg8n

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdFuSg9Gn9SayEDHAJWg8n)_