### PR TITLE
chore: promote UAT bug fixes to main — BUG-D-001/002/003/004/007 + E2E fix

### DIFF
--- a/backend/app/api/v1/admin/users.py
+++ b/backend/app/api/v1/admin/users.py
@@ -145,14 +145,22 @@ async def create_user(
         created_at=datetime.utcnow(),
     )
     db.add(user)
+    await db.flush()  # ensure user.id is persisted before FK reference in audit log
 
-    await _write_audit_log(
-        db,
-        current_user,
-        user,
-        AdminAction.create_user,
-        details=f"created with role {request.role.value}",
-    )
+    try:
+        await _write_audit_log(
+            db,
+            current_user,
+            user,
+            AdminAction.create_user,
+            details=f"created with role {request.role.value}",
+        )
+    except Exception:
+        logger.warning(
+            "audit_log_write_failed",
+            admin_id=current_user.id,
+            action="create_user",
+        )
     await db.commit()
     await db.refresh(user)
 

--- a/backend/app/api/v1/qbank.py
+++ b/backend/app/api/v1/qbank.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from celery.result import AsyncResult
 from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, UploadFile, status
 from fastapi.responses import StreamingResponse
+from sqlalchemy import func, select
 
 from app.api.deps import get_db_session
 from app.api.deps_local_auth import AuthenticatedUser, get_current_user
@@ -378,7 +379,13 @@ async def get_bank(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="Question bank not found.",
             )
-    return _bank_response(bank)
+    q_count_result = await db.execute(
+        select(func.count())
+        .select_from(QBankQuestion)
+        .where(QBankQuestion.question_bank_id == bank_id)
+    )
+    q_count = q_count_result.scalar_one()
+    return _bank_response(bank, question_count=q_count)
 
 
 @router.patch("/banks/{bank_id}", response_model=QuestionBankResponse)
@@ -397,7 +404,13 @@ async def update_bank(
             detail="Only platform admins can make a question bank public.",
         )
     bank = await _svc.update_bank(db, bank_id, uuid.UUID(current_user.id), **updates)
-    return _bank_response(bank)
+    q_count_result = await db.execute(
+        select(func.count())
+        .select_from(QBankQuestion)
+        .where(QBankQuestion.question_bank_id == bank_id)
+    )
+    q_count = q_count_result.scalar_one()
+    return _bank_response(bank, question_count=q_count)
 
 
 @router.delete("/banks/{bank_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/tasks/qbank_processing.py
+++ b/backend/app/tasks/qbank_processing.py
@@ -72,6 +72,23 @@ async def _process_pdf_async(task, bank_id: str, pdf_filename: str) -> dict:
         logger.warning("No questions extracted from PDF", bank_id=bank_id)
         return {"bank_id": bank_id, "questions_created": 0, "errors": []}
 
+    # Deduplicate by normalized question text (case-insensitive, strip whitespace)
+    seen_texts: set[str] = set()
+    deduped = []
+    for q in extracted:
+        key = (q.question_text or "").strip().lower()
+        if key and key not in seen_texts:
+            seen_texts.add(key)
+            deduped.append(q)
+        else:
+            logger.info(
+                "Skipping duplicate question",
+                bank_id=bank_id,
+                page=q.page_number,
+                text=(q.question_text or "")[:60],
+            )
+    extracted = deduped
+
     # Store images and create DB rows
     storage = S3StorageService()
     engine = create_engine(settings.database_url_sync, pool_pre_ping=True)
@@ -90,7 +107,23 @@ async def _process_pdf_async(task, bank_id: str, pdf_filename: str) -> dict:
         )
         next_order = (max_order or 0) + 1
 
+        # Collect existing question texts to skip re-insertion across uploads
+        existing_texts_result = session.execute(
+            select(QBankQuestion.question_text).where(QBankQuestion.question_bank_id == bank_uuid)
+        )
+        existing_texts = {
+            (row[0] or "").strip().lower() for row in existing_texts_result.all() if row[0]
+        }
+
         for idx, q in enumerate(extracted):
+            key = (q.question_text or "").strip().lower()
+            if key and key in existing_texts:
+                logger.info(
+                    "Skipping already-existing question",
+                    bank_id=bank_id,
+                    page=q.page_number,
+                )
+                continue
             try:
                 # Upload image to MinIO directly — we're already in an async
                 # context, so await the coroutine. A previous nested

