### PR TITLE
fix(e2e): wait for networkidle in gotoCodes — org-codes test timing

### DIFF
--- a/frontend/e2e/pages/org-page.ts
+++ b/frontend/e2e/pages/org-page.ts
@@ -1,0 +1,61 @@
+/**
+ * Page object for /[locale]/org/{slug} and its sub-routes.
+ *
+ * Thin wrapper — locators only.
+ *
+ * Routes covered (verified during 2026-04-30 sweep — all 200):
+ *   /fr/org/{slug}                org dashboard (stats, quick links)
+ *   /fr/org/{slug}/courses        course list
+ *   /fr/org/{slug}/curricula      curriculum list
+ *   /fr/org/{slug}/qbank          question banks
+ *   /fr/org/{slug}/codes          activation codes
+ *   /fr/org/{slug}/reports        learner reports
+ *   /fr/org/{slug}/members        org members
+ */
+
+import type { Locator, Page } from '@playwright/test';
+
+export class OrgPage {
+  constructor(public readonly page: Page) {}
+
+  async gotoDashboard(slug: string, locale: 'fr' | 'en' = 'fr'): Promise<void> {
+    await this.page.goto(`/${locale}/org/${slug}`);
+  }
+
+  async gotoCourses(slug: string, locale: 'fr' | 'en' = 'fr'): Promise<void> {
+    await this.page.goto(`/${locale}/org/${slug}/courses`);
+  }
+
+  async gotoCodes(slug: string, locale: 'fr' | 'en' = 'fr'): Promise<void> {
+    await this.page.goto(`/${locale}/org/${slug}/codes`);
+    // Wait for the async useEffect API call to populate the codes list
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  async gotoMembers(slug: string, locale: 'fr' | 'en' = 'fr'): Promise<void> {
+    await this.page.goto(`/${locale}/org/${slug}/members`);
+  }
+
+  /** Org-name heading on the dashboard view. */
+  heading(): Locator {
+    return this.page.locator('main h1');
+  }
+
+  /** Stat tile by label (e.g. "Total codes", "Apprenants total"). */
+  statTile(label: string): Locator {
+    return this.page.locator('main', { hasText: label });
+  }
+
+  /** Course card by slug (the slug is rendered as a link href). */
+  courseLink(slug: string): Locator {
+    return this.page.locator(`main a[href*="/courses/"][href$="${slug}"], main a[href*="/${slug}"]`);
+  }
+
+  /**
+   * Activation code row by code value.
+   * Matches any element whose text contains the code (the table cell or chip).
+   */
+  activationCodeRow(code: string): Locator {
+    return this.page.locator('main').getByText(code, { exact: true });
+  }
+}


### PR DESCRIPTION
## Summary

`03-org-owner/org-codes.spec.ts` was failing because `gotoCodes()` navigated to the page without waiting for the async `useEffect` API call that populates the activation codes list.

**Fix:** Add `waitForLoadState('networkidle')` in `OrgPage.gotoCodes()`.

**Root cause confirmed:** `E2E-FIXTURE-CODE` exists in staging DB — the failure was a race condition, not missing data.

## Files
- `frontend/e2e/pages/org-page.ts` — add `waitForLoadState('networkidle')` in `gotoCodes`

Unblocks PR #2309 (dev→main).