### PR TITLE
fix(ci): remove redundant ClaudeService import causing ruff F823

### DIFF
--- a/backend/app/tasks/content_generation.py
+++ b/backend/app/tasks/content_generation.py
@@ -1784,7 +1784,6 @@ def pregenerate_on_publish_task(self, course_id: str) -> dict:
             # Auto-trigger a full course quality sweep now that the first
             # units are generated. Best-effort — never block the publish.
             try:
-                from app.ai.claude_service import ClaudeService
                 from app.domain.services.quality_agent_service import CourseQualityService
                 from app.tasks.quality_assessment import assess_course_task
 


### PR DESCRIPTION
## Summary

Fixes ruff `F823` introduced in #2358 (#2359).

The `from app.ai.claude_service import ClaudeService` added inside `_run()` in `pregenerate_on_publish_task` shadowed the outer-scope import at line 1566, making ruff treat `ClaudeService` as a local variable for the entire `_run()` function — so the existing use at line 1683 appeared "referenced before assignment".

`ClaudeService` is accessible via closure from the outer function body. Removing the redundant inner import.

**One-line change, no logic impact.**

🤖 Generated with [Claude Code](https://claude.ai/claude-code)