### PR TITLE
perf(rag): content-hash dedup for source indexation — skip re-embedding for shared PDFs

### DIFF
--- a/backend/app/ai/rag/image_extractor.py
+++ b/backend/app/ai/rag/image_extractor.py
@@ -40,6 +40,26 @@ HIGH_DRAWING_COUNT_THRESHOLD = 2000
 RASTERIZE_DPI = 200
 
 
+def _avg_hash_hex(image_bytes: bytes) -> str | None:
+    """Return a 16-char hex 64-bit average hash, or None on error.
+
+    The same algorithm used for within-PDF deduplication; exposing it here
+    allows the RAG pipeline to persist the hash and detect cross-course duplicates.
+    """
+    try:
+        from PIL import Image
+
+        img = Image.open(io.BytesIO(image_bytes)).convert("L").resize((8, 8), Image.LANCZOS)
+        pixels = list(img.tobytes())
+        avg = sum(pixels) / len(pixels)
+        bits = 0
+        for px in pixels:
+            bits = (bits << 1) | (1 if px >= avg else 0)
+        return f"{bits:016x}"
+    except Exception:
+        return None
+
+
 @dataclass
 class ExtractedImage:
     """Represents an image extracted from a PDF with rich metadata."""
@@ -57,6 +77,7 @@ class ExtractedImage:
     surrounding_text: str
     chapter: str | None
     section: str | None
+    image_hash: str | None = None
 
 
 # Multi-part numbering pattern: matches "1", "1.5", "2-8", "12.3.4", "1-2-3".
@@ -746,14 +767,18 @@ class PDFImageExtractor:
         """Remove near-duplicate images using average hash (8x8 grayscale, Hamming distance < 5).
 
         When duplicates found, keeps the higher-resolution one.
+        Persists the hash on each surviving image for cross-course dedup in the pipeline.
         """
         if len(images) <= 1:
+            if images:
+                images[0].image_hash = _avg_hash_hex(images[0].image_bytes)
             return images
 
-        from PIL import Image
-
-        def avg_hash(img_bytes: bytes) -> int | None:
+        def _hash_int(img_bytes: bytes) -> int | None:
+            """Return raw 64-bit integer for Hamming comparison."""
             try:
+                from PIL import Image
+
                 img = Image.open(io.BytesIO(img_bytes)).convert("L").resize((8, 8), Image.LANCZOS)
                 pixels = list(img.tobytes())
                 avg = sum(pixels) / len(pixels)
@@ -772,7 +797,7 @@ class PDFImageExtractor:
                 xor >>= 1
             return count
 
-        hashes: list[int | None] = [avg_hash(img.image_bytes) for img in images]
+        hashes: list[int | None] = [_hash_int(img.image_bytes) for img in images]
         keep = [True] * len(images)
 
         for i in range(len(images)):
@@ -790,7 +815,11 @@ class PDFImageExtractor:
                         keep[i] = False
                         break
 
-        return [img for img, k in zip(images, keep, strict=True) if k]
+        survivors = [img for img, k in zip(images, keep, strict=True) if k]
+        # Persist the hex hash on each survivor for cross-course dedup.
+        for img in survivors:
+            img.image_hash = _avg_hash_hex(img.image_bytes)
+        return survivors
 
     def extract_all_pdfs(self) -> dict[str, list[ExtractedImage]]:
         """Extract images from all PDFs in resources_path.

--- a/backend/app/ai/rag/pipeline.py
+++ b/backend/app/ai/rag/pipeline.py
@@ -1,5 +1,6 @@
 """RAG pipeline for processing documents into searchable chunks with embeddings."""
 
+import uuid
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -51,6 +52,7 @@ class RAGPipeline:
         level: int | None = None,
         session: AsyncSession | None = None,
         course_resource_id: UUID | None = None,
+        content_hash: str | None = None,
     ) -> int:
         """
         Process a single PDF document through the complete RAG pipeline.
