### PR TITLE
fix(tutor): add visible close button to desktop floating chat panel

### DIFF
--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -538,6 +538,19 @@ export function ChatPanel({
           className
         )}
       >
+        {/* Desktop floating close button — absolutely positioned top-right, visible regardless of header overflow */}
+        {!embedded && (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onClose}
+            className="hidden md:flex absolute top-1 right-1 h-8 w-8 z-10 rounded-full"
+            aria-label={t('closeChat')}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        )}
+
         {/* Header */}
         <div className="flex items-center justify-between p-3 border-b bg-background shrink-0 gap-2 flex-nowrap">
           <div className="flex items-center gap-2 shrink-0">
@@ -625,7 +638,7 @@ export function ChatPanel({
               variant="ghost"
               size="icon"
               onClick={onClose}
-              className="h-11 w-11"
+              className="h-11 w-11 md:hidden"
             >
               <X className="h-4 w-4" />
             </Button>


### PR DESCRIPTION
## Summary

- The header X close button was clipped and invisible on desktop: the header row (course selector ≤160px + mode toggle ~100px + MoreVertical 44px + X 44px) exceeds the 384px panel inner width under `flex-nowrap`, and `md:overflow-hidden` silently clips the X
- Added an absolutely-positioned close button (`absolute top-1 right-1 h-8 w-8`) inside the panel — always within bounds regardless of header content width
- Restored `md:hidden` on the original header X (it was mobile-only by design; the new absolute button handles desktop)

## Test plan

- [ ] Open dashboard on desktop (≥768px) → click Tutor IA FAB → floating window appears
- [ ] Close button (X) visible in top-right corner of the floating panel
- [ ] Click X → panel closes, FAB reappears
- [ ] Mobile unchanged — full-screen overlay still has X in the header
- [ ] `/tutor` embedded mode unaffected (`!embedded` guard)

Fixes #2315

🤖 Generated with [Claude Code](https://claude.com/claude-code)