### PR TITLE
fix(migration): correct down_revision in 092 — fix broken alembic chain

### DIFF
--- a/backend/migrations/versions/092_fix_cascade_fk_module_units_summative_attempts.py
+++ b/backend/migrations/versions/092_fix_cascade_fk_module_units_summative_attempts.py
@@ -1,7 +1,7 @@
 """fix ON DELETE CASCADE on module_units and summative_assessment_attempts
 
 Revision ID: 092_fix_cascade_fk_module_units_summative_attempts
-Revises: 091_relax_module_progress_locked_post_2125
+Revises: 091
 Create Date: 2026-05-15
 
 Both tables were created without ondelete in their FK constraints (defaulting to
@@ -14,7 +14,7 @@ from collections.abc import Sequence
 from alembic import op
 
 revision: str = "092_fix_cascade_fk_module_units_summative_attempts"
-down_revision: str | None = "091_relax_module_progress_locked_post_2125"
+down_revision: str | None = "091"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
## Bug

Migration `092_fix_cascade_fk_module_units_summative_attempts.py` had:
```python
down_revision = "091_relax_module_progress_locked_post_2125"  # WRONG
```

But `091`'s actual `revision` is `"091"` (not the full filename slug).
This broke alembic's revision map, causing `KeyError: '091_relax_module_progress_locked_post_2125'` on every `alembic upgrade head` call, blocking all tenant updates.

## Fix

```python
down_revision = "091"  # correct
```

Also updates the docstring `Revises:` comment to match.