### PR TITLE
fix(tutor): render chat panel as fixed floating window on desktop

### DIFF
--- a/frontend/components/chat/chat-layout.tsx
+++ b/frontend/components/chat/chat-layout.tsx
@@ -2,9 +2,10 @@
 
 import { ChatProvider, useChatContext, ChatPanel, FloatingChatButton } from '@/components/chat';
 import { usePathname } from 'next/navigation';
+import { cn } from '@/lib/utils';
 
 function ChatUIComponents() {
-  const { isOpen, openChat, closeChat } = useChatContext();
+  const { isOpen, closeChat, toggleChat } = useChatContext();
   const pathname = usePathname();
   
   // Extract moduleId from pathname if we're in a module page
@@ -21,7 +22,12 @@ function ChatUIComponents() {
 
   return (
     <>
-      {!hideFab && <FloatingChatButton onClick={openChat} />}
+      {!hideFab && (
+        <FloatingChatButton
+          onClick={toggleChat}
+          className={cn(isOpen && 'md:hidden')}
+        />
+      )}
       <ChatPanel 
         isOpen={isOpen} 
         onClose={closeChat}

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -531,7 +531,7 @@ export function ChatPanel({
             ? 'flex flex-col h-full w-full bg-background'
             : cn(
                 'fixed inset-0 z-50 flex flex-col bg-background',
-                'md:relative md:inset-auto md:w-96 md:border-l',
+                'md:fixed md:inset-auto md:bottom-24 md:right-4 md:w-96 md:max-h-[600px] md:rounded-xl md:shadow-2xl md:border md:overflow-hidden',
                 'transition-transform duration-300 ease-in-out',
                 isOpen ? 'translate-x-0' : 'translate-x-full md:translate-x-0'
               ),
@@ -625,7 +625,7 @@ export function ChatPanel({
               variant="ghost"
               size="icon"
               onClick={onClose}
-              className="h-11 w-11 md:hidden"
+              className="h-11 w-11"
             >
               <X className="h-4 w-4" />
             </Button>


### PR DESCRIPTION
## Summary

- `ChatPanel` was using `md:relative` on desktop, placing it in normal document flow after page children — causing it to render **below** curriculum cards rather than floating
- Changed to `md:fixed md:bottom-24 md:right-4` so the panel floats as a popup window above content in the bottom-right corner
- Removed `md:hidden` from the close (X) button so desktop users can dismiss the window
- Wired FAB to `toggleChat` (was `openChat`) so clicking it again closes the panel; FAB is also hidden on desktop when panel is open to avoid duplicate controls

## Test plan

- [ ] Open dashboard on desktop (≥768px) — click Tutor IA FAB → rounded floating window appears bottom-right, overlaying content
- [ ] Click X in the floating window header → panel closes, FAB reappears
- [ ] Click FAB again while panel is open → panel closes (toggle behaviour)
- [ ] Mobile unchanged — chat still opens as full-screen overlay
- [ ] `/tutor` page embedded mode unaffected (uses `embedded={true}` path)

Fixes #2303

🤖 Generated with [Claude Code](https://claude.com/claude-code)