### PR TITLE
feat(quality): auto-trigger QA sweep after course publish

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -532,6 +532,39 @@ async def publish_course(
             course_id=str(course_id),
             error=str(exc),
         )
+    # Schedule a quality sweep as a backstop (countdown=180 lets pregenerate
+    # finish first). The day-bucketed idempotency key in assess_course() collapses
+    # this and the pregenerate task's own quality trigger into a single run (#2358).
+    try:
+        from app.ai.claude_service import ClaudeService
+        from app.domain.services.quality_agent_service import CourseQualityService
+        from app.tasks.quality_assessment import assess_course_task as _qa_task
+
+        qa_svc = CourseQualityService(ClaudeService(), semantic_retriever=None)
+        qa_run = await qa_svc.assess_course(
+            course_id=course_id,
+            triggered_by_user_id=None,
+            session=db,
+            run_kind="full",
+        )
+        await db.commit()
+        if qa_run.status == "queued":
+            _qa_task.apply_async(
+                kwargs={"run_id": str(qa_run.id)},
+                priority=4,
+                countdown=180,
+            )
+            logger.info(
+                "publish_course: quality sweep scheduled",
+                course_id=str(course_id),
+                run_id=str(qa_run.id),
+            )
+    except Exception as _exc:
+        logger.warning(
+            "publish_course: quality sweep scheduling failed (non-blocking)",
+            course_id=str(course_id),
+            error=str(_exc),
+        )
     return _course_to_response(course, image_count=img_count)
 
 

--- a/backend/app/tasks/content_generation.py
+++ b/backend/app/tasks/content_generation.py
@@ -1828,6 +1828,61 @@ def pregenerate_on_publish_task(self, course_id: str) -> dict:
             result=result,
             task_id=self.request.id,
         )
+        # The quality block inside _run() only fires when generation reaches the
+        # end of the loop.  Early returns ("no_module", "no_units") bypass it.
+        # Backstop: fire quality here too when real content exists — the service's
+        # day-bucketed idempotency key collapses both triggers to one run (#2358).
+        if not result.get("reason"):
+            try:
+                from sqlalchemy.ext.asyncio import (
+                    AsyncSession,
+                    async_sessionmaker,
+                    create_async_engine,
+                )
+
+                from app.ai.claude_service import ClaudeService as _ClaudeService
+                from app.domain.services.quality_agent_service import (
+                    CourseQualityService as _CourseQualityService,
+                )
+                from app.infrastructure.config.settings import settings as _cfg
+                from app.tasks.quality_assessment import assess_course_task
+
+                async def _trigger_quality() -> None:
+                    _engine = create_async_engine(
+                        _cfg.database_url, echo=False, pool_size=2, max_overflow=1
+                    )
+                    _sf = async_sessionmaker(_engine, class_=AsyncSession, expire_on_commit=False)
+                    try:
+                        async with _sf() as qa_session:
+                            svc = _CourseQualityService(_ClaudeService(), semantic_retriever=None)
+                            run = await svc.assess_course(
+                                course_id=uuid.UUID(course_id),
+                                triggered_by_user_id=None,
+                                session=qa_session,
+                                run_kind="full",
+                            )
+                            await qa_session.commit()
+                        if run.status == "queued":
+                            assess_course_task.apply_async(
+                                kwargs={"run_id": str(run.id)},
+                                priority=4,
+                                countdown=30,
+                            )
+                            logger.info(
+                                "pregenerate_on_publish: backstop quality sweep dispatched",
+                                course_id=course_id,
+                                run_id=str(run.id),
+                            )
+                    finally:
+                        await _engine.dispose()
+
+                asyncio.run(_trigger_quality())
+            except Exception as _exc:
+                logger.warning(
+                    "pregenerate_on_publish: backstop quality dispatch failed (non-fatal)",
+                    course_id=course_id,
+                    error=str(_exc),
+                )
         return result
     except Exception as exc:
         logger.error(


### PR DESCRIPTION
## Summary

Ensures the course quality sweep always fires after publish, even when `pregenerate_on_publish_task` exits early.

### Root cause of gap
The existing quality trigger inside `_run()` was unreachable when the task returned early via `"no_module"` or `"no_units"` exits — those `return` statements exit `_run()` entirely, skipping the quality dispatch block.

### Two trigger points (idempotent)

**1. `publish_course` endpoint** (`admin_courses.py`): schedules `assess_course_task` with `countdown=180` immediately on publish. Fires unconditionally, independent of whether pregenerate ran.

**2. `pregenerate_on_publish_task` backstop** (`content_generation.py`): after `asyncio.run(_run())`, fires quality if `result` has no `"reason"` key (full generation loop ran). Covers the case where content was generated but the early-path quality block was bypassed.

Both triggers call `quality_svc.assess_course()` which uses a day-bucketed idempotency key — two calls with the same `(course_id, system, today)` always return the same `CourseQualityRun` row. No double-runs.

## Test plan
- [ ] Publish a course → `CourseQualityRun` row created within 3 min
- [ ] Publish a course with no modules → run still created from publish endpoint

Fixes #2358

🤖 Generated with [Claude Code](https://claude.com/claude-code)