### PR TITLE
sync: dev → main (bug fixes #2054 #1997 #1934 #1898 #1897 + CI format)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -313,22 +313,39 @@ jobs:
             # years ago and left us blind when the token rotated.
             echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
-            # Write .env
-            cat > .env << EOF
-            POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-            ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-            OPENAI_API_KEY=${OPENAI_API_KEY}
-            GOOGLE_API_KEY=${GOOGLE_API_KEY}
-            SENTRY_DSN=${SENTRY_DSN}
-            NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}
-            NEXT_PUBLIC_POSTHOG_KEY=${NEXT_PUBLIC_POSTHOG_KEY}
-            NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST}
-            SMS_RELAY_API_KEY=${SMS_RELAY_API_KEY}
-            SMS_RELAY_TRUSTED_SENDERS=${SMS_RELAY_TRUSTED_SENDERS}
-            MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
-            MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
-            HEYGEN_API_KEY=${HEYGEN_API_KEY}
-            EOF
+            # Write managed secrets to a temp file, then merge with any
+            # host-specific overrides (e.g. ENABLE_FIGURE_VISION) that are
+            # not part of the managed set — those survive each deploy (#1934).
+            cat > .env.deploy << 'ENVEOF'
+POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+OPENAI_API_KEY=${OPENAI_API_KEY}
+GOOGLE_API_KEY=${GOOGLE_API_KEY}
+SENTRY_DSN=${SENTRY_DSN}
+NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}
+NEXT_PUBLIC_POSTHOG_KEY=${NEXT_PUBLIC_POSTHOG_KEY}
+NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST}
+SMS_RELAY_API_KEY=${SMS_RELAY_API_KEY}
+SMS_RELAY_TRUSTED_SENDERS=${SMS_RELAY_TRUSTED_SENDERS}
+MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
+MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
+HEYGEN_API_KEY=${HEYGEN_API_KEY}
+ENVEOF
+            # Expand secrets inside the file (heredoc used 'ENVEOF' to suppress
+            # shell expansion above, so expand now via envsubst).
+            envsubst < .env.deploy > .env.deploy.expanded && mv .env.deploy.expanded .env.deploy
+
+            # Preserve host-specific keys not managed by CI (e.g. ENABLE_FIGURE_VISION).
+            # Managed keys always win; host overrides are kept for unmanaged keys only.
+            MANAGED_KEYS=$(grep -oE '^[A-Z_0-9]+' .env.deploy | paste -sd '|')
+            if [ -f .env ] && [ -n "$MANAGED_KEYS" ]; then
+              grep -vE "^(${MANAGED_KEYS})=" .env > .env.host 2>/dev/null || true
+              cat .env.host .env.deploy > .env
+              rm -f .env.host
+            else
+              cp .env.deploy .env
+            fi
+            rm -f .env.deploy
 
             # Capture previous deploy SHA so the smoke gate can roll back.
             PREV_SHA=""
@@ -505,21 +522,31 @@ jobs:
             # Fresh GHCR login every deploy, same pattern as staging (#1651).
             echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
