### PR TITLE
fix(quality): repair budget enforcement, constraints passthrough, revision counter

### DIFF
--- a/backend/app/api/v1/admin_quality.py
+++ b/backend/app/api/v1/admin_quality.py
@@ -364,6 +364,7 @@ async def regenerate_unit_with_constraints(
             kwargs={
                 "content_id": str(content_id),
                 "triggered_by_user_id": str(current_user.id),
+                "override_constraints": payload.constraints or None,
             },
             priority=5,
         )

--- a/backend/app/domain/services/quality_agent_service.py
+++ b/backend/app/domain/services/quality_agent_service.py
@@ -689,7 +689,6 @@ class CourseQualityService:
 
         gc.quality_status = "regenerating"
         gc.regeneration_attempts = (gc.regeneration_attempts or 0) + 1
-        gc.content_revision = (gc.content_revision or 1) + 1
         await session.flush()
 
         # Resolve unit_id string for the generator API.
@@ -760,6 +759,10 @@ class CourseQualityService:
         else:
             raise ValueError(f"Unknown content_type for regeneration: {gc.content_type}")
 
+        # Increment revision only after a successful generator call.
+        gc.content_revision = (gc.content_revision or 1) + 1
+        await session.flush()
+
         # Refresh the row from the DB after the generator overwrote it.
         await session.refresh(gc)
         return gc
@@ -771,6 +774,7 @@ class CourseQualityService:
         session: AsyncSession,
         cached_blocks: list[dict[str, Any]] | None = None,
         triggered_by_user_id: uuid.UUID | None = None,
+        override_constraints: list[str] | None = None,
     ) -> UnitQualityAssessment:
         """Full assess → (regen → reassess)*N loop for a single unit.
 
@@ -817,11 +821,17 @@ class CourseQualityService:
                 )
                 break
 
-            # Regenerate.
+            # Regenerate. Admin override_constraints apply on attempt 1 only;
+            # subsequent passes use the LLM-derived constraints from the last report.
+            constraints_to_use = (
+                override_constraints
+                if override_constraints and attempt == 1
+                else last_report.regeneration_constraints
+            )
             try:
                 await self.regenerate_with_constraints(
                     content_id=content_id,
-                    constraints=last_report.regeneration_constraints,
+                    constraints=constraints_to_use,
                     session=session,
                     triggered_by_user_id=triggered_by_user_id,
                     trigger="quality_loop",

--- a/backend/app/tasks/quality_assessment.py
+++ b/backend/app/tasks/quality_assessment.py
@@ -170,6 +170,7 @@ def assess_and_regenerate_unit_task(
     content_id: str,
     run_id: str | None = None,
     triggered_by_user_id: str | None = None,
+    override_constraints: list[str] | None = None,
 ) -> dict:
     """Run the bounded assess→regenerate loop for one unit."""
 
@@ -195,6 +196,7 @@ def assess_and_regenerate_unit_task(
                     run_id=run_uuid,
                     session=session,
                     triggered_by_user_id=user_uuid,
+                    override_constraints=override_constraints or None,
                 )
                 await session.commit()
                 return {
@@ -304,6 +306,7 @@ def assess_course_task(
     async def _run() -> dict:
         from datetime import datetime
 
+        from sqlalchemy import func as sa_func
         from sqlalchemy import select
 
         from app.ai.claude_service import ClaudeService
@@ -312,7 +315,7 @@ def assess_course_task(
         from app.ai.rag.retriever import SemanticRetriever
         from app.domain.models.content import GeneratedContent
         from app.domain.models.course import Course
-        from app.domain.models.course_quality import CourseQualityRun
+        from app.domain.models.course_quality import CourseQualityRun, UnitQualityAssessment
         from app.domain.models.module import Module
         from app.domain.services.quality_agent_service import CourseQualityService
         from app.infrastructure.config.settings import settings
@@ -415,13 +418,21 @@ def assess_course_task(
                             if (gc.regeneration_attempts or 0) > attempts_before:
                                 regenerated += 1
                             processed += 1
+
+                            # Accumulate cost so the budget guard is meaningful.
+                            cost_row = await session.execute(
+                                select(
+                                    sa_func.coalesce(
+                                        sa_func.sum(UnitQualityAssessment.cost_cents), 0
+                                    )
+                                ).where(UnitQualityAssessment.run_id == run.id)
+                            )
+                            run.spent_credits = int(cost_row.scalar())
+
                             await session.commit()
 
                             # Course-level early exit check.
                             if processed >= 5:
-                                # Only check after some real data accumulated.
-                                from sqlalchemy import func as sa_func
-
                                 stat_q = select(
                                     sa_func.count().label("total"),
                                     sa_func.count()


### PR DESCRIPTION
## Summary

Fixes three silent bugs in the course QA agent found during critical review.

- **BUG 1 (budget enforcement):** `CourseQualityRun.spent_credits` was never written during a sweep — the budget cap check always evaluated to false, so every run ran to full completion regardless of cost. Fix: sum `UnitQualityAssessment.cost_cents` after each unit and write to `run.spent_credits`.
- **BUG 2 (constraints passthrough):** `POST .../quality/regenerate` accepted `payload.constraints` but never forwarded them to the Celery task. Thread `override_constraints` from endpoint → task → service loop (applied on first regeneration only; subsequent passes revert to LLM-derived constraints).
- **BUG 3 (revision counter):** `gc.content_revision` was incremented before the generator call succeeded, leaving the live counter ahead of the `GeneratedContentRevision` backup table on generator failure. Moved increment to after success.

## Files changed

- `backend/app/tasks/quality_assessment.py` — BUG 1 + BUG 2
- `backend/app/domain/services/quality_agent_service.py` — BUG 2 + BUG 3
- `backend/app/api/v1/admin_quality.py` — BUG 2

## Test plan

- [ ] Start a quality sweep with `budget_credits=5`; verify `CourseQualityRun.spent_credits` increments after each unit and run stops with `notes="budget_exhausted"` once spent ≥ budget
- [ ] Call `POST .../quality/regenerate` with `{"constraints": ["..."]}` and confirm Celery task log shows `override_constraints` received
- [ ] Confirm `content_revision` is NOT incremented when generator raises (mock test)

Fixes #2326

🤖 Generated with [Claude Code](https://claude.com/claude-code)