### PR TITLE
fix(schemas): remove storage_url from SourceImageRef call sites (Fixes #2388)

### DIFF
--- a/backend/app/domain/services/lesson_service.py
+++ b/backend/app/domain/services/lesson_service.py
@@ -442,8 +442,6 @@ class LessonGenerationService:
                     caption_en=db_img.caption_en or caption,
                     attribution=db_img.attribution or ref.attribution,
                     image_type=db_img.image_type or ref.image_type,
-                    storage_url=db_img.storage_url or ref.storage_url,
-                    storage_url_fr=db_img.storage_url_fr or ref.storage_url_fr,
                     alt_text_fr=db_img.alt_text_fr or ref.alt_text_fr,
                     alt_text_en=db_img.alt_text_en or ref.alt_text_en,
                 )
@@ -895,8 +893,6 @@ class LessonGenerationService:
                         caption_en=img.get("caption_en") or img.get("caption"),
                         attribution=img.get("attribution"),
                         image_type=img.get("image_type") or "unknown",
-                        storage_url=img.get("storage_url"),
-                        storage_url_fr=img.get("storage_url_fr"),
                         alt_text_fr=img.get("alt_text_fr"),
                         alt_text_en=img.get("alt_text_en"),
                     )

--- a/backend/tests/test_source_image_injection.py
+++ b/backend/tests/test_source_image_injection.py
@@ -158,7 +158,6 @@ class TestSourceImageRefSchema:
         ref = SourceImageRef(id=str(uuid.uuid4()), image_type="photo")
         assert ref.figure_number is None
         assert ref.caption is None
-        assert ref.storage_url is None
         assert ref.alt_text_fr is None
         assert ref.alt_text_en is None
 
@@ -276,7 +275,6 @@ class TestExtractSourceImageRefs:
         assert result[0].figure_number == "3.1"
         assert result[0].caption == "A diagram"
         assert result[0].image_type == "diagram"
-        assert result[0].storage_url == "https://cdn.example.com/x.webp"
         assert result[0].alt_text_fr == "Diag FR"
         assert result[0].alt_text_en == "Diag EN"
 
@@ -462,62 +460,3 @@ class TestRehydrateSourceImageRefs:
         out = await LessonGenerationService._rehydrate_source_image_refs(cached, session)
         assert len(out) == 2  # second entry skipped entirely; third parsed but no DB overlay
 
-    async def test_overlays_storage_url_fr_from_db(self):
-        img_id = uuid.uuid4()
-        cached = [
-            {
-                "id": str(img_id),
-                "caption": "English caption",
-                "image_type": "diagram",
-                "storage_url": "https://cdn.example.com/default.webp",
-                "storage_url_fr": None,
-            }
-        ]
-        db_row = _make_db_image(
-            img_id,
-            storage_url="https://cdn.example.com/default.webp",
-            storage_url_fr="https://cdn.example.com/fr.webp",
-        )
-        session = _FakeSession([db_row])
-        out = await LessonGenerationService._rehydrate_source_image_refs(cached, session)
-        assert out[0].storage_url_fr == "https://cdn.example.com/fr.webp"
-
-    async def test_storage_url_fr_null_when_no_french_variant(self):
-        img_id = uuid.uuid4()
-        cached = [
-            {
-                "id": str(img_id),
-                "caption": "English caption",
-                "image_type": "diagram",
-                "storage_url": "https://cdn.example.com/default.webp",
-            }
-        ]
-        db_row = _make_db_image(img_id, storage_url_fr=None)
-        session = _FakeSession([db_row])
-        out = await LessonGenerationService._rehydrate_source_image_refs(cached, session)
-        assert out[0].storage_url_fr is None
-
-
-class TestExtractSourceImageRefsStorageUrlFr:
-    async def test_storage_url_fr_passed_through_from_img_meta(self):
-        img_id = str(uuid.uuid4())
-        text = f"{{{{source_image:{img_id}}}}}"
-        img_meta = _make_image_meta(
-            img_id=uuid.UUID(img_id),
-            storage_url="https://cdn.example.com/default.webp",
-            storage_url_fr="https://cdn.example.com/fr.webp",
-        )
-        linked = {uuid.uuid4(): [img_meta]}
-        result = await LessonGenerationService._extract_source_image_refs(text, linked)
-        assert result[0].storage_url_fr == "https://cdn.example.com/fr.webp"
-
-    async def test_storage_url_fr_null_when_not_in_meta(self):
-        img_id = str(uuid.uuid4())
-        text = f"{{{{source_image:{img_id}}}}}"
-        img_meta = _make_image_meta(
-            img_id=uuid.UUID(img_id),
-            storage_url="https://cdn.example.com/default.webp",
-        )
-        linked = {uuid.uuid4(): [img_meta]}
-        result = await LessonGenerationService._extract_source_image_refs(text, linked)
-        assert result[0].storage_url_fr is None


### PR DESCRIPTION
## Summary

- PR #1610 removed `storage_url` and `storage_url_fr` from `SourceImageRef` to prevent MinIO URLs reaching the browser, but two sites in `lesson_service.py` still read `ref.storage_url` / `ref.storage_url_fr` from existing `SourceImageRef` objects, causing `AttributeError` at runtime in `_rehydrate_source_image_refs` and `_extract_source_image_refs`.
- Removed the two `storage_url`/`storage_url_fr` kwargs from both `SourceImageRef(...)` constructor call sites (`extra="ignore"` already silently dropped them, so this is safe).
- Dropped 4 test assertions/tests in `test_source_image_injection.py` that asserted the now-deleted fields.

## Test plan

- [ ] `pytest tests/test_source_image_injection.py` → 27 passed, 0 failed
- [ ] CI Backend (Python) was the only failing check on dev; this PR fixes that blocker

🤖 Generated with [Claude Code](https://claude.com/claude-code)