### PR TITLE
fix(rag): use canonical unit_number in pregenerate task + fix quiz free-units regex

### DIFF
--- a/backend/app/api/v1/quiz.py
+++ b/backend/app/api/v1/quiz.py
@@ -60,7 +60,9 @@ async def _check_subscription_or_first_unit(user: AuthenticatedUser, unit_id: st
         return
 
     free_count = SettingsCache.instance().get("subscription-free-units-count", 2)
-    m = re.search(r"-U0*(\d+)$", unit_id.upper()) if unit_id else None
+    # Canonical unit_number is "X.Y" (e.g. "1.2"). The legacy M01-U02 regex
+    # never matched after migration 081 removed that format (#1897).
+    m = re.match(r"^\d+\.(\d+)$", unit_id) if unit_id else None
     if m and int(m.group(1)) <= free_count:
         return
 

--- a/backend/app/tasks/content_generation.py
+++ b/backend/app/tasks/content_generation.py
@@ -1181,17 +1181,15 @@ def prefetch_next_lessons_task(
         current_idx = -1
         if current_unit_id:
             for i, u in enumerate(all_units):
-                uid = f"M{module.module_number:02d}-U{u.order_index + 1:02d}"
-                has_dot = "." in u.unit_number
-                ordinal = int(u.unit_number.split(".")[-1]) if has_dot else 0
-                alt_uid = f"M{module.module_number:02d}-U{ordinal:02d}" if has_dot else uid
-                if uid == current_unit_id or alt_uid == current_unit_id:
+                # Use canonical unit_number ("1.1") — the M01-U01 format was
+                # removed by migration 081 (#1897).
+                if u.unit_number == current_unit_id:
                     current_idx = i
                     break
 
         next_units: list[tuple[str, str]] = []
         for u in all_units[current_idx + 1 :]:
-            uid = f"M{module.module_number:02d}-U{u.order_index + 1:02d}"
+            uid = u.unit_number
             raw_type = (u.unit_type or "").lower().replace("-", "_").replace(" ", "_")
             if "quiz" in raw_type or "evaluation" in raw_type or "évaluation" in raw_type:
                 content_type = "quiz"
@@ -1687,7 +1685,7 @@ def pregenerate_on_publish_task(self, course_id: str) -> dict:
                 case_study_service = CaseStudyGenerationService(ClaudeService(), retriever)
 
                 for unit in units:
-                    unit_id = f"M{module.module_number:02d}-U{unit.order_index + 1:02d}"
+                    unit_id = unit.unit_number  # canonical "1.1" format (#1898)
                     raw_type = (unit.unit_type or "").lower().replace("-", "_").replace(" ", "_")
                     if "quiz" in raw_type or "evaluation" in raw_type or "évaluation" in raw_type:
                         content_type = "quiz"


### PR DESCRIPTION
## Summary

### #1898 — Quiz generation writes M-format unit_id
`pregenerate_on_publish_task` and `_get_next_units` built `unit_id` as `M{N:02d}-U{i:02d}` from `module_number` + `order_index`. This M-format string was stored in `generated_content.content->unit_id`. Migration 086 then failed to backfill `module_unit_id` (FK match fails: `M01-U04 != 1.4`), leaving orphan rows invisible to `_get_completed_units`.
**Fix**: use `unit.unit_number` (the canonical `"1.1"` value already in `module_units`).

### #1897 — Dead M01-U01 format comparison code
`_get_next_units` did multi-format fallback matching (`uid` + `alt_uid`) that assumed callers send M-format IDs — migration 081 removed all M-format rows from the DB.
**Fix**: simplified to direct `u.unit_number == current_unit_id` equality check.

### Quiz free-unit regex (bonus)
`quiz.py:63` subscription free-unit check regex `r"-U0*(\d+)$"` expected M01-U01 format, never matched canonical `"1.2"` input after migration 081. Always fell through to the slower DB subscription check.
**Fix**: `r"^\d+\.(\d+)$"` matches canonical format, ordinal after dot.

## Test plan
- [ ] Publish a course → pregenerate fires → `generated_content.content->>'unit_id'` is `"1.1"` not `"M01-U01"`
- [ ] Free learner on unit `1.2` → quiz access allowed (ordinal 2 ≤ free_count 2)
- [x] `uv run ruff check` → clean

Fixes #1898  
Fixes #1897

🤖 Generated with [Claude Code](https://claude.com/claude-code)