### PR TITLE
fix(progress): lesson Mark Complete persists across refresh + case-study quiz bypass

### DIFF
--- a/backend/app/api/v1/progress.py
+++ b/backend/app/api/v1/progress.py
@@ -248,6 +248,14 @@ async def complete_lesson(
 
         unit_type = await service.get_unit_type(request.module_id, request.unit_id)
 
+        # Safety net for AI-syllabus mislabelling: if module_units.unit_type says
+        # "quiz" but the actual GeneratedContent for this unit is a case study,
+        # trust the content and skip the quiz gate (#2163).
+        if unit_type not in ("case-study", "scenario", "lesson", None):
+            has_case = await service.unit_has_case_content(request.module_id, request.unit_id)
+            if has_case:
+                unit_type = "case-study"
+
         if unit_type in ("case-study", "scenario", "lesson", None):
             progress = await service.mark_unit_complete_no_quiz(
                 user_id=user_id,

--- a/backend/app/domain/services/progress_service.py
+++ b/backend/app/domain/services/progress_service.py
@@ -241,6 +241,30 @@ class ProgressService:
         row = result.first()
         return row[0] if row is not None else None
 
+    async def unit_has_case_content(self, module_id: UUID, unit_id: str) -> bool:
+        """Return True if the unit has a case-study GeneratedContent row.
+
+        Used as a safety net in complete_lesson to bypass the quiz gate when
+        module_units.unit_type was mislabelled 'quiz' by AI syllabus generation
+        but the actual content is a case study (#2163).
+        """
+        from app.domain.models.content import GeneratedContent
+        from app.domain.services._unit_resolution import resolve_module_unit_id
+
+        unit_uuid = await resolve_module_unit_id(self.db, module_id, unit_id)
+        q = select(GeneratedContent.id).where(
+            GeneratedContent.content_type == "case",
+        )
+        if unit_uuid is not None:
+            q = q.where(GeneratedContent.module_unit_id == unit_uuid)
+        else:
+            q = q.where(
+                GeneratedContent.module_id == module_id,
+                GeneratedContent.content["unit_id"].astext == unit_id,
+            )
+        result = await self.db.execute(q.limit(1))
+        return result.scalar_one_or_none() is not None
+
     async def mark_unit_complete_no_quiz(
         self,
         user_id: UUID,
@@ -274,9 +298,13 @@ class ProgressService:
                 GeneratedContent.module_unit_id == progress_unit_uuid
             )
         else:
+            # Unit not found in module_units (legacy/seeded content): match by
+            # content.unit_id JSON field. Do NOT restrict to module_unit_id IS NULL —
+            # newer content rows may have module_unit_id set even without a matching
+            # module_units row, and excluding them silently skips the LessonReading
+            # write, causing completion to not persist across refreshes (#2175).
             content_query = content_query.where(
                 GeneratedContent.module_id == module_id,
-                GeneratedContent.module_unit_id.is_(None),
                 GeneratedContent.content["unit_id"].astext == unit_id,
             )
         content_query = content_query.order_by(


### PR DESCRIPTION
## Summary

### #2175 — Mark Complete not persisted across refresh
**Root cause**: `mark_unit_complete_no_quiz` queried `GeneratedContent` with `module_unit_id IS NULL` in the fallback path — content rows that had `module_unit_id` set were invisible, so no `LessonReading` was written and `_get_completed_units` couldn't see the completion on refresh.
**Fix**: Remove the `module_unit_id IS NULL` restriction; `module_id` + `content["unit_id"]` filter is already specific enough.

### #2163 — Case-study units rejected with quiz_required
**Root cause**: AI syllabus generation outputs `type: "quiz"` for some case-study units, causing `complete_lesson` to require a passing quiz attempt.
**Fix**: Add `unit_has_case_content()` — if `unit_type` is not in the bypass set but `GeneratedContent.content_type = "case"`, override and skip the quiz gate.

## Test plan
- [x] `uv run pytest backend/tests/test_progress_service.py -v` → 32 passed
- [ ] Mark a lesson complete → refresh → shows Completed
- [ ] Mark a case-study complete → no 403 quiz_required

Fixes #2175
Fixes #2163

🤖 Generated with [Claude Code](https://claude.com/claude-code)