### PR TITLE
feat(e2e): persona specs + CI gate + hourly smoke (#2116-2 through #2119)

### DIFF
--- a/.github/PROD_SMOKE_FAILURE_TEMPLATE.md
+++ b/.github/PROD_SMOKE_FAILURE_TEMPLATE.md
@@ -1,0 +1,27 @@
+---
+title: "[prod-smoke] Hourly smoke is RED on app.sira-donnia.org"
+labels: ["bug", "priority:high", "observability", "automated"]
+assignees: []
+---
+
+The hourly production read-only smoke ([`./.github/workflows/prod-smoke.yml`](../../.github/workflows/prod-smoke.yml)) failed at least once. While this issue is open, subsequent failures append a comment instead of spamming new issues.
+
+**Latest failing run**: {{ env.RUN_URL }}
+
+**What the smoke checks**: see [`frontend/e2e/smoke/critical-paths.spec.ts`](../../frontend/e2e/smoke/critical-paths.spec.ts) — anonymous-only, read-only assertions on `app.sira-donnia.org`:
+- backend `/health`
+- public settings endpoint
+- PWA service worker `/sw.js` (currently `.fixme` until #2113 deploys)
+- anonymous course catalog / curricula index / about / login form
+- English locale parity
+- protected admin/user endpoints reject anonymous (auth-bypass sentinels)
+
+**What to do**:
+
+1. Open the workflow run linked above.
+2. Download the `prod-smoke-{run_id}` artifact (Playwright HTML report + traces).
+3. The report identifies which assertion failed. Trace files (under `test-results/`) replay the full browser session.
+4. Triage:
+   - If a real prod regression: file a fix issue, link it here, and **leave this open** until the smoke goes green again.
+   - If a transient (network, GH Actions infra): close this with a `transient` label.
+5. When the next green run occurs, the smoke job does **not** auto-close this issue (intentional — keeps a paper trail). Close manually after triage.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,57 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  e2e:
+    name: E2E Persona Suite (Playwright vs staging)
+    runs-on: ubuntu-latest
+    # Skip on push events (avoid running twice for PR + push). PR runs are
+    # what gate merges. Workflow_dispatch keeps manual ad-hoc runs available.
+    if: github.event_name != 'push' || github.ref == 'refs/heads/main'
+    needs: frontend
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run persona suite against staging
+        env:
+          STAGING_URL: https://etutor.elearning.portfolio2.kimbetien.com
+          NO_WEB_SERVER: "1"
+          E2E_LEARNER_PASSWORD: ${{ secrets.E2E_LEARNER_PASSWORD }}
+          E2E_ORG_OWNER_PASSWORD: ${{ secrets.E2E_ORG_OWNER_PASSWORD }}
+          E2E_SUB_ADMIN_PASSWORD: ${{ secrets.E2E_SUB_ADMIN_PASSWORD }}
+          E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
+        run: |
+          npx playwright test \
+            --project=setup \
+            --project=01-anonymous \
+            --project=02-learner \
+            --project=03-org-owner \
+            --project=04-sub-admin \
+            --project=05-admin \
+            --reporter=line,html
+
+      - name: Upload Playwright trace + report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ github.run_id }}
+          path: |
+            frontend/playwright-report/
+            frontend/test-results/
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,10 @@ jobs:
   e2e:
     name: E2E Persona Suite (Playwright vs staging)
     runs-on: ubuntu-latest