@@ -62,6 +64,9 @@ class RAGPipeline:
             session: Database session (will create one if not provided)
             course_resource_id: FK back to ``course_resources.id`` (#2186) so
                 stored chunks know their originating PDF.
+            content_hash: SHA-256 of the resource's extracted text. When set,
+                the pipeline checks if another course already has chunks for
+                this content and clones them instead of re-embedding.
 
         Returns:
             Number of chunks processed
@@ -69,6 +74,24 @@ class RAGPipeline:
         pdf_path = Path(pdf_path)
         if not pdf_path.exists():
             raise FileNotFoundError(f"PDF file not found: {pdf_path}")
+
+        # Content-hash dedup: clone from a donor course instead of re-embedding.
+        if content_hash and course_resource_id:
+            async with async_session_factory() as _dedup_session:
+                donors = await self._find_donor_chunks(
+                    content_hash, course_resource_id, _dedup_session
+                )
+                if donors:
+                    cloned = await self._clone_chunks(
+                        donors, source, course_resource_id, _dedup_session
+                    )
+                    logger.info(
+                        "Cloned chunks from donor — skipped embedding API",
+                        cloned=cloned,
+                        source=source,
+                        content_hash=content_hash,
+                    )
+                    return cloned
 
         logger.info("Starting PDF processing", pdf_path=str(pdf_path), source=source)
 
@@ -184,6 +207,59 @@ class RAGPipeline:
 
         return stored_count
 
+    async def _find_donor_chunks(
+        self,
+        content_hash: str,
+        new_resource_id: UUID,
+        session: AsyncSession,
+    ) -> list[DocumentChunk]:
+        """Return existing chunks from another course resource with the same content_hash.
+
+        Uses ix_course_resources_content_hash + ix_document_chunks_course_resource_id.
+        """
+        from app.domain.models.course_resource import CourseResource
+
+        result = await session.execute(
+            select(DocumentChunk)
+            .join(CourseResource, CourseResource.id == DocumentChunk.course_resource_id)
+            .where(
+                CourseResource.content_hash == content_hash,
+                DocumentChunk.course_resource_id != new_resource_id,
+                DocumentChunk.course_resource_id.is_not(None),
+            )
+            .order_by(DocumentChunk.chunk_index)
+            .limit(5000)
+        )
+        return list(result.scalars().all())
+
+    async def _clone_chunks(
+        self,
+        donor_chunks: list[DocumentChunk],
+        new_source: str,
+        new_resource_id: UUID,
+        session: AsyncSession,
+    ) -> int:
+        """Insert copies of donor_chunks under new_source/new_resource_id without re-embedding."""
+        cloned = 0
+        for donor in donor_chunks:
+            db_chunk = DocumentChunk(
+                id=uuid.uuid4(),
+                content=donor.content,
+                embedding=donor.embedding,
+                source=new_source,
+                chapter=donor.chapter,
+                page=donor.page,
+                level=donor.level,
+                language=donor.language,
+                token_count=donor.token_count,
+                chunk_index=donor.chunk_index,
+                course_resource_id=new_resource_id,
+            )
+            session.add(db_chunk)
+            cloned += 1
+        await session.commit()
+        return cloned
+
     async def process_pdf_images(
         self,
         pdf_path: str | Path,
@@ -249,6 +325,65 @@ class RAGPipeline:
             readable_name = pdf_path.stem.replace("_", " ")
             prefix = rag_collection_id or source
             key = f"source-images/{prefix}/{readable_name}/{img.page_number}_{safe_label}.webp"
+
+            # Cross-course image dedup: reuse existing storage + computed fields.
+            if img.image_hash:
+                donor_result = await session.execute(
+                    select(SourceImage)
+                    .where(SourceImage.image_hash == img.image_hash)
+                    .limit(1)
+                )
+                donor_img = donor_result.scalar_one_or_none()
+                if donor_img is not None:
+                    cloned_img = SourceImage(
+                        id=uuid4(),
+                        source=source,
+                        rag_collection_id=rag_collection_id,
+                        image_hash=img.image_hash,
+                        # Reuse all expensive computed fields from donor:
+                        storage_key=donor_img.storage_key,
+                        storage_url=donor_img.storage_url,
+                        storage_key_fr=donor_img.storage_key_fr,
+                        storage_url_fr=donor_img.storage_url_fr,
+                        embedding=donor_img.embedding,
+                        caption_fr=donor_img.caption_fr,
+                        caption_en=donor_img.caption_en,
+                        alt_text_fr=donor_img.alt_text_fr,
+                        alt_text_en=donor_img.alt_text_en,
+                        figure_kind=donor_img.figure_kind,
+                        image_type=donor_img.image_type,
+                        width=donor_img.width,
+                        height=donor_img.height,
+                        file_size_bytes=donor_img.file_size_bytes,
+                        original_format=donor_img.original_format,
+                        format=donor_img.format,
+                        # Keep per-document positional metadata:
+                        page_number=img.page_number,
+                        chapter=img.chapter,
+                        section=img.section,
+                        surrounding_text=img.surrounding_text,
+                        figure_number=img.figure_number,
+                        caption=img.caption,
+                        attribution=img.attribution,
+                    )
+                    session.add(cloned_img)
+                    await session.commit()
+                    stored_count += 1
+                    logger.debug(
+                        "Reused image from donor — skipped MinIO upload and Claude API",
+                        source=source,
+                        image_hash=img.image_hash,
+                        figure=img.figure_number,
+                    )
+                    if progress_callback is not None:
+                        try:
+                            progress_callback(stored_count, len(images), figure_label)
+                        except Exception as cb_exc:
+                            logger.debug(
+                                "image progress_callback raised, ignoring",
+                                error=str(cb_exc),
+                            )
+                    continue
 
             try:
                 storage_url = await storage.upload_bytes(
@@ -391,6 +526,7 @@ class RAGPipeline:
                 id=uuid4(),
                 source=source,
                 rag_collection_id=rag_collection_id,
+                image_hash=img.image_hash,
                 figure_number=img.figure_number,
                 caption=img.caption,
                 caption_fr=caption_fr,

--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -1,5 +1,6 @@
 """Admin endpoints for course management (CRUD, publish, RAG indexation)."""
 
+import hashlib
 import re
 import shutil
 import uuid
@@ -17,7 +18,11 @@ from structlog import get_logger
 from app.api.deps import get_db as get_db_session
 from app.api.deps_local_auth import AuthenticatedUser, require_role
 from app.domain.models.course import Course, UserCourseEnrollment
-from app.domain.models.course_resource import EXTRACTION_STATUS_DONE, CourseResource
+from app.domain.models.course_resource import (
+    EXTRACTION_STATUS_DONE,
+    EXTRACTION_STATUS_PENDING,
+    CourseResource,
+)
 from app.domain.models.document_chunk import DocumentChunk
 from app.domain.models.module import Module
 from app.domain.models.module_unit import ModuleUnit
@@ -1609,19 +1614,66 @@ async def upload_course_resource(
             detail="File does not appear to be a valid PDF",
         )
 
+    file_hash = hashlib.sha256(data).hexdigest()
+
     safe_name = re.sub(r"[^\w.\-]", "_", Path(file.filename or "resource.pdf").name)
     if not safe_name.lower().endswith(".pdf"):
         safe_name += ".pdf"
+
+    # File-hash dedup: if an identical PDF was already extracted for any course,
+    # create a thin CourseResource reference without re-writing to disk or
+    # re-running the extraction task.
+    donor_result = await db.execute(
+        select(CourseResource)
+        .where(
+            CourseResource.file_hash == file_hash,
+            CourseResource.extraction_status == EXTRACTION_STATUS_DONE,
+        )
+        .limit(1)
+    )
+    donor = donor_result.scalar_one_or_none()
+
+    if donor is not None:
+        resource = CourseResource(
+            course_id=course_id,
+            filename=Path(safe_name).stem,
+            parent_filename=donor.parent_filename,
+            raw_text=donor.raw_text,
+            toc_json=donor.toc_json,
+            char_count=donor.char_count,
+            content_hash=donor.content_hash,
+            file_hash=file_hash,
+            summary_text=donor.summary_text,
+            summary_model=donor.summary_model,
+            summary_status=donor.summary_status,
+            extraction_status=EXTRACTION_STATUS_DONE,
+        )
+        db.add(resource)
+        if course.creation_step == "upload":
+            course.creation_step = "info"
+        await db.commit()
+        await db.refresh(resource)
+        logger.info(
+            "Course resource deduped from existing file_hash — skipped extraction",
+            course_id=str(course_id),
+            filename=safe_name,
+            file_hash=file_hash,
+            donor_id=str(donor.id),
+            resource_id=str(resource.id),
+        )
+        return {
+            "course_id": str(course_id),
+            "name": safe_name,
+            "size_bytes": len(data),
+            "resource_id": str(resource.id),
+            "extraction_status": EXTRACTION_STATUS_DONE,
+        }
 
     course_dir = UPLOAD_DIR / str(course_id)
     course_dir.mkdir(parents=True, exist_ok=True)
     dest = course_dir / safe_name
     dest.write_bytes(data)
 
-    from app.domain.models.course_resource import (
-        EXTRACTION_STATUS_PENDING,
-        CourseResource,
-    )
     from app.tasks.resource_extraction import extract_course_resource
 
     resource = CourseResource(
@@ -1630,6 +1682,7 @@ async def upload_course_resource(
         parent_filename=None,
         raw_text="",
         char_count=0,
+        file_hash=file_hash,
         extraction_status=EXTRACTION_STATUS_PENDING,
     )
     db.add(resource)

--- a/backend/app/domain/models/course_resource.py
+++ b/backend/app/domain/models/course_resource.py
@@ -35,6 +35,7 @@ class CourseResource(Base):
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
     content_hash: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
+    file_hash: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
     summary_text: Mapped[str | None] = mapped_column(Text, nullable=True)
     summary_model: Mapped[str | None] = mapped_column(String(50), nullable=True)
     summary_status: Mapped[str | None] = mapped_column(String(10), nullable=True)

--- a/backend/app/domain/models/source_image.py
+++ b/backend/app/domain/models/source_image.py
@@ -74,6 +74,7 @@ class SourceImage(Base):
     alt_text_en: Mapped[str | None] = mapped_column(Text, nullable=True)
     figure_kind: Mapped[str | None] = mapped_column(Text, nullable=True)
     semantic_tags: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    image_hash: Mapped[str | None] = mapped_column(String(16), nullable=True, index=True)
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
 
     linked_chunks: Mapped[list[SourceImageChunk]] = relationship(

--- a/backend/app/tasks/rag_indexation.py
+++ b/backend/app/tasks/rag_indexation.py
@@ -241,6 +241,25 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
                         "estimated_seconds_remaining": _remaining(extract_progress),
                     },
                 )
+                # Content-hash dedup: clone from donor course if same text already indexed.
+                if res.content_hash:
+                    async with async_session_factory() as _dedup_session:
+                        donors = await pipeline._find_donor_chunks(
+                            res.content_hash, res.id, _dedup_session
+                        )
+                        if donors:
+                            cloned = await pipeline._clone_chunks(
+                                donors, rag_collection_id, res.id, _dedup_session
+                            )
+                            total_chunks += cloned
+                            logger.info(
+                                "Cloned chunks from donor — skipped embedding API (DB path)",
+                                filename=resource_name,
+                                cloned=cloned,
+                                course_id=course_id,
+                            )
+                            continue
+
                 text = res.raw_text
                 language = detect_language(text)
                 chunks = list(
@@ -295,7 +314,9 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
         # Build pdf_path → course_resource_id lookup so chunks land with
         # their originating PDF identity (#2186). Resolves by `filename` or
         # `parent_filename` (DB stores stems without extension).
+        # Also capture content_hash for cross-course chunk dedup.
         resource_id_by_stem: dict[str, uuid.UUID] = {}
+        resource_hash_by_stem: dict[str, str] = {}
         if pdf_files:
             from sqlalchemy import create_engine, select
             from sqlalchemy.orm import Session
@@ -312,14 +333,19 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
                                 CourseResource.id,
                                 CourseResource.filename,
                                 CourseResource.parent_filename,
+                                CourseResource.content_hash,
                             ).where(CourseResource.course_id == uuid.UUID(course_id))
                         )
                     ).all()
-                    for rid, fname, parent in res_rows:
+                    for rid, fname, parent, chash in res_rows:
                         if fname:
                             resource_id_by_stem.setdefault(fname, rid)
+                            if chash:
+                                resource_hash_by_stem.setdefault(fname, chash)
                         if parent:
                             resource_id_by_stem.setdefault(parent, rid)
+                            if chash:
+                                resource_hash_by_stem.setdefault(parent, chash)
             finally:
                 _eng.dispose()
 
@@ -371,10 +397,14 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
             resource_id = resource_id_by_stem.get(pdf_path.stem) or resource_id_by_stem.get(
                 pdf_path.name
             )
+            content_hash = resource_hash_by_stem.get(pdf_path.stem) or resource_hash_by_stem.get(
+                pdf_path.name
+            )
             chunks = await pipeline.process_pdf_document(
                 pdf_path=str(pdf_path),
                 source=rag_collection_id,
                 course_resource_id=resource_id,
+                content_hash=content_hash,
             )
             total_chunks += chunks
 

--- a/backend/app/tasks/resource_extraction.py
+++ b/backend/app/tasks/resource_extraction.py
@@ -144,6 +144,8 @@ def extract_course_resource(self, resource_id: str) -> dict:
                 resource.toc_json = toc or None
                 resource.char_count = len(full_text)
                 resource.content_hash = hashlib.sha256(full_text.encode("utf-8")).hexdigest()
+                if not resource.file_hash:
+                    resource.file_hash = hashlib.sha256(data).hexdigest()
                 resource.extraction_status = EXTRACTION_STATUS_DONE
                 session.commit()
                 new_resource_ids.append(resource_id)
@@ -165,6 +167,8 @@ def extract_course_resource(self, resource_id: str) -> dict:
                 resource.content_hash = hashlib.sha256(
                     (resource.raw_text or "").encode("utf-8")
                 ).hexdigest()
+                if not resource.file_hash:
+                    resource.file_hash = hashlib.sha256(data).hexdigest()
                 resource.filename = f"{parent_stem}_part1"
                 resource.parent_filename = parent_stem
                 resource.extraction_status = EXTRACTION_STATUS_DONE

--- a/backend/migrations/versions/095_add_image_hash_to_source_images.py
+++ b/backend/migrations/versions/095_add_image_hash_to_source_images.py
@@ -1,0 +1,39 @@
+"""add image_hash to source_images for cross-course dedup
+
+Revision ID: 095_add_image_hash_to_source_images
+Revises: 094_fix_generated_images_fk_set_null
+Create Date: 2026-05-16
+
+Persists a 16-char hex 64-bit average-hash for each source image so the RAG
+pipeline can detect cross-course duplicates and reuse existing MinIO objects,
+OpenAI embeddings, and Claude translations instead of recomputing them.
+
+The hash is derived from the same avg-hash algorithm already used for within-PDF
+deduplication in PDFImageExtractor._deduplicate_images(). No UNIQUE constraint:
+the copy-on-write model stores one row per course but reuses the expensive fields.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "095_add_image_hash_to_source_images"
+down_revision: str | None = "094_fix_generated_images_fk_set_null"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "source_images",
+        sa.Column("image_hash", sa.String(16), nullable=True),
+    )
+    op.create_index(
+        "ix_source_images_image_hash",
+        "source_images",
+        ["image_hash"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_source_images_image_hash", table_name="source_images")
+    op.drop_column("source_images", "image_hash")

--- a/backend/migrations/versions/096_add_file_hash_to_course_resources.py
+++ b/backend/migrations/versions/096_add_file_hash_to_course_resources.py
@@ -1,0 +1,37 @@
+"""add file_hash to course_resources for upload-time dedup
+
+Revision ID: 096_add_file_hash_to_course_resources
+Revises: 095_add_image_hash_to_source_images
+Create Date: 2026-05-16
+
+SHA-256 of the raw PDF bytes computed at upload time. Allows the upload
+endpoint to detect binary-identical PDFs before writing to disk or enqueuing
+extraction — the most aggressive deduplication gate. content_hash (SHA-256 of
+extracted text) fires only after extraction completes; file_hash fires at the
+moment of upload.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "096_add_file_hash_to_course_resources"
+down_revision: str | None = "095_add_image_hash_to_source_images"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "course_resources",
+        sa.Column("file_hash", sa.String(64), nullable=True),
+    )
+    op.create_index(
+        "ix_course_resources_file_hash",
+        "course_resources",
+        ["file_hash"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_course_resources_file_hash", table_name="course_resources")
+    op.drop_column("course_resources", "file_hash")


### PR DESCRIPTION
## Summary

Closes #2340

When the same PDF is uploaded to multiple courses the system was indexing it in full every time: re-embedding all chunks (OpenAI), re-uploading images (MinIO), re-running Claude translation/classification. This PR adds three independent dedup gates based on content hashes — completely transparent to end users.

### Part 1 — Text chunk copy-on-write (no schema change)
- `RAGPipeline._find_donor_chunks` — joins `document_chunks → course_resources` on existing `content_hash` index to find already-indexed chunks for identical content
- `RAGPipeline._clone_chunks` — bulk-inserts copies with the new course's `rag_collection_id` as `source`, reusing embeddings (zero OpenAI calls)
- `process_pdf_document` — new `content_hash` param triggers early return via clone if donors exist
- Both the PDF-on-disk path and the DB-resources path in `rag_indexation.py` are updated

### Part 2 — Image dedup (`migration 095`: `image_hash VARCHAR(16)` on `source_images`)
- `_avg_hash_hex` — module-level helper reusing the same 64-bit avg-hash algorithm already in `_deduplicate_images`; now persisted on every extracted image
- `_process_images` — before MinIO upload, checks for an existing row with the same `image_hash`; if found, clones the row reusing `storage_key`, `embedding`, translated captions, `figure_kind` — skips MinIO + Claude + OpenAI entirely

### Part 3 — Upload-time file gate (`migration 096`: `file_hash VARCHAR(64)` on `course_resources`)
- SHA-256 of raw PDF bytes computed at upload before disk write
- If an identical file already has `extraction_status=done`, a thin `CourseResource` reference is created instantly — no disk write, no Celery extraction task

### Transparency guarantee
- `DocumentChunk.source = rag_collection_id` **unchanged** — retrieval queries unmodified
- `SourceImage.rag_collection_id` **unchanged** — image linking queries unmodified
- Course deletion safety: cloned chunks have a different `source` than the donor course; deleting the donor does not affect clones
- All new columns are nullable; all existing INSERT paths work unchanged

## Test plan

- [ ] Run `alembic upgrade head` — should reach `096_add_file_hash_to_course_resources` cleanly
- [ ] Run `ruff check backend/` — all checks pass
- [ ] Upload same PDF to two different courses; second indexation Celery task should log `"Cloned chunks from donor — skipped embedding API"` with zero OpenAI calls
- [ ] Both courses load lessons, quizzes, AI tutor responses correctly after dedup indexation
- [ ] Delete one course; the other course's chunks and images survive
- [ ] Re-index either course; idempotent (no duplicate rows)
- [ ] Upload same PDF a third time (Part 3 gate): upload returns `extraction_status: done` immediately with no Celery task

🤖 Generated with [Claude Code](https://claude.ai/claude-code)