### PR TITLE
fix(ux): prevent quiz/case-study reset on network reconnect

### DIFF
--- a/frontend/components/learning/case-study-viewer.tsx
+++ b/frontend/components/learning/case-study-viewer.tsx
@@ -112,6 +112,8 @@ export function CaseStudyViewer({
 
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pollStartRef = useRef<number>(0);
+  // Freeze country on first hydration so a network blip cannot reload live content (#2226).
+  const frozenCountryRef = useRef<string | null>(null);
 
   const { user: currentUser, isHydrated } = useCurrentUser();
   const country = countryContext || currentUser?.country || 'CI';
@@ -155,6 +157,11 @@ export function CaseStudyViewer({
     // Wait for the localStorage-backed user to settle before fetching, otherwise
     // `country` flips mid-mount and re-fires this effect with a duplicate Celery task.
     if (!isHydrated) return;
+    // Don't re-fetch while content is already displayed and the learner didn't
+    // explicitly ask to regenerate — a reconnect must not wipe the case study (#2226).
+    if (caseStudyData !== null && !forceRegenerate) return;
+    if (frozenCountryRef.current === null) frozenCountryRef.current = country;
+    const resolvedCountry = frozenCountryRef.current;
 
     let cancelled = false;
     if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
@@ -179,7 +186,7 @@ export function CaseStudyViewer({
 
           if (statusRes.status === 'complete') {
             const caseRes = await apiFetch<CaseStudyData>(
-              `/api/v1/content/cases/${moduleId}/${unitId}?language=${language}&level=${level}&country=${country}`
+              `/api/v1/content/cases/${moduleId}/${unitId}?language=${language}&level=${level}&country=${resolvedCountry}`
             );
             if (cancelled) return;
             setCaseStudyData(caseRes);
@@ -224,7 +231,7 @@ export function CaseStudyViewer({
         setError(null);
 
         const result = await loadCaseStudy<CaseStudyData | GeneratingResponse>(
-          moduleId, unitId, language, level, country, forceRegenerate
+          moduleId, unitId, language, level, resolvedCountry, forceRegenerate
         );
         if (cancelled) return;
 
@@ -271,7 +278,7 @@ export function CaseStudyViewer({
       if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [moduleId, unitId, language, level, country, forceRegenerate, isHydrated]);
+  }, [moduleId, unitId, language, level, forceRegenerate, isHydrated, caseStudyData]);
 
   const handleRefresh = () => {
     if (storageKey) clearQuizState(storageKey);

--- a/frontend/components/quiz/quiz-container.tsx
+++ b/frontend/components/quiz/quiz-container.tsx
@@ -66,6 +66,9 @@ export function QuizContainer({
 
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pollStartRef = useRef<number>(0);
+  // Freeze country on first hydration so a network blip that briefly flips
+  // currentUser.country cannot restart a live quiz session (#2226).
+  const frozenCountryRef = useRef<string | null>(null);
   const { isOnline } = useNetworkStatus();
 
   useEffect(() => {
@@ -73,6 +76,12 @@ export function QuizContainer({
     // `resolvedCountry` flips from default → real country mid-mount and re-fires
     // this effect, dispatching a duplicate Celery task for the same logical request.
     if (!isHydrated) return;
+    // Don't restart the effect while the learner is actively answering or has
+    // already finished — a dependency flap (e.g. country ref settling) must not
+    // wipe in-progress answers (#2226).
+    if (state === 'in-progress' || state === 'completed') return;
+    if (frozenCountryRef.current === null) frozenCountryRef.current = resolvedCountry;
+    const country = frozenCountryRef.current;
 
     let stale = false;
     if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
@@ -163,7 +172,7 @@ export function QuizContainer({
         setError('');
 
         const result = await loadQuiz<Quiz | GeneratingResponse>(
-          moduleId, unitId, language, level, resolvedCountry,
+          moduleId, unitId, language, level, country,
           unitQuestionsCount, forceRegenerate,
         );
         if (stale) return;
@@ -217,7 +226,7 @@ export function QuizContainer({
       if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [moduleId, unitId, language, resolvedCountry, level, retryCount, forceRegenerate, isHydrated]);
+  }, [moduleId, unitId, language, level, retryCount, forceRegenerate, isHydrated, state]);
   
   const handleStartQuiz = () => {
     setState('in-progress');

--- a/frontend/lib/query-provider.tsx
+++ b/frontend/lib/query-provider.tsx
@@ -8,7 +8,15 @@ export function QueryProvider({ children }: { children: ReactNode }) {
     () =>
       new QueryClient({
         defaultOptions: {
-          queries: { staleTime: 5 * 60 * 1000, retry: 1 },
+          queries: {
+            staleTime: 5 * 60 * 1000,
+            retry: 1,
+            // Prevent TanStack Query from refetching on network reconnect or
+            // window focus — both are disruptive on flaky 3G (#2226). Components
+            // that need fresh data use explicit invalidation or refetchInterval.
+            refetchOnReconnect: false,
+            refetchOnWindowFocus: false,
+          },
         },
       })
   );


### PR DESCRIPTION
## Summary
- **Root cause**: `resolvedCountry`/`country` flipped from `undefined` → real value on reconnect, re-triggering the load `useEffect` which called `setState('loading')` unconditionally — wiping in-progress quiz answers and case-study position
- **quiz-container.tsx**: Freeze country in a ref on first hydration; bail out of the effect entirely if `state === 'in-progress' | 'completed'` — a dependency flap cannot restart a live session
- **case-study-viewer.tsx**: Same freeze pattern; bail when `caseStudyData !== null && !forceRegenerate` — content already displayed must not re-fetch on reconnect
- **query-provider.tsx**: Set `refetchOnReconnect: false` + `refetchOnWindowFocus: false` globally — prevents TanStack Query cascading re-renders on 3G network flicker

## Test plan
- [ ] Start a quiz → toggle offline/online (DevTools Network tab) → answers preserved, question position unchanged
- [ ] Open a case study → toggle offline/online → content stays, no blink back to skeleton
- [ ] Complete a quiz → results screen persists through network toggle

Fixes #2226

🤖 Generated with [Claude Code](https://claude.com/claude-code)