### PR TITLE
fix(admin): ISO date for Created column + phone_number in user search

### DIFF
--- a/backend/app/api/v1/admin/users.py
+++ b/backend/app/api/v1/admin/users.py
@@ -284,7 +284,11 @@ async def export_users_csv(
 
         if search:
             pattern = f"%{search}%"
-            stmt = stmt.where(or_(User.name.ilike(pattern), User.email.ilike(pattern)))
+            stmt = stmt.where(or_(
+                User.name.ilike(pattern),
+                User.email.ilike(pattern),
+                User.phone_number.ilike(pattern),
+            ))
         if country:
             stmt = stmt.where(User.country == country)
         if level is not None:
@@ -369,7 +373,11 @@ async def count_users(
 
         if search:
             pattern = f"%{search}%"
-            stmt = stmt.where(or_(User.name.ilike(pattern), User.email.ilike(pattern)))
+            stmt = stmt.where(or_(
+                User.name.ilike(pattern),
+                User.email.ilike(pattern),
+                User.phone_number.ilike(pattern),
+            ))
         if country:
             stmt = stmt.where(User.country == country)
         if level is not None:
@@ -407,7 +415,11 @@ async def list_users(
 
         if search:
             pattern = f"%{search}%"
-            stmt = stmt.where(or_(User.name.ilike(pattern), User.email.ilike(pattern)))
+            stmt = stmt.where(or_(
+                User.name.ilike(pattern),
+                User.email.ilike(pattern),
+                User.phone_number.ilike(pattern),
+            ))
         if country:
             stmt = stmt.where(User.country == country)
         if level is not None:

--- a/frontend/components/admin/user-list-client.tsx
+++ b/frontend/components/admin/user-list-client.tsx
@@ -657,7 +657,7 @@ function UserRow({
       </td>
       <td className="py-2 pr-4 text-muted-foreground whitespace-nowrap text-xs">{user.country ?? "—"}</td>
       <td className="py-2 pr-4 text-muted-foreground whitespace-nowrap text-xs">{t("level", { level: user.current_level })}</td>
-      <td className="py-2 pr-4 text-muted-foreground whitespace-nowrap text-xs">{new Date(user.created_at).toLocaleDateString()}</td>
+      <td className="py-2 pr-4 text-muted-foreground whitespace-nowrap text-xs">{user.created_at.slice(0, 10)}</td>
       <td className="py-2">
         <DropdownMenu>
           <DropdownMenuTrigger


### PR DESCRIPTION
- Created column: `YYYY-MM-DD` (ISO slice) instead of locale-formatted date
- Add `phone_number` to the `ilike` OR filter in list, count, and export CSV endpoints

Fixes #2295

🤖 Generated with [Claude Code](https://claude.com/claude-code)