### PR TITLE
fix(demo): resolve BUG-D-001 + BUG-D-002 + BUG-D-003

### DIFF
--- a/backend/app/api/v1/admin/users.py
+++ b/backend/app/api/v1/admin/users.py
@@ -145,14 +145,22 @@ async def create_user(
         created_at=datetime.utcnow(),
     )
     db.add(user)
+    await db.flush()  # ensure user.id is persisted before FK reference in audit log
 
-    await _write_audit_log(
-        db,
-        current_user,
-        user,
-        AdminAction.create_user,
-        details=f"created with role {request.role.value}",
-    )
+    try:
+        await _write_audit_log(
+            db,
+            current_user,
+            user,
+            AdminAction.create_user,
+            details=f"created with role {request.role.value}",
+        )
+    except Exception:
+        logger.warning(
+            "audit_log_write_failed",
+            admin_id=current_user.id,
+            action="create_user",
+        )
     await db.commit()
     await db.refresh(user)
 

--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from celery.result import AsyncResult
 from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, UploadFile, status
 from fastapi.responses import StreamingResponse
+from sqlalchemy import func, select
 
 from app.api.deps import get_db_session
 from app.api.deps_local_auth import AuthenticatedUser, get_current_user
@@ -378,7 +379,13 @@ async def get_bank(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="Question bank not found.",
             )
-    return _bank_response(bank)
+    q_count_result = await db.execute(
+        select(func.count())
+        .select_from(QBankQuestion)
+        .where(QBankQuestion.question_bank_id == bank_id)
+    )
+    q_count = q_count_result.scalar_one()
+    return _bank_response(bank, question_count=q_count)
 
 
 @router.patch("/banks/{bank_id}", response_model=QuestionBankResponse)
@@ -397,7 +404,13 @@ async def update_bank(
             detail="Only platform admins can make a question bank public.",
         )
     bank = await _svc.update_bank(db, bank_id, uuid.UUID(current_user.id), **updates)
-    return _bank_response(bank)
+    q_count_result = await db.execute(
+        select(func.count())
+        .select_from(QBankQuestion)
+        .where(QBankQuestion.question_bank_id == bank_id)
+    )
+    q_count = q_count_result.scalar_one()
+    return _bank_response(bank, question_count=q_count)
 
 
 @router.delete("/banks/{bank_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/tasks/qbank_processing.py
+++ b/backend/app/tasks/qbank_processing.py
@@ -108,8 +108,6 @@ async def _process_pdf_async(task, bank_id: str, pdf_filename: str) -> dict:
         next_order = (max_order or 0) + 1
 
         # Collect existing question texts to skip re-insertion across uploads
-        from sqlalchemy import text as sql_text  # noqa: F401 (unused alias kept for clarity)
-
         existing_texts_result = session.execute(
             select(QBankQuestion.question_text).where(QBankQuestion.question_bank_id == bank_uuid)
         )

--- a/backend/app/tasks/qbank_processing.py
+++ b/backend/app/tasks/qbank_processing.py
@@ -72,6 +72,23 @@ async def _process_pdf_async(task, bank_id: str, pdf_filename: str) -> dict:
         logger.warning("No questions extracted from PDF", bank_id=bank_id)
         return {"bank_id": bank_id, "questions_created": 0, "errors": []}
 
+    # Deduplicate by normalized question text (case-insensitive, strip whitespace)
+    seen_texts: set[str] = set()
+    deduped = []
+    for q in extracted:
+        key = (q.question_text or "").strip().lower()
+        if key and key not in seen_texts:
+            seen_texts.add(key)
+            deduped.append(q)
+        else:
+            logger.info(
+                "Skipping duplicate question",
+                bank_id=bank_id,
+                page=q.page_number,
+                text=(q.question_text or "")[:60],
+            )
+    extracted = deduped
+
     # Store images and create DB rows
     storage = S3StorageService()
     engine = create_engine(settings.database_url_sync, pool_pre_ping=True)
@@ -90,7 +107,25 @@ async def _process_pdf_async(task, bank_id: str, pdf_filename: str) -> dict:
         )
         next_order = (max_order or 0) + 1
 
+        # Collect existing question texts to skip re-insertion across uploads
+        from sqlalchemy import text as sql_text  # noqa: F401 (unused alias kept for clarity)
+
+        existing_texts_result = session.execute(
+            select(QBankQuestion.question_text).where(QBankQuestion.question_bank_id == bank_uuid)
+        )
+        existing_texts = {
+            (row[0] or "").strip().lower() for row in existing_texts_result.all() if row[0]
+        }
+
         for idx, q in enumerate(extracted):
+            key = (q.question_text or "").strip().lower()
+            if key and key in existing_texts:
+                logger.info(
+                    "Skipping already-existing question",
+                    bank_id=bank_id,
+                    page=q.page_number,
+                )
+                continue
             try:
                 # Upload image to MinIO directly — we're already in an async
                 # context, so await the coroutine. A previous nested


### PR DESCRIPTION
## Summary

- **BUG-D-001**: `POST /api/v1/admin/users` returned 500 on fresh tenants. Added `await db.flush()` before writing the audit log so `target_user_id` FK resolves within the transaction; wrapped `_write_audit_log()` in `try/except` so an audit log failure never aborts user creation.
- **BUG-D-002**: `GET /api/v1/qbank/banks/{id}` returned `question_count: 0` even after PDF upload. Added a `COUNT(*)` query in `get_bank` (and `update_bank`) before returning `_bank_response`.
- **BUG-D-003**: QBank PDF upload generated duplicate questions from repeated slides. Added in-memory deduplication by normalised `question_text` after extraction, plus a check against already-stored questions before each insert.

## Files changed
- `backend/app/api/v1/admin/users.py` — BUG-D-001
- `backend/app/api/v1/qbank.py` — BUG-D-002
- `backend/app/tasks/qbank_processing.py` — BUG-D-003

## Test plan
- [ ] POST /admin/users succeeds on fresh tenants (no more 500)
- [ ] GET /qbank/banks/{id} returns correct `question_count`
- [ ] Re-upload of same PDF does not create duplicate questions
- [ ] Ruff: zero violations (`ruff check` passes)

Closes BUG-D-001, BUG-D-002, BUG-D-003 from docs/DEMO_UAT_BUGS.md