### PR TITLE
fix(ci): replace unindented heredocs in deploy.yml with printf

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -316,24 +316,21 @@ jobs:
             # Write managed secrets to a temp file, then merge with any
             # host-specific overrides (e.g. ENABLE_FIGURE_VISION) that are
             # not part of the managed set — those survive each deploy (#1934).
-            cat > .env.deploy << 'ENVEOF'
-POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-OPENAI_API_KEY=${OPENAI_API_KEY}
-GOOGLE_API_KEY=${GOOGLE_API_KEY}
-SENTRY_DSN=${SENTRY_DSN}
-NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}
-NEXT_PUBLIC_POSTHOG_KEY=${NEXT_PUBLIC_POSTHOG_KEY}
-NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST}
-SMS_RELAY_API_KEY=${SMS_RELAY_API_KEY}
-SMS_RELAY_TRUSTED_SENDERS=${SMS_RELAY_TRUSTED_SENDERS}
-MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
-MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
-HEYGEN_API_KEY=${HEYGEN_API_KEY}
-ENVEOF
-            # Expand secrets inside the file (heredoc used 'ENVEOF' to suppress
-            # shell expansion above, so expand now via envsubst).
-            envsubst < .env.deploy > .env.deploy.expanded && mv .env.deploy.expanded .env.deploy
+            # printf avoids a heredoc (unindented heredoc body breaks YAML parsers).
+            printf '%s\n' \
+              "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}" \
+              "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" \
+              "OPENAI_API_KEY=${OPENAI_API_KEY}" \
+              "GOOGLE_API_KEY=${GOOGLE_API_KEY}" \
+              "SENTRY_DSN=${SENTRY_DSN}" \
+              "NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}" \
+              "NEXT_PUBLIC_POSTHOG_KEY=${NEXT_PUBLIC_POSTHOG_KEY}" \
+              "NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST}" \
+              "SMS_RELAY_API_KEY=${SMS_RELAY_API_KEY}" \
+              "SMS_RELAY_TRUSTED_SENDERS=${SMS_RELAY_TRUSTED_SENDERS}" \
+              "MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}" \
+              "MINIO_SECRET_KEY=${MINIO_SECRET_KEY}" \
+              "HEYGEN_API_KEY=${HEYGEN_API_KEY}" > .env.deploy
 
             # Preserve host-specific keys not managed by CI (e.g. ENABLE_FIGURE_VISION).
             # Managed keys always win; host overrides are kept for unmanaged keys only.
@@ -522,22 +519,20 @@ ENVEOF
             # Fresh GHCR login every deploy, same pattern as staging (#1651).
             echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
-            cat > .env.deploy << 'ENVEOF'
-POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-OPENAI_API_KEY=${OPENAI_API_KEY}
-GOOGLE_API_KEY=${GOOGLE_API_KEY}
-SENTRY_DSN=${SENTRY_DSN}
-NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}
-NEXT_PUBLIC_POSTHOG_KEY=${NEXT_PUBLIC_POSTHOG_KEY}
-NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST}
-SMS_RELAY_API_KEY=${SMS_RELAY_API_KEY}
-SMS_RELAY_TRUSTED_SENDERS=${SMS_RELAY_TRUSTED_SENDERS}
-MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
-MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
-HEYGEN_API_KEY=${HEYGEN_API_KEY}
-ENVEOF
-            envsubst < .env.deploy > .env.deploy.expanded && mv .env.deploy.expanded .env.deploy
+            printf '%s\n' \
+              "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}" \
+              "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" \
+              "OPENAI_API_KEY=${OPENAI_API_KEY}" \
+              "GOOGLE_API_KEY=${GOOGLE_API_KEY}" \
+              "SENTRY_DSN=${SENTRY_DSN}" \
+              "NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}" \
+              "NEXT_PUBLIC_POSTHOG_KEY=${NEXT_PUBLIC_POSTHOG_KEY}" \
+              "NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST}" \
+              "SMS_RELAY_API_KEY=${SMS_RELAY_API_KEY}" \
+              "SMS_RELAY_TRUSTED_SENDERS=${SMS_RELAY_TRUSTED_SENDERS}" \
+              "MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}" \
+              "MINIO_SECRET_KEY=${MINIO_SECRET_KEY}" \
+              "HEYGEN_API_KEY=${HEYGEN_API_KEY}" > .env.deploy
             MANAGED_KEYS=$(grep -oE '^[A-Z_0-9]+' .env.deploy | paste -sd '|')
             if [ -f .env ] && [ -n "$MANAGED_KEYS" ]; then
               grep -vE "^(${MANAGED_KEYS})=" .env > .env.host 2>/dev/null || true


### PR DESCRIPTION
The `cat > .env << 'ENVEOF'` heredoc body at column 0 exits the YAML literal block scalar in the `script:` stanza, breaking GitHub's workflow parser ("workflow file issue" in run #26282040440). Replace with `printf '%s\n' ...` so all lines stay at script indentation level. No envsubst needed — shell vars expand directly via SSH action's `envs:` injection. Fixes staging deploy blocked since #2366 merged.