### PR TITLE
fix(pwa): queue lesson & case-study completion offline, sync on reconnect

### DIFF
--- a/frontend/components/learning/case-study-viewer.tsx
+++ b/frontend/components/learning/case-study-viewer.tsx
@@ -18,6 +18,7 @@ import { SourceCitations } from './source-citations';
 import { apiFetch, getModuleDetailWithProgress } from '@/lib/api';
 import { useCurrentUser } from '@/lib/hooks/use-current-user';
 import { loadCaseStudy, OfflineContentNotAvailable } from '@/lib/offline/content-loader';
+import { addOfflineAction } from '@/lib/offline/db';
 import { OfflineBadge } from '@/components/shared/offline-badge';
 import { useNetworkStatus } from '@/lib/hooks/use-network-status';
 import { loadQuizState, saveQuizState, clearQuizState } from '@/lib/quiz-state-persistence';
@@ -289,6 +290,17 @@ export function CaseStudyViewer({
 
   const handleMarkComplete = async () => {
     setCompleteError(null);
+    if (!isOnline) {
+      // Offline: queue for replay when reconnected. Optimistically show completed (#2151).
+      await addOfflineAction({
+        actionType: 'case_study_complete',
+        payload: { module_id: moduleId, unit_id: unitId },
+      });
+      if (storageKey) clearQuizState(storageKey);
+      setIsCompleted(true);
+      onComplete?.();
+      return;
+    }
     try {
       await apiFetch(`/api/v1/progress/complete-lesson`, {
         method: 'POST',

--- a/frontend/components/learning/lesson-viewer.tsx
+++ b/frontend/components/learning/lesson-viewer.tsx
@@ -306,6 +306,16 @@ export function LessonViewer({
 
   const handleMarkComplete = async () => {
     setCompleteError(null);
+    if (!isOnline) {
+      // Offline: queue for replay when reconnected. Optimistically show completed (#2151).
+      await addOfflineAction({
+        actionType: 'case_study_complete',
+        payload: { module_id: moduleId, unit_id: unitId },
+      });
+      setIsCompleted(true);
+      onComplete?.();
+      return;
+    }
     try {
       await apiFetch(`/api/v1/progress/complete-lesson`, {
         method: 'POST',
@@ -604,7 +614,7 @@ export function LessonViewer({
       <div className="mt-8 text-center">
         <Button
           onClick={handleMarkComplete}
-          disabled={isCompleted || isLoading || isGenerating || !isOnline}
+          disabled={isCompleted || isLoading || isGenerating}
           className="min-h-11 px-8"
           size="lg"
         >


### PR DESCRIPTION
## Summary
Both `handleMarkComplete` handlers called `apiFetch` unconditionally — when offline the lesson silently dropped the click, and the case-study showed an error.

**Fix**: Branch on `isOnline` in both handlers:
- **Offline path**: call `addOfflineAction({ actionType: 'case_study_complete', payload: { module_id, unit_id } })` — the sync-manager already routes this to `POST /api/v1/progress/complete-lesson`. Optimistically set `isCompleted = true` so the learner sees their completion immediately.
- **Online path**: unchanged — direct `apiFetch` as before.
- Also ungates the lesson "Mark Complete" button from `!isOnline` so it's reachable while offline.

No sync-manager or backend changes — `case_study_complete` already handles both content types correctly (calls `complete-lesson` with `{ module_id, unit_id }`).

## Test plan
- [ ] Disable network in DevTools → click Mark Complete on lesson → button shows Completed ✓
- [ ] Reconnect → check IndexedDB `offline_actions` store was flushed → backend progress updated
- [ ] Same flow for case-study unit

Fixes #2151

🤖 Generated with [Claude Code](https://claude.com/claude-code)