### PR TITLE
fix(db): set generated_images FKs to SET NULL to unblock course deletion (#2334)

### DIFF
--- a/backend/migrations/versions/094_fix_generated_images_fk_set_null.py
+++ b/backend/migrations/versions/094_fix_generated_images_fk_set_null.py
@@ -1,0 +1,74 @@
+"""fix generated_images FK constraints to SET NULL on delete
+
+Revision ID: 094_fix_generated_images_fk_set_null
+Revises: 093_fix_audit_log_schema
+Create Date: 2026-05-16
+
+The generated_images table has two FK constraints that are NO ACTION in the DB
+despite the SQLAlchemy model declaring ondelete="SET NULL". This causes course
+deletion to fail with a ForeignKeyViolationError when the delete cascades from
+courses -> modules and PostgreSQL tries to delete modules rows referenced by
+generated_images.module_id.
+
+Both generated_images_module_id_fkey and generated_images_lesson_id_fkey are
+affected. generated_audio equivalents are already SET NULL and do not need fixing.
+"""
+
+from alembic import op
+
+revision: str = "094_fix_generated_images_fk_set_null"
+down_revision: str | None = "093_fix_audit_log_schema"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # generated_images.module_id → modules.id
+    op.drop_constraint(
+        "generated_images_module_id_fkey", "generated_images", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "generated_images_module_id_fkey",
+        "generated_images",
+        "modules",
+        ["module_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    # generated_images.lesson_id → generated_content.id
+    op.drop_constraint(
+        "generated_images_lesson_id_fkey", "generated_images", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "generated_images_lesson_id_fkey",
+        "generated_images",
+        "generated_content",
+        ["lesson_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "generated_images_lesson_id_fkey", "generated_images", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "generated_images_lesson_id_fkey",
+        "generated_images",
+        "generated_content",
+        ["lesson_id"],
+        ["id"],
+    )
+
+    op.drop_constraint(
+        "generated_images_module_id_fkey", "generated_images", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "generated_images_module_id_fkey",
+        "generated_images",
+        "modules",
+        ["module_id"],
+        ["id"],
+    )


### PR DESCRIPTION
## Summary

Course deletion still fails with 500 for courses with generated images. Root cause: `generated_images_module_id_fkey` and `generated_images_lesson_id_fkey` are `NO ACTION` in the DB despite the model declaring `ondelete="SET NULL"` — another model-migration drift.

Migration `094_fix_generated_images_fk_set_null` drops and recreates both with `ON DELETE SET NULL`.

**Confirmed via staging DB query:**
```
generated_images_lesson_id_fkey | generated_content | NO ACTION  ← fixed
generated_images_module_id_fkey | modules           | NO ACTION  ← fixed
generated_audio_lesson_id_fkey  | generated_content | SET NULL   ✅
generated_audio_module_id_fkey  | modules           | SET NULL   ✅
```

Fixes #2334

🤖 Generated with [Claude Code](https://claude.com/claude-code)