### PR TITLE
ci: promote E2E gate to blocking (staging seeded, first green run confirmed)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,6 @@ jobs:
   e2e:
     name: E2E Persona Suite (Playwright vs staging)
     runs-on: ubuntu-latest
-    # Non-blocking until fixture accounts are seeded on staging and
-    # E2E_*_PASSWORD secrets are configured in repo settings (#2109 runbook).
-    # Remove continue-on-error once the first clean green run is confirmed.
-    continue-on-error: true
     # Skip on push events (avoid running twice for PR + push). PR runs are
     # what gate merges. Workflow_dispatch keeps manual ad-hoc runs available.
     if: github.event_name != 'push' || github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary

Removes `continue-on-error: true` from the E2E Persona Suite job in `ci.yml`.

- First confirmed green E2E run: workflow_dispatch run `25765389786` on 2026-05-12 — all personas passed
- Staging fixture accounts seeded and passwords synced to `E2E_*_PASSWORD` GH Actions secrets
- E2E job now **blocks PR merges to dev** on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)