+    # Non-blocking until fixture accounts are seeded on staging and
+    # E2E_*_PASSWORD secrets are configured in repo settings (#2109 runbook).
+    # Remove continue-on-error once the first clean green run is confirmed.
+    continue-on-error: true
     # Skip on push events (avoid running twice for PR + push). PR runs are
     # what gate merges. Workflow_dispatch keeps manual ad-hoc runs available.
     if: github.event_name != 'push' || github.ref == 'refs/heads/main'

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -1,0 +1,77 @@
+name: Prod read-only smoke
+
+on:
+  schedule:
+    # Every hour at :15 (avoids the :00 GH Actions cron storm).
+    - cron: "15 * * * *"
+  workflow_dispatch:
+    inputs:
+      prod_url:
+        description: "Override PROD_URL for ad-hoc invocation"
+        required: false
+        default: ""
+
+# Cancel any older in-progress run when a newer one starts. Hourly cron + the
+# odd workflow_dispatch should never overlap, but this hardens against retries.
+concurrency:
+  group: prod-smoke
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write   # for the on-failure issue-creation step (see below)
+
+jobs:
+  smoke:
+    name: Smoke — app.sira-donnia.org
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run smoke against prod
+        env:
+          PROD_URL: ${{ inputs.prod_url || 'https://app.sira-donnia.org' }}
+          PROD_API: https://api.sira-donnia.org
+          NO_WEB_SERVER: "1"
+        run: npx playwright test --project=smoke --reporter=line,html
+
+      - name: Upload Playwright trace + report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: prod-smoke-${{ github.run_id }}
+          path: |
+            frontend/playwright-report/
+            frontend/test-results/
+          retention-days: 30
+
+      - name: Open / update tracking issue on failure
+        # Avoid pinging on every hourly red while the same regression is open.
+        # The action below upserts a single issue keyed on the title — first
+        # failure opens, subsequent failures comment.
+        if: failure() && github.event_name == 'schedule'
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          filename: .github/PROD_SMOKE_FAILURE_TEMPLATE.md
+          update_existing: true
+          search_existing: open

--- a/frontend/e2e/auth.setup.ts
+++ b/frontend/e2e/auth.setup.ts
@@ -21,6 +21,12 @@ import path from 'node:path';
 
 import { applyAuthToLocalStorage, loginViaApi, PERSONAS, type Persona } from './fixtures/auth';
 
+// Serial mode — running 4 persona setup tests in parallel races on
+// page.context().storageState() and some files end up missing localStorage
+// entries set by an earlier evaluate. Serial setup keeps all 4 outputs
+// complete; total cost ~6s vs the parallel cost of flaky CI.
+setup.describe.configure({ mode: 'serial' });
+
 const STAGING_URL =
   process.env.STAGING_URL ?? 'https://etutor.elearning.portfolio2.kimbetien.com';
 

--- a/frontend/e2e/pages/org-page.ts
+++ b/frontend/e2e/pages/org-page.ts
@@ -1,0 +1,59 @@
+/**
+ * Page object for /[locale]/org/{slug} and its sub-routes.
+ *
+ * Thin wrapper — locators only.
+ *
+ * Routes covered (verified during 2026-04-30 sweep — all 200):
+ *   /fr/org/{slug}                org dashboard (stats, quick links)
+ *   /fr/org/{slug}/courses        course list
+ *   /fr/org/{slug}/curricula      curriculum list
+ *   /fr/org/{slug}/qbank          question banks
+ *   /fr/org/{slug}/codes          activation codes
+ *   /fr/org/{slug}/reports        learner reports
+ *   /fr/org/{slug}/members        org members
+ */
+
+import type { Locator, Page } from '@playwright/test';
+
+export class OrgPage {
+  constructor(public readonly page: Page) {}
+
+  async gotoDashboard(slug: string, locale: 'fr' | 'en' = 'fr'): Promise<void> {
+    await this.page.goto(`/${locale}/org/${slug}`);
+  }
+
+  async gotoCourses(slug: string, locale: 'fr' | 'en' = 'fr'): Promise<void> {
+    await this.page.goto(`/${locale}/org/${slug}/courses`);
+  }
+
+  async gotoCodes(slug: string, locale: 'fr' | 'en' = 'fr'): Promise<void> {
+    await this.page.goto(`/${locale}/org/${slug}/codes`);
+  }
+
+  async gotoMembers(slug: string, locale: 'fr' | 'en' = 'fr'): Promise<void> {
+    await this.page.goto(`/${locale}/org/${slug}/members`);
+  }
+
+  /** Org-name heading on the dashboard view. */
+  heading(): Locator {
+    return this.page.locator('main h1');
+  }
+
+  /** Stat tile by label (e.g. "Total codes", "Apprenants total"). */
+  statTile(label: string): Locator {
+    return this.page.locator('main', { hasText: label });
+  }
+
+  /** Course card by slug (the slug is rendered as a link href). */
+  courseLink(slug: string): Locator {
+    return this.page.locator(`main a[href*="/courses/"][href$="${slug}"], main a[href*="/${slug}"]`);
+  }
+
+  /**
+   * Activation code row by code value.
+   * Matches any element whose text contains the code (the table cell or chip).
+   */
+  activationCodeRow(code: string): Locator {
+    return this.page.locator('main').getByText(code, { exact: true });
+  }
+}

