### PR TITLE
fix(ux): module back-link navigates to course instead of global modules list

### DIFF
--- a/backend/app/api/v1/content.py
+++ b/backend/app/api/v1/content.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse, StreamingResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.ai.claude_service import ClaudeService
 from app.ai.rag.embeddings import EmbeddingService
@@ -1490,7 +1491,11 @@ async def get_module_units(
         )
 
     try:
-        module_query = select(Module).where(Module.id == resolved_module_id)
+        module_query = (
+            select(Module)
+            .options(selectinload(Module.course))
+            .where(Module.id == resolved_module_id)
+        )
         module_result = await session.execute(module_query)
         module = module_result.scalar_one_or_none()
 
@@ -1545,6 +1550,7 @@ async def get_module_units(
             learning_objectives_fr=module.learning_objectives_fr,
             learning_objectives_en=module.learning_objectives_en,
             units=public_units,
+            course_slug=module.course.slug if module.course else None,
         )
 
     except HTTPException:

--- a/backend/app/api/v1/schemas/content.py
+++ b/backend/app/api/v1/schemas/content.py
@@ -309,6 +309,7 @@ class ModuleUnitsResponse(BaseModel):
     learning_objectives_fr: list[str] | None = None
     learning_objectives_en: list[str] | None = None
     units: list[PublicUnitDetail] = Field(default_factory=list)
+    course_slug: str | None = None
 
 
 class ErrorResponse(BaseModel):

--- a/backend/app/api/v1/schemas/progress.py
+++ b/backend/app/api/v1/schemas/progress.py
@@ -72,6 +72,7 @@ class ModuleDetailWithProgressResponse(BaseModel):
     time_spent_minutes: int = 0
     last_accessed: str | None = None
     units: list[UnitProgressDetail] = Field(default_factory=list)
+    course_slug: str | None = None
 
 
 class CompleteLessonRequest(BaseModel):

--- a/backend/app/domain/services/progress_service.py
+++ b/backend/app/domain/services/progress_service.py
@@ -10,6 +10,7 @@ from uuid import UUID
 import structlog
 from sqlalchemy import case, func, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.domain.models.course import UserCourseEnrollment
 from app.domain.models.lesson_reading import LessonReading
