### PR TITLE
fix(ux): sort enrolled course list by last content view

### DIFF
--- a/frontend/app/[locale]/(app)/dashboard/dashboard-client.tsx
+++ b/frontend/app/[locale]/(app)/dashboard/dashboard-client.tsx
@@ -25,7 +25,7 @@ export function DashboardClient({ curriculumSlug }: { curriculumSlug?: string })
 
   useEffect(() => {
     let cancelled = false;
-    getMyEnrollments()
+    getMyEnrollments({ orderBy: 'last_accessed' })
       .then((data) => {
         if (!cancelled) {
           setEnrollments(data);

--- a/frontend/components/learning/module-map.tsx
+++ b/frontend/components/learning/module-map.tsx
@@ -73,7 +73,7 @@ export function ModuleMap({ onModuleClick, courseId }: ModuleMapProps) {
             modules: progressData.map(apiProgressToModule),
           }]);
         } else {
-          const enrollments = await getMyEnrollments();
+          const enrollments = await getMyEnrollments({ orderBy: 'last_accessed' });
           if (cancelled) return;
           const progressResults = await Promise.all(
             enrollments.map((course: CourseWithEnrollment) =>


### PR DESCRIPTION
## Summary
- Enrolled course list on dashboard and module map was sorted by `enrolled_at DESC` (join date) instead of last interaction
- Pass `{ orderBy: 'last_accessed' }` to `getMyEnrollments()` in the two affected call sites
- Backend sort (`last_interacted_at DESC NULLS LAST, enrolled_at DESC`) already existed — no backend or schema changes

## Files changed
- `frontend/app/[locale]/(app)/dashboard/dashboard-client.tsx`
- `frontend/components/learning/module-map.tsx`

## Test plan
- [ ] Enroll in 2+ courses, open a lesson in the older-enrolled one
- [ ] Dashboard: recently-accessed course appears first
- [ ] Module map (multi-course): same order
- [ ] Brand-new enrolled course with no activity appears last

Fixes #2301

🤖 Generated with [Claude Code](https://claude.com/claude-code)