### PR TITLE
fix(tutor): scope cross-session compact to current course

### DIFF
--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -1015,12 +1015,14 @@ class SessionManager:
         ctx.learner_memory = await self.learner_memory_service.format_for_prompt(user.id, session)
 
         if is_new_conversation:
-            # Scope cross-session continuity to the same module/course (#1997).
-            # The conversation row carries module_id; course_id is resolved
-            # via the Module FK when needed.
+            # Scope cross-session continuity to the same course (#1997).
+            # Prefer the durable course_id on the conversation row (written by
+            # _get_or_create_conversation from the client's course_id). Fall back
+            # to resolving via module_id → Module.course_id for conversations
+            # created before migration 085 added the column.
             module_id = getattr(conversation, "module_id", None)
-            course_id: uuid.UUID | None = None
-            if module_id is not None:
+            course_id: uuid.UUID | None = getattr(conversation, "course_id", None)
+            if course_id is None and module_id is not None:
                 module = await session.get(Module, module_id)
                 course_id = getattr(module, "course_id", None) if module else None
             prior = await self._get_previous_compact(
@@ -2349,23 +2351,6 @@ class TutorService:
             async with contextlib.AsyncExitStack():
                 with contextlib.suppress(Exception):
                     await engine.dispose()
-
-    async def _get_previous_compact(
-        self, user_id: uuid.UUID, current_conversation_id: uuid.UUID, session: AsyncSession
-    ) -> str | None:
-        """Return the compacted_context from the most recent prior conversation (cross-session)."""
-        result = await session.execute(
-            select(TutorConversation)
-            .where(
-                TutorConversation.user_id == user_id,
-                TutorConversation.id != current_conversation_id,
-                TutorConversation.compacted_context.isnot(None),
-            )
-            .order_by(TutorConversation.created_at.desc())
-            .limit(1)
-        )
-        prev = result.scalar_one_or_none()
-        return prev.compacted_context if prev else None
 
     def _extract_activity_suggestions(
         self, response: str, context_type: str | None, user_level: int

--- a/backend/tests/test_tutor_compaction.py
+++ b/backend/tests/test_tutor_compaction.py
@@ -415,7 +415,7 @@ async def test_message_count_updated_on_send(tutor_service, sample_user):
             tutor_service, "_get_or_create_conversation", new_callable=AsyncMock, return_value=conv
         ),
         patch.object(
-            tutor_service, "_get_previous_compact", new_callable=AsyncMock, return_value=None
+            tutor_service.session_manager, "_get_previous_compact", new_callable=AsyncMock, return_value=None
         ),
         patch.object(tutor_service, "_resolve_course", new_callable=AsyncMock, return_value=None),
     ):


### PR DESCRIPTION
## Summary
`build_session_context` derived `course_id` only via `module_id → Module.course_id`, starting from `None`. For course-level chats (`module_id=None`), `course_id` stayed `None`, so `_get_previous_compact` received `(module_id=None, course_id=None)` and hit the short-circuit return — correct by accident. But when `tutor-cross-session-continuity` is enabled by an operator and a `module_id` IS provided, the scoped SQL was correct. The latent risk was the duplicate unscoped `TutorService._get_previous_compact` (never called by production code, no course filter) which could be accidentally wired up in the future.

**Fix**:
- Read `course_id` from `conversation.course_id` first (written by `_get_or_create_conversation` from the client's course_id). Fall back to `Module` lookup only for conversations pre-dating migration 085.
- Delete the dead unscoped `_get_previous_compact` on `TutorService`.
- Fix the test that was patching the deleted method to patch `session_manager._get_previous_compact` instead.

## Test plan
- [x] `uv run pytest tests/test_tutor_compaction.py -v` → 17 passed
- [ ] Chat in Course A → switch to Course B → new session has no Course A topics in prompt

Fixes #1997

🤖 Generated with [Claude Code](https://claude.com/claude-code)