### PR TITLE
chore(schemas): remove storage_url from SourceImageRef + tighten MinIO guardrail (#1610)

### DIFF
--- a/backend/app/api/v1/schemas/content.py
+++ b/backend/app/api/v1/schemas/content.py
@@ -30,7 +30,15 @@ class LessonGenerationRequest(BaseModel):
 
 
 class SourceImageRef(BaseModel):
-    """Reference to a source image extracted from a reference PDF."""
+    """Reference to a source image extracted from a reference PDF.
+
+    The frontend fetches the actual image bytes via
+    ``/api/v1/source-images/{id}/data?lang=<locale>`` — the ``id`` field is
+    the only locator needed.  Internal MinIO storage URLs are intentionally
+    absent from this schema so they never reach the browser (#1610).
+    """
+
+    model_config = {"extra": "ignore"}
 
     id: str = Field(..., description="UUID of the source image")
     figure_number: str | None = Field(None, description="Figure number e.g. '1.3'")
@@ -40,13 +48,6 @@ class SourceImageRef(BaseModel):
     attribution: str | None = Field(None, description="Source attribution text")
     image_type: str = Field(
         ..., description="Image type: diagram, photo, chart, formula, icon, unknown"
-    )
-    storage_url: str | None = Field(
-        None, description="CDN URL to the default (usually English) image"
-    )
-    storage_url_fr: str | None = Field(
-        None,
-        description="CDN URL to the French-variant image, when Phase 2 has produced one. NULL means the backend /data endpoint will fall back to storage_url for fr requests.",
     )
     alt_text_fr: str | None = Field(None, description="French alt text")
     alt_text_en: str | None = Field(None, description="English alt text")

--- a/backend/tests/test_no_minio_leaks_in_schemas.py
+++ b/backend/tests/test_no_minio_leaks_in_schemas.py
@@ -4,30 +4,25 @@ MinIO is private in prod (no Traefik route). Any field containing a raw
 storage URL or storage key serializes an internal Docker hostname to the
 browser. The fix pattern is to expose proxy URLs via /api/v1/.../data
 endpoints instead. This test fails any future schema that re-introduces
-the leak.
+the leak (#1610).
+
+Two rules enforced statically:
+1. No field named ``storage_url``, ``storage_key``, or ``minio_url``.
+2. No field whose *default* is a string matching ``http(s)?://.*minio``.
 """
 
 from __future__ import annotations
 
 import importlib
 import pkgutil
+import re
 
 import pydantic
 
 import app.api.v1.schemas as schemas_pkg
 
-FORBIDDEN_FIELD_NAMES = {"storage_url", "storage_key", "minio_url"}
-
-# Intentionally-allowed carry-overs: schemas where the field is kept on purpose.
-# Keyed by "module.ClassName" and accompanied by a comment explaining why. New
-# entries should be rare; prefer dropping the field and routing through a
-# /api/v1/.../data proxy endpoint (the pattern that closed #1603/#1628).
-ALLOWED_LEAKS: dict[str, set[str]] = {
-    # Retained per owner decision 2026-04-18: lesson output carries a CDN URL
-    # reference via SourceImageRef that the frontend renderer may consume
-    # directly. Byte streams still flow through /api/v1/source-images/{id}/data.
-    "app.api.v1.schemas.content.SourceImageRef": {"storage_url"},
-}
+FORBIDDEN_FIELD_NAMES = frozenset({"storage_url", "storage_key", "minio_url"})
+_MINIO_URL_RE = re.compile(r"https?://.*minio", re.IGNORECASE)
 
 
 def _walk_response_models() -> list[type[pydantic.BaseModel]]:
@@ -47,17 +42,35 @@ def _walk_response_models() -> list[type[pydantic.BaseModel]]:
 
 
 def test_no_storage_url_or_key_field_in_v1_schemas():
+    """No response schema should expose raw storage_url / storage_key / minio_url.
+
+    All known violations have been cleaned up:
+    - SourceImageRef.storage_url / storage_url_fr removed (#1610): frontend
+      uses /api/v1/source-images/{id}/data proxy URL via the ``id`` field.
+
+    If you need to add a truly exceptional allow-list entry, add it here with
+    a comment and owner sign-off.
+    """
     offenders = []
     for model in _walk_response_models():
         leaked = set(model.model_fields) & FORBIDDEN_FIELD_NAMES
-        key = f"{model.__module__}.{model.__name__}"
-        leaked -= ALLOWED_LEAKS.get(key, set())
         if leaked:
-            offenders.append(f"{key}: {sorted(leaked)}")
+            offenders.append(f"{model.__module__}.{model.__name__}: {sorted(leaked)}")
     assert not offenders, (
         "Response schemas must not expose internal storage URLs or keys. "
-        "Use /api/v1/.../data proxy endpoints instead. If a field is "
-        "intentionally retained, add it to ALLOWED_LEAKS with a comment "
-        "explaining why.\n"
+        "Use /api/v1/.../data proxy endpoints instead.\n"
         "Offenders:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_no_minio_url_as_default():
+    """No field default may hard-code an internal http://minio URL."""
+    offenders = []
+    for model in _walk_response_models():
+        for field_name, field_info in model.model_fields.items():
+            default = field_info.default
+            if isinstance(default, str) and _MINIO_URL_RE.search(default):
+                offenders.append(f"{model.__module__}.{model.__name__}.{field_name}: {default!r}")
+    assert not offenders, (
+        "Schema fields must not have internal MinIO URLs as defaults:\n  " + "\n  ".join(offenders)
     )


### PR DESCRIPTION
## Summary

- Removes `storage_url` and `storage_url_fr` from `SourceImageRef` Pydantic schema — the frontend already constructs image URLs via `/api/v1/source-images/{id}/data?lang=<locale>` using only the `id` field, so these fields were dead payload that could expose internal MinIO hostnames
- Adds `model_config = {"extra": "ignore"}` to `SourceImageRef` so service-layer code that still passes `storage_url=...` to the constructor doesn't crash (backward compat)
- Tightens `test_no_minio_leaks_in_schemas.py`:
  - Removes the `ALLOWED_LEAKS` exception for `SourceImageRef.storage_url` (now genuinely clean)
  - Adds `test_no_minio_url_as_default` — checks that no Pydantic default is a hard-coded `http(s)?://.*minio` URL
  - Both rules now pass with zero violations

## Test plan

- [x] `uv run pytest tests/test_no_minio_leaks_in_schemas.py` → 2 passed
- [x] `ruff check` + `ruff format --check` → clean
- [x] Frontend's `SourceImageMeta` interface already lacks `storage_url` — no frontend change needed

Fixes #1610

🤖 Generated with [Claude Code](https://claude.com/claude-code)