### PR TITLE
fix(db): add ON DELETE CASCADE to module_units and summative_assessment_attempts FKs

### DIFF
--- a/backend/migrations/versions/092_fix_cascade_fk_module_units_summative_attempts.py
+++ b/backend/migrations/versions/092_fix_cascade_fk_module_units_summative_attempts.py
@@ -11,7 +11,6 @@ causes course deletion to fail because PostgreSQL blocks module row deletion.
 
 from collections.abc import Sequence
 
-import sqlalchemy as sa
 from alembic import op
 
 revision: str = "092_fix_cascade_fk_module_units_summative_attempts"

--- a/backend/migrations/versions/092_fix_cascade_fk_module_units_summative_attempts.py
+++ b/backend/migrations/versions/092_fix_cascade_fk_module_units_summative_attempts.py
@@ -1,0 +1,100 @@
+"""fix ON DELETE CASCADE on module_units and summative_assessment_attempts
+
+Revision ID: 092_fix_cascade_fk_module_units_summative_attempts
+Revises: 091_relax_module_progress_locked_post_2125
+Create Date: 2026-05-15
+
+Both tables were created without ondelete in their FK constraints (defaulting to
+RESTRICT), while the SQLAlchemy models specify ondelete="CASCADE". This mismatch
+causes course deletion to fail because PostgreSQL blocks module row deletion.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "092_fix_cascade_fk_module_units_summative_attempts"
+down_revision: str | None = "091_relax_module_progress_locked_post_2125"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # module_units.module_id → modules.id
+    op.drop_constraint("module_units_module_id_fkey", "module_units", type_="foreignkey")
+    op.create_foreign_key(
+        "module_units_module_id_fkey",
+        "module_units",
+        "modules",
+        ["module_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    # summative_assessment_attempts.module_id → modules.id
+    op.drop_constraint(
+        "summative_assessment_attempts_module_id_fkey",
+        "summative_assessment_attempts",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "summative_assessment_attempts_module_id_fkey",
+        "summative_assessment_attempts",
+        "modules",
+        ["module_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    # summative_assessment_attempts.assessment_id → generated_content.id
+    op.drop_constraint(
+        "summative_assessment_attempts_assessment_id_fkey",
+        "summative_assessment_attempts",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "summative_assessment_attempts_assessment_id_fkey",
+        "summative_assessment_attempts",
+        "generated_content",
+        ["assessment_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "summative_assessment_attempts_assessment_id_fkey",
+        "summative_assessment_attempts",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "summative_assessment_attempts_assessment_id_fkey",
+        "summative_assessment_attempts",
+        "generated_content",
+        ["assessment_id"],
+        ["id"],
+    )
+
+    op.drop_constraint(
+        "summative_assessment_attempts_module_id_fkey",
+        "summative_assessment_attempts",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "summative_assessment_attempts_module_id_fkey",
+        "summative_assessment_attempts",
+        "modules",
+        ["module_id"],
+        ["id"],
+    )
+
+    op.drop_constraint("module_units_module_id_fkey", "module_units", type_="foreignkey")
+    op.create_foreign_key(
+        "module_units_module_id_fkey",
+        "module_units",
+        "modules",
+        ["module_id"],
+        ["id"],
+    )


### PR DESCRIPTION
## Summary

- Model-migration drift: two migrations created FK constraints without `ON DELETE CASCADE` (defaulting to `RESTRICT`) while the SQLAlchemy models already declare `ondelete="CASCADE"`
- New migration `092_fix_cascade_fk_module_units_summative_attempts.py` fixes all three affected constraints

**Broken constraints (before this fix):**

| Table | Column | References |
|---|---|---|
| `module_units` | `module_id` | `modules.id` |
| `summative_assessment_attempts` | `module_id` | `modules.id` |
| `summative_assessment_attempts` | `assessment_id` | `generated_content.id` |

**Delete chain:** `DELETE course` → cascade to `modules` → BLOCKED by RESTRICT on both child tables → 500 "Failed to delete course — database error"

## Test plan

- [ ] Deploy to staging (`alembic upgrade head` runs automatically)
- [ ] Admin UI → Courses → ⋮ → Supprimer on any course → type `DELETE` → confirm
- [ ] Expect: course removed from list, no error toast
- [ ] Backend logs show `"Admin deleted course"` not `"Course delete failed"`

Fixes #2318

🤖 Generated with [Claude Code](https://claude.com/claude-code)