### PR TITLE
fix(tutor): strip trailing orphaned user turns to prevent cascade failure (Fixes #2385)

### DIFF
--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -2224,6 +2224,14 @@ class TutorService:
                     }
                 )
 
+        # Strip trailing orphaned user turns — messages persisted before a
+        # failed API call that never received an assistant reply (#2385).
+        # Anthropic requires strictly alternating user/assistant turns; leaving
+        # these in causes a 400 on the next request and creates an infinite
+        # retry cascade where every subsequent attempt also fails.
+        while claude_messages and claude_messages[-1]["role"] == "user":
+            claude_messages.pop()
+
         return claude_messages
 
     async def _persist_user_message(

--- a/backend/tests/test_tutor_compaction.py
+++ b/backend/tests/test_tutor_compaction.py
@@ -126,10 +126,12 @@ async def test_compact_summarize_up_to_constant():
 
 
 async def test_prepare_history_no_compact_returns_all_when_short(tutor_service, sample_user):
-    """With no compacted_context and a conversation under the cap, all messages are returned."""
-    conv = _make_conversation(sample_user.id, n_messages=15)
+    """With no compacted_context and a healthy conversation under the cap, all messages are
+    returned. Uses an even message count so the last turn is assistant (no orphaned user turn
+    to strip — see #2385)."""
+    conv = _make_conversation(sample_user.id, n_messages=14)
     history = await tutor_service._prepare_conversation_history(conv)
-    assert len(history) == 15
+    assert len(history) == 14
 
 
 async def test_prepare_history_no_compact_caps_long_conversation(tutor_service, sample_user):

--- a/backend/tests/test_tutor_service.py
+++ b/backend/tests/test_tutor_service.py
@@ -552,3 +552,80 @@ async def test_persist_user_message_commit_durability_invariant(tutor_service, s
 
     # commit() — not just flush() — is required for cross-session visibility.
     assert mock_session.commit.await_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# _prepare_conversation_history — orphaned user-turn guard (#2385)
+# ---------------------------------------------------------------------------
+
+
+async def test_prepare_conversation_history_strips_trailing_orphaned_user_turn(
+    tutor_service, sample_conversation
+):
+    """Orphaned user turn at the end (from a prior failed API call) must be
+    dropped so the Anthropic API never receives consecutive user messages."""
+    sample_conversation.messages = [
+        {"role": "user", "content": "Q1", "timestamp": "t0"},
+        {"role": "assistant", "content": "A1", "timestamp": "t1"},
+        # Orphaned: persisted before the API call that failed, no reply saved.
+        {"role": "user", "content": "Q2", "timestamp": "t2"},
+    ]
+    sample_conversation.compacted_context = None
+
+    result = await tutor_service._prepare_conversation_history(sample_conversation)
+
+    assert result[-1]["role"] == "assistant", (
+        "History must end with assistant turn so a new user message can be appended "
+        "without producing consecutive user messages (Anthropic 400)."
+    )
+    assert result[-1]["content"] == "A1"
+
+
+async def test_prepare_conversation_history_strips_multiple_trailing_orphaned_user_turns(
+    tutor_service, sample_conversation
+):
+    """Multiple orphaned user turns (from N failed retries) are all stripped."""
+    sample_conversation.messages = [
+        {"role": "user", "content": "Q1", "timestamp": "t0"},
+        {"role": "assistant", "content": "A1", "timestamp": "t1"},
+        {"role": "user", "content": "Q2_retry1", "timestamp": "t2"},
+        {"role": "user", "content": "Q2_retry2", "timestamp": "t3"},
+        {"role": "user", "content": "Q2_retry3", "timestamp": "t4"},
+    ]
+    sample_conversation.compacted_context = None
+
+    result = await tutor_service._prepare_conversation_history(sample_conversation)
+
+    assert result[-1]["role"] == "assistant"
+    assert result[-1]["content"] == "A1"
+    # Only the valid exchange survives
+    assert len(result) == 2
+
+
+async def test_prepare_conversation_history_empty_conversation(tutor_service, sample_conversation):
+    """Brand-new conversation with no messages returns empty list (not an error)."""
+    sample_conversation.messages = []
+    sample_conversation.compacted_context = None
+
+    result = await tutor_service._prepare_conversation_history(sample_conversation)
+
+    assert result == []
+
+
+async def test_prepare_conversation_history_preserves_healthy_history(
+    tutor_service, sample_conversation
+):
+    """Healthy alternating history is returned unchanged."""
+    sample_conversation.messages = [
+        {"role": "user", "content": "Q1", "timestamp": "t0"},
+        {"role": "assistant", "content": "A1", "timestamp": "t1"},
+        {"role": "user", "content": "Q2", "timestamp": "t2"},
+        {"role": "assistant", "content": "A2", "timestamp": "t3"},
+    ]
+    sample_conversation.compacted_context = None
+
+    result = await tutor_service._prepare_conversation_history(sample_conversation)
+
+    assert len(result) == 4
+    assert result[-1]["role"] == "assistant"
+    assert result[-1]["content"] == "A2"


### PR DESCRIPTION
## Summary

- **Root cause:** `_persist_user_message` saves the user turn to DB *before* the Anthropic API call. When the API fails, that turn is persisted with no assistant reply. On retry the client sends the same `conversation_id`, so `_prepare_conversation_history` includes the orphaned turn immediately before the new user message — two consecutive user-role messages that Anthropic rejects with a 400. Each retry adds another orphaned turn, making recovery permanent.
- **Fix:** Added a while-loop guard at the end of `_prepare_conversation_history` that strips any trailing user-role messages before the list is passed to the API. Healthy conversations always end with an assistant turn and are unaffected. Already-corrupted conversations self-heal on the next retry.
- **No schema change, no data migration** — orphaned messages stay in the DB (for display), they're just excluded from the Claude payload.

## Test plan

- [ ] `pytest tests/test_tutor_service.py tests/test_tutor_compaction.py` → 32 passed, 0 failed
- [ ] Four new regression tests cover: single orphaned turn, multiple orphaned turns, empty conversation, healthy conversation
- [ ] Updated `test_prepare_history_no_compact_returns_all_when_short` to use even message count (ends with assistant) — the old n=15 ended with a user turn, which the guard now strips (correct behavior, wrong test setup)
- [ ] On staging: open the broken conversation ("Pourquoi on parle de ratio…"), send a message, expect normal response

🤖 Generated with [Claude Code](https://claude.com/claude-code)