### PR TITLE
fix(ux): inline markdown images now fill lesson text column

### DIFF
--- a/frontend/components/learning/case-study-viewer.tsx
+++ b/frontend/components/learning/case-study-viewer.tsx
@@ -363,6 +363,10 @@ export function CaseStudyViewer({
     code: ({ children, ...props }: React.HTMLAttributes<HTMLElement>) => (
       <code className="bg-gray-100 rounded px-1.5 py-0.5 text-sm font-mono" {...props}>{children}</code>
     ),
+    img: ({ src, alt }: React.ImgHTMLAttributes<HTMLImageElement>) => (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img src={src} alt={alt ?? ''} className="w-full h-auto rounded-lg my-4" />
+    ),
   };
 
   if (error) {

--- a/frontend/components/learning/lesson-viewer.tsx
+++ b/frontend/components/learning/lesson-viewer.tsx
@@ -349,6 +349,12 @@ export function LessonViewer({
     tr: ({ children, ...props }: React.HTMLAttributes<HTMLTableRowElement>) => (
       <tr className="even:bg-gray-50" {...props}>{children}</tr>
     ),
+    // Inline markdown images default to intrinsic pixel size in @tailwindcss/typography.
+    // Override to fill the text column, matching LessonImage and SourceImage (#2094).
+    img: ({ src, alt }: React.ImgHTMLAttributes<HTMLImageElement>) => (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img src={src} alt={alt ?? ''} className="w-full h-auto rounded-lg my-4" />
+    ),
   };
 
 


### PR DESCRIPTION
## Summary
`@tailwindcss/typography` applies no `width` rule to `prose img` — inline `![alt](url)` images in lesson/case-study markdown rendered at their intrinsic pixel size (e.g. a 512×512 diagram shows as 512 px wide even in an 800 px column).

**Fix**: Add `img` entry to `mdComponents` in both `lesson-viewer.tsx` and `case-study-viewer.tsx`:
```tsx
img: ({ src, alt }) => (
  <img src={src} alt={alt ?? ''} className="w-full h-auto rounded-lg my-4" />
)
```
This matches the style already used by `LessonImage` and `SourceImage`, which were already `w-full`.

## Test plan
- [ ] Open a lesson with inline markdown images → images fill the prose column width
- [ ] Open a case-study with inline images → same behaviour
- [x] `npx tsc --noEmit` → 0 errors

Fixes #2094

🤖 Generated with [Claude Code](https://claude.com/claude-code)