### PR TITLE
fix(quiz): stop infinite useEffect loop that prevented quiz loading

### DIFF
--- a/frontend/components/quiz/quiz-container.tsx
+++ b/frontend/components/quiz/quiz-container.tsx
@@ -69,6 +69,11 @@ export function QuizContainer({
   // Freeze country on first hydration so a network blip that briefly flips
   // currentUser.country cannot restart a live quiz session (#2226).
   const frozenCountryRef = useRef<string | null>(null);
+  // Track state via ref so the in-progress/completed guard can read it without
+  // making `state` an effect dependency — including it caused an infinite
+  // restart loop that killed the poll timer before it could fire.
+  const stateRef = useRef<QuizState>(state);
+  useEffect(() => { stateRef.current = state; }, [state]);
   const { isOnline } = useNetworkStatus();
 
   useEffect(() => {
@@ -79,7 +84,7 @@ export function QuizContainer({
     // Don't restart the effect while the learner is actively answering or has
     // already finished — a dependency flap (e.g. country ref settling) must not
     // wipe in-progress answers (#2226).
-    if (state === 'in-progress' || state === 'completed') return;
+    if (stateRef.current === 'in-progress' || stateRef.current === 'completed') return;
     if (frozenCountryRef.current === null) frozenCountryRef.current = resolvedCountry;
     const country = frozenCountryRef.current;
 
@@ -226,7 +231,7 @@ export function QuizContainer({
       if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [moduleId, unitId, language, level, retryCount, forceRegenerate, isHydrated, state]);
+  }, [moduleId, unitId, language, level, retryCount, forceRegenerate, isHydrated]);
   
   const handleStartQuiz = () => {
     setState('in-progress');


### PR DESCRIPTION
## Summary

Major regression: unit-level quizzes (e.g. "Quiz sommaire du module 1, Unité 1.7") were stuck forever on "Génération des questions du quiz... Chargement du quiz...". The backend Celery generation worked, but the frontend never settled.

Root cause in `frontend/components/quiz/quiz-container.tsx`: `state` was in the `useEffect` dependency array, but the early-return guard only caught `'in-progress'`/`'completed'` — not `'generating'` or `'loading'`. The loop:

1. Effect runs → `fetchQuiz()` calls `setState('loading')`, then on cache miss `setState('generating')`.
2. Each `setState` re-triggers the effect. Cleanup sets `stale = true` and clears the 3 s poll timer **before it can fire**.
3. New effect runs, dispatches a fresh Celery task, repeats forever.

Net effect: the poll-status round trip never completed, the spinner never stopped, and a new Celery task was dispatched on every loop iteration. Even the 3-minute timeout never triggered because `pollStartRef.current` reset on every restart.

## Changes

- `frontend/components/quiz/quiz-container.tsx`: track state via a `stateRef` so the in-progress/completed guard still works without making `state` a dependency. Drop `state` from the effect's dependency array. Frozen-country ref (#2226) and offline fallback paths untouched.

7 added / 2 removed lines, single file.

## Test plan

- [ ] Backend tests pass (`uv run pytest`) — n/a, no backend change
- [ ] Backend lint passes (`uv run ruff check . && uv run ruff format --check .`) — n/a, no backend change
- [x] Frontend lint passes (`npm run lint`) — clean for the touched file (only a pre-existing unused-import warning on `scoreQuizOffline`)
- [x] Frontend type-check passes (`npx tsc --noEmit`) — clean for `quiz-container.tsx`
- [ ] Frontend build passes (`npm run build`) — not run in this environment
- [ ] Tested on mobile viewport (360x640) — fix is logic-only, no UI markup changed

### Manual regression spot-checks (post-merge)

- Toggle FR ↔ EN on the `'ready'` card → effect re-runs and reloads the quiz in the new language.
- Click "Try again" on error → `retryCount` increments, effect re-runs.
- Click "Refresh content" → `forceRegenerate` flips, effect re-runs.
- Click "Start quiz" → state becomes `'in-progress'`. Then trigger a dep change (e.g. language toggle) and confirm the in-progress session is NOT wiped — the `stateRef` guard returns early.

## Checklist

- [x] No hardcoded strings (all text via next-intl)
- [x] No new ChromaDB references (pgvector only)
- [x] API keys remain server-side only
- [x] Sources cited in any AI-generated content — n/a, no AI generation code touched

https://claude.ai/code/session_01CCXo6k9LiSc9MZ4gi2rZUD

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCXo6k9LiSc9MZ4gi2rZUD)_