@@ -448,7 +449,9 @@ class ProgressService:
         Return module detail with units and per-unit completion status,
         merging DB data with progress records.
         """
-        module_result = await self.db.execute(select(Module).where(Module.id == module_id))
+        module_result = await self.db.execute(
+            select(Module).options(selectinload(Module.course)).where(Module.id == module_id)
+        )
         module = module_result.scalar_one_or_none()
         if not module:
             raise ValueError(f"Module {module_id} not found")
@@ -509,6 +512,7 @@ class ProgressService:
                 progress.last_accessed.isoformat() if progress and progress.last_accessed else None
             ),
             "units": units_data,
+            "course_slug": module.course.slug if module.course else None,
         }
 
     # ------------------------------------------------------------------

--- a/frontend/components/learning/module-lock-gate.tsx
+++ b/frontend/components/learning/module-lock-gate.tsx
@@ -78,6 +78,7 @@ export function ModuleLockGate({ moduleId, language }: ModuleLockGateProps) {
               quiz_score_avg: null,
               time_spent_minutes: 0,
               last_accessed: null,
+              course_slug: pub.course_slug,
               units: pub.units.map((u) => ({
                 id: u.id,
                 unit_number: u.unit_number,
@@ -104,13 +105,15 @@ export function ModuleLockGate({ moduleId, language }: ModuleLockGateProps) {
 
   const status = moduleData?.status ?? 'locked';
 
+  const backHref = moduleData?.course_slug ? `/courses/${moduleData.course_slug}` : '/modules';
+
   if (loading) {
     return (
       <div className="container mx-auto max-w-4xl px-4 py-6">
         <div className="mb-6">
           <Link href="/modules" className="inline-flex items-center text-stone-600 hover:text-stone-900 transition-colors">
             <ChevronLeft className="w-4 h-4 mr-1" />
-            {t('backToModules')}
+            {t('backToCourse')}
           </Link>
         </div>
         <div className="animate-pulse space-y-4">
@@ -129,9 +132,9 @@ export function ModuleLockGate({ moduleId, language }: ModuleLockGateProps) {
     return (
       <div className="container mx-auto max-w-4xl px-4 py-6">
         <div className="mb-6">
-          <Link href="/modules" className="inline-flex items-center text-stone-600 hover:text-stone-900 transition-colors">
+          <Link href={backHref} className="inline-flex items-center text-stone-600 hover:text-stone-900 transition-colors">
             <ChevronLeft className="w-4 h-4 mr-1" />
-            {t('backToModules')}
+            {t('backToCourse')}
           </Link>
         </div>
 
@@ -168,9 +171,9 @@ export function ModuleLockGate({ moduleId, language }: ModuleLockGateProps) {
   return (
     <div className="container mx-auto max-w-4xl px-4 py-6">
       <div className="mb-6">
-        <Link href="/modules" className="inline-flex items-center text-stone-600 hover:text-stone-900 transition-colors">
+        <Link href={backHref} className="inline-flex items-center text-stone-600 hover:text-stone-900 transition-colors">
           <ChevronLeft className="w-4 h-4 mr-1" />
-          {t('backToModules')}
+          {t('backToCourse')}
         </Link>
       </div>
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -221,6 +221,7 @@ export interface ModuleDetailWithProgressResponse {
   time_spent_minutes: number;
   last_accessed: string | null;
   units: UnitProgressDetail[];
+  course_slug?: string;
 }
 
 export interface LessonAccessRequest {
@@ -284,6 +285,7 @@ export interface ModuleUnitsResponse {
   learning_objectives_fr?: string[];
   learning_objectives_en?: string[];
   units: PublicUnitDetail[];
+  course_slug?: string;
 }
 
 export async function getModuleUnits(

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -271,6 +271,7 @@
   },
   "ModuleOverview": {
     "backToModules": "Back to Modules",
+    "backToCourse": "Back to course",
     "level": "Level {level}",
     "estimatedDuration": "Estimated duration",
     "hours": "{count, plural, one {# hour} other {# hours}}",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -271,6 +271,7 @@
   },
   "ModuleOverview": {
     "backToModules": "Retour aux modules",
+    "backToCourse": "Retour au cours",
     "level": "Niveau {level}",
     "estimatedDuration": "Durée estimée",
     "hours": "{count, plural, one {# heure} other {# heures}}",


### PR DESCRIPTION
## Summary

- Module detail page back-link used to say "Retour aux modules" and navigate to `/modules` (the global list), losing learner's course context
- Now reads **"Retour au cours"** / **"Back to course"** and navigates to `/courses/[courseSlug]`
- `course_slug` surfaced through both module API endpoints (`GET /progress/modules/{id}/detail` and `GET /content/modules/{id}/units`) via `selectinload(Module.course)` — no migration needed

## Changed files

**Backend**
- `backend/app/api/v1/schemas/progress.py` — `course_slug: str | None` added to `ModuleDetailWithProgressResponse`
- `backend/app/domain/services/progress_service.py` — `selectinload(Module.course)` + `course_slug` in return dict
- `backend/app/api/v1/schemas/content.py` — `course_slug: str | None` added to `ModuleUnitsResponse`
- `backend/app/api/v1/content.py` — `selectinload(Module.course)` + `course_slug` in `ModuleUnitsResponse`

**Frontend**
- `frontend/lib/api.ts` — `course_slug?: string` on both TS types
- `frontend/components/learning/module-lock-gate.tsx` — `backHref` derived from `course_slug`; all 3 back-link instances updated; fallback mapping includes `course_slug`
- `frontend/messages/fr.json` — `backToCourse: "Retour au cours"`
- `frontend/messages/en.json` — `backToCourse: "Back to course"`

## Test plan

- [ ] Navigate to a module detail page on staging (`/fr/modules/[id]`)
- [ ] Back link reads "Retour au cours" and navigates to the correct course page
- [ ] Switch to English — reads "Back to course"
- [ ] Works in locked state (public fallback endpoint)
- [ ] Modules without a course fall back to `/modules` silently

Fixes #2275

🤖 Generated with [Claude Code](https://claude.com/claude-code)