--- a/frontend/e2e/pages/org-page.ts
+++ b/frontend/e2e/pages/org-page.ts
@@ -28,6 +28,8 @@ export class OrgPage {
 
   async gotoCodes(slug: string, locale: 'fr' | 'en' = 'fr'): Promise<void> {
     await this.page.goto(`/${locale}/org/${slug}/codes`);
+    // Wait for the async useEffect API call to populate the codes list
+    await this.page.waitForLoadState('networkidle');
   }
 
   async gotoMembers(slug: string, locale: 'fr' | 'en' = 'fr'): Promise<void> {

--- a/frontend/e2e/specs/demo/learner-stories.spec.ts
+++ b/frontend/e2e/specs/demo/learner-stories.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * Demo / learner user-story acceptance suite.
+ *
+ * Covers the high-priority H.x acceptance stories for the demo tenant.
+ * All tests run against the production demo URL configured in playwright.config.ts.
+ *
+ * H.1  — Anonymous visitor sees landing + login
+ * H.2  — Learner can log in and reach the dashboard
+ * H.3  — No raw i18n keys are rendered (translation completeness canary)
+ * H.4  — Dashboard renders in the user's preferred locale
+ * H.5  — Learner can navigate to Modules
+ */
+
+import { expect, test } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// H.1 — Anonymous visitor
+// ---------------------------------------------------------------------------
+test.describe('H.1 — Anonymous visitor', () => {
+  test('login page is reachable and renders the sign-in form', async ({ page }) => {
+    await page.goto('/fr/login');
+    await expect(page.locator('#email')).toBeVisible();
+    await expect(page.locator('#totp_code')).toBeVisible();
+  });
+
+  test('redirects to login when accessing a protected route', async ({ page }) => {
+    await page.goto('/fr/dashboard');
+    await expect(page).toHaveURL(/\/login/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// H.2 — Learner login
+// ---------------------------------------------------------------------------
+test.describe('H.2 — Learner login', () => {
+  test('login page renders form elements in French', async ({ page }) => {
+    await page.goto('/fr/login');
+    await expect(page.locator('#email')).toBeVisible();
+    await expect(page.locator('#totp_code')).toBeVisible();
+    // Page should contain at least one <button> for form submission
+    await expect(page.locator('button[type="submit"]')).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// H.3 — i18n completeness: no raw translation keys visible in the UI
+//
+// A "raw key" is a dotted string that looks like "namespace.subKey.leaf" —
+// the pattern react-i18next / next-intl emit when a key is missing from the
+// active locale's message catalogue.
+//
+// False-positive exclusions:
+//   • Strings that contain a digit (version strings, IDs, …)
+//   • React/Next.js SSR internals: "Sreact.*" and "React.*" that match the
+//     dotted-key shape but are internal framework identifiers, not i18n keys.
+// ---------------------------------------------------------------------------
+test.describe('H.3 — No raw i18n keys rendered', () => {
+  const PAGES_TO_CHECK = ['/fr/login', '/en/login'];
+
+  for (const route of PAGES_TO_CHECK) {
+    test(`no raw i18n keys on ${route}`, async ({ page }) => {
+      await page.goto(route);
+
+      // Collect every text node on the page.
+      const rawKeys: string[] = await page.evaluate(() => {
+        const walker = document.createTreeWalker(
+          document.body,
+          NodeFilter.SHOW_TEXT,
+          null,
+        );
+        const texts: string[] = [];
+        let node: Text | null;
+        while ((node = walker.nextNode() as Text | null)) {
+          const t = node.textContent?.trim();
+          if (t) texts.push(t);
+        }
+        return texts;
+      });
+
+      // A raw key looks like "some.dotted.path" where every segment is > 2
+      // characters long and there are no digits in the whole string.
+      // Exclude React / Next.js SSR internal identifiers that match the same
+      // shape but are not missing translation keys.
+      const suspicious = rawKeys.filter(
+        k =>
+          !k.match(/\d/) &&
+          k.split('.').every(p => p.length > 2) &&
+          !k.startsWith('Sreact.') &&
+          !k.startsWith('React.'),
+      );
+
+      expect(
+        suspicious,
+        `Raw i18n keys detected on ${route}: ${suspicious.join(', ')}`,
+      ).toEqual([]);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// H.4 — Locale rendering
+// ---------------------------------------------------------------------------
+test.describe('H.4 — Locale rendering', () => {
+  test('French login page has lang="fr" on <html>', async ({ page }) => {
+    await page.goto('/fr/login');
+    const lang = await page.locator('html').getAttribute('lang');
+    expect(lang).toBe('fr');
+  });
+
+  test('English login page has lang="en" on <html>', async ({ page }) => {
+    await page.goto('/en/login');
+    const lang = await page.locator('html').getAttribute('lang');
+    expect(lang).toBe('en');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// H.5 — Modules navigation
+// ---------------------------------------------------------------------------
+test.describe('H.5 — Modules navigation', () => {
+  test('modules route returns a page (not 404)', async ({ page }) => {
+    const response = await page.goto('/fr/modules');
+    // Allow 200 or redirect (3xx → resolved to 200 by Playwright follow)
+    expect(response?.status()).not.toBe(404);
+  });
+});

--- a/frontend/public/manifest.webmanifest
+++ b/frontend/public/manifest.webmanifest
@@ -1,0 +1,36 @@
+{
+  "name": "Sira — Plateforme d'apprentissage",
+  "short_name": "Sira",
+  "description": "Votre plateforme d'apprentissage intelligente avec IA",
+  "start_url": "/fr/dashboard",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#6366f1",
+  "lang": "fr",
+  "icons": [
+    {
+      "src": "/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
+    },
+    {
+      "src": "/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Cherry-picks the UAT bug fixes from `dev` onto `main`, bypassing the `dev`↔`main` `org-page.ts` add/add conflict.

### Included fixes
- **#2307 / BUG-D-001** — `POST /admin/users` 500 on fresh tenants: `db.flush()` + try/except around audit log
- **#2307 / BUG-D-002** — `GET /qbank/banks/{id}` `question_count: 0`: COUNT query in `get_bank`/`update_bank`
- **#2307 / BUG-D-003** — QBank PDF duplicate questions: dedup by normalised `question_text`
- **#2308 / BUG-D-004** — Missing `manifest.webmanifest` (PWA installability)
- **#2308 / BUG-D-007** — i18n test `Sreact.*` false-positives filtered
- **#2310** — `gotoCodes()` networkidle wait (fixes `org-codes.spec.ts` race condition)

Supersedes PR #2309.

## Test plan
- [ ] All CI checks green
- [ ] Curl: `GET /manifest.webmanifest` → 200
- [ ] Curl: `POST /admin/users` on demo tenant → 201
- [ ] Curl: `GET /qbank/banks/{id}` → `question_count: 11`