### PR TITLE
fix(tutor): anchor voice-call to course/module, suppress country-topic drift (#1960)

### DIFF
--- a/backend/app/api/v1/tutor_voice.py
+++ b/backend/app/api/v1/tutor_voice.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
 
 import httpx
 import structlog
@@ -22,6 +23,9 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.ai.prompts.tutor import get_socratic_system_prompt
+
+if TYPE_CHECKING:
+    from app.ai.prompts.tutor import TutorContext
 from app.api.deps import get_db_session
 from app.api.deps_local_auth import AuthenticatedUser, get_current_user
 from app.api.v1.schemas.tutor_voice import (
@@ -192,7 +196,40 @@ async def _minutes_used_today(user_id: uuid.UUID, db: AsyncSession) -> int:
     return (int(seconds) + 59) // 60
 
 
-_VOICE_MODE_SUFFIX = """
+def _get_voice_mode_suffix(context: TutorContext) -> str:
+    """Build the voice-call suffix injected after the main system prompt.
+
+    The text tutor is grounded by RAG chunks + conversation history, so the
+    country-context line ("Focus paludisme, méningite, malnutrition") is just
+    background colour.  The voice tutor has NEITHER — it gets only the system
+    prompt — so the model latches onto the specific topics it names.  This
+    suffix explicitly anchors the session to the current course/module and
+    blocks country-topic drift (#1960).
+    """
+    course_label = context.course_title or "la formation en cours"
+    if context.module_title:
+        module_ref = (
+            f"Module {context.module_number}: {context.module_title}"
+            if context.module_number
+            else context.module_title
+        )
+        opening_directive = (
+            f"Open by welcoming the learner and asking one Socratic question "
+            f"grounded in {module_ref} of the course «{course_label}»."
+            if context.user_language != "fr"
+            else f"Commence par accueillir l'apprenant et pose une question "
+            f"socratique ancrée dans le {module_ref} du cours «{course_label}»."
+        )
+    else:
+        opening_directive = (
+            f"Open by welcoming the learner and asking which topic within "
+            f"«{course_label}» they'd like to explore today."
+            if context.user_language != "fr"
+            else f"Commence par accueillir l'apprenant et demande-lui quel "
+            f"sujet du cours «{course_label}» il souhaite explorer aujourd'hui."
+        )
+
+    return f"""
 
 ## Voice-call mode (spoken output)
 
@@ -201,7 +238,17 @@ You are now in a **live voice call** with the learner. Adapt your responses:
 - Use natural spoken phrasing. Do not use markdown, bullet points, or source_image markers.
 - Still follow the Socratic pedagogy above: ask probing questions, guide rather than lecture.
 - If you'd normally cite a source, say it briefly in speech ("as covered in Chapter 4") rather than a formal citation.
-- If the learner asks you to speak louder / slower / in a different language, acknowledge and comply."""
+- If the learner asks you to speak louder / slower / in a different language, acknowledge and comply.
+
+## Voice-call anchoring (CRITICAL — override country-context drift)
+
+{opening_directive}
+
+- **Every reply MUST stay anchored in «{course_label}»** and what the learner just said.
+- The "Pays" line above (e.g. "Focus paludisme, méningite, malnutrition") is BACKGROUND COLOUR ONLY. \
+Do NOT bring up country-specific health priorities, diseases, or statistics unless the learner \
+explicitly asks about them. Treat them as reference material, not a conversation starter.
+- If the learner's message is off-topic, gently redirect to the course content with a question."""
 
 
 @router.post("/voice-session", response_model=VoiceSessionResponse)
@@ -249,7 +296,7 @@ async def create_voice_session(
         locale=body.locale,
         session=db,
     )
-    instructions = get_socratic_system_prompt(context, []) + _VOICE_MODE_SUFFIX
+    instructions = get_socratic_system_prompt(context, []) + _get_voice_mode_suffix(context)
 
     voice = "alloy" if body.locale == "en" else "shimmer"
     openai_payload: dict[str, object] = {

--- a/backend/tests/test_tutor_voice_session.py
+++ b/backend/tests/test_tutor_voice_session.py
@@ -4,6 +4,9 @@ Uses a mocked async session because the integration db_session fixture is
 blocked on #554 (Base.metadata.create_all vs Alembic-managed enum types).
 The interesting logic here is the round-up-to-minutes rule and the cap
 clamp formula; both are pure arithmetic once the DB returns a seconds sum.
+
+Also covers _get_voice_mode_suffix (#1960) — verifies the dynamic suffix
+anchors to course/module and suppresses country-topic drift.
 """
 
 from __future__ import annotations
@@ -63,6 +66,62 @@ class TestMinutesUsedToday:
 
         session = _session_returning_seconds(None)
         assert await _minutes_used_today(uuid.uuid4(), session) == 0
+
+
+class TestVoiceModeSuffix:
+    """_get_voice_mode_suffix anchors to course/module and blocks country drift (#1960)."""
+
+    def _make_context(self, **kwargs):
+        from app.ai.prompts.tutor import TutorContext
+
+        defaults = {
+            "user_level": 2,
+            "user_language": "fr",
+            "user_country": "BF",
+        }
+        defaults.update(kwargs)
+        return TutorContext(**defaults)
+
+    def test_contains_anti_drift_instruction(self):
+        from app.api.v1.tutor_voice import _get_voice_mode_suffix
+
+        ctx = self._make_context(course_title="Santé Publique en Afrique de l'Ouest")
+        suffix = _get_voice_mode_suffix(ctx)
+        assert "BACKGROUND COLOUR ONLY" in suffix
+        assert "Do NOT bring up country-specific" in suffix or "ne pas" in suffix.lower()
+
+    def test_no_module_asks_for_topic(self):
+        from app.api.v1.tutor_voice import _get_voice_mode_suffix
+
+        ctx = self._make_context(course_title="Marketing Digital", module_title=None)
+        suffix = _get_voice_mode_suffix(ctx)
+        assert "Marketing Digital" in suffix
+
+    def test_with_module_anchors_to_module(self):
+        from app.api.v1.tutor_voice import _get_voice_mode_suffix
+
+        ctx = self._make_context(
+            course_title="Santé Publique",
+            module_title="Épidémiologie",
+            module_number=3,
+        )
+        suffix = _get_voice_mode_suffix(ctx)
+        assert "Épidémiologie" in suffix
+        assert "Santé Publique" in suffix
+
+    def test_en_suffix_uses_english_phrases(self):
+        from app.api.v1.tutor_voice import _get_voice_mode_suffix
+
+        ctx = self._make_context(user_language="en", course_title="Public Health")
+        suffix = _get_voice_mode_suffix(ctx)
+        assert "Public Health" in suffix
+
+    def test_fallback_course_label_when_no_title(self):
+        from app.api.v1.tutor_voice import _get_voice_mode_suffix
+
+        ctx = self._make_context(course_title=None)
+        suffix = _get_voice_mode_suffix(ctx)
+        assert "la formation en cours" in suffix
 
 
 class TestDurationClamp:

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslations, useLocale } from 'next-intl';
 import { track } from '@/lib/analytics';
 import { Link } from '@/i18n/routing';
-import { X, MoreVertical, Trash2, Menu, HelpCircle, BookOpen, GraduationCap, ChevronDown, Globe } from 'lucide-react';
+import { X, MoreVertical, Trash2, Menu, HelpCircle, BookOpen, GraduationCap, ChevronDown, Globe, Phone } from 'lucide-react';
 import { getMyEnrollments, type CourseWithEnrollment, API_BASE } from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import {
@@ -595,9 +595,15 @@ export function ChatPanel({
                 {activeCourseLabel}
               </span>
             ) : null}
-            {/* Voice-call button hidden until voice tutor has proper RAG
-                grounding (#1960). Backend endpoints stay live so existing
-                in-flight sessions complete cleanly. */}
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setShowVoiceCall(true)}
+              className="h-11 w-11"
+              title={t('voiceCall')}
+            >
+              <Phone className="h-4 w-4" />
+            </Button>
             <Button
               variant={tutorMode === 'socratic' ? 'default' : 'outline'}
               size="sm"

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -437,6 +437,7 @@
     "modeExplanatory": "Explanatory Mode",
     "modeSocraticTooltip": "Guided questions",
     "modeExplanatoryTooltip": "Direct answers",
+    "voiceCall": "Voice call",
     "fileUpload": {
       "attach": "Attach a file",
       "attachAriaLabel": "Attach a file",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -437,6 +437,7 @@
     "modeExplanatory": "Mode Explicatif",
     "modeSocraticTooltip": "Guidage par questions",
     "modeExplanatoryTooltip": "Réponses directes",
+    "voiceCall": "Appel vocal",
     "fileUpload": {
       "attach": "Joindre un fichier",
       "attachAriaLabel": "Joindre un fichier",


### PR DESCRIPTION
## Summary

- Replaces the static `_VOICE_MODE_SUFFIX` in `tutor_voice.py` with a dynamic `_get_voice_mode_suffix(context)` that:
  - Names the active course (and module, if selected) explicitly in the voice-call system prompt
  - Labels the country-context line as **background colour only** — model must not lead with country health priorities (e.g. "malnutrition for BF") unless the learner raises them
  - When no module is active, opens by asking which topic in the course the learner wants to explore
- Re-enables the Phone call button in `chat-panel.tsx` (previously hidden as a band-aid — comment referenced this issue)
- Adds `voiceCall` i18n key to FR/EN message files
- Adds 5 unit tests for `_get_voice_mode_suffix` covering FR/EN, with/without module, and fallback course label

## Root cause

The text tutor is grounded by RAG chunks + conversation history, so the "Focus paludisme, méningite, malnutrition" country-context line is just background. The voice tutor receives **only** the system prompt — no tool use, no history — so the model latches onto that specific disease list, producing off-topic monologues.

## Test plan

- [x] `uv run pytest tests/test_tutor_voice_session.py` → 15 passed (5 new)
- [x] `ruff check app/api/v1/tutor_voice.py` → all checks passed
- [ ] After staging deploy: start a voice call with course selected + country=BF → tutor should open with a Socratic question about the course, not malnutrition

Fixes #1960

🤖 Generated with [Claude Code](https://claude.com/claude-code)