### PR TITLE
feat(bundles): course ZIP export for offline use

### DIFF
--- a/backend/app/api/v1/course_bundles.py
+++ b/backend/app/api/v1/course_bundles.py
@@ -1,0 +1,337 @@
+"""Course bundle export — create, poll, list, download, and delete ZIP packages."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Literal
+
+from celery.result import AsyncResult
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from app.api.deps import get_db_session
+from app.api.deps_local_auth import AuthenticatedUser, require_role
+from app.domain.models.course import Course
+from app.domain.models.course_bundle import CourseBundle
+from app.domain.models.user import UserRole
+from app.infrastructure.storage.s3 import S3StorageService
+from app.tasks.course_bundle import generate_course_bundle_task
+
+logger = get_logger(__name__)
+
+router = APIRouter(tags=["Course Bundles"])
+
+_ADMIN_ROLES = (UserRole.admin, UserRole.sub_admin, UserRole.expert)
+
+
+# ── Schemas ───────────────────────────────────────────────────────────
+
+
+class BundleCreateRequest(BaseModel):
+    language: Literal["fr", "en"]
+    level: int = Field(default=1, ge=1, le=4)
+    country: str = Field(default="SN", max_length=4)
+
+
+class BundleCreatedResponse(BaseModel):
+    bundle_id: str
+    task_id: str
+    status: str
+
+
+class BundleStatusResponse(BaseModel):
+    bundle_id: str
+    status: str
+    progress: int | None = None
+    current_file: str | None = None
+    download_url: str | None = None
+    file_count: int | None = None
+    file_size_bytes: int | None = None
+    error_message: str | None = None
+
+
+class BundleListItem(BaseModel):
+    bundle_id: str
+    course_id: str
+    course_title: str
+    language: str
+    level: int
+    status: str
+    file_count: int | None
+    file_size_bytes: int | None
+    created_at: str
+    completed_at: str | None
+    download_url: str | None
+    error_message: str | None
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+async def _get_course_or_404(course_id: uuid.UUID, session: AsyncSession) -> Course:
+    course = await session.get(Course, course_id)
+    if course is None:
+        raise HTTPException(status_code=404, detail="Course not found")
+    return course
+
+
+def _expert_owns_course(user: AuthenticatedUser, course: Course) -> bool:
+    return str(course.created_by) == user.id
+
+
+def _guard_expert(user: AuthenticatedUser, course: Course) -> None:
+    if user.role == UserRole.expert.value and not _expert_owns_course(user, course):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Experts can only bundle their own courses",
+        )
+
+
+def _celery_progress(task_id: str) -> tuple[int, str | None]:
+    """Return (progress 0-100, current_file) from Celery state."""
+    if not task_id:
+        return 0, None
+    try:
+        res = AsyncResult(task_id)
+        if res.state == "PROGRESS" and isinstance(res.info, dict):
+            return res.info.get("progress", 0), res.info.get("current_file")
+    except Exception:
+        pass
+    return 0, None
+
+
+def _bundle_download_url(bundle: CourseBundle, user: AuthenticatedUser) -> str | None:
+    """Return the API download URL (requires auth) when the bundle is ready."""
+    if bundle.status != "ready":
+        return None
+    return f"/api/v1/admin/bundles/{bundle.id}/download"
+
+
+def _bundle_to_status(bundle: CourseBundle, user: AuthenticatedUser) -> BundleStatusResponse:
+    progress, current_file = 0, None
+    if bundle.status == "generating" and bundle.task_id:
+        progress, current_file = _celery_progress(bundle.task_id)
+    return BundleStatusResponse(
+        bundle_id=str(bundle.id),
+        status=bundle.status,
+        progress=progress,
+        current_file=current_file,
+        download_url=_bundle_download_url(bundle, user),
+        file_count=bundle.file_count,
+        file_size_bytes=bundle.file_size_bytes,
+        error_message=bundle.error_message,
+    )
+
+
+# ── Endpoints ─────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/admin/courses/{course_id}/bundle",
+    response_model=BundleCreatedResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def create_course_bundle(
+    course_id: uuid.UUID,
+    body: BundleCreateRequest,
+    current_user: AuthenticatedUser = Depends(require_role(*_ADMIN_ROLES)),
+    session: AsyncSession = Depends(get_db_session),
+) -> BundleCreatedResponse:
+    """Trigger bundle generation for a course. Returns immediately with a bundle_id."""
+    course = await _get_course_or_404(course_id, session)
+    _guard_expert(current_user, course)
+
+    bundle = CourseBundle(
+        course_id=course_id,
+        requested_by=uuid.UUID(current_user.id),
+        language=body.language,
+        level=body.level,
+        country=body.country,
+        status="pending",
+    )
+    session.add(bundle)
+    await session.flush()  # assign bundle.id before dispatching task
+
+    task = generate_course_bundle_task.delay(str(bundle.id))
+    bundle.task_id = task.id
+    await session.commit()
+
+    logger.info(
+        "bundle.created",
+        bundle_id=str(bundle.id),
+        course_id=str(course_id),
+        language=body.language,
+        task_id=task.id,
+    )
+    return BundleCreatedResponse(
+        bundle_id=str(bundle.id),
+        task_id=task.id,
+        status="pending",
+    )
+
+
+@router.get(
+    "/admin/courses/{course_id}/bundle/status",
+    response_model=BundleStatusResponse,
+)
+async def get_bundle_status(
+    course_id: uuid.UUID,
+    bundle_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(require_role(*_ADMIN_ROLES)),
+    session: AsyncSession = Depends(get_db_session),
+) -> BundleStatusResponse:
+    """Poll the status of a bundle job."""
+    course = await _get_course_or_404(course_id, session)
+    _guard_expert(current_user, course)
+
+    bundle = await session.get(CourseBundle, bundle_id)
+    if bundle is None or bundle.course_id != course_id:
+        raise HTTPException(status_code=404, detail="Bundle not found")
+
+    return _bundle_to_status(bundle, current_user)
+
+
+@router.get(
+    "/admin/bundles",
+    response_model=list[BundleListItem],
+)
+async def list_bundles(
+    course_id: uuid.UUID | None = None,
+    bundle_status: str | None = None,
+    limit: int = 50,
+    current_user: AuthenticatedUser = Depends(require_role(*_ADMIN_ROLES)),
+    session: AsyncSession = Depends(get_db_session),
+) -> list[BundleListItem]:
+    """List course bundles.
+
+    Admin/sub_admin see all bundles. Experts see only bundles for their
+    own courses.
+    """
+    q = select(CourseBundle, Course).join(Course, Course.id == CourseBundle.course_id)
+
+    if current_user.role == UserRole.expert.value:
+        q = q.where(Course.created_by == uuid.UUID(current_user.id))
+
+    if course_id is not None:
+        q = q.where(CourseBundle.course_id == course_id)
+
+    if bundle_status is not None:
+        q = q.where(CourseBundle.status == bundle_status)
+
+    q = q.order_by(CourseBundle.created_at.desc()).limit(limit)
+    rows = (await session.execute(q)).all()
+
+    items: list[BundleListItem] = []
+    for bundle, course in rows:
+        lang = bundle.language
+        course_title = course.title_fr if lang == "fr" else course.title_en
+        items.append(
+            BundleListItem(
+                bundle_id=str(bundle.id),
+                course_id=str(bundle.course_id),
+                course_title=course_title,
+                language=bundle.language,
+                level=bundle.level,
+                status=bundle.status,
+                file_count=bundle.file_count,
+                file_size_bytes=bundle.file_size_bytes,
+                created_at=bundle.created_at.isoformat(),
+                completed_at=(bundle.completed_at.isoformat() if bundle.completed_at else None),
+                download_url=_bundle_download_url(bundle, current_user),
+                error_message=bundle.error_message,
+            )
+        )
+    return items
+
+
+@router.get("/admin/bundles/{bundle_id}/download")
+async def download_bundle(
+    bundle_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(require_role(*_ADMIN_ROLES)),
+    session: AsyncSession = Depends(get_db_session),
+) -> StreamingResponse:
+    """Stream the ZIP archive from MinIO.
+
+    Experts can only download bundles for their own courses.
+    """
+    result = await session.execute(
+        select(CourseBundle, Course)
+        .join(Course, Course.id == CourseBundle.course_id)
+        .where(CourseBundle.id == bundle_id)
+    )
+    row = result.first()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Bundle not found")
+
+    bundle, course = row
+    _guard_expert(current_user, course)
+
+    if bundle.status != "ready" or not bundle.storage_key:
+        raise HTTPException(status_code=409, detail="Bundle is not ready yet")
+
+    storage = S3StorageService()
+    try:
+        data = await storage.download_bytes(bundle.storage_key)
+    except Exception as exc:
+        logger.error(
+            "bundle.download_failed",
+            bundle_id=str(bundle_id),
+            error=str(exc),
+        )
+        raise HTTPException(
+            status_code=502, detail="Could not retrieve bundle from storage"
+        ) from exc
+
+    lang = bundle.language
+    slug = course.slug or str(course.id)
+    filename = f"{slug}_{lang}.zip"
+
+    return StreamingResponse(
+        iter([data]),
+        media_type="application/zip",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "Content-Length": str(len(data)),
+        },
+    )
+
+
+@router.delete(
+    "/admin/bundles/{bundle_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_bundle(
+    bundle_id: uuid.UUID,
+    current_user: AuthenticatedUser = Depends(require_role(*_ADMIN_ROLES)),
+    session: AsyncSession = Depends(get_db_session),
+) -> None:
+    """Delete a bundle and its MinIO object."""
+    result = await session.execute(
+        select(CourseBundle, Course)
+        .join(Course, Course.id == CourseBundle.course_id)
+        .where(CourseBundle.id == bundle_id)
+    )
+    row = result.first()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Bundle not found")
+
+    bundle, course = row
+    _guard_expert(current_user, course)
+
+    if bundle.storage_key:
+        try:
+            storage = S3StorageService()
+            await storage.delete_object(bundle.storage_key)
+        except Exception as exc:
+            logger.warning(
+                "bundle.delete_storage_failed",
+                bundle_id=str(bundle_id),
+                error=str(exc),
+            )
+
+    await session.delete(bundle)
+    await session.commit()

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -16,6 +16,9 @@ from app.api.v1.admin_taxonomy import router as admin_taxonomy_router
 from app.api.v1.analytics import router as analytics_router
 from app.api.v1.certificates import router as certificates_router
 from app.api.v1.content import router as content_router
+from app.api.v1.course_bundles import (
+    router as course_bundles_router,
+)
 from app.api.v1.course_preassessment import router as course_preassessment_router
 from app.api.v1.courses import router as courses_router
 from app.api.v1.curricula import router as curricula_router
@@ -85,3 +88,4 @@ api_v1_router.include_router(org_codes_router)
 api_v1_router.include_router(org_reports_router)
 api_v1_router.include_router(qbank_router)
 api_v1_router.include_router(certificates_router)
+api_v1_router.include_router(course_bundles_router)

--- a/backend/app/domain/models/__init__.py
+++ b/backend/app/domain/models/__init__.py
@@ -6,6 +6,7 @@ from app.domain.models.certificate import Certificate, CertificateTemplate
 from app.domain.models.content import GeneratedContent
 from app.domain.models.conversation import TutorConversation, TutorMessage
 from app.domain.models.course import Course, UserCourseEnrollment
+from app.domain.models.course_bundle import CourseBundle
 from app.domain.models.course_quality import (
     CourseGlossaryTerm,
     CourseQualityRun,
@@ -70,6 +71,7 @@ __all__ = [
     "Certificate",
     "CertificateTemplate",
     "Course",
+    "CourseBundle",
     "CourseGlossaryTerm",
     "CoursePreAssessment",
     "CourseQualityRun",

--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -31,6 +31,7 @@ celery_app = Celery(
         "app.tasks.syllabus_generation",
         "app.tasks.subscription",
         "app.tasks.sms_relay",
+        "app.tasks.course_bundle",
     ],
 )
 

--- a/frontend/app/[locale]/admin/bundles/page.tsx
+++ b/frontend/app/[locale]/admin/bundles/page.tsx
@@ -1,0 +1,23 @@
+import { getTranslations } from "next-intl/server";
+import { BundlesClient } from "@/components/admin/bundles-client";
+
+export async function generateMetadata() {
+  const t = await getTranslations("Admin.bundles");
+  return {
+    title: t("pageTitle"),
+    description: t("pageDescription"),
+  };
+}
+
+export default async function AdminBundlesPage() {
+  const t = await getTranslations("Admin.bundles");
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <div className="border-b bg-background p-4 shrink-0">
+        <h1 className="text-2xl font-bold">{t("pageTitle")}</h1>
+        <p className="text-muted-foreground mt-1">{t("pageDescription")}</p>
+      </div>
+      <BundlesClient />
+    </div>
+  );
+}

--- a/frontend/app/[locale]/admin/courses/[courseId]/quality/page.tsx
+++ b/frontend/app/[locale]/admin/courses/[courseId]/quality/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { getTranslations } from "next-intl/server";
+import { BundleTrigger } from "@/components/admin/bundle-trigger";
 import { QualityClient } from "@/components/admin/quality/quality-client";
 
 export async function generateMetadata({
@@ -34,8 +35,15 @@ export default async function AdminCourseQualityPage({
           <ArrowLeft className="size-4" />
           {t("backToCourses")}
         </Link>
-        <h1 className="text-2xl font-bold">{t("pageTitle")}</h1>
-        <p className="text-muted-foreground mt-1">{t("pageDescription")}</p>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold">{t("pageTitle")}</h1>
+            <p className="text-muted-foreground mt-1">
+              {t("pageDescription")}
+            </p>
+          </div>
+          <BundleTrigger courseId={courseId} />
+        </div>
       </div>
       <QualityClient courseId={courseId} />
     </div>

--- a/frontend/components/admin/admin-nav.tsx
+++ b/frontend/components/admin/admin-nav.tsx
@@ -50,6 +50,7 @@ export function AdminNav() {
     { href: `/${locale}/admin/users`, label: t("users.title"), adminOnly: false, badge: 0 },
     { href: `/${locale}/admin/courses`, label: t("courses.title"), adminOnly: false, badge: 0 },
     { href: `/${locale}/admin/quality`, label: t("quality.title"), adminOnly: false, badge: attentionCount },
+    { href: `/${locale}/admin/bundles`, label: t("bundles.nav"), adminOnly: false, badge: 0 },
     { href: `/${locale}/admin/curricula`, label: t("curricula.title"), adminOnly: false, badge: 0 },
     { href: `/${locale}/admin/groups`, label: t("groups.title"), adminOnly: false, badge: 0 },
     { href: `/${locale}/admin/taxonomy`, label: t("taxonomy.title"), adminOnly: false, badge: 0 },

--- a/frontend/components/admin/bundle-trigger.tsx
+++ b/frontend/components/admin/bundle-trigger.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { Package, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { createCourseBundle } from "@/lib/api-bundles";
+
+interface BundleTriggerProps {
+  /** Pre-selected course. When set, the course picker is hidden. */
+  courseId: string;
+  /** Optional callback after successful trigger. */
+  onSuccess?: () => void;
+}
+
+export function BundleTrigger({ courseId, onSuccess }: BundleTriggerProps) {
+  const t = useTranslations("Admin.bundles.trigger");
+  const tLevel = useTranslations("Admin.bundles.levelLabels");
+  const router = useRouter();
+
+  const [open, setOpen] = useState(false);
+  const [language, setLanguage] = useState<"fr" | "en">("fr");
+  const [level, setLevel] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      await createCourseBundle(courseId, { language, level, country: "SN" });
+      setOpen(false);
+      if (onSuccess) {
+        onSuccess();
+      } else {
+        router.push(`/admin/bundles`);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setOpen(true)}
+        className="gap-2"
+      >
+        <Package className="size-4" />
+        {t("title")}
+      </Button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setOpen(false);
+          }}
+        >
+          <div className="w-full max-w-sm rounded-lg bg-background p-6 shadow-xl">
+            <div className="mb-4 flex items-start justify-between gap-2">
+              <div>
+                <h2 className="text-lg font-semibold">{t("title")}</h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {t("description")}
+                </p>
+              </div>
+              <button
+                onClick={() => setOpen(false)}
+                className="rounded-sm text-muted-foreground hover:text-foreground"
+              >
+                <X className="size-4" />
+              </button>
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <label className="text-sm font-medium">{t("language")}</label>
+                <div className="flex gap-3">
+                  {(["fr", "en"] as const).map((lang) => (
+                    <label
+                      key={lang}
+                      className="flex cursor-pointer items-center gap-2"
+                    >
+                      <input
+                        type="radio"
+                        name="language"
+                        value={lang}
+                        checked={language === lang}
+                        onChange={() => setLanguage(lang)}
+                        className="accent-primary"
+                      />
+                      <span className="text-sm uppercase">{lang}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium">{t("level")}</label>
+                <select
+                  value={level}
+                  onChange={(e) => setLevel(Number(e.target.value))}
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                >
+                  {([1, 2, 3, 4] as const).map((l) => (
+                    <option key={l} value={l}>
+                      {l} — {tLevel(String(l) as "1" | "2" | "3" | "4")}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {error && <p className="text-sm text-destructive">{error}</p>}
+
+              <div className="flex justify-end gap-2 pt-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setOpen(false)}
+                  disabled={loading}
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" size="sm" disabled={loading}>
+                  {loading ? t("submitting") : t("submit")}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/components/admin/bundles-client.tsx
+++ b/frontend/components/admin/bundles-client.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Download, Loader2, Package, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  type BundleListItem,
+  deleteBundle,
+  downloadBundle,
+  listBundles,
+} from "@/lib/api-bundles";
+
+function formatBytes(bytes: number | null): string {
+  if (bytes == null) return "—";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    dateStyle: "short",
+    timeStyle: "short",
+  });
+}
+
+export function BundlesClient() {
+  const t = useTranslations("Admin.bundles");
+
+  const [bundles, setBundles] = useState<BundleListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState<string | null>(null);
+  const [downloading, setDownloading] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevStatusRef = useRef<Record<string, string>>({});
+
+  function showToast(msg: string) {
+    setToast(msg);
+    setTimeout(() => setToast(null), 4000);
+  }
+
+  const load = useCallback(async () => {
+    try {
+      const data = await listBundles({ limit: 100 });
+      const prev = prevStatusRef.current;
+      for (const b of data) {
+        const was = prev[b.bundle_id];
+        if (was && was !== b.status) {
+          if (b.status === "ready") showToast(t("toastReady"));
+          if (b.status === "failed") showToast(t("toastFailed"));
+        }
+      }
+      prevStatusRef.current = Object.fromEntries(
+        data.map((b) => [b.bundle_id, b.status]),
+      );
+      setBundles(data);
+      setError(null);
+    } catch {
+      setError(t("error"));
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    const hasActive = bundles.some(
+      (b) => b.status === "generating" || b.status === "pending",
+    );
+    if (!hasActive) {
+      if (pollRef.current) clearTimeout(pollRef.current);
+      return;
+    }
+    pollRef.current = setTimeout(load, 3000);
+    return () => {
+      if (pollRef.current) clearTimeout(pollRef.current);
+    };
+  }, [bundles, load]);
+
+  async function handleDownload(b: BundleListItem) {
+    setDownloading(b.bundle_id);
+    try {
+      const filename = `${b.course_title}_${b.language}.zip`.replace(
+        /[^a-zA-Z0-9_.-]/g,
+        "_",
+      );
+      await downloadBundle(b.bundle_id, filename);
+    } catch {
+      showToast(t("error"));
+    } finally {
+      setDownloading(null);
+    }
+  }
+
+  async function handleDelete(bundleId: string) {
+    setDeleting(bundleId);
+    try {
+      await deleteBundle(bundleId);
+      await load();
+    } catch {
+      showToast(t("error"));
+    } finally {
+      setDeleting(null);
+      setConfirmDelete(null);
+    }
+  }
+
+  function statusBadge(bundleStatus: string) {
+    const label = t(`status.${bundleStatus}` as Parameters<typeof t>[0]);
+    const cls: Record<string, string> = {
+      pending: "bg-muted text-muted-foreground",
+      generating:
+        "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
+      ready:
+        "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300",
+      failed:
+        "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300",
+    };
+    return (
+      <span
+        className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${cls[bundleStatus] ?? cls.pending}`}
+      >
+        {bundleStatus === "generating" && (
+          <Loader2 className="size-3 animate-spin" />
+        )}
+        {label}
+      </span>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center p-12 text-muted-foreground">
+        <Loader2 className="mr-2 size-5 animate-spin" />
+        {t("loading")}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-1 flex-col overflow-auto p-4">
+      {toast && (
+        <div className="fixed right-4 top-4 z-50 rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground shadow-lg">
+          {toast}
+        </div>
+      )}
+
+      {confirmDelete && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+          <div className="w-full max-w-sm rounded-lg bg-background p-6 shadow-xl">
+            <p className="text-sm">{t("deleteConfirm")}</p>
+            <div className="mt-4 flex justify-end gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setConfirmDelete(null)}
+                disabled={!!deleting}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => handleDelete(confirmDelete)}
+                disabled={!!deleting}
+              >
+                {deleting === confirmDelete ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  t("delete")
+                )}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <div className="mb-4 rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {bundles.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-3 py-16 text-center text-muted-foreground">
+          <Package className="size-10 opacity-40" />
+          <p className="text-sm">{t("empty")}</p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-md border">
+          <table className="w-full text-sm">
+            <thead className="border-b bg-muted/50 text-xs font-medium text-muted-foreground">
+              <tr>
+                <th className="px-4 py-3 text-left">{t("table.course")}</th>
+                <th className="px-4 py-3 text-left">
+                  {t("table.language")}
+                </th>
+                <th className="px-4 py-3 text-left">{t("table.level")}</th>
+                <th className="px-4 py-3 text-left">{t("table.status")}</th>
+                <th className="px-4 py-3 text-left">{t("table.size")}</th>
+                <th className="px-4 py-3 text-left">{t("table.created")}</th>
+                <th className="px-4 py-3 text-right">
+                  {t("table.actions")}
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {bundles.map((b) => (
+                <tr key={b.bundle_id} className="hover:bg-muted/30">
+                  <td className="px-4 py-3 font-medium">
+                    {b.course_title}
+                    {b.error_message && b.status === "failed" && (
+                      <p className="mt-0.5 max-w-[200px] truncate text-xs text-destructive/80">
+                        {b.error_message}
+                      </p>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 uppercase">{b.language}</td>
+                  <td className="px-4 py-3">{b.level}</td>
+                  <td className="px-4 py-3">{statusBadge(b.status)}</td>
+                  <td className="px-4 py-3 tabular-nums text-muted-foreground">
+                    {b.file_count != null && (
+                      <span className="mr-1 text-xs">{b.file_count}f</span>
+                    )}
+                    {formatBytes(b.file_size_bytes)}
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {formatDate(b.created_at)}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex justify-end gap-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={b.status !== "ready" || !!downloading}
+                        onClick={() => handleDownload(b)}
+                        title={t("download")}
+                      >
+                        {downloading === b.bundle_id ? (
+                          <Loader2 className="size-4 animate-spin" />
+                        ) : (
+                          <Download className="size-4" />
+                        )}
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={!!deleting}
+                        onClick={() => setConfirmDelete(b.bundle_id)}
+                        title={t("delete")}
+                        className="text-destructive hover:text-destructive"
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/api-bundles.ts
+++ b/frontend/lib/api-bundles.ts
@@ -1,0 +1,103 @@
+/**
+ * API client for course bundle (ZIP export) operations.
+ */
+import { API_BASE, apiFetch } from "@/lib/api";
+import { getAuthHeaders } from "@/lib/api-course-admin";
+
+export type BundleStatus = "pending" | "generating" | "ready" | "failed";
+
+export interface BundleCreatedResponse {
+  bundle_id: string;
+  task_id: string;
+  status: string;
+}
+
+export interface BundleStatusResponse {
+  bundle_id: string;
+  status: BundleStatus;
+  progress: number | null;
+  current_file: string | null;
+  download_url: string | null;
+  file_count: number | null;
+  file_size_bytes: number | null;
+  error_message: string | null;
+}
+
+export interface BundleListItem {
+  bundle_id: string;
+  course_id: string;
+  course_title: string;
+  language: string;
+  level: number;
+  status: BundleStatus;
+  file_count: number | null;
+  file_size_bytes: number | null;
+  created_at: string;
+  completed_at: string | null;
+  download_url: string | null;
+  error_message: string | null;
+}
+
+export interface BundleCreatePayload {
+  language: "fr" | "en";
+  level?: number;
+  country?: string;
+}
+
+export async function createCourseBundle(
+  courseId: string,
+  payload: BundleCreatePayload,
+): Promise<BundleCreatedResponse> {
+  return apiFetch<BundleCreatedResponse>(
+    `/api/v1/admin/courses/${courseId}/bundle`,
+    {
+      method: "POST",
+      body: JSON.stringify(payload),
+    },
+  );
+}
+
+export async function getCourseBundleStatus(
+  courseId: string,
+  bundleId: string,
+): Promise<BundleStatusResponse> {
+  return apiFetch<BundleStatusResponse>(
+    `/api/v1/admin/courses/${courseId}/bundle/status?bundle_id=${bundleId}`,
+  );
+}
+
+export async function listBundles(params?: {
+  course_id?: string;
+  bundle_status?: string;
+  limit?: number;
+}): Promise<BundleListItem[]> {
+  const qs = new URLSearchParams();
+  if (params?.course_id) qs.set("course_id", params.course_id);
+  if (params?.bundle_status) qs.set("bundle_status", params.bundle_status);
+  if (params?.limit != null) qs.set("limit", String(params.limit));
+  const suffix = qs.toString() ? `?${qs.toString()}` : "";
+  return apiFetch<BundleListItem[]>(`/api/v1/admin/bundles${suffix}`);
+}
+
+export async function downloadBundle(
+  bundleId: string,
+  filename: string,
+): Promise<void> {
+  const headers = await getAuthHeaders();
+  const res = await fetch(
+    `${API_BASE}/api/v1/admin/bundles/${bundleId}/download`,
+    { headers },
+  );
+  if (!res.ok) throw new Error(`Download failed: ${res.status}`);
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(url), 5000);
+}
+
+export async function deleteBundle(bundleId: string): Promise<void> {
+  await apiFetch(`/api/v1/admin/bundles/${bundleId}`, { method: "DELETE" });
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1520,6 +1520,51 @@
     },
     "quality": {
       "title": "Quality"
+    },
+    "bundles": {
+      "pageTitle": "Course Packages",
+      "pageDescription": "Download a course as a flat ZIP of self-contained HTML files for offline use.",
+      "backToCourses": "Back to courses",
+      "newBundle": "New Package",
+      "nav": "Packages",
+      "table": {
+        "course": "Course",
+        "language": "Language",
+        "level": "Level",
+        "status": "Status",
+        "size": "Size",
+        "created": "Created",
+        "actions": "Actions"
+      },
+      "status": {
+        "pending": "Queued",
+        "generating": "Generating…",
+        "ready": "Ready",
+        "failed": "Failed"
+      },
+      "download": "Download",
+      "delete": "Delete",
+      "deleteConfirm": "Delete this bundle? This cannot be undone.",
+      "empty": "No packages yet. Trigger one from the course quality page.",
+      "loading": "Loading packages…",
+      "error": "Could not load packages.",
+      "toastReady": "Package ready — click Download.",
+      "toastFailed": "Package generation failed.",
+      "trigger": {
+        "title": "Package course",
+        "description": "Generate an offline ZIP archive. Missing content will be created automatically.",
+        "language": "Language",
+        "level": "Content level",
+        "submit": "Generate package",
+        "submitting": "Starting…",
+        "successToast": "Package generation started — visit Packages to download when ready."
+      },
+      "levelLabels": {
+        "1": "Beginner",
+        "2": "Intermediate",
+        "3": "Advanced",
+        "4": "Expert"
+      }
     }
   },
   "Courses": {

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1520,6 +1520,51 @@
     },
     "quality": {
       "title": "Qualité"
+    },
+    "bundles": {
+      "pageTitle": "Packages de cours",
+      "pageDescription": "Téléchargez un cours sous forme d'archive ZIP de fichiers HTML autonomes pour une utilisation hors-ligne.",
+      "backToCourses": "Retour aux cours",
+      "newBundle": "Nouveau package",
+      "nav": "Packages",
+      "table": {
+        "course": "Cours",
+        "language": "Langue",
+        "level": "Niveau",
+        "status": "Statut",
+        "size": "Taille",
+        "created": "Créé le",
+        "actions": "Actions"
+      },
+      "status": {
+        "pending": "En attente",
+        "generating": "Génération…",
+        "ready": "Prêt",
+        "failed": "Échoué"
+      },
+      "download": "Télécharger",
+      "delete": "Supprimer",
+      "deleteConfirm": "Supprimer ce package ? Cette action est irréversible.",
+      "empty": "Aucun package. Lancez-en un depuis la page qualité d'un cours.",
+      "loading": "Chargement des packages…",
+      "error": "Impossible de charger les packages.",
+      "toastReady": "Package prêt — cliquez sur Télécharger.",
+      "toastFailed": "La génération du package a échoué.",
+      "trigger": {
+        "title": "Packager le cours",
+        "description": "Générez une archive ZIP hors-ligne. Le contenu manquant sera créé automatiquement.",
+        "language": "Langue",
+        "level": "Niveau de contenu",
+        "submit": "Générer le package",
+        "submitting": "Démarrage…",
+        "successToast": "Génération démarrée — consultez les Packages pour télécharger quand c'est prêt."
+      },
+      "levelLabels": {
+        "1": "Débutant",
+        "2": "Intermédiaire",
+        "3": "Avancé",
+        "4": "Expert"
+      }
     }
   },
   "Courses": {


### PR DESCRIPTION
## Summary

Implements course bundle export (Fixes #2363). Admin, sub-admin, and expert users can now generate a flat ZIP archive of any course where every lesson, quiz, case study, and flashcard set is a self-contained HTML file with images and audio embedded as base64 — no internet required to read offline.

**Backend:**
- `CourseBundle` ORM model + Alembic migration 097 (`bundlestatus` PG enum, MinIO storage keys, Celery task_id tracking)
- `BundleService`: renders lesson / quiz / case-study / flashcard content to standalone HTML (embedded CSS, source images from MinIO as base64, audio from MinIO as base64)
- `generate_course_bundle_task`: Celery task (30 min soft limit, 2 retries) — generates missing content on-the-fly per unit, assembles flat ZIP, uploads to MinIO, updates `CourseBundle.status`
- 5 FastAPI endpoints: `POST` trigger, `GET` status (+ Celery PROGRESS), `GET` list (expert-scoped), `GET` download (StreamingResponse), `DELETE`
- Router + celery_app include registration

**Frontend:**
- `api-bundles.ts`: typed API client (create, status, list, download-as-blob, delete)
- `BundleTrigger` modal: language (FR/EN) + level (1–4) picker; used inline on course quality page
- `BundlesClient`: live-polling table (3 s while active), toast on `ready`/`failed`, download + delete with confirmation
- `/admin/bundles` page + **Packages** nav link in `AdminNav`
- i18n: `Admin.bundles` namespace in EN + FR

## Test plan

- [ ] `POST /api/v1/admin/courses/{id}/bundle` returns 202 with `bundle_id`
- [ ] Poll `GET /api/v1/admin/courses/{id}/bundle/status?bundle_id=…` → progresses 0→99→ready
- [ ] `GET /api/v1/admin/bundles/{id}/download` returns a ZIP with HTML files
- [ ] Open an HTML file offline — images and audio player render without network
- [ ] Expert attempting to bundle another expert's course → 403
- [ ] `/admin/bundles` page: spinner while generating, download button appears when ready, toast fires on status change

🤖 Generated with [Claude Code](https://claude.ai/claude-code)