### PR TITLE
fix(ci): replace fixed sleep with wait loop in deploy health gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -367,8 +367,14 @@ jobs:
             # Record deploy SHA
             echo "${DEPLOY_SHA}" > .deploy-sha
 
-            # Wait for services to be healthy
-            sleep 15
+            # Wait for backend to become healthy (up to 90s)
+            echo "Waiting for backend to become healthy..."
+            WAITED=0
+            until [ "$(docker inspect etutor-backend --format='{{.State.Health.Status}}' 2>/dev/null)" = "healthy" ] || [ "$WAITED" -ge 90 ]; do
+              sleep 5
+              WAITED=$((WAITED + 5))
+              echo "  backend health: $(docker inspect etutor-backend --format='{{.State.Health.Status}}' 2>/dev/null) (${WAITED}s)"
+            done
             docker compose ps
 
             # Post-deploy smoke gate: verify the API is healthy.
@@ -548,7 +554,14 @@ jobs:
 
             echo "${DEPLOY_SHA}" > .deploy-sha
 
-            sleep 15
+            # Wait for backend to become healthy (up to 90s)
+            echo "Waiting for backend to become healthy..."
+            WAITED=0
+            until [ "$(docker inspect etutor-backend --format='{{.State.Health.Status}}' 2>/dev/null)" = "healthy" ] || [ "$WAITED" -ge 90 ]; do
+              sleep 5
+              WAITED=$((WAITED + 5))
+              echo "  backend health: $(docker inspect etutor-backend --format='{{.State.Health.Status}}' 2>/dev/null) (${WAITED}s)"
+            done
             docker compose ps
 
             # Post-deploy smoke gate.


### PR DESCRIPTION
## Problem

Post-deploy health check fires while \`etutor-backend\` is still \`health: starting\`, causing the smoke gate to roll back a perfectly good deploy.

**Evidence (run 25890835872):**
```
Container etutor-backend  Up 31 seconds (health: starting)
Post-deploy health check...
Health check FAILED — rolling back to 752693f
```

## Fix

Replace the fixed \`sleep 15\` before \`docker compose ps\` with a polling loop (5s intervals, 90s max) that waits for \`docker inspect\` to report \`healthy\` before firing the external curl.

Applied to both staging and production blocks.

Fixes #2311

🤖 Generated with [Claude Code](https://claude.com/claude-code)