### PR TITLE
sync: dev → main

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -532,6 +532,39 @@ async def publish_course(
             course_id=str(course_id),
             error=str(exc),
         )
+    # Schedule a quality sweep as a backstop (countdown=180 lets pregenerate
+    # finish first). The day-bucketed idempotency key in assess_course() collapses
+    # this and the pregenerate task's own quality trigger into a single run (#2358).
+    try:
+        from app.ai.claude_service import ClaudeService
+        from app.domain.services.quality_agent_service import CourseQualityService
+        from app.tasks.quality_assessment import assess_course_task as _qa_task
+
+        qa_svc = CourseQualityService(ClaudeService(), semantic_retriever=None)
+        qa_run = await qa_svc.assess_course(
+            course_id=course_id,
+            triggered_by_user_id=None,
+            session=db,
+            run_kind="full",
+        )
+        await db.commit()
+        if qa_run.status == "queued":
+            _qa_task.apply_async(
+                kwargs={"run_id": str(qa_run.id)},
+                priority=4,
+                countdown=180,
+            )
+            logger.info(
+                "publish_course: quality sweep scheduled",
+                course_id=str(course_id),
+                run_id=str(qa_run.id),
+            )
+    except Exception as _exc:
+        logger.warning(
+            "publish_course: quality sweep scheduling failed (non-blocking)",
+            course_id=str(course_id),
+            error=str(_exc),
+        )
     return _course_to_response(course, image_count=img_count)
 
 

