### PR TITLE
feat(quality): auto-trigger QA after course creation and content generation

### DIFF
--- a/backend/app/domain/services/quality_agent_service.py
+++ b/backend/app/domain/services/quality_agent_service.py
@@ -600,6 +600,178 @@ class CourseQualityService:
 
         return run
 
+    # ---- Structural consistency check (no Claude) -----------------------
+
+    async def assess_course_structure(
+        self,
+        course_id: uuid.UUID,
+        session: AsyncSession,
+    ) -> CourseQualityRun:
+        """Check syllabus structural consistency without any Claude calls.
+
+        Compares declared hours against the sum of unit minutes, flags thin
+        modules, unrealistic unit durations, and missing bilingual metadata.
+        Creates a CourseQualityRun with run_kind='structural' and
+        status='completed' (instant — no Celery continuation needed).
+
+        Idempotent: at most one structural run per course per UTC day.
+        """
+        day = datetime.utcnow().strftime("%Y-%m-%d")
+        key_src = f"structural:{course_id}:{day}"
+        idempotency_key = hashlib.sha256(key_src.encode()).hexdigest()[:64]
+
+        course = await session.get(Course, course_id)
+        if course is None:
+            raise ValueError(f"Course {course_id} not found")
+
+        modules_result = await session.execute(
+            select(Module).where(Module.course_id == course_id).order_by(Module.module_number)
+        )
+        modules = list(modules_result.scalars().all())
+
+        findings: list[dict] = []
+        target_hours = course.estimated_hours or 0
+        sum_module_hours = sum(m.estimated_hours or 0 for m in modules)
+        sum_unit_minutes_total = 0
+
+        for module in modules:
+            units_result = await session.execute(
+                select(ModuleUnit)
+                .where(ModuleUnit.module_id == module.id)
+                .order_by(ModuleUnit.order_index)
+            )
+            units = list(units_result.scalars().all())
+
+            unit_minutes = sum(u.estimated_minutes or 0 for u in units)
+            sum_unit_minutes_total += unit_minutes
+
+            if len(units) < 2:
+                findings.append({
+                    "check": "thin_module",
+                    "severity": "warning",
+                    "module_number": module.module_number,
+                    "unit_count": len(units),
+                    "detail": f"Module {module.module_number} has only {len(units)} unit(s); recommend ≥ 2.",
+                })
+
+            module_hours = module.estimated_hours or 0
+            if module_hours > 0 and unit_minutes > 0:
+                module_as_minutes = module_hours * 60
+                divergence = abs(unit_minutes - module_as_minutes) / module_as_minutes
+                if divergence > 0.30:
+                    findings.append({
+                        "check": "module_hours_vs_units",
+                        "severity": "warning",
+                        "module_number": module.module_number,
+                        "module_hours": module_hours,
+                        "unit_minutes_sum": unit_minutes,
+                        "detail": (
+                            f"Module {module.module_number}: declared {module_hours}h"
+                            f" but units sum to {unit_minutes}min ({unit_minutes/60:.1f}h),"
+                            f" divergence {divergence*100:.0f}%."
+                        ),
+                    })
+
+            if not module.learning_objectives_fr or not module.learning_objectives_en:
+                findings.append({
+                    "check": "missing_module_objectives",
+                    "severity": "warning",
+                    "module_number": module.module_number,
+                    "detail": f"Module {module.module_number} is missing learning objectives in one or both languages.",
+                })
+
+            for unit in units:
+                mins = unit.estimated_minutes or 0
+                if mins < 5 or mins > 180:
+                    findings.append({
+                        "check": "unrealistic_unit_minutes",
+                        "severity": "warning",
+                        "unit_number": unit.unit_number,
+                        "estimated_minutes": mins,
+                        "detail": f"Unit {unit.unit_number}: {mins}min is outside the 5–180 min range.",
+                    })
+                if not unit.title_fr or not unit.title_en:
+                    findings.append({
+                        "check": "missing_unit_title",
+                        "severity": "warning",
+                        "unit_number": unit.unit_number,
+                        "detail": f"Unit {unit.unit_number} is missing title in one or both languages.",
+                    })
+
+        if target_hours > 0 and sum_module_hours > 0:
+            divergence = abs(sum_module_hours - target_hours) / target_hours
+            if divergence > 0.20:
+                findings.append({
+                    "check": "course_hours_vs_modules",
+                    "severity": "warning",
+                    "target_hours": target_hours,
+                    "module_hours_sum": sum_module_hours,
+                    "detail": (
+                        f"course.estimated_hours={target_hours}h but"
+                        f" SUM(modules.hours)={sum_module_hours}h,"
+                        f" divergence {divergence*100:.0f}%."
+                    ),
+                })
+
+        if target_hours > 0 and sum_unit_minutes_total > 0:
+            unit_hours = sum_unit_minutes_total / 60
+            divergence = abs(unit_hours - target_hours) / target_hours
+            if divergence > 0.25:
+                findings.append({
+                    "check": "course_hours_vs_unit_minutes",
+                    "severity": "warning",
+                    "target_hours": target_hours,
+                    "unit_hours_sum": round(unit_hours, 2),
+                    "detail": (
+                        f"course.estimated_hours={target_hours}h but"
+                        f" units total {sum_unit_minutes_total}min ({unit_hours:.1f}h),"
+                        f" divergence {divergence*100:.0f}%."
+                    ),
+                })
+
+        now = datetime.utcnow()
+        run = CourseQualityRun(
+            course_id=course_id,
+            run_kind="structural",
+            status="completed",
+            triggered_by_user_id=None,
+            budget_credits=0,
+            spent_credits=0,
+            idempotency_key=idempotency_key,
+            started_at=now,
+            finished_at=now,
+            notes=json.dumps(findings) if findings else None,
+        )
+        session.add(run)
+        try:
+            await session.flush()
+        except IntegrityError:
+            await session.rollback()
+            existing_q = await session.execute(
+                select(CourseQualityRun).where(
+                    and_(
+                        CourseQualityRun.course_id == course_id,
+                        CourseQualityRun.idempotency_key == idempotency_key,
+                    )
+                )
+            )
+            existing = existing_q.scalar_one_or_none()
+            if existing is not None:
+                logger.info(
+                    "Structural QA run already exists for today",
+                    course_id=str(course_id),
+                    run_id=str(existing.id),
+                )
+                return existing
+            raise
+
+        logger.info(
+            "Structural QA completed",
+            course_id=str(course_id),
+            finding_count=len(findings),
+        )
+        return run
+
     async def finalize_run(
         self,
         run_id: uuid.UUID,

--- a/backend/app/tasks/content_generation.py
+++ b/backend/app/tasks/content_generation.py
@@ -279,9 +279,9 @@ def generate_lesson_task(
         # — never block the generation result on the assessment task.
         try:
             if result.get("status") == "complete" and result.get("content_id"):
-                from app.tasks.quality_assessment import assess_unit_task
+                from app.tasks.quality_assessment import assess_and_regenerate_unit_task
 
-                assess_unit_task.apply_async(
+                assess_and_regenerate_unit_task.apply_async(
                     kwargs={"content_id": result["content_id"]},
                     priority=5,
                 )
@@ -382,9 +382,9 @@ def generate_case_study_task(
         )
         try:
             if result.get("status") == "complete" and result.get("content_id"):
-                from app.tasks.quality_assessment import assess_unit_task
+                from app.tasks.quality_assessment import assess_and_regenerate_unit_task
 
-                assess_unit_task.apply_async(
+                assess_and_regenerate_unit_task.apply_async(
                     kwargs={"content_id": result["content_id"]},
                     priority=5,
                 )
@@ -489,9 +489,9 @@ def generate_quiz_task(
         )
         try:
             if result.get("status") == "complete" and result.get("content_id"):
-                from app.tasks.quality_assessment import assess_unit_task
+                from app.tasks.quality_assessment import assess_and_regenerate_unit_task
 
-                assess_unit_task.apply_async(
+                assess_and_regenerate_unit_task.apply_async(
                     kwargs={"content_id": result["content_id"]},
                     priority=5,
                 )
@@ -799,9 +799,9 @@ def generate_flashcard_task(
         )
         try:
             if result.get("status") == "complete" and result.get("content_id"):
-                from app.tasks.quality_assessment import assess_unit_task
+                from app.tasks.quality_assessment import assess_and_regenerate_unit_task
 
-                assess_unit_task.apply_async(
+                assess_and_regenerate_unit_task.apply_async(
                     kwargs={"content_id": result["content_id"]},
                     priority=5,
                 )
@@ -1780,6 +1780,40 @@ def pregenerate_on_publish_task(self, course_id: str) -> dict:
                                 label=label,
                                 error=str(exc),
                             )
+
+            # Auto-trigger a full course quality sweep now that the first
+            # units are generated. Best-effort — never block the publish.
+            try:
+                from app.ai.claude_service import ClaudeService
+                from app.domain.services.quality_agent_service import CourseQualityService
+                from app.tasks.quality_assessment import assess_course_task
+
+                async with session_factory() as qa_session:
+                    svc = CourseQualityService(ClaudeService(), semantic_retriever=None)
+                    run = await svc.assess_course(
+                        course_id=uuid.UUID(course_id),
+                        triggered_by_user_id=None,
+                        session=qa_session,
+                        run_kind="full",
+                    )
+                    await qa_session.commit()
+                if run.status == "queued":
+                    assess_course_task.apply_async(
+                        kwargs={"run_id": str(run.id)},
+                        priority=4,
+                        countdown=30,
+                    )
+                    logger.info(
+                        "pregenerate_on_publish: auto quality sweep dispatched",
+                        course_id=course_id,
+                        run_id=str(run.id),
+                    )
+            except Exception as _exc:
+                logger.warning(
+                    "pregenerate_on_publish: auto quality sweep dispatch failed (non-fatal)",
+                    course_id=course_id,
+                    error=str(_exc),
+                )
 
         finally:
             await engine.dispose()

--- a/backend/app/tasks/quality_assessment.py
+++ b/backend/app/tasks/quality_assessment.py
@@ -69,6 +69,67 @@ def _make_session_factory(settings):
     return engine, factory
 
 
+# ---- 0. Structural consistency check (no Claude) ----------------------
+
+
+@celery_app.task(
+    bind=True,
+    base=QualityCallbackTask,
+    autoretry_for=(Exception,),
+    retry_kwargs={"max_retries": 1, "countdown": 30},
+    soft_time_limit=120,
+    time_limit=180,
+    rate_limit="5/m",
+)
+def assess_course_structure_task(self, course_id: str) -> dict:
+    """Check structural consistency of a course's syllabus (no Claude calls).
+
+    Triggered automatically after ``generate_course_syllabus`` completes.
+    Compares declared hours against unit-minutes, flags thin modules,
+    unrealistic unit durations, and missing bilingual metadata.  Writes
+    findings into a ``CourseQualityRun`` row with ``run_kind='structural'``.
+    """
+
+    async def _run() -> dict:
+        from app.ai.claude_service import ClaudeService
+        from app.domain.services.quality_agent_service import CourseQualityService
+        from app.infrastructure.config.settings import settings
+
+        engine, session_factory = _make_session_factory(settings)
+        try:
+            async with session_factory() as session:
+                service = CourseQualityService(ClaudeService(), semantic_retriever=None)
+                run = await service.assess_course_structure(
+                    course_id=uuid.UUID(course_id),
+                    session=session,
+                )
+                await session.commit()
+                findings = []
+                if run.notes:
+                    import json as _json
+
+                    findings = _json.loads(run.notes)
+                return {
+                    "status": "complete",
+                    "run_id": str(run.id),
+                    "course_id": course_id,
+                    "findings_count": len(findings),
+                }
+        finally:
+            await engine.dispose()
+
+    try:
+        return asyncio.run(_run())
+    except Exception as exc:
+        logger.error(
+            "assess_course_structure_task failed",
+            course_id=course_id,
+            exception=str(exc),
+            task_id=self.request.id,
+        )
+        return {"status": "failed", "error": str(exc), "course_id": course_id}
+
+
 # ---- 1. Per-unit assessment (cheap path) ------------------------------
 
 

--- a/backend/app/tasks/syllabus_generation.py
+++ b/backend/app/tasks/syllabus_generation.py
@@ -622,6 +622,25 @@ def generate_course_syllabus(
         },
     )
 
+    # Auto-trigger structural QA (no Claude, pure DB checks). Best-effort —
+    # never block the syllabus result on this. Small countdown so the sync
+    # session's commit is visible to a fresh async session.
+    try:
+        from app.tasks.quality_assessment import assess_course_structure_task
+
+        assess_course_structure_task.apply_async(
+            kwargs={"course_id": course_id},
+            priority=5,
+            countdown=5,
+        )
+        logger.info("Structural QA dispatched", course_id=course_id)
+    except Exception as _exc:
+        logger.warning(
+            "Structural QA dispatch failed (non-fatal)",
+            course_id=course_id,
+            error=str(_exc),
+        )
+
     return {
         "status": "complete",
         "modules_count": len(saved_modules),


### PR DESCRIPTION
## Summary

- **Structural QA after syllabus generation** — `assess_course_structure_task` (no Claude, pure DB): hours vs unit-minutes divergence, thin modules (<2 units), unrealistic durations, missing bilingual titles/objectives. Writes to `course_quality_runs` with `run_kind='structural'`.
- **Per-unit QA now regenerates** — all 4 generator tasks (lesson, quiz, case study, flashcard) upgraded from `assess_unit_task` (score-only) to `assess_and_regenerate_unit_task` (MAX 2 regen attempts, +3 anti-oscillation guard).
- **Post-publish cross-unit sweep** — `pregenerate_on_publish_task` auto-dispatches a full `assess_course_task` (glossary + cross-unit + regen loop) 30s after first units are generated. Day-idempotent.
- All triggers are **non-blocking** (best-effort `try/except`). No DB migration needed.

## Files changed

- `backend/app/domain/services/quality_agent_service.py` — `assess_course_structure()` (+172 lines)
- `backend/app/tasks/quality_assessment.py` — `assess_course_structure_task` (+61 lines)
- `backend/app/tasks/syllabus_generation.py` — dispatch after syllabus save (+19 lines)
- `backend/app/tasks/content_generation.py` — regen-capable per-unit QA + post-publish sweep (+50/-8 lines)

Fixes #2358

🤖 Generated with [Claude Code](https://claude.ai/claude-code)