### PR TITLE
fix(migration): 093 — fix admin_audit_logs schema (target_user_email + details type)

### DIFF
--- a/backend/migrations/versions/093_fix_audit_log_schema.py
+++ b/backend/migrations/versions/093_fix_audit_log_schema.py
@@ -23,7 +23,6 @@ that already have the correct schema.
 
 from alembic import op
 
-
 revision = "093_fix_audit_log_schema"
 down_revision = "092_fix_cascade_fk_module_units_summative_attempts"
 branch_labels = None

--- a/backend/migrations/versions/093_fix_audit_log_schema.py
+++ b/backend/migrations/versions/093_fix_audit_log_schema.py
@@ -1,0 +1,73 @@
+"""fix admin_audit_logs schema: add target_user_email, convert details jsonb→text
+
+Revision ID: 093_fix_audit_log_schema
+Revises: 092_fix_cascade_fk_module_units_summative_attempts
+Create Date: 2026-05-15
+
+Two schema bugs found during demo tenant UAT:
+
+1. target_user_email VARCHAR column was missing from admin_audit_logs.
+   The AuditLog SQLAlchemy model defines it, but the column was never added
+   via migration — the table was originally created before this field existed.
+
+2. details column was created as JSONB in some tenants, while the model
+   defines it as Text. This causes DatatypeMismatchError when inserting
+   audit log rows (e.g. on POST /admin/users).
+
+Both issues affect the santepublique_aof baseline used to clone all new
+tenant schemas, so every tenant provisioned before this migration runs will
+have the same bugs. This migration is idempotent: it uses IF NOT EXISTS /
+conditional type-change so it is safe to run multiple times or on tenants
+that already have the correct schema.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "093_fix_audit_log_schema"
+down_revision = "092_fix_cascade_fk_module_units_summative_attempts"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. Add target_user_email if it doesn't exist
+    op.execute("""
+        ALTER TABLE admin_audit_logs
+        ADD COLUMN IF NOT EXISTS target_user_email VARCHAR;
+    """)
+
+    # 2. Convert details from jsonb to text only if currently jsonb
+    #    (tenants that already have TEXT are unaffected)
+    op.execute("""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'admin_audit_logs'
+                  AND column_name = 'details'
+                  AND data_type = 'jsonb'
+            ) THEN
+                ALTER TABLE admin_audit_logs
+                    ALTER COLUMN details TYPE TEXT USING (details::text);
+            END IF;
+        END
+        $$;
+    """)
+
+
+def downgrade() -> None:
+    # target_user_email: drop the column (safe — was missing before)
+    op.execute("""
+        ALTER TABLE admin_audit_logs
+        DROP COLUMN IF EXISTS target_user_email;
+    """)
+
+    # details: convert text back to jsonb (best-effort; may fail on non-JSON values)
+    op.execute("""
+        ALTER TABLE admin_audit_logs
+            ALTER COLUMN details TYPE JSONB USING (details::jsonb);
+    """)

--- a/backend/migrations/versions/093_fix_audit_log_schema.py
+++ b/backend/migrations/versions/093_fix_audit_log_schema.py
@@ -21,8 +21,6 @@ conditional type-change so it is safe to run multiple times or on tenants
 that already have the correct schema.
 """
 
-from __future__ import annotations
-
 from alembic import op
 
 

--- a/backend/migrations/versions/093_fix_audit_log_schema.py
+++ b/backend/migrations/versions/093_fix_audit_log_schema.py
@@ -24,7 +24,6 @@ that already have the correct schema.
 from __future__ import annotations
 
 from alembic import op
-import sqlalchemy as sa
 
 
 revision = "093_fix_audit_log_schema"


### PR DESCRIPTION
## Problem

Two schema bugs in `admin_audit_logs` affect **every tenant** provisioned from the `santepublique_aof` baseline:

| Column | Expected | Actual |
|--------|----------|--------|
| `target_user_email` | `VARCHAR` (present) | Missing entirely |
| `details` | `TEXT` | `JSONB` |

**Impact:** `POST /api/v1/admin/users` returns 500 on all tenants because every `INSERT INTO admin_audit_logs` fails:
- `target_user_email` missing → `UndefinedColumnError`
- `details` type mismatch → `DatatypeMismatchError`

## Fix

New migration `093_fix_audit_log_schema.py`:
- `ADD COLUMN IF NOT EXISTS target_user_email VARCHAR`
- Conditionally converts `details JSONB → TEXT` (idempotent — skips if already TEXT)

**The migration is idempotent** and safe to run against tenants already patched manually.

## Scope

This is a **systemic fix** — not just a demo tenant patch:
- `santepublique_aof` baseline updated to `093` (applied in-place)
- All new tenants provisioned after this change get the correct schema via baseline clone
- All existing tenants get the fix when their next `POST /tenants/{id}/update` runs `alembic upgrade head`
- All 3 existing staging tenant DBs already patched in-place

## Test

BUG-D-001 (POST /admin/users 500) is now verified fixed on the demo tenant:
```
HTTP 200 — user_id=e4755d9c
```

Closes BUG-D-001 (systemic root cause).