--- a/backend/app/api/v1/course_bundles.py
+++ b/backend/app/api/v1/course_bundles.py
@@ -1,0 +1,365 @@
+"""Course bundle export — create, poll, list, download, and delete ZIP packages."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Literal
+
+from celery.result import AsyncResult
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from app.api.deps import get_db_session
+from app.api.deps_local_auth import AuthenticatedUser, require_role
+from app.domain.models.course import Course
+from app.domain.models.course_bundle import CourseBundle
+from app.domain.models.user import UserRole
+from app.infrastructure.storage.s3 import S3StorageService
+from app.tasks.course_bundle import generate_course_bundle_task
+
+logger = get_logger(__name__)
+
+router = APIRouter(tags=["Course Bundles"])
+
+_ADMIN_ROLES = (UserRole.admin, UserRole.sub_admin, UserRole.expert)
+
+
+# ── Schemas ───────────────────────────────────────────────────────────
+
+
+class BundleCreateRequest(BaseModel):
+    language: Literal["fr", "en"]
+    level: int = Field(default=1, ge=1, le=4)
+    country: str = Field(default="SN", max_length=4)
+
+
+class BundleCreatedResponse(BaseModel):
+    bundle_id: str
+    task_id: str
+    status: str
+
+
+class BundleStatusResponse(BaseModel):
+    bundle_id: str
+    status: str
+    progress: int | None = None
+    current_file: str | None = None
+    download_url: str | None = None
+    file_count: int | None = None
+    file_size_bytes: int | None = None
+    error_message: str | None = None
+
+
+class BundleListItem(BaseModel):
+    bundle_id: str
+    course_id: str
+    course_title: str
+    language: str
+    level: int
+    status: str
+    file_count: int | None
+    file_size_bytes: int | None
+    created_at: str
+    completed_at: str | None
+    download_url: str | None
+    error_message: str | None
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+async def _get_course_or_404(
+    course_id: uuid.UUID, session: AsyncSession
+) -> Course:
+    course = await session.get(Course, course_id)
+    if course is None:
+        raise HTTPException(status_code=404, detail="Course not found")
+    return course
+
+
+def _expert_owns_course(user: AuthenticatedUser, course: Course) -> bool:
+    return str(course.created_by) == user.id
+
+
+def _guard_expert(user: AuthenticatedUser, course: Course) -> None:
+    if user.role == UserRole.expert.value and not _expert_owns_course(
+        user, course
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Experts can only bundle their own courses",
+        )
+
+
+def _celery_progress(task_id: str) -> tuple[int, str | None]:
+    """Return (progress 0-100, current_file) from Celery state."""
+    if not task_id:
+        return 0, None
+    try:
+        res = AsyncResult(task_id)
+        if res.state == "PROGRESS" and isinstance(res.info, dict):
+            return res.info.get("progress", 0), res.info.get("current_file")
+    except Exception:
+        pass
+    return 0, None
+
+
+def _bundle_download_url(bundle: CourseBundle, user: AuthenticatedUser) -> str | None:
+    """Return the API download URL (requires auth) when the bundle is ready."""
+    if bundle.status != "ready":
+        return None
+    return f"/api/v1/admin/bundles/{bundle.id}/download"
+
+
+def _bundle_to_status(
+    bundle: CourseBundle, user: AuthenticatedUser
+) -> BundleStatusResponse:
+    progress, current_file = 0, None
+    if bundle.status == "generating" and bundle.task_id:
+        progress, current_file = _celery_progress(bundle.task_id)
+    return BundleStatusResponse(
+        bundle_id=str(bundle.id),
+        status=bundle.status,
+        progress=progress,
+        current_file=current_file,
+        download_url=_bundle_download_url(bundle, user),
+        file_count=bundle.file_count,
+        file_size_bytes=bundle.file_size_bytes,
+        error_message=bundle.error_message,
+    )
+
+
+# ── Endpoints ─────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/admin/courses/{course_id}/bundle",
+    response_model=BundleCreatedResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def create_course_bundle(
+    course_id: uuid.UUID,
+    body: BundleCreateRequest,
+    current_user: AuthenticatedUser = Depends(
+        require_role(*_ADMIN_ROLES)
+    ),
+    session: AsyncSession = Depends(get_db_session),
+) -> BundleCreatedResponse:
+    """Trigger bundle generation for a course. Returns immediately with a bundle_id."""
+    course = await _get_course_or_404(course_id, session)
+    _guard_expert(current_user, course)
+
+    bundle = CourseBundle(
+        course_id=course_id,
+        requested_by=uuid.UUID(current_user.id),
+        language=body.language,
+        level=body.level,
+        country=body.country,
+        status="pending",
+    )
+    session.add(bundle)
+    await session.flush()  # assign bundle.id before dispatching task
+
+    task = generate_course_bundle_task.delay(str(bundle.id))
+    bundle.task_id = task.id
+    await session.commit()
+
+    logger.info(
+        "bundle.created",
+        bundle_id=str(bundle.id),
+        course_id=str(course_id),
+        language=body.language,
+        task_id=task.id,
+    )
+    return BundleCreatedResponse(
+        bundle_id=str(bundle.id),
+        task_id=task.id,
+        status="pending",
+    )
+
+
+@router.get(
+    "/admin/courses/{course_id}/bundle/status",
+    response_model=BundleStatusResponse,
+)
+async def get_bundle_status(
+    course_id: uuid.UUID,
+    bundle_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(
+        require_role(*_ADMIN_ROLES)
+    ),
+    session: AsyncSession = Depends(get_db_session),
+) -> BundleStatusResponse:
+    """Poll the status of a bundle job."""
+    course = await _get_course_or_404(course_id, session)
+    _guard_expert(current_user, course)
+
+    bundle = await session.get(CourseBundle, bundle_id)
+    if bundle is None or bundle.course_id != course_id:
+        raise HTTPException(status_code=404, detail="Bundle not found")
+
+    return _bundle_to_status(bundle, current_user)
+
+
+@router.get(
+    "/admin/bundles",
+    response_model=list[BundleListItem],
+)
+async def list_bundles(
+    course_id: uuid.UUID | None = None,
+    bundle_status: str | None = None,
+    limit: int = 50,
+    current_user: AuthenticatedUser = Depends(
+        require_role(*_ADMIN_ROLES)
+    ),
+    session: AsyncSession = Depends(get_db_session),
+) -> list[BundleListItem]:
+    """List course bundles.
+
+    Admin/sub_admin see all bundles. Experts see only bundles for their
+    own courses.
+    """
+    q = select(CourseBundle, Course).join(
+        Course, Course.id == CourseBundle.course_id
+    )
+
+    if current_user.role == UserRole.expert.value:
+        q = q.where(
+            Course.created_by == uuid.UUID(current_user.id)
+        )
+
+    if course_id is not None:
+        q = q.where(CourseBundle.course_id == course_id)
+
+    if bundle_status is not None:
+        q = q.where(CourseBundle.status == bundle_status)
+
+    q = q.order_by(CourseBundle.created_at.desc()).limit(limit)
+    rows = (await session.execute(q)).all()
+
+    items: list[BundleListItem] = []
+    for bundle, course in rows:
+        lang = bundle.language
+        course_title = (
+            course.title_fr if lang == "fr" else course.title_en
+        )
+        items.append(
+            BundleListItem(
+                bundle_id=str(bundle.id),
+                course_id=str(bundle.course_id),
+                course_title=course_title,
+                language=bundle.language,
+                level=bundle.level,
+                status=bundle.status,
+                file_count=bundle.file_count,
+                file_size_bytes=bundle.file_size_bytes,
+                created_at=bundle.created_at.isoformat(),
+                completed_at=(
+                    bundle.completed_at.isoformat()
+                    if bundle.completed_at
+                    else None
+                ),
+                download_url=_bundle_download_url(bundle, current_user),
+                error_message=bundle.error_message,
+            )
+        )
+    return items
+
+
+@router.get("/admin/bundles/{bundle_id}/download")
+async def download_bundle(
+    bundle_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(
+        require_role(*_ADMIN_ROLES)
+    ),
+    session: AsyncSession = Depends(get_db_session),
+) -> StreamingResponse:
+    """Stream the ZIP archive from MinIO.
+
+    Experts can only download bundles for their own courses.
+    """
+    result = await session.execute(
+        select(CourseBundle, Course)
+        .join(Course, Course.id == CourseBundle.course_id)
+        .where(CourseBundle.id == bundle_id)
+    )
+    row = result.first()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Bundle not found")
+
+    bundle, course = row
+    _guard_expert(current_user, course)
+
+    if bundle.status != "ready" or not bundle.storage_key:
+        raise HTTPException(
+            status_code=409, detail="Bundle is not ready yet"
+        )
+
+    storage = S3StorageService()
+    try:
+        data = await storage.download_bytes(bundle.storage_key)
+    except Exception as exc:
+        logger.error(
+            "bundle.download_failed",
+            bundle_id=str(bundle_id),
+            error=str(exc),
+        )
+        raise HTTPException(
+            status_code=502, detail="Could not retrieve bundle from storage"
+        ) from exc
+
+    lang = bundle.language
+    slug = course.slug or str(course.id)
+    filename = f"{slug}_{lang}.zip"
+
+    return StreamingResponse(
+        iter([data]),
+        media_type="application/zip",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "Content-Length": str(len(data)),
+        },
+    )
+
+
+@router.delete(
+    "/admin/bundles/{bundle_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_bundle(
+    bundle_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(
+        require_role(*_ADMIN_ROLES)
+    ),
+    session: AsyncSession = Depends(get_db_session),
+) -> None:
+    """Delete a bundle and its MinIO object."""
+    result = await session.execute(
+        select(CourseBundle, Course)
+        .join(Course, Course.id == CourseBundle.course_id)
+        .where(CourseBundle.id == bundle_id)
+    )
+    row = result.first()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Bundle not found")
+
+    bundle, course = row
+    _guard_expert(current_user, course)
+
+    if bundle.storage_key:
+        try:
+            storage = S3StorageService()
+            await storage.delete_object(bundle.storage_key)
+        except Exception as exc:
+            logger.warning(
+                "bundle.delete_storage_failed",
+                bundle_id=str(bundle_id),
+                error=str(exc),
+            )
+
+    await session.delete(bundle)
+    await session.commit()

--- a/backend/app/api/v1/course_bundles.py
+++ b/backend/app/api/v1/course_bundles.py
@@ -72,9 +72,7 @@ class BundleListItem(BaseModel):
 # ── Helpers ───────────────────────────────────────────────────────────
 
 
-async def _get_course_or_404(
-    course_id: uuid.UUID, session: AsyncSession
-) -> Course:
+async def _get_course_or_404(course_id: uuid.UUID, session: AsyncSession) -> Course:
     course = await session.get(Course, course_id)
     if course is None:
         raise HTTPException(status_code=404, detail="Course not found")
@@ -86,9 +84,7 @@ def _expert_owns_course(user: AuthenticatedUser, course: Course) -> bool:
 
 
 def _guard_expert(user: AuthenticatedUser, course: Course) -> None:
-    if user.role == UserRole.expert.value and not _expert_owns_course(
-        user, course
-    ):
+    if user.role == UserRole.expert.value and not _expert_owns_course(user, course):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Experts can only bundle their own courses",
@@ -115,9 +111,7 @@ def _bundle_download_url(bundle: CourseBundle, user: AuthenticatedUser) -> str |
     return f"/api/v1/admin/bundles/{bundle.id}/download"
 
 
-def _bundle_to_status(
-    bundle: CourseBundle, user: AuthenticatedUser
-) -> BundleStatusResponse:
+def _bundle_to_status(bundle: CourseBundle, user: AuthenticatedUser) -> BundleStatusResponse:
     progress, current_file = 0, None
     if bundle.status == "generating" and bundle.task_id:
         progress, current_file = _celery_progress(bundle.task_id)
@@ -144,9 +138,7 @@ def _bundle_to_status(
 async def create_course_bundle(
     course_id: uuid.UUID,
     body: BundleCreateRequest,
-    current_user: AuthenticatedUser = Depends(
-        require_role(*_ADMIN_ROLES)
-    ),
+    current_user: AuthenticatedUser = Depends(require_role(*_ADMIN_ROLES)),
     session: AsyncSession = Depends(get_db_session),
 ) -> BundleCreatedResponse:
     """Trigger bundle generation for a course. Returns immediately with a bundle_id."""
@@ -189,9 +181,7 @@ async def create_course_bundle(
 async def get_bundle_status(
     course_id: uuid.UUID,
     bundle_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(
-        require_role(*_ADMIN_ROLES)
-    ),
+    current_user: AuthenticatedUser = Depends(require_role(*_ADMIN_ROLES)),
     session: AsyncSession = Depends(get_db_session),
 ) -> BundleStatusResponse:
     """Poll the status of a bundle job."""
@@ -213,9 +203,7 @@ async def list_bundles(
     course_id: uuid.UUID | None = None,
     bundle_status: str | None = None,
     limit: int = 50,
-    current_user: AuthenticatedUser = Depends(
-        require_role(*_ADMIN_ROLES)
-    ),
+    current_user: AuthenticatedUser = Depends(require_role(*_ADMIN_ROLES)),
     session: AsyncSession = Depends(get_db_session),
 ) -> list[BundleListItem]:
     """List course bundles.
