### PR TITLE
ci: PR lifecycle automation — auto review + dev auto-merge + dev→main sync

### DIFF
--- a/.github/workflows/dev-to-main.yml
+++ b/.github/workflows/dev-to-main.yml
@@ -1,0 +1,41 @@
+name: Sync dev → main
+
+on:
+  push:
+    branches: [dev]
+
+# Only one sync job at a time; do not cancel an in-flight sync.
+concurrency:
+  group: dev-to-main
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Create or enable auto-merge on dev→main PR
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          PR_NUMBER=$(gh pr list \
+            --base main --head dev \
+            --state open \
+            --json number \
+            --jq '.[0].number' \
+            --repo "${{ github.repository }}")
+
+          if [ -z "$PR_NUMBER" ]; then
+            PR_URL=$(gh pr create \
+              --base main --head dev \
+              --title "sync: dev → main" \
+              --body "Automated sync: squash-merges dev into main." \
+              --repo "${{ github.repository }}")
+            PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+          fi
+
+          # Squash merge required by main ruleset.
+          gh pr merge "$PR_NUMBER" --auto --squash \
+            --repo "${{ github.repository }}"

--- a/.github/workflows/pr-lifecycle.yml
+++ b/.github/workflows/pr-lifecycle.yml
@@ -1,0 +1,50 @@
+name: PR Lifecycle — Review + Auto-merge
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+    branches: [dev]
+
+concurrency:
+  group: pr-lifecycle-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  # Post "@claude /review" so the existing claude.yml workflow picks it up.
+  request-review:
+    if: |
+      !github.event.pull_request.draft &&
+      github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: '@claude /review'
+            });
+
+  # Enable auto-merge so the PR merges automatically once all required
+  # status checks pass (Backend, Frontend, GitGuardian — per dev ruleset).
+  enable-auto-merge:
+    if: |
+      !github.event.pull_request.draft &&
+      github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Enable auto-merge (merge-commit into dev)
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          gh pr merge "${{ github.event.pull_request.number }}" \
+            --auto --merge \
+            --repo "${{ github.repository }}"


### PR DESCRIPTION
## Summary

Automates the full PR lifecycle so no manual merge or review trigger is needed.

- **PR opened targeting dev** → auto-posts `@claude /review` → `claude.yml` picks it up and reviews
- **CI passes** → PR auto-merges into dev (merge-commit, per dev ruleset)
- **Push to dev** → standing dev→main sync PR created/updated + auto-merge enabled (squash, per main ruleset) → staging deploy fires

## Changes

- `.github/workflows/pr-lifecycle.yml` — new: review request + auto-merge enablement
- `.github/workflows/dev-to-main.yml` — new: dev→main sync on every push to dev
- Repo setting `allow_auto_merge` already enabled as pre-requisite

## Flow

```
feature PR opened → @claude /review posted + auto-merge enabled
  └─ CI passes → merge-commit into dev
       └─ dev-to-main.yml fires → sync PR → squash merge → main → staging deploy
```

## Test plan

- [ ] Open a test PR targeting `dev` → `@claude /review` comment appears automatically
- [ ] Let CI complete → PR auto-merges into `dev`
- [ ] `dev-to-main.yml` creates/updates the sync PR
- [ ] CI passes on sync PR → squash merge to `main` → staging deploy kicks off

Fixes #2328

🤖 Generated with [Claude Code](https://claude.com/claude-code)