### PR TITLE
ci(deploy): SHA-pin images + pre-deploy pg_dump + post-deploy smoke gate (#2119)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -329,8 +329,27 @@ jobs:
             HEYGEN_API_KEY=${HEYGEN_API_KEY}
             EOF
 
-            # Pull new images (only changed layers transferred)
-            docker compose pull backend frontend mms-tts
+            # Capture previous deploy SHA so the smoke gate can roll back.
+            PREV_SHA=""
+            [ -f .deploy-sha ] && PREV_SHA=$(cat .deploy-sha)
+
+            # Pre-deploy DB backup — gzip to ~1/10 of raw size; prune after 7d.
+            BACKUP_FILE="/tmp/pre-deploy-${DEPLOY_SHA:0:7}-$(date +%s).sql.gz"
+            echo "Pre-deploy backup → $BACKUP_FILE"
+            docker exec etutor-postgres pg_dump -U postgres santepublique_aof | gzip > "$BACKUP_FILE"
+            echo "Backup: $(du -sh $BACKUP_FILE | cut -f1)"
+            find /tmp -name 'pre-deploy-*.sql.gz' -mtime +7 -delete 2>/dev/null || true
+
+            # Pull the exact SHA image built by this CI run and retag as :latest
+            # so docker-compose.yml (which references :latest) picks it up.
+            SHORT_SHA="${DEPLOY_SHA:0:7}"
+            docker pull "ghcr.io/benidrissa/etutor-digital-ph/backend:${SHORT_SHA}"
+            docker pull "ghcr.io/benidrissa/etutor-digital-ph/frontend:${SHORT_SHA}"
+            docker tag "ghcr.io/benidrissa/etutor-digital-ph/backend:${SHORT_SHA}" \
+                       "ghcr.io/benidrissa/etutor-digital-ph/backend:latest"
+            docker tag "ghcr.io/benidrissa/etutor-digital-ph/frontend:${SHORT_SHA}" \
+                       "ghcr.io/benidrissa/etutor-digital-ph/frontend:latest"
+            docker compose pull mms-tts || echo "::warning::mms-tts pull skipped (rebuilt only when infra/ changes)"
             docker compose pull nllb || echo "::warning::nllb pull failed, continuing with existing image"
 
             # Restart services
@@ -350,6 +369,29 @@ jobs:
             # Wait for services to be healthy
             sleep 15
             docker compose ps
+
+            # Post-deploy smoke gate: verify the API is healthy.
+            # On failure, re-pull and restart with the previous SHA images.
+            echo "Post-deploy health check..."
+            HEALTH_URL="https://api.elearning.portfolio2.kimbetien.com/health"
+            if ! curl -sf --retry 3 --retry-delay 5 "$HEALTH_URL" > /dev/null; then
+              echo "::error::Health check FAILED at $HEALTH_URL — rolling back to ${PREV_SHA:0:7}"
+              if [ -n "$PREV_SHA" ]; then
+                PREV_SHORT="${PREV_SHA:0:7}"
+                docker pull "ghcr.io/benidrissa/etutor-digital-ph/backend:${PREV_SHORT}" || true
+                docker pull "ghcr.io/benidrissa/etutor-digital-ph/frontend:${PREV_SHORT}" || true
+                docker tag "ghcr.io/benidrissa/etutor-digital-ph/backend:${PREV_SHORT}" \
+                           "ghcr.io/benidrissa/etutor-digital-ph/backend:latest" || true
+                docker tag "ghcr.io/benidrissa/etutor-digital-ph/frontend:${PREV_SHORT}" \
+                           "ghcr.io/benidrissa/etutor-digital-ph/frontend:latest" || true
+                docker compose up -d --remove-orphans --force-recreate backend frontend
+                sleep 15
+                echo "$PREV_SHA" > .deploy-sha
+              fi
+              docker logout ghcr.io
+              exit 1
+            fi
+            echo "Health check passed."
 
             # Cleanup old images
             docker image prune -f
@@ -471,11 +513,26 @@ jobs:
             HEYGEN_API_KEY=${HEYGEN_API_KEY}
             EOF
 
-            # Pull new images. mms-tts is an optional sidecar (audio TTS);
-            # its pull currently fails on a ghcr permissions issue tracked
-            # elsewhere. Don't let that block the backend/frontend rollout.
-            docker compose pull backend frontend
-            docker compose pull mms-tts || echo "::warning::mms-tts pull failed, continuing with existing image"
+            # Capture previous deploy SHA for rollback.
+            PREV_SHA=""
+            [ -f .deploy-sha ] && PREV_SHA=$(cat .deploy-sha)
+
+            # Pre-deploy DB backup.
+            BACKUP_FILE="/tmp/pre-deploy-${DEPLOY_SHA:0:7}-$(date +%s).sql.gz"
+            echo "Pre-deploy backup → $BACKUP_FILE"
+            docker exec etutor-postgres pg_dump -U postgres santepublique_aof | gzip > "$BACKUP_FILE"
+            echo "Backup: $(du -sh $BACKUP_FILE | cut -f1)"
+            find /tmp -name 'pre-deploy-*.sql.gz' -mtime +7 -delete 2>/dev/null || true
+
+            # Pull exact SHA images built by this CI run.
+            SHORT_SHA="${DEPLOY_SHA:0:7}"
+            docker pull "ghcr.io/benidrissa/etutor-digital-ph/backend:${SHORT_SHA}"
+            docker pull "ghcr.io/benidrissa/etutor-digital-ph/frontend:${SHORT_SHA}"
+            docker tag "ghcr.io/benidrissa/etutor-digital-ph/backend:${SHORT_SHA}" \
+                       "ghcr.io/benidrissa/etutor-digital-ph/backend:latest"
+            docker tag "ghcr.io/benidrissa/etutor-digital-ph/frontend:${SHORT_SHA}" \
+                       "ghcr.io/benidrissa/etutor-digital-ph/frontend:latest"
+            docker compose pull mms-tts || echo "::warning::mms-tts pull skipped (rebuilt only when infra/ changes)"
             docker compose pull nllb || echo "::warning::nllb pull failed, continuing with existing image"
 
             docker compose up -d --remove-orphans
@@ -491,6 +548,28 @@ jobs:
 
             sleep 15
             docker compose ps
+
+            # Post-deploy smoke gate.
+            echo "Post-deploy health check..."
+            HEALTH_URL="https://api.sira-donnia.org/health"
+            if ! curl -sf --retry 3 --retry-delay 5 "$HEALTH_URL" > /dev/null; then
+              echo "::error::Health check FAILED at $HEALTH_URL — rolling back to ${PREV_SHA:0:7}"
+              if [ -n "$PREV_SHA" ]; then
+                PREV_SHORT="${PREV_SHA:0:7}"
+                docker pull "ghcr.io/benidrissa/etutor-digital-ph/backend:${PREV_SHORT}" || true
+                docker pull "ghcr.io/benidrissa/etutor-digital-ph/frontend:${PREV_SHORT}" || true
+                docker tag "ghcr.io/benidrissa/etutor-digital-ph/backend:${PREV_SHORT}" \
+                           "ghcr.io/benidrissa/etutor-digital-ph/backend:latest" || true
+                docker tag "ghcr.io/benidrissa/etutor-digital-ph/frontend:${PREV_SHORT}" \
+                           "ghcr.io/benidrissa/etutor-digital-ph/frontend:latest" || true
+                docker compose up -d --remove-orphans --force-recreate backend frontend
+                sleep 15
+                echo "$PREV_SHA" > .deploy-sha
+              fi
+              docker logout ghcr.io
+              exit 1
+            fi
+            echo "Health check passed."
 
             docker image prune -f
             docker logout ghcr.io


### PR DESCRIPTION
## Summary

Three deploy hardening changes to both the staging (`deploy`) and production (`deploy-production`) jobs. Fixes #2119.

### 1 — SHA-pinned image pulls

```bash
SHORT_SHA="${DEPLOY_SHA:0:7}"
docker pull "ghcr.io/.../backend:${SHORT_SHA}"
docker tag  "ghcr.io/.../backend:${SHORT_SHA}" "ghcr.io/.../backend:latest"
```

Previously `docker compose pull backend frontend` always pulled `:latest`, which could pick up a concurrent push mid-deploy. Now we pull the exact SHA tag built by this CI run (e.g. `abc1234`) and retag it as `:latest` so the unchanged `docker-compose.yml` still resolves correctly.

### 2 — Pre-deploy pg_dump

```bash
docker exec etutor-postgres pg_dump -U postgres santepublique_aof | gzip > /tmp/pre-deploy-<sha>-<ts>.sql.gz
```

Creates a gzip snapshot before every `docker compose up`. Retained 7 days in `/tmp`, auto-pruned. Provides a restore point if a bad migration damages data.

### 3 — Post-deploy smoke gate

```bash
if ! curl -sf --retry 3 --retry-delay 5 "$HEALTH_URL" > /dev/null; then
  # roll back to PREV_SHA and exit 1
fi
```

After services restart, checks `/health`. On failure: re-pulls the previous SHA images, restarts `backend + frontend`, restores `.deploy-sha`, and exits 1 so the CI job goes red.

- Staging URL: `https://api.elearning.portfolio2.kimbetien.com/health`
- Prod URL: `https://api.sira-donnia.org/health`

## Test plan

- [ ] Verify the next staging deploy log shows "Pre-deploy backup", "Health check passed"
- [ ] `ls /tmp/pre-deploy-*.sql.gz` on staging server after deploy confirms backup exists
- [ ] (Manual) temporarily commenting out the health endpoint and triggering a `workflow_dispatch` would exercise the rollback path — out of scope for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)