### PR TITLE
fix(test): patch session_manager._get_previous_compact in test_tutor_service

### DIFF
--- a/backend/tests/test_tutor_service.py
+++ b/backend/tests/test_tutor_service.py
@@ -150,7 +150,7 @@ async def test_send_message_yields_content_type_chunks(
             return_value=sample_conversation,
         ),
         patch.object(
-            tutor_service,
+            tutor_service.session_manager,
             "_get_previous_compact",
             new_callable=AsyncMock,
             return_value=None,
@@ -217,7 +217,7 @@ async def test_send_message_yields_sources_cited_type(
             return_value=sample_conversation,
         ),
         patch.object(
-            tutor_service,
+            tutor_service.session_manager,
             "_get_previous_compact",
             new_callable=AsyncMock,
             return_value=None,
@@ -354,7 +354,7 @@ async def test_send_message_never_yields_text_type(tutor_service, sample_user, s
             return_value=sample_conversation,
         ),
         patch.object(
-            tutor_service,
+            tutor_service.session_manager,
             "_get_previous_compact",
             new_callable=AsyncMock,
             return_value=None,


### PR DESCRIPTION
## Summary
Three `patch.object` calls in `test_tutor_service.py` targeted `tutor_service._get_previous_compact`, which was removed in the #1997 fix (dead unscoped method with no course-id filter). The same fix was already applied to `test_tutor_compaction.py` but this file was missed, causing CI failure.

No logic change — only the mock target changes from the deleted `TutorService._get_previous_compact` to `tutor_service.session_manager._get_previous_compact`.

## Test plan
- [x] `uv run pytest tests/test_tutor_service.py -v` → 11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)