@@ -223,14 +211,10 @@ async def list_bundles(
     Admin/sub_admin see all bundles. Experts see only bundles for their
     own courses.
     """
-    q = select(CourseBundle, Course).join(
-        Course, Course.id == CourseBundle.course_id
-    )
+    q = select(CourseBundle, Course).join(Course, Course.id == CourseBundle.course_id)
 
     if current_user.role == UserRole.expert.value:
-        q = q.where(
-            Course.created_by == uuid.UUID(current_user.id)
-        )
+        q = q.where(Course.created_by == uuid.UUID(current_user.id))
 
     if course_id is not None:
         q = q.where(CourseBundle.course_id == course_id)
@@ -244,9 +228,7 @@ async def list_bundles(
     items: list[BundleListItem] = []
     for bundle, course in rows:
         lang = bundle.language
-        course_title = (
-            course.title_fr if lang == "fr" else course.title_en
-        )
+        course_title = course.title_fr if lang == "fr" else course.title_en
         items.append(
             BundleListItem(
                 bundle_id=str(bundle.id),
@@ -258,11 +240,7 @@ async def list_bundles(
                 file_count=bundle.file_count,
                 file_size_bytes=bundle.file_size_bytes,
                 created_at=bundle.created_at.isoformat(),
-                completed_at=(
-                    bundle.completed_at.isoformat()
-                    if bundle.completed_at
-                    else None
-                ),
+                completed_at=(bundle.completed_at.isoformat() if bundle.completed_at else None),
                 download_url=_bundle_download_url(bundle, current_user),
                 error_message=bundle.error_message,
             )
@@ -273,9 +251,7 @@ async def list_bundles(
 @router.get("/admin/bundles/{bundle_id}/download")
 async def download_bundle(
     bundle_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(
-        require_role(*_ADMIN_ROLES)
-    ),
+    current_user: AuthenticatedUser = Depends(require_role(*_ADMIN_ROLES)),
     session: AsyncSession = Depends(get_db_session),
 ) -> StreamingResponse:
     """Stream the ZIP archive from MinIO.
@@ -295,9 +271,7 @@ async def download_bundle(
     _guard_expert(current_user, course)
 
     if bundle.status != "ready" or not bundle.storage_key:
-        raise HTTPException(
-            status_code=409, detail="Bundle is not ready yet"
-        )
+        raise HTTPException(status_code=409, detail="Bundle is not ready yet")
 
     storage = S3StorageService()
     try:
@@ -332,9 +306,7 @@ async def download_bundle(
 )
 async def delete_bundle(
     bundle_id: uuid.UUID,
-    current_user: AuthenticatedUser = Depends(
-        require_role(*_ADMIN_ROLES)
-    ),
+    current_user: AuthenticatedUser = Depends(require_role(*_ADMIN_ROLES)),
     session: AsyncSession = Depends(get_db_session),
 ) -> None:
     """Delete a bundle and its MinIO object."""

--- a/backend/app/tasks/content_generation.py
+++ b/backend/app/tasks/content_generation.py
@@ -1827,6 +1827,61 @@ def pregenerate_on_publish_task(self, course_id: str) -> dict:
             result=result,
             task_id=self.request.id,
         )
+        # The quality block inside _run() only fires when generation reaches the
+        # end of the loop.  Early returns ("no_module", "no_units") bypass it.
+        # Backstop: fire quality here too when real content exists — the service's
+        # day-bucketed idempotency key collapses both triggers to one run (#2358).
+        if not result.get("reason"):
+            try:
+                from sqlalchemy.ext.asyncio import (
+                    AsyncSession,
+                    async_sessionmaker,
+                    create_async_engine,
+                )
+
+                from app.ai.claude_service import ClaudeService as _ClaudeService
+                from app.domain.services.quality_agent_service import (
+                    CourseQualityService as _CourseQualityService,
+                )
+                from app.infrastructure.config.settings import settings as _cfg
+                from app.tasks.quality_assessment import assess_course_task
+
+                async def _trigger_quality() -> None:
+                    _engine = create_async_engine(
+                        _cfg.database_url, echo=False, pool_size=2, max_overflow=1
+                    )
+                    _sf = async_sessionmaker(_engine, class_=AsyncSession, expire_on_commit=False)
+                    try:
+                        async with _sf() as qa_session:
+                            svc = _CourseQualityService(_ClaudeService(), semantic_retriever=None)
+                            run = await svc.assess_course(
+                                course_id=uuid.UUID(course_id),
+                                triggered_by_user_id=None,
+                                session=qa_session,
+                                run_kind="full",
+                            )
+                            await qa_session.commit()
+                        if run.status == "queued":
+                            assess_course_task.apply_async(
+                                kwargs={"run_id": str(run.id)},
+                                priority=4,
+                                countdown=30,
+                            )
+                            logger.info(
+                                "pregenerate_on_publish: backstop quality sweep dispatched",
+                                course_id=course_id,
+                                run_id=str(run.id),
+                            )
+                    finally:
+                        await _engine.dispose()
+
+                asyncio.run(_trigger_quality())
+            except Exception as _exc:
+                logger.warning(
+                    "pregenerate_on_publish: backstop quality dispatch failed (non-fatal)",
+                    course_id=course_id,
+                    error=str(_exc),
+                )
         return result
     except Exception as exc:
         logger.error(

--- a/backend/migrations/versions/097_add_course_bundles.py
+++ b/backend/migrations/versions/097_add_course_bundles.py
@@ -15,7 +15,13 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute("CREATE TYPE bundlestatus AS ENUM ('pending', 'generating', 'ready', 'failed')")
+    # Idempotent enum creation — staging may have the type from a prior
+    # partial migration run that failed before the table was created.
+    op.execute(
+        "DO $$ BEGIN "
+        "CREATE TYPE bundlestatus AS ENUM ('pending', 'generating', 'ready', 'failed'); "
+        "EXCEPTION WHEN duplicate_object THEN NULL; END $$"
+    )
 
     op.create_table(
         "course_bundles",

--- a/frontend/app/[locale]/admin/bundles/page.tsx
+++ b/frontend/app/[locale]/admin/bundles/page.tsx
@@ -1,0 +1,23 @@
+import { getTranslations } from "next-intl/server";
+import { BundlesClient } from "@/components/admin/bundles-client";
+
+export async function generateMetadata() {
+  const t = await getTranslations("Admin.bundles");
+  return {
+    title: t("pageTitle"),
+    description: t("pageDescription"),
+  };
+}
+
+export default async function AdminBundlesPage() {
+  const t = await getTranslations("Admin.bundles");
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <div className="border-b bg-background p-4 shrink-0">
+        <h1 className="text-2xl font-bold">{t("pageTitle")}</h1>
+        <p className="text-muted-foreground mt-1">{t("pageDescription")}</p>
+      </div>
+      <BundlesClient />
+    </div>
+  );
+}

--- a/frontend/components/admin/bundle-trigger.tsx
+++ b/frontend/components/admin/bundle-trigger.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { Package, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { createCourseBundle } from "@/lib/api-bundles";
+
+interface BundleTriggerProps {
+  /** Pre-selected course. When set, the course picker is hidden. */
+  courseId: string;
+  /** Optional callback after successful trigger. */
+  onSuccess?: () => void;
+}
+
+export function BundleTrigger({ courseId, onSuccess }: BundleTriggerProps) {
+  const t = useTranslations("Admin.bundles.trigger");
+  const tLevel = useTranslations("Admin.bundles.levelLabels");
+  const router = useRouter();
+
+  const [open, setOpen] = useState(false);
+  const [language, setLanguage] = useState<"fr" | "en">("fr");
+  const [level, setLevel] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      await createCourseBundle(courseId, { language, level, country: "SN" });
+      setOpen(false);
+      if (onSuccess) {
+        onSuccess();
+      } else {
+        router.push(`/admin/bundles`);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setOpen(true)}
+        className="gap-2"
+      >
+        <Package className="size-4" />
+        {t("title")}
+      </Button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setOpen(false);
+          }}
+        >
+          <div className="w-full max-w-sm rounded-lg bg-background p-6 shadow-xl">
+            <div className="mb-4 flex items-start justify-between gap-2">
+              <div>
+                <h2 className="text-lg font-semibold">{t("title")}</h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {t("description")}
+                </p>
+              </div>
+              <button
+                onClick={() => setOpen(false)}
+                className="rounded-sm text-muted-foreground hover:text-foreground"
+              >
+                <X className="size-4" />
+              </button>
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+              {/* Language */}
+              <div className="space-y-2">
+                <label className="text-sm font-medium">{t("language")}</label>
+                <div className="flex gap-3">
+                  {(["fr", "en"] as const).map((lang) => (
+                    <label
+                      key={lang}
+                      className="flex cursor-pointer items-center gap-2"
+                    >
+                      <input
+                        type="radio"
+                        name="language"
+                        value={lang}
+                        checked={language === lang}
+                        onChange={() => setLanguage(lang)}
+                        className="accent-primary"
+                      />
+                      <span className="text-sm uppercase">{lang}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              {/* Level */}
+              <div className="space-y-2">
+                <label className="text-sm font-medium">{t("level")}</label>
+                <select
+                  value={level}
+                  onChange={(e) => setLevel(Number(e.target.value))}
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                >
+                  {([1, 2, 3, 4] as const).map((l) => (
+                    <option key={l} value={l}>
+                      {l} — {tLevel(String(l) as "1" | "2" | "3" | "4")}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {error && (
+                <p className="text-sm text-destructive">{error}</p>
+              )}
+
+              <div className="flex justify-end gap-2 pt-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setOpen(false)}
+                  disabled={loading}
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" size="sm" disabled={loading}>
+                  {loading ? t("submitting") : t("submit")}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/components/admin/bundles-client.tsx
+++ b/frontend/components/admin/bundles-client.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import {
+  Download,
+  Loader2,
+  Package,
+  Trash2,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  type BundleListItem,
+  deleteBundle,
+  downloadBundle,
+  listBundles,
+} from "@/lib/api-bundles";
+
+function formatBytes(bytes: number | null): string {
+  if (bytes == null) return "—";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    dateStyle: "short",
+    timeStyle: "short",
+  });
+}
+
+export function BundlesClient() {
+  const t = useTranslations("Admin.bundles");
+
+  const [bundles, setBundles] = useState<BundleListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState<string | null>(null);
+  const [downloading, setDownloading] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevStatusRef = useRef<Record<string, string>>({});
+
+  function showToast(msg: string) {
+    setToast(msg);
+    setTimeout(() => setToast(null), 4000);
+  }
+
+  const load = useCallback(async () => {
+    try {
+      const data = await listBundles({ limit: 100 });
+
+      // Detect transitions to "ready" or "failed" for notifications
+      const prev = prevStatusRef.current;
+      for (const b of data) {
+        const was = prev[b.bundle_id];
+        if (was && was !== b.status) {
+          if (b.status === "ready") showToast(t("toastReady"));
+          if (b.status === "failed") showToast(t("toastFailed"));
+        }
+      }
+      prevStatusRef.current = Object.fromEntries(
+        data.map((b) => [b.bundle_id, b.status]),
+      );
+
+      setBundles(data);
+      setError(null);
+    } catch {
+      setError(t("error"));
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Auto-poll every 3s while any bundle is generating or pending
+  useEffect(() => {
+    const hasActive = bundles.some(
+      (b) => b.status === "generating" || b.status === "pending",
+    );
+    if (!hasActive) {
+      if (pollRef.current) clearTimeout(pollRef.current);
+      return;
+    }
+    pollRef.current = setTimeout(load, 3000);
+    return () => {
+      if (pollRef.current) clearTimeout(pollRef.current);
+    };
+  }, [bundles, load]);
+
+  async function handleDownload(b: BundleListItem) {
+    setDownloading(b.bundle_id);
+    try {
+      const filename = `${b.course_title}_${b.language}.zip`
+        .replace(/[^a-zA-Z0-9_.-]/g, "_");
+      await downloadBundle(b.bundle_id, filename);
+    } catch {
+      showToast(t("error"));
+    } finally {
+      setDownloading(null);
+    }
+  }
+
+  async function handleDelete(bundleId: string) {
+    setDeleting(bundleId);
+    try {
+      await deleteBundle(bundleId);
+      await load();
+    } catch {
+      showToast(t("error"));
+    } finally {
+      setDeleting(null);
+      setConfirmDelete(null);
+    }
+  }
+
+  function statusBadge(status: string) {
+    const label = t(`status.${status}` as Parameters<typeof t>[0]);
+    const cls: Record<string, string> = {
+      pending:
+        "bg-muted text-muted-foreground",
+      generating:
+        "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
+      ready:
+        "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300",
+      failed:
+        "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300",
+    };
+    return (
+      <span
+        className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${cls[status] ?? cls.pending}`}
+      >
+        {status === "generating" && (
+          <Loader2 className="size-3 animate-spin" />
+        )}
+        {label}
+      </span>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center p-12 text-muted-foreground">
+        <Loader2 className="mr-2 size-5 animate-spin" />
+        {t("loading")}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-1 flex-col overflow-auto p-4">
+      {toast && (
+        <div className="fixed right-4 top-4 z-50 rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground shadow-lg">
+          {toast}
+        </div>
+      )}
+
+      {/* Delete confirmation overlay */}
+      {confirmDelete && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+          <div className="w-full max-w-sm rounded-lg bg-background p-6 shadow-xl">
+            <p className="text-sm">{t("deleteConfirm")}</p>
+            <div className="mt-4 flex justify-end gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setConfirmDelete(null)}
+                disabled={!!deleting}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => handleDelete(confirmDelete)}
+                disabled={!!deleting}
+              >
+                {deleting === confirmDelete ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  t("delete")
+                )}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <div className="mb-4 rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {bundles.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-3 py-16 text-center text-muted-foreground">
+          <Package className="size-10 opacity-40" />
+          <p className="text-sm">{t("empty")}</p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-md border">
+          <table className="w-full text-sm">
+            <thead className="border-b bg-muted/50 text-xs font-medium text-muted-foreground">
+              <tr>
+                <th className="px-4 py-3 text-left">{t("table.course")}</th>
+                <th className="px-4 py-3 text-left">{t("table.language")}</th>
+                <th className="px-4 py-3 text-left">{t("table.level")}</th>
+                <th className="px-4 py-3 text-left">{t("table.status")}</th>
+                <th className="px-4 py-3 text-left">{t("table.size")}</th>
+                <th className="px-4 py-3 text-left">{t("table.created")}</th>
+                <th className="px-4 py-3 text-right">{t("table.actions")}</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {bundles.map((b) => (
+                <tr key={b.bundle_id} className="hover:bg-muted/30">
+                  <td className="px-4 py-3 font-medium">
+                    {b.course_title}
+                    {b.error_message && b.status === "failed" && (
+                      <p className="mt-0.5 text-xs text-destructive/80 truncate max-w-[200px]">
+                        {b.error_message}
+                      </p>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 uppercase">{b.language}</td>
+                  <td className="px-4 py-3">{b.level}</td>
+                  <td className="px-4 py-3">{statusBadge(b.status)}</td>
+                  <td className="px-4 py-3 tabular-nums text-muted-foreground">
+                    {b.file_count != null && (
+                      <span className="mr-1 text-xs">{b.file_count}f</span>
+                    )}
+                    {formatBytes(b.file_size_bytes)}
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {formatDate(b.created_at)}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex justify-end gap-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={b.status !== "ready" || !!downloading}
+                        onClick={() => handleDownload(b)}
+                        title={t("download")}
+                      >
+                        {downloading === b.bundle_id ? (
+                          <Loader2 className="size-4 animate-spin" />
+                        ) : (
+                          <Download className="size-4" />
+                        )}
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={!!deleting}
+                        onClick={() => setConfirmDelete(b.bundle_id)}
+                        title={t("delete")}
+                        className="text-destructive hover:text-destructive"
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/quiz/quiz-container.tsx
+++ b/frontend/components/quiz/quiz-container.tsx
@@ -61,7 +61,8 @@ export function QuizContainer({
   const [result, setResult] = useState<QuizAttemptResponse | null>(null);
   const [error, setError] = useState<string>('');
   const [retryCount, setRetryCount] = useState(0);
-  const [forceRegenerate, setForceRegenerate] = useState(false);
+  // forceRegenerate is tracked via forceRegenerateRef (below) — not state — so
+  // that resetting it after a fetch does not re-trigger the main useEffect.
   const [contentSource, setContentSource] = useState<'api' | 'indexeddb'>('api');
 
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -69,6 +70,15 @@ export function QuizContainer({
   // Freeze country on first hydration so a network blip that briefly flips
   // currentUser.country cannot restart a live quiz session (#2226).
   const frozenCountryRef = useRef<string | null>(null);
+  // Track state via ref so the in-progress/completed guard can read it without
+  // making `state` an effect dependency — including it caused an infinite
+  // restart loop that killed the poll timer before it could fire.
+  const stateRef = useRef<QuizState>(state);
+  useEffect(() => { stateRef.current = state; }, [state]);
+  // Track forceRegenerate via ref for the same reason: setForceRegenerate(false)
+  // inside pollStatus/fetchQuiz was re-triggering the effect and killing the
+  // poll timer, causing an infinite POST loop (#2376).
+  const forceRegenerateRef = useRef(false);
   const { isOnline } = useNetworkStatus();
 
   useEffect(() => {
@@ -79,7 +89,7 @@ export function QuizContainer({
     // Don't restart the effect while the learner is actively answering or has
     // already finished — a dependency flap (e.g. country ref settling) must not
     // wipe in-progress answers (#2226).
-    if (state === 'in-progress' || state === 'completed') return;
+    if (stateRef.current === 'in-progress' || stateRef.current === 'completed') return;
     if (frozenCountryRef.current === null) frozenCountryRef.current = resolvedCountry;
     const country = frozenCountryRef.current;
 
@@ -113,7 +123,6 @@ export function QuizContainer({
             if (cached) {
               setQuiz(cached.content as Quiz);
               setContentSource('indexeddb');
-              setForceRegenerate(false);
               setState('ready');
               return;
             }
@@ -139,13 +148,12 @@ export function QuizContainer({
               module_id: moduleId,
               unit_id: unitId,
               language,
-              country: resolvedCountry,
+              country,
               level,
               num_questions: unitQuestionsCount,
             });
             if (stale) return;
             setQuiz(quizData);
-            setForceRegenerate(false);
             setState('ready');
           } else if (statusRes.status === 'failed') {
             const rawError = statusRes.error?.trim();
@@ -173,15 +181,17 @@ export function QuizContainer({
 
         const result = await loadQuiz<Quiz | GeneratingResponse>(
           moduleId, unitId, language, level, country,
-          unitQuestionsCount, forceRegenerate,
+          unitQuestionsCount, forceRegenerateRef.current,
         );
+        // Reset immediately so a subsequent retryCount-triggered run doesn't
+        // re-force generation unless the user explicitly clicked Refresh again.
+        forceRegenerateRef.current = false;
         if (stale) return;
 
         setContentSource(result.source);
 
         if (result.source === 'indexeddb') {
           setQuiz(result.data as Quiz);
-          setForceRegenerate(false);
           setState('ready');
           return;
         }
@@ -193,7 +203,6 @@ export function QuizContainer({
           pollStatus((rawData as GeneratingResponse).task_id, pollStartRef.current);
         } else {
           setQuiz(rawData as Quiz);
-          setForceRegenerate(false);
           setState('ready');
         }
       } catch (err) {
@@ -226,7 +235,7 @@ export function QuizContainer({
       if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [moduleId, unitId, language, level, retryCount, forceRegenerate, isHydrated, state]);
+  }, [moduleId, unitId, language, level, retryCount, isHydrated]);
   
   const handleStartQuiz = () => {
     setState('in-progress');
@@ -263,7 +272,8 @@ export function QuizContainer({
   const handleRefreshContent = () => {
     setResult(null);
     setQuiz(null);
-    setForceRegenerate(true);
+    forceRegenerateRef.current = true;
+    setRetryCount(prev => prev + 1);
   };
   
   const handleContinue = () => {

--- a/frontend/e2e/specs/04-sub-admin/admin-pages.spec.ts
+++ b/frontend/e2e/specs/04-sub-admin/admin-pages.spec.ts
@@ -30,4 +30,9 @@ test.describe('@sub-admin admin pages', () => {
     await page.goto('/fr/admin/taxonomy');
     await expect(page.locator('main h1')).toContainText(/taxonom/i);
   });
+
+  test('/fr/admin/quality renders quality review queue', async ({ page }) => {
+    await page.goto('/fr/admin/quality');
+    await expect(page.locator('main h1')).toContainText(/qualit/i);
+  });
 });

--- a/frontend/e2e/specs/05-admin/admin-pages.spec.ts
+++ b/frontend/e2e/specs/05-admin/admin-pages.spec.ts
@@ -32,4 +32,9 @@ test.describe('@admin admin pages', () => {
     await page.goto('/fr/admin/analytics');
     await expect(page.locator('main h1')).toContainText(/analy/i);
   });
+
+  test('/fr/admin/quality renders quality review queue', async ({ page }) => {
+    await page.goto('/fr/admin/quality');
+    await expect(page.locator('main h1')).toContainText(/qualit/i);
+  });
 });

--- a/frontend/lib/api-bundles.ts
+++ b/frontend/lib/api-bundles.ts
@@ -1,0 +1,102 @@
+/**
+ * API client for course bundle (ZIP export) operations.
+ */
+import { API_BASE, apiFetch } from "@/lib/api";
+import { getAuthHeaders } from "@/lib/api-course-admin";
+
+export type BundleStatus = "pending" | "generating" | "ready" | "failed";
+
+export interface BundleCreatedResponse {
+  bundle_id: string;
+  task_id: string;
+  status: string;
+}
+
+export interface BundleStatusResponse {
+  bundle_id: string;
+  status: BundleStatus;
+  progress: number | null;
+  current_file: string | null;
+  download_url: string | null;
+  file_count: number | null;
+  file_size_bytes: number | null;
+  error_message: string | null;
+}
+
+export interface BundleListItem {
+  bundle_id: string;
+  course_id: string;
+  course_title: string;
+  language: string;
+  level: number;
+  status: BundleStatus;
+  file_count: number | null;
+  file_size_bytes: number | null;
+  created_at: string;
+  completed_at: string | null;
+  download_url: string | null;
+  error_message: string | null;
+}
+
+export interface BundleCreatePayload {
+  language: "fr" | "en";
+  level?: number;
+  country?: string;
+}
+
+export async function createCourseBundle(
+  courseId: string,
+  payload: BundleCreatePayload,
+): Promise<BundleCreatedResponse> {
+  return apiFetch<BundleCreatedResponse>(
+    `/api/v1/admin/courses/${courseId}/bundle`,
+    {
+      method: "POST",
+      body: JSON.stringify(payload),
+    },
+  );
+}
+
+export async function getCourseBundleStatus(
+  courseId: string,
+  bundleId: string,
+): Promise<BundleStatusResponse> {
+  return apiFetch<BundleStatusResponse>(
+    `/api/v1/admin/courses/${courseId}/bundle/status?bundle_id=${bundleId}`,
+  );
+}
+
+export async function listBundles(params?: {
+  course_id?: string;
+  bundle_status?: string;
+  limit?: number;
+}): Promise<BundleListItem[]> {
+  const qs = new URLSearchParams();
+  if (params?.course_id) qs.set("course_id", params.course_id);
+  if (params?.bundle_status) qs.set("bundle_status", params.bundle_status);
+  if (params?.limit != null) qs.set("limit", String(params.limit));
+  const suffix = qs.toString() ? `?${qs.toString()}` : "";
+  return apiFetch<BundleListItem[]>(`/api/v1/admin/bundles${suffix}`);
+}
+
+export async function downloadBundle(
+  bundleId: string,
+  filename: string,
+): Promise<void> {
+  const headers = await getAuthHeaders();
+  const res = await fetch(`${API_BASE}/api/v1/admin/bundles/${bundleId}/download`, {
+    headers,
+  });
+  if (!res.ok) throw new Error(`Download failed: ${res.status}`);
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(url), 5000);
+}
+
+export async function deleteBundle(bundleId: string): Promise<void> {
+  await apiFetch(`/api/v1/admin/bundles/${bundleId}`, { method: "DELETE" });
+}


### PR DESCRIPTION
Fresh sync branch to replace #2373 (phantom-conflict from prior squash SHAs).

Applied `git diff origin/main origin/dev` cleanly onto a branch off main HEAD — no cherry-pick conflicts.

## Changes included

- **fix(quiz)**: move `forceRegenerate` to ref — stops 300+ POST infinite loop (#2376)
- **fix(migration)**: idempotent `BundleStatus` enum creation in 097 (#2372)
- **feat(quality)**: auto-trigger QA sweep after course publish + pregenerate backstop (#2358)
- **fix(ci)**: replace unindented heredocs in deploy.yml with printf (#2368)
- **test(e2e)**: quality review queue reachability for admin + sub-admin (#2375)
- **feat(bundles)**: course bundle admin UI + API

🤖 Generated with [Claude Code](https://claude.com/claude-code)