--- a/frontend/e2e/smoke/critical-paths.spec.ts
+++ b/frontend/e2e/smoke/critical-paths.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Production read-only smoke (#2116-5/5, completes #2116; runs hourly via
+ * cron in #2118).
+ *
+ * Targets PROD_URL (default https://sira-donnia.org) — separate from the
+ * persona projects which target staging. Anonymous-only — no fixture
+ * accounts on prod, no CRUD, no AI tokens. Each test is a single GET
+ * assertion; the suite should complete in well under 60s.
+ *
+ * What this catches:
+ *   - Public-facing pages crash or return 5xx
+ *   - PWA service worker disappears (#2113 regression)
+ *   - Curricula index disappears (#2111 regression)
+ *   - Public-settings endpoint becomes unreachable
+ *   - Authenticated endpoints stop returning 401 for anonymous (auth-bypass
+ *     regression — would be a serious security bug)
+ *
+ * What this does NOT catch:
+ *   - Auth flows (covered by persona suite on staging)
+ *   - Role-scoped behavior (covered by persona suite on staging)
+ *   - Anything that requires login
+ */
+
+import { expect, test } from '@playwright/test';
+
+// Prod FE lives at app.sira-donnia.org (the bare sira-donnia.org domain is a
+// parked redirect — staying away from it). API lives at api.sira-donnia.org.
+const PROD_URL = process.env.PROD_URL || 'https://app.sira-donnia.org';
+const PROD_API = process.env.PROD_API || 'https://api.sira-donnia.org';
+
+test.describe('@smoke production read-only', () => {
+  test('backend /health returns healthy', async ({ request }) => {
+    const res = await request.get(`${PROD_API}/health`);
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('healthy');
+  });
+
+  test('public settings endpoint returns 200', async ({ request }) => {
+    const res = await request.get(`${PROD_API}/api/v1/settings/public`);
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('settings');
+    expect(body).toHaveProperty('branding');
+  });
+
+  test.fixme(
+    'PWA service worker /sw.js is reachable — pending #2113 deploy to prod',
+    async ({ request }) => {
+      // F-005 sentinel. #2113 + #2146 added the SW build; both are merged on
+      // main but verified 404 on app.sira-donnia.org/sw.js as of 2026-05-01.
+      // Remove .fixme once a prod deploy ships the fix — then this smoke
+      // catches future regressions.
+      const res = await request.get(`${PROD_URL}/sw.js`);
+      expect(res.status()).toBe(200);
+      const body = await res.text();
+      expect(body.length).toBeGreaterThan(0);
+    },
+  );
+
+  test('anonymous can browse courses catalog', async ({ page }) => {
+    await page.goto(`${PROD_URL}/fr/courses`);
+    await expect(page.locator('main h1')).toContainText(/catalogue|formation/i);
+  });
+
+  test('anonymous can view curricula index', async ({ page }) => {
+    // F-003 sentinel — /fr/curricula was 404 on staging during the 2026-04-30
+    // sweep (#2111). Catches a future regression of the same shape.
+    await page.goto(`${PROD_URL}/fr/curricula`);
+    await expect(page).not.toHaveTitle(/404/i);
+  });
+
+  test('anonymous about page renders', async ({ page }) => {
+    await page.goto(`${PROD_URL}/fr/about`);
+    await expect(page.locator('h1')).toBeVisible();
+  });
+
+  test('anonymous login page renders form', async ({ page }) => {
+    await page.goto(`${PROD_URL}/fr/login`);
+    await expect(page.locator('input[name="identifier"]')).toBeVisible();
+    await expect(page.locator('input[name="password"]')).toBeVisible();
+  });
+
+  test('English locale renders /en/about', async ({ page }) => {
+    await page.goto(`${PROD_URL}/en/about`);
+    await expect(page.locator('h1')).toBeVisible();
+    expect(await page.evaluate(() => document.documentElement.lang)).toBe('en');
+  });
+
+  test('protected admin endpoint rejects anonymous (auth-bypass sentinel)', async ({ request }) => {
+    // Critical security check — if this ever returns 200, it means an
+    // auth-bypass regression shipped to prod.
+    const res = await request.get(`${PROD_API}/api/v1/admin/users?offset=0&limit=1`);
+    expect(res.status()).toBe(401);
+  });
+
+  test('protected user endpoint rejects anonymous', async ({ request }) => {
+    const res = await request.get(`${PROD_API}/api/v1/users/me`);
+    expect(res.status()).toBe(401);
+  });
+});

--- a/frontend/e2e/specs/03-org-owner/nav.spec.ts
+++ b/frontend/e2e/specs/03-org-owner/nav.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Org-owner sidebar nav — verifies role-scoped UI gating.
+ *
+ * The org-owner is a `role=user` who owns at least one organization. Per the
+ * role-model pivot (#2134, project_role_model_pivot.md), this is the new
+ * canonical "expert" — their elevated capabilities come from
+ * OrgMemberRole.owner, not from a platform UserRole.
+ *
+ * Expected sidebar shape:
+ *   - all 9 learner links visible (Dashboard / Formations / Modules / etc.)
+ *   - "Organisations" visible (they own one)
+ *   - "Administration" hidden (platform-admin gating, not theirs)
+ *
+ * Server-side RBAC for admin endpoints was independently verified during the
+ * 2026-04-30 sweep — this spec catches frontend nav-gating regressions
+ * specifically.
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { DashboardPage } from '../../pages/dashboard-page';
+
+test.describe('@org-owner nav', () => {
+  test.fixme(
+    'sidebar shows Organisations link (user has org membership) — BLOCKED on #2137',
+    async ({ page }) => {
+      const dashboard = new DashboardPage(page);
+      await dashboard.goto('fr');
+
+      // Today this fails because frontend/components/layout/sidebar.tsx:163-172
+      // gates Organisations on `userRole === "admin" || userRole === "sub_admin"`
+      // — explicitly NOT on expert or on "user with org membership". So a
+      // role=user org-owner (the new canonical "expert" per role-model pivot
+      // #2134) does NOT see the link.
+      //
+      // The frontend phase of the migration (#2137) replaces that gating with
+      // a "user has at least one OrgMembership" check. When that lands,
+      // remove the .fixme — this test should pass.
+      await expect(
+        dashboard.sidebarLink('Organisations'),
+        'expected Organisations link visible for an org-member user (post-migration target state)',
+      ).toBeVisible();
+    },
+  );
+
+  test('sidebar hides Administration link (org-owner is not platform admin)', async ({ page }) => {
+    const dashboard = new DashboardPage(page);
+    await dashboard.goto('fr');
+
+    await expect(
+      dashboard.sidebarLink('Administration'),
+      'expected Administration link hidden for an org-owner who is not role=admin',
+    ).toHaveCount(0);
+  });
+});

--- a/frontend/e2e/specs/03-org-owner/org-codes.spec.ts
+++ b/frontend/e2e/specs/03-org-owner/org-codes.spec.ts
@@ -1,0 +1,22 @@
+/**
+ * Org-owner activation codes view — /[locale]/org/{slug}/codes lists
+ * activation codes scoped to the org. Seeded code: E2E-FIXTURE-CODE
+ * (see SEED_ACTIVATION_CODE in fixtures/seed-data.ts).
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { OrgPage } from '../../pages/org-page';
+import { SEED_ACTIVATION_CODE, SEED_ORG } from '../../fixtures/seed-data';
+
+test.describe('@org-owner activation codes', () => {
+  test('lists the seeded fixture activation code', async ({ page }) => {
+    const org = new OrgPage(page);
+    await org.gotoCodes(SEED_ORG.slug, 'fr');
+
+    await expect(
+      page.getByText(SEED_ACTIVATION_CODE, { exact: false }).first(),
+      `expected activation code "${SEED_ACTIVATION_CODE}" visible in org's codes list`,
+    ).toBeVisible();
+  });
+});

--- a/frontend/e2e/specs/03-org-owner/org-courses.spec.ts
+++ b/frontend/e2e/specs/03-org-owner/org-courses.spec.ts
@@ -1,0 +1,24 @@
+/**
+ * Org-owner courses view — /[locale]/org/{slug}/courses lists the org's
+ * courses (e2e-published-course + e2e-draft-course from the #2109 seed).
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { OrgPage } from '../../pages/org-page';
+import { SEED_COURSES, SEED_ORG } from '../../fixtures/seed-data';
+
+test.describe('@org-owner courses', () => {
+  test('lists both seeded courses (published + draft)', async ({ page }) => {
+    const org = new OrgPage(page);
+    await org.gotoCourses(SEED_ORG.slug, 'fr');
+
+    // Match by visible title — seed sets title to "E2E — {slug}".
+    for (const slug of [SEED_COURSES.published.slug, SEED_COURSES.draft.slug]) {
+      await expect(
+        page.getByText(`E2E — ${slug}`, { exact: false }).first(),
+        `expected course "${slug}" visible in org's courses list`,
+      ).toBeVisible();
+    }
+  });
+});

--- a/frontend/e2e/specs/03-org-owner/org-dashboard.spec.ts
+++ b/frontend/e2e/specs/03-org-owner/org-dashboard.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Org-owner dashboard — /[locale]/org/{slug} renders the org's dashboard
+ * with the org name as h1 and stat tiles.
+ *
+ * Fixture: e2e-test-org (slug from #2109 seed, see SEED_ORG in fixtures/seed-data.ts).
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { OrgPage } from '../../pages/org-page';
+import { SEED_ORG } from '../../fixtures/seed-data';
+
+test.describe('@org-owner dashboard', () => {
+  test('renders the org name as h1', async ({ page }) => {
+    const org = new OrgPage(page);
+    await org.gotoDashboard(SEED_ORG.slug, 'fr');
+
+    await expect(org.heading()).toHaveText(SEED_ORG.name, { ignoreCase: true });
+  });
+
+  test('shows the standard org stat tiles (codes, apprenants, complétion, crédits)', async ({
+    page,
+  }) => {
+    const org = new OrgPage(page);
+    await org.gotoDashboard(SEED_ORG.slug, 'fr');
+
+    // Stat tile labels confirmed during the 2026-04-30 sweep.
+    for (const label of ['Total codes', 'Apprenants total', 'Complétion', 'Crédits']) {
+      await expect(
+        page.getByText(label, { exact: false }).first(),
+        `expected stat tile "${label}" visible on org dashboard`,
+      ).toBeVisible();
+    }
+  });
+
+  test('navigates from /fr/organizations index to the org dashboard', async ({ page }) => {
+    await page.goto('/fr/organizations');
+
+    // The org-owner sees their org listed as a card with "Propriétaire" badge.
+    const orgCard = page.locator('main a').filter({ hasText: SEED_ORG.name });
+    await expect(orgCard).toBeVisible();
+
+    // Click through to /fr/org/{slug}.
+    await orgCard.click();
+    await expect(page).toHaveURL(new RegExp(`/fr/org/${SEED_ORG.slug}/?$`));
+  });
+});

--- a/frontend/e2e/specs/04-sub-admin/admin-pages.spec.ts
+++ b/frontend/e2e/specs/04-sub-admin/admin-pages.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * Sub_admin admin-page reachability — confirms sub_admin can navigate to and
+ * load the admin pages they're authorized for.
+ *
+ * Per `backend/app/api/v1/admin_*.py`, sub_admin is included in
+ * `require_role(UserRole.admin, UserRole.sub_admin)` for users / courses /
+ * curricula / taxonomy / groups / payments / audit-logs / analytics / qbank.
+ * Only `/admin/settings/*` is admin-only — covered by settings-403.spec.ts.
+ */
+
+import { expect, test } from '@playwright/test';
+
+test.describe('@sub-admin admin pages', () => {
+  test('/fr/admin/users renders user-management page', async ({ page }) => {
+    await page.goto('/fr/admin/users');
+    await expect(page.locator('main h1')).toContainText(/utilisateurs|user/i);
+  });
+
+  test('/fr/admin/courses renders course-management page', async ({ page }) => {
+    await page.goto('/fr/admin/courses');
+    await expect(page.locator('main h1')).toContainText(/formations|courses/i);
+  });
+
+  test('/fr/admin/curricula renders curriculum-management page', async ({ page }) => {
+    await page.goto('/fr/admin/curricula');
+    await expect(page.locator('main h1')).toContainText(/curricula/i);
+  });
+
+  test('/fr/admin/taxonomy renders taxonomy page', async ({ page }) => {
+    await page.goto('/fr/admin/taxonomy');
+    await expect(page.locator('main h1')).toContainText(/taxonom/i);
+  });
+});

--- a/frontend/e2e/specs/04-sub-admin/nav.spec.ts
+++ b/frontend/e2e/specs/04-sub-admin/nav.spec.ts
@@ -1,0 +1,27 @@
+/**
+ * Sub_admin sidebar nav — verifies role-scoped UI.
+ *
+ * Sub_admin sees the same admin nav links as admin (Administration,
+ * Organisations, QBank-author) but the API gates `/admin/settings/*`
+ * to UserRole.admin only — that's the canary in settings-403.spec.ts.
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { DashboardPage } from '../../pages/dashboard-page';
+
+test.describe('@sub-admin nav', () => {
+  test('sidebar shows Administration link', async ({ page }) => {
+    const dashboard = new DashboardPage(page);
+    await dashboard.goto('fr');
+
+    await expect(dashboard.sidebarLink('Administration')).toBeVisible();
+  });
+
+  test('sidebar shows Organisations link (admin/sub_admin gated)', async ({ page }) => {
+    const dashboard = new DashboardPage(page);
+    await dashboard.goto('fr');
+
+    await expect(dashboard.sidebarLink('Organisations')).toBeVisible();
+  });
+});

--- a/frontend/e2e/specs/04-sub-admin/settings-403.spec.ts
+++ b/frontend/e2e/specs/04-sub-admin/settings-403.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Sub_admin settings restriction — the distinguishing canary for this role.
+ *
+ * `backend/app/api/v1/admin_settings.py:57,71,99,125` gates ALL settings
+ * endpoints on `UserRole.admin` only — sub_admin is NOT included. This spec
+ * confirms the restriction holds at the API layer.
+ *
+ * Memory `project_saas_reseller` notes: "Phase 0 done (BACKEND_URL,
+ * sub_admin)" and #1365 added sub_admin specifically to restrict AI/prompt
+ * settings access. The current implementation is broader — sub_admin can't
+ * touch ANY settings — but that's the production state we want pinned.
+ */
+
+import { expect, test } from '@playwright/test';
+
+const STAGING_API =
+  process.env.STAGING_API ||
+  (process.env.STAGING_URL || 'https://etutor.elearning.portfolio2.kimbetien.com').replace(
+    /^https:\/\/etutor\./,
+    'https://api.',
+  );
+
+test.describe('@sub-admin settings restriction', () => {
+  // Navigate to origin first so localStorage is accessible (otherwise
+  // page.evaluate fires on about:blank and SecurityError-rejects the
+  // localStorage read).
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/fr/dashboard');
+  });
+
+  test('GET /api/v1/admin/settings returns 403 for sub_admin (admin-only endpoint)', async ({
+    page,
+  }) => {
+    const accessToken = await page.evaluate(() => localStorage.getItem('access_token'));
+    expect(accessToken, 'sub_admin storageState should include access_token').toBeTruthy();
+
+    const res = await page.request.get(`${STAGING_API}/api/v1/admin/settings`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    expect(res.status()).toBe(403);
+
+    const body = await res.json();
+    expect(body.detail).toMatch(/insufficient permissions|forbidden/i);
+  });
+
+  test('GET /api/v1/admin/users succeeds for sub_admin (allowed admin endpoint)', async ({
+    page,
+  }) => {
+    // Negative-control: confirm the 403 above isn't a generic "all admin
+    // routes are blocked" — sub_admin should reach /admin/users fine.
+    const accessToken = await page.evaluate(() => localStorage.getItem('access_token'));
+    const res = await page.request.get(`${STAGING_API}/api/v1/admin/users?offset=0&limit=1`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    expect(res.status()).toBe(200);
+  });
+});

--- a/frontend/e2e/specs/05-admin/admin-pages.spec.ts
+++ b/frontend/e2e/specs/05-admin/admin-pages.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * Admin admin-page reachability — confirms admin can navigate the admin
+ * panel. Same scope as sub_admin's reachability spec, plus the audit-logs +
+ * analytics + payments pages which are admin/sub_admin shared but were
+ * already verified in the sweep doc to render.
+ */
+
+import { expect, test } from '@playwright/test';
+
+test.describe('@admin admin pages', () => {
+  test('/fr/admin/users renders user-management page', async ({ page }) => {
+    await page.goto('/fr/admin/users');
+    await expect(page.locator('main h1')).toContainText(/utilisateurs|user/i);
+  });
+
+  test('/fr/admin/courses renders course-management page', async ({ page }) => {
+    await page.goto('/fr/admin/courses');
+    await expect(page.locator('main h1')).toContainText(/formations|courses/i);
+  });
+
+  test('/fr/admin/curricula renders curriculum-management page', async ({ page }) => {
+    await page.goto('/fr/admin/curricula');
+    await expect(page.locator('main h1')).toContainText(/curricula/i);
+  });
+
+  test('/fr/admin/audit-logs renders audit log page', async ({ page }) => {
+    await page.goto('/fr/admin/audit-logs');
+    await expect(page.locator('main h1')).toContainText(/audit|journal/i);
+  });
+
+  test('/fr/admin/analytics renders analytics page', async ({ page }) => {
+    await page.goto('/fr/admin/analytics');
+    await expect(page.locator('main h1')).toContainText(/analy/i);
+  });
+});

--- a/frontend/e2e/specs/05-admin/nav.spec.ts
+++ b/frontend/e2e/specs/05-admin/nav.spec.ts
@@ -1,0 +1,27 @@
+/**
+ * Admin sidebar nav — verifies the highest-privilege persona's nav.
+ *
+ * Admin sees the same admin nav links as sub_admin (Administration,
+ * Organisations, QBank-author). The distinguishing capability — settings
+ * page access — is covered by settings.spec.ts via direct API + UI checks.
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { DashboardPage } from '../../pages/dashboard-page';
+
+test.describe('@admin nav', () => {
+  test('sidebar shows Administration link', async ({ page }) => {
+    const dashboard = new DashboardPage(page);
+    await dashboard.goto('fr');
+
+    await expect(dashboard.sidebarLink('Administration')).toBeVisible();
+  });
+
+  test('sidebar shows Organisations link', async ({ page }) => {
+    const dashboard = new DashboardPage(page);
+    await dashboard.goto('fr');
+
+    await expect(dashboard.sidebarLink('Organisations')).toBeVisible();
+  });
+});

--- a/frontend/e2e/specs/05-admin/settings.spec.ts
+++ b/frontend/e2e/specs/05-admin/settings.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Admin settings access — the distinguishing canary for admin vs sub_admin.
+ *
+ * Sub_admin gets 403 on /api/v1/admin/settings (verified in 04-sub-admin/
+ * settings-403.spec.ts); admin should get 200 and the page should render
+ * the categories list.
+ *
+ * Per `backend/app/api/v1/admin_settings.py:57`, /admin/settings is gated on
+ * UserRole.admin only.
+ */
+
+import { expect, test } from '@playwright/test';
+
+const STAGING_API =
+  process.env.STAGING_API ||
+  (process.env.STAGING_URL || 'https://etutor.elearning.portfolio2.kimbetien.com').replace(
+    /^https:\/\/etutor\./,
+    'https://api.',
+  );
+
+test.describe('@admin settings access', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/fr/dashboard');
+  });
+
+  test('GET /api/v1/admin/settings returns 200 for admin', async ({ page }) => {
+    const accessToken = await page.evaluate(() => localStorage.getItem('access_token'));
+    const res = await page.request.get(`${STAGING_API}/api/v1/admin/settings`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    expect(res.status()).toBe(200);
+
+    // Response is a list of category objects; quick shape check.
+    const body = await res.json();
+    expect(Array.isArray(body), 'expected /admin/settings to return an array of categories').toBe(
+      true,
+    );
+    expect(body.length).toBeGreaterThan(0);
+  });
+
+  test('/fr/admin/settings page renders the categories list', async ({ page }) => {
+    await page.goto('/fr/admin/settings');
+
+    await expect(page.locator('main h1')).toContainText(/paramètres|settings/i);
+
+    // Verified during 2026-04-30 sweep — these category labels appear on
+    // /fr/admin/settings (some are correctly localized, some leak raw
+    // English — see #2128 for the i18n audit follow-up). Just check that
+    // *some* categories render.
+    await expect(
+      page.getByText(/AI.*Content Generation|Auth.*Security|Quiz.*Assessment/i).first(),
+    ).toBeVisible();
+  });
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -65,8 +65,8 @@ export default defineConfig({
     personaProject('01-anonymous'),
     personaProject('02-learner'),
     personaProject('03-org-owner'),
-    // 04-sub-admin / 05-admin: declared in follow-up PRs (2116-3..2116-4)
-    // once their spec dirs exist.
+    personaProject('04-sub-admin'),
+    // 05-admin: declared in 2116-4 once its spec dir exists.
   ],
 
   webServer:

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -66,7 +66,7 @@ export default defineConfig({
     personaProject('02-learner'),
     personaProject('03-org-owner'),
     personaProject('04-sub-admin'),
-    // 05-admin: declared in 2116-4 once its spec dir exists.
+    personaProject('05-admin'),
   ],
 
   webServer:

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -3,6 +3,7 @@ import { defineConfig, devices } from '@playwright/test';
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const STAGING_URL =
   process.env.STAGING_URL || 'https://etutor.elearning.portfolio2.kimbetien.com';
+const PROD_URL = process.env.PROD_URL || 'https://app.sira-donnia.org';
 
 // Persona projects (#2116) authenticate via auth.setup.ts and load the saved
 // storageState file. New specs go under e2e/specs/{persona}/. Old flat specs
@@ -44,12 +45,12 @@ export default defineConfig({
     // they're migrated or retired (cleanup follow-up to #2116).
     {
       name: 'chromium',
-      testIgnore: ['**/specs/**', '**/auth.setup.ts'],
+      testIgnore: ['**/specs/**', '**/smoke/**', '**/auth.setup.ts'],
       use: { ...devices['Desktop Chrome'] },
     },
     {
       name: 'mobile-chrome',
-      testIgnore: ['**/specs/**', '**/auth.setup.ts'],
+      testIgnore: ['**/specs/**', '**/smoke/**', '**/auth.setup.ts'],
       use: { ...devices['Pixel 5'] },
     },
 
@@ -67,6 +68,15 @@ export default defineConfig({
     personaProject('03-org-owner'),
     personaProject('04-sub-admin'),
     personaProject('05-admin'),
+
+    // Production read-only smoke (#2116-5). Anonymous-only; targets PROD_URL
+    // (default https://sira-donnia.org). Run hourly via cron in #2118.
+    // Invoke locally with `--project=smoke`. No setup dependency — no auth.
+    {
+      name: 'smoke',
+      testDir: './e2e/smoke',
+      use: { ...devices['Desktop Chrome'], baseURL: PROD_URL },
+    },
   ],
 
   webServer:

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -64,8 +64,9 @@ export default defineConfig({
     },
     personaProject('01-anonymous'),
     personaProject('02-learner'),
-    // 03-org-owner / 04-sub-admin / 05-admin: declared in follow-up PRs
-    // (2116-2..2116-4) once their spec dirs exist.
+    personaProject('03-org-owner'),
+    // 04-sub-admin / 05-admin: declared in follow-up PRs (2116-3..2116-4)
+    // once their spec dirs exist.
   ],
 
   webServer:


### PR DESCRIPTION
## Summary

Lands the complete E2E persona-spec stack from PRs #2154–#2159 into `dev`. These were stacked on `feat/issue-2116-1-playwright-suite-scaffolding` (already on main via #2153) and got merged into each other rather than directly to dev.

**What's included** (7 commits):

| Issue | Content |
|---|---|
| #2116-2 | org-owner persona specs (`03-org-owner/`) + OrgPage page object |
| #2116-3 | sub_admin persona specs (`04-sub-admin/`) + serial auth.setup mode |
| #2116-4 | admin persona specs (`05-admin/`) |
| #2116-5 | production read-only smoke (`e2e/smoke/critical-paths.spec.ts`) |
| #2117 | E2E persona-suite job added to `ci.yml` |
| #2118 | `prod-smoke.yml` cron (hourly) + `PROD_SMOKE_FAILURE_TEMPLATE.md` |

**No new secrets** — E2E passwords come from `${{ secrets.E2E_*_PASSWORD }}` vars.

Closes #2116, #2117, #2118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)