### PR TITLE
test(e2e): add quality review queue to admin + sub-admin reachability specs

### DIFF
--- a/frontend/e2e/specs/04-sub-admin/admin-pages.spec.ts
+++ b/frontend/e2e/specs/04-sub-admin/admin-pages.spec.ts
@@ -30,4 +30,9 @@ test.describe('@sub-admin admin pages', () => {
     await page.goto('/fr/admin/taxonomy');
     await expect(page.locator('main h1')).toContainText(/taxonom/i);
   });
+
+  test('/fr/admin/quality renders quality review queue', async ({ page }) => {
+    await page.goto('/fr/admin/quality');
+    await expect(page.locator('main h1')).toContainText(/qualit/i);
+  });
 });

--- a/frontend/e2e/specs/05-admin/admin-pages.spec.ts
+++ b/frontend/e2e/specs/05-admin/admin-pages.spec.ts
@@ -32,4 +32,9 @@ test.describe('@admin admin pages', () => {
     await page.goto('/fr/admin/analytics');
     await expect(page.locator('main h1')).toContainText(/analy/i);
   });
+
+  test('/fr/admin/quality renders quality review queue', async ({ page }) => {
+    await page.goto('/fr/admin/quality');
+    await expect(page.locator('main h1')).toContainText(/qualit/i);
+  });
 });


### PR DESCRIPTION
## Summary
The quality agent pages (`/admin/quality`, `/admin/courses/[id]/quality`, etc.) were implemented across multiple PRs but never added to the E2E persona reachability suites for admin and sub-admin.

Adds one test to each spec confirming `/fr/admin/quality` renders with a heading matching `/qualit/i` — same pattern as all other page reachability tests.

## Test plan
- [x] Pattern matches all existing reachability tests exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)