-            cat > .env << EOF
-            POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-            ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-            OPENAI_API_KEY=${OPENAI_API_KEY}
-            GOOGLE_API_KEY=${GOOGLE_API_KEY}
-            SENTRY_DSN=${SENTRY_DSN}
-            NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}
-            NEXT_PUBLIC_POSTHOG_KEY=${NEXT_PUBLIC_POSTHOG_KEY}
-            NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST}
-            SMS_RELAY_API_KEY=${SMS_RELAY_API_KEY}
-            SMS_RELAY_TRUSTED_SENDERS=${SMS_RELAY_TRUSTED_SENDERS}
-            MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
-            MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
-            HEYGEN_API_KEY=${HEYGEN_API_KEY}
-            EOF
+            cat > .env.deploy << 'ENVEOF'
+POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+OPENAI_API_KEY=${OPENAI_API_KEY}
+GOOGLE_API_KEY=${GOOGLE_API_KEY}
+SENTRY_DSN=${SENTRY_DSN}
+NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}
+NEXT_PUBLIC_POSTHOG_KEY=${NEXT_PUBLIC_POSTHOG_KEY}
+NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST}
+SMS_RELAY_API_KEY=${SMS_RELAY_API_KEY}
+SMS_RELAY_TRUSTED_SENDERS=${SMS_RELAY_TRUSTED_SENDERS}
+MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
+MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
+HEYGEN_API_KEY=${HEYGEN_API_KEY}
+ENVEOF
+            envsubst < .env.deploy > .env.deploy.expanded && mv .env.deploy.expanded .env.deploy
+            MANAGED_KEYS=$(grep -oE '^[A-Z_0-9]+' .env.deploy | paste -sd '|')
+            if [ -f .env ] && [ -n "$MANAGED_KEYS" ]; then
+              grep -vE "^(${MANAGED_KEYS})=" .env > .env.host 2>/dev/null || true
+              cat .env.host .env.deploy > .env
+              rm -f .env.host
+            else
+              cp .env.deploy .env
+            fi
+            rm -f .env.deploy
 
             # Capture previous deploy SHA for rollback.
             PREV_SHA=""

--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -184,6 +184,39 @@ def _safe_task_meta(task_result: AsyncResult) -> tuple[str, dict]:
 
 _TERMINAL_TASK_STATES = frozenset({"SUCCESS", "FAILURE", "REVOKED"})
 
