### PR TITLE
style: ruff format test_source_image_injection.py

### DIFF
--- a/backend/tests/test_source_image_injection.py
+++ b/backend/tests/test_source_image_injection.py
@@ -459,4 +459,3 @@ class TestRehydrateSourceImageRefs:
         session = _FakeSession([])
         out = await LessonGenerationService._rehydrate_source_image_refs(cached, session)
         assert len(out) == 2  # second entry skipped entirely; third parsed but no DB overlay
-


### PR DESCRIPTION
Formatting-only follow-up to #2389. The ruff format check failed because
deleting the storage_url test blocks left trailing blank lines that ruff
requires to be removed. No logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)