### PR TITLE
fix(ops): preserve host .env overrides (ENABLE_FIGURE_VISION) across deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -313,22 +313,39 @@ jobs:
             # years ago and left us blind when the token rotated.
             echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
-            # Write .env
-            cat > .env << EOF
-            POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-            ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-            OPENAI_API_KEY=${OPENAI_API_KEY}
-            GOOGLE_API_KEY=${GOOGLE_API_KEY}
-            SENTRY_DSN=${SENTRY_DSN}
-            NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}
-            NEXT_PUBLIC_POSTHOG_KEY=${NEXT_PUBLIC_POSTHOG_KEY}
-            NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST}
-            SMS_RELAY_API_KEY=${SMS_RELAY_API_KEY}
-            SMS_RELAY_TRUSTED_SENDERS=${SMS_RELAY_TRUSTED_SENDERS}
-            MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
-            MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
-            HEYGEN_API_KEY=${HEYGEN_API_KEY}
-            EOF
+            # Write managed secrets to a temp file, then merge with any
+            # host-specific overrides (e.g. ENABLE_FIGURE_VISION) that are
+            # not part of the managed set — those survive each deploy (#1934).
+            cat > .env.deploy << 'ENVEOF'
+POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+OPENAI_API_KEY=${OPENAI_API_KEY}
+GOOGLE_API_KEY=${GOOGLE_API_KEY}
+SENTRY_DSN=${SENTRY_DSN}
+NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}
+NEXT_PUBLIC_POSTHOG_KEY=${NEXT_PUBLIC_POSTHOG_KEY}
+NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST}
+SMS_RELAY_API_KEY=${SMS_RELAY_API_KEY}
+SMS_RELAY_TRUSTED_SENDERS=${SMS_RELAY_TRUSTED_SENDERS}
+MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
+MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
+HEYGEN_API_KEY=${HEYGEN_API_KEY}
+ENVEOF
+            # Expand secrets inside the file (heredoc used 'ENVEOF' to suppress
+            # shell expansion above, so expand now via envsubst).
+            envsubst < .env.deploy > .env.deploy.expanded && mv .env.deploy.expanded .env.deploy
+
+            # Preserve host-specific keys not managed by CI (e.g. ENABLE_FIGURE_VISION).
+            # Managed keys always win; host overrides are kept for unmanaged keys only.
+            MANAGED_KEYS=$(grep -oE '^[A-Z_0-9]+' .env.deploy | paste -sd '|')
+            if [ -f .env ] && [ -n "$MANAGED_KEYS" ]; then
+              grep -vE "^(${MANAGED_KEYS})=" .env > .env.host 2>/dev/null || true
+              cat .env.host .env.deploy > .env
+              rm -f .env.host
+            else
+              cp .env.deploy .env
+            fi
+            rm -f .env.deploy
 
             # Capture previous deploy SHA so the smoke gate can roll back.
             PREV_SHA=""
@@ -505,21 +522,31 @@ jobs:
             # Fresh GHCR login every deploy, same pattern as staging (#1651).
             echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
-            cat > .env << EOF
-            POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-            ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-            OPENAI_API_KEY=${OPENAI_API_KEY}
-            GOOGLE_API_KEY=${GOOGLE_API_KEY}
-            SENTRY_DSN=${SENTRY_DSN}
-            NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}
-            NEXT_PUBLIC_POSTHOG_KEY=${NEXT_PUBLIC_POSTHOG_KEY}
-            NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST}
-            SMS_RELAY_API_KEY=${SMS_RELAY_API_KEY}
-            SMS_RELAY_TRUSTED_SENDERS=${SMS_RELAY_TRUSTED_SENDERS}
-            MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
-            MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
-            HEYGEN_API_KEY=${HEYGEN_API_KEY}
-            EOF
+            cat > .env.deploy << 'ENVEOF'
+POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+OPENAI_API_KEY=${OPENAI_API_KEY}
+GOOGLE_API_KEY=${GOOGLE_API_KEY}
+SENTRY_DSN=${SENTRY_DSN}
+NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}
+NEXT_PUBLIC_POSTHOG_KEY=${NEXT_PUBLIC_POSTHOG_KEY}
+NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST}
+SMS_RELAY_API_KEY=${SMS_RELAY_API_KEY}
+SMS_RELAY_TRUSTED_SENDERS=${SMS_RELAY_TRUSTED_SENDERS}
+MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
+MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
+HEYGEN_API_KEY=${HEYGEN_API_KEY}
+ENVEOF
+            envsubst < .env.deploy > .env.deploy.expanded && mv .env.deploy.expanded .env.deploy
+            MANAGED_KEYS=$(grep -oE '^[A-Z_0-9]+' .env.deploy | paste -sd '|')
+            if [ -f .env ] && [ -n "$MANAGED_KEYS" ]; then
+              grep -vE "^(${MANAGED_KEYS})=" .env > .env.host 2>/dev/null || true
+              cat .env.host .env.deploy > .env
+              rm -f .env.host
+            else
+              cp .env.deploy .env
+            fi
+            rm -f .env.deploy
 
             # Capture previous deploy SHA for rollback.
             PREV_SHA=""


### PR DESCRIPTION
## Summary
`deploy.yml` used `cat > .env << EOF` which completely overwrites the host `.env` on every deploy. Host-specific settings like `ENABLE_FIGURE_VISION=false` added directly on the server were silently lost.

**Fix**: Write managed secrets to `.env.deploy`, expand with `envsubst`, then merge — lines whose keys are NOT in the managed set are preserved from the existing `.env`. Managed secrets always win; host-only overrides survive. Applied to both staging (line ~317) and production (line ~525) deploy blocks.

## How it works
```bash
# Extract managed key names → regex
MANAGED_KEYS=$(grep -oE '^[A-Z_0-9]+' .env.deploy | paste -sd '|')
# Keep host-specific lines not in managed set
grep -vE "^(${MANAGED_KEYS})=" .env > .env.host
# Merge: host overrides first, managed secrets on top (managed wins on conflict)
cat .env.host .env.deploy > .env
```

## Test plan
- [ ] On staging: manually add `ENABLE_FIGURE_VISION=false` to `.env` → trigger deploy → key still present after deploy
- [ ] Managed secrets (ANTHROPIC_API_KEY etc.) are correctly updated from GitHub Secrets

Fixes #1934

🤖 Generated with [Claude Code](https://claude.com/claude-code)