### PR TITLE
fix(ci): ruff format admin_courses.py + test_tutor_compaction.py

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -1380,9 +1380,8 @@ async def get_rag_index_status(
             and effective_task_id == course.indexation_task_id
             and (chunks_indexed > 0 or images_indexed > 0)
         )
-        is_zombie = (
-            effective_task_id == course.indexation_task_id
-            and _is_zombie_task(state, meta, chunks_indexed, images_indexed)
+        is_zombie = effective_task_id == course.indexation_task_id and _is_zombie_task(
+            state, meta, chunks_indexed, images_indexed
         )
         if is_evicted_pointer or is_zombie:
             course.indexation_task_id = None

--- a/backend/tests/test_tutor_compaction.py
+++ b/backend/tests/test_tutor_compaction.py
@@ -415,7 +415,10 @@ async def test_message_count_updated_on_send(tutor_service, sample_user):
             tutor_service, "_get_or_create_conversation", new_callable=AsyncMock, return_value=conv
         ),
         patch.object(
-            tutor_service.session_manager, "_get_previous_compact", new_callable=AsyncMock, return_value=None
+            tutor_service.session_manager,
+            "_get_previous_compact",
+            new_callable=AsyncMock,
+            return_value=None,
         ),
         patch.object(tutor_service, "_resolve_course", new_callable=AsyncMock, return_value=None),
     ):


### PR DESCRIPTION
## Summary
Two files introduced in the #2054 (zombie task detection) and #1997 (tutor cross-course bleed) fixes had formatting violations that failed the Backend (Python) CI `ruff format --check` gate, blocking all dev→main deploys.

Auto-fixed with `ruff format` — no logic changes.

## Files
- `backend/app/api/v1/admin_courses.py` — `is_zombie` multi-line assignment wrapping
- `backend/tests/test_tutor_compaction.py` — `patch.object` argument splitting

## Test plan
- [x] `uv run ruff format --check backend/` → 423 files already formatted, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)