+# Custom states published by the RAG indexation task via update_state().
+# When a worker dies after publishing one of these states but before finishing,
+# AsyncResult still reports the custom state (it stays in Redis until TTL).
+# We detect death by: custom state + chunks_processed == 0 + eta == 0 + progress > 0
+# — meaning the task published its initial meta but never completed a chunk (#2054).
+_CUSTOM_INDEXATION_STATES = frozenset({"EXTRACTING", "EMBEDDING", "LINKING"})
+
+
+def _is_zombie_task(state: str, meta: dict, chunks_indexed: int, images_indexed: int) -> bool:
+    """Return True when a task is provably dead despite appearing active in Redis.
+
+    Detects the signature of a worker that published its initial progress update
+    (so meta is non-empty and state is a custom RAG state) but then died without
+    processing any chunks — distinguishable from a truly active task by
+    ``chunks_processed == 0`` AND ``estimated_seconds_remaining == 0``.
+
+    The second guard (chunks_indexed OR images_indexed > 0) ensures we only
+    self-heal when there's durable DB evidence that prior indexation already ran —
+    i.e. the task that died had already committed some work.
+    """
+    if state not in _CUSTOM_INDEXATION_STATES:
+        return False
+    if not meta:
+        return False
+    chunks_processed = meta.get("chunks_processed", -1)
+    eta = meta.get("estimated_seconds_remaining", -1)
+    progress = meta.get("progress", 0)
+    # Task published initial meta (progress > 0) but ETA zeroed and no chunks
+    # processed — classic dead-worker signature.
+    dead_signal = chunks_processed == 0 and eta == 0 and progress > 0
+    has_prior_data = chunks_indexed > 0 or images_indexed > 0
+    return dead_signal and has_prior_data
+
 
 def _diagnose_indexation_pointer(
     course: Course,
@@ -1347,13 +1380,19 @@ async def get_rag_index_status(
             and effective_task_id == course.indexation_task_id
             and (chunks_indexed > 0 or images_indexed > 0)
         )
-        if is_evicted_pointer:
+        is_zombie = (
+            effective_task_id == course.indexation_task_id
+            and _is_zombie_task(state, meta, chunks_indexed, images_indexed)
+        )
+        if is_evicted_pointer or is_zombie:
             course.indexation_task_id = None
             await db.commit()
             logger.info(
-                "Cleared evicted indexation_task_id pointer",
+                "Cleared stale indexation_task_id pointer",
                 course_id=str(course_id),
                 task_id=effective_task_id,
+                reason="zombie" if is_zombie else "evicted",
+                task_state=state,
             )
         else:
             response["task"] = {

--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -1380,9 +1380,8 @@ async def get_rag_index_status(
             and effective_task_id == course.indexation_task_id
             and (chunks_indexed > 0 or images_indexed > 0)
         )
-        is_zombie = (
-            effective_task_id == course.indexation_task_id
-            and _is_zombie_task(state, meta, chunks_indexed, images_indexed)
+        is_zombie = effective_task_id == course.indexation_task_id and _is_zombie_task(
+            state, meta, chunks_indexed, images_indexed
         )
         if is_evicted_pointer or is_zombie:
             course.indexation_task_id = None

--- a/backend/app/api/v1/quiz.py
+++ b/backend/app/api/v1/quiz.py
@@ -60,7 +60,9 @@ async def _check_subscription_or_first_unit(user: AuthenticatedUser, unit_id: st
         return
 
     free_count = SettingsCache.instance().get("subscription-free-units-count", 2)
-    m = re.search(r"-U0*(\d+)$", unit_id.upper()) if unit_id else None
+    # Canonical unit_number is "X.Y" (e.g. "1.2"). The legacy M01-U02 regex
+    # never matched after migration 081 removed that format (#1897).
+    m = re.match(r"^\d+\.(\d+)$", unit_id) if unit_id else None
     if m and int(m.group(1)) <= free_count:
         return
 

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -1015,12 +1015,14 @@ class SessionManager:
         ctx.learner_memory = await self.learner_memory_service.format_for_prompt(user.id, session)
 
         if is_new_conversation:
-            # Scope cross-session continuity to the same module/course (#1997).
-            # The conversation row carries module_id; course_id is resolved
-            # via the Module FK when needed.
+            # Scope cross-session continuity to the same course (#1997).
+            # Prefer the durable course_id on the conversation row (written by
+            # _get_or_create_conversation from the client's course_id). Fall back
+            # to resolving via module_id → Module.course_id for conversations
+            # created before migration 085 added the column.
             module_id = getattr(conversation, "module_id", None)
-            course_id: uuid.UUID | None = None
-            if module_id is not None:
+            course_id: uuid.UUID | None = getattr(conversation, "course_id", None)
+            if course_id is None and module_id is not None:
                 module = await session.get(Module, module_id)
                 course_id = getattr(module, "course_id", None) if module else None
             prior = await self._get_previous_compact(
@@ -2349,23 +2351,6 @@ class TutorService:
             async with contextlib.AsyncExitStack():
                 with contextlib.suppress(Exception):
                     await engine.dispose()
-
-    async def _get_previous_compact(
-        self, user_id: uuid.UUID, current_conversation_id: uuid.UUID, session: AsyncSession
-    ) -> str | None:
-        """Return the compacted_context from the most recent prior conversation (cross-session)."""
-        result = await session.execute(
-            select(TutorConversation)
-            .where(
-                TutorConversation.user_id == user_id,
-                TutorConversation.id != current_conversation_id,
-                TutorConversation.compacted_context.isnot(None),
-            )
-            .order_by(TutorConversation.created_at.desc())
-            .limit(1)
-        )
-        prev = result.scalar_one_or_none()
-        return prev.compacted_context if prev else None
 
     def _extract_activity_suggestions(
         self, response: str, context_type: str | None, user_level: int

--- a/backend/app/tasks/content_generation.py
+++ b/backend/app/tasks/content_generation.py
@@ -1181,17 +1181,15 @@ def prefetch_next_lessons_task(
         current_idx = -1
         if current_unit_id:
             for i, u in enumerate(all_units):
-                uid = f"M{module.module_number:02d}-U{u.order_index + 1:02d}"
-                has_dot = "." in u.unit_number
-                ordinal = int(u.unit_number.split(".")[-1]) if has_dot else 0
-                alt_uid = f"M{module.module_number:02d}-U{ordinal:02d}" if has_dot else uid
-                if uid == current_unit_id or alt_uid == current_unit_id:
+                # Use canonical unit_number ("1.1") — the M01-U01 format was
+                # removed by migration 081 (#1897).
+                if u.unit_number == current_unit_id:
                     current_idx = i
                     break
 
         next_units: list[tuple[str, str]] = []
         for u in all_units[current_idx + 1 :]:
-            uid = f"M{module.module_number:02d}-U{u.order_index + 1:02d}"
+            uid = u.unit_number
             raw_type = (u.unit_type or "").lower().replace("-", "_").replace(" ", "_")
             if "quiz" in raw_type or "evaluation" in raw_type or "évaluation" in raw_type:
                 content_type = "quiz"
@@ -1687,7 +1685,7 @@ def pregenerate_on_publish_task(self, course_id: str) -> dict:
                 case_study_service = CaseStudyGenerationService(ClaudeService(), retriever)
 
                 for unit in units:
-                    unit_id = f"M{module.module_number:02d}-U{unit.order_index + 1:02d}"
+                    unit_id = unit.unit_number  # canonical "1.1" format (#1898)
                     raw_type = (unit.unit_type or "").lower().replace("-", "_").replace(" ", "_")
                     if "quiz" in raw_type or "evaluation" in raw_type or "évaluation" in raw_type:
                         content_type = "quiz"

--- a/backend/tests/test_tutor_compaction.py
+++ b/backend/tests/test_tutor_compaction.py
@@ -415,7 +415,7 @@ async def test_message_count_updated_on_send(tutor_service, sample_user):
             tutor_service, "_get_or_create_conversation", new_callable=AsyncMock, return_value=conv
         ),
         patch.object(
-            tutor_service, "_get_previous_compact", new_callable=AsyncMock, return_value=None
+            tutor_service.session_manager, "_get_previous_compact", new_callable=AsyncMock, return_value=None
         ),
         patch.object(tutor_service, "_resolve_course", new_callable=AsyncMock, return_value=None),
     ):

--- a/backend/tests/test_tutor_compaction.py
+++ b/backend/tests/test_tutor_compaction.py
@@ -415,7 +415,10 @@ async def test_message_count_updated_on_send(tutor_service, sample_user):
             tutor_service, "_get_or_create_conversation", new_callable=AsyncMock, return_value=conv
         ),
         patch.object(
-            tutor_service.session_manager, "_get_previous_compact", new_callable=AsyncMock, return_value=None
+            tutor_service.session_manager,
+            "_get_previous_compact",
+            new_callable=AsyncMock,
+            return_value=None,
         ),
         patch.object(tutor_service, "_resolve_course", new_callable=AsyncMock, return_value=None),
     ):

--- a/backend/tests/test_tutor_service.py
+++ b/backend/tests/test_tutor_service.py
@@ -150,7 +150,7 @@ async def test_send_message_yields_content_type_chunks(
             return_value=sample_conversation,
         ),
         patch.object(
-            tutor_service,
+            tutor_service.session_manager,
             "_get_previous_compact",
             new_callable=AsyncMock,
             return_value=None,
@@ -217,7 +217,7 @@ async def test_send_message_yields_sources_cited_type(
             return_value=sample_conversation,
         ),
         patch.object(
-            tutor_service,
+            tutor_service.session_manager,
             "_get_previous_compact",
             new_callable=AsyncMock,
             return_value=None,
@@ -354,7 +354,7 @@ async def test_send_message_never_yields_text_type(tutor_service, sample_user, s
             return_value=sample_conversation,
         ),
         patch.object(
-            tutor_service,
+            tutor_service.session_manager,
             "_get_previous_compact",
             new_callable=AsyncMock,
             return_value=None,


### PR DESCRIPTION
## Summary
Promotes 5 bug fixes from dev to main (staging deploy).

| PR | Fix |
|----|-----|
| #2354 (CI) | ruff format violations that blocked dev CI |
| #2352 | Canonical `unit.unit_number` in pregenerate task + quiz free-units regex |
| #2351 | Deploy pipeline now preserves host `.env` overrides (ENABLE_FIGURE_VISION) |
| #2350 | Tutor cross-course compact bleed — scope to current course |
| #2348 | Zombie indexation task auto-cleared in index-status |

Also supersedes conflicting PR #2349.

## Already on main (included in last sync #2344)
- #2226 quiz/case-study reset on reconnect
- #2175 + #2163 lesson Mark Complete persists + case-study quiz bypass
- #2151 offline lesson completion queued
- #2338 SW pages cache-name drift
- #2343 quiz state reset on reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)