### PR TITLE
fix(quiz): cherry-pick infinite useEffect loop fix to main

### DIFF
--- a/frontend/components/quiz/quiz-container.tsx
+++ b/frontend/components/quiz/quiz-container.tsx
@@ -69,6 +69,11 @@ export function QuizContainer({
   // Freeze country on first hydration so a network blip that briefly flips
   // currentUser.country cannot restart a live quiz session (#2226).
   const frozenCountryRef = useRef<string | null>(null);
+  // Track state via ref so the in-progress/completed guard can read it without
+  // making `state` an effect dependency — including it caused an infinite
+  // restart loop that killed the poll timer before it could fire.
+  const stateRef = useRef<QuizState>(state);
+  useEffect(() => { stateRef.current = state; }, [state]);
   const { isOnline } = useNetworkStatus();
 
   useEffect(() => {
@@ -79,7 +84,7 @@ export function QuizContainer({
     // Don't restart the effect while the learner is actively answering or has
     // already finished — a dependency flap (e.g. country ref settling) must not
     // wipe in-progress answers (#2226).
-    if (state === 'in-progress' || state === 'completed') return;
+    if (stateRef.current === 'in-progress' || stateRef.current === 'completed') return;
     if (frozenCountryRef.current === null) frozenCountryRef.current = resolvedCountry;
     const country = frozenCountryRef.current;
 
@@ -226,7 +231,7 @@ export function QuizContainer({
       if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [moduleId, unitId, language, level, retryCount, forceRegenerate, isHydrated, state]);
+  }, [moduleId, unitId, language, level, retryCount, forceRegenerate, isHydrated]);
   
   const handleStartQuiz = () => {
     setState('in-progress');


### PR DESCRIPTION
## Summary

Cherry-picks the quiz loading fix from dev (#2362, commit `a861bb5e`) directly to main, bypassing the stalled dev→main sync.

The full dev→main sync is blocked by structural divergence (squash-history vs merge-history), and a recent partial sync only brought the deploy.yml YAML fix. This PR specifically targets the production-blocking quiz regression.

## Changes

- `frontend/components/quiz/quiz-container.tsx`: track state via a `stateRef` so the in-progress/completed guard still works without making `state` a dependency. Drop `state` from the effect's dependency array.

7 added / 2 removed lines, single file. Same content that's been on dev for ~8 hours and passed CI there.

## Test plan

- [x] Backend tests pass — n/a, no backend change
- [x] Frontend lint passes — clean for the touched file
- [x] Frontend type-check passes — clean for `quiz-container.tsx`
- [x] CI already validated on PR #2362 (Backend/Frontend/E2E/GitGuardian all green there)

## Checklist

- [x] No hardcoded strings (all text via next-intl)
- [x] No new ChromaDB references
- [x] API keys remain server-side only
- [x] Sources cited in any AI-generated content — n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCXo6k9LiSc9MZ4gi2rZUD)_