### PR TITLE
fix(pwa): align PAGES_CACHE_NAME with SW v7 + add v7 prewarm migration

### DIFF
--- a/frontend/lib/offline/download-manager.ts
+++ b/frontend/lib/offline/download-manager.ts
@@ -460,7 +460,7 @@ async function downloadUnitQuiz(
 
 // Cache name MUST stay aligned with `pages-${CACHE_VERSION}` in frontend/sw.ts.
 // Bump both together when changing.
-const PAGES_CACHE_NAME = "pages-v6-offline-routes";
+const PAGES_CACHE_NAME = "pages-v7-status-no-cache";
 
 /**
  * Pre-fetch a same-origin page and stash it in the SW page cache so an offline

--- a/frontend/lib/offline/sync-manager.ts
+++ b/frontend/lib/offline/sync-manager.ts
@@ -18,6 +18,7 @@ import { apiFetch } from '@/lib/api';
 import { prewarmPage } from './download-manager';
 
 const PREWARM_V6_DONE_KEY = 'offline_prewarm_v6_done';
+const PREWARM_V7_DONE_KEY = 'offline_prewarm_v7_done';
 
 export type SyncStatus =
   | { state: 'idle' }
@@ -53,14 +54,16 @@ class SyncManager {
     this.onlineHandler = () => {
       this.syncNow();
       this.runV6PrewarmMigration();
+      this.runV7PrewarmMigration();
     };
     window.addEventListener('online', this.onlineHandler);
 
     // Also run on startup in case the app is already online — covers the
-    // common case where a v5 user opens the app online without a network
+    // common case where a v5/v6 user opens the app online without a network
     // toggle.
     if (typeof navigator !== 'undefined' && navigator.onLine) {
       this.runV6PrewarmMigration();
+      this.runV7PrewarmMigration();
     }
   }
 
@@ -160,6 +163,44 @@ class SyncManager {
         }
       }
       localStorage.setItem(PREWARM_V6_DONE_KEY, '1');
+    } catch {
+      // best-effort; failure must not break sync
+    }
+  }
+
+  /**
+   * One-shot migration for users who downloaded a module under SW v6.
+   * The v7 cache-version bump (adding progress no-cache) renamed the pages
+   * cache from `pages-v6-offline-routes` to `pages-v7-status-no-cache`.
+   * Without this, previously-prewarm pages are invisible to the v7 SW and
+   * offline navigation falls through to /offline.html.
+   */
+  async runV7PrewarmMigration(): Promise<void> {
+    if (typeof window === 'undefined') return;
+    try {
+      if (localStorage.getItem(PREWARM_V7_DONE_KEY)) return;
+      if (typeof navigator !== 'undefined' && !navigator.onLine) return;
+
+      const modules = await getOfflineModulesByStatus('downloaded');
+      for (const mod of modules) {
+        const entries = await getOfflineContentByModule(mod.moduleId);
+        const flashcardKey = `__module_${mod.moduleId}__`;
+        const seen = new Set<string>();
+        for (const entry of entries) {
+          if (entry.unitId === flashcardKey) continue;
+          const key = `${entry.locale}|${entry.unitId}`;
+          if (seen.has(key)) continue;
+          seen.add(key);
+          await prewarmPage(
+            `/${entry.locale}/modules/${mod.moduleId}/units/${entry.unitId}`,
+          );
+        }
+        const locales = new Set(entries.map((e) => e.locale));
+        for (const loc of locales) {
+          await prewarmPage(`/${loc}/modules/${mod.moduleId}`);
+        }
+      }
+      localStorage.setItem(PREWARM_V7_DONE_KEY, '1');
     } catch {
       // best-effort; failure must not break sync
     }


### PR DESCRIPTION
## Summary
- `download-manager.ts:463` was hardcoded to `pages-v6-offline-routes` but `sw.ts` CACHE_VERSION is now `v7-status-no-cache`, so `prewarmPage()` was writing to a cache the SW never reads — offline module navigation silently fell through to `/offline.html`
- Adds `runV7PrewarmMigration()` in `sync-manager.ts` so users whose pages were prewarm under v6 get them re-prewarm under v7 on next online event

## Test plan
- [ ] Download a module, clear app storage, reload — module pages render offline
- [ ] `localStorage.getItem('offline_prewarm_v7_done')` is set to `'1'` after first online event

Fixes #2332

🤖 Generated with [Claude Code](https://claude.com/claude-code)