### PR TITLE
sync: dev → main

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -16,6 +16,9 @@ from app.api.v1.admin_taxonomy import router as admin_taxonomy_router
 from app.api.v1.analytics import router as analytics_router
 from app.api.v1.certificates import router as certificates_router
 from app.api.v1.content import router as content_router
+from app.api.v1.course_bundles import (
+    router as course_bundles_router,
+)
 from app.api.v1.course_preassessment import router as course_preassessment_router
 from app.api.v1.courses import router as courses_router
 from app.api.v1.curricula import router as curricula_router
@@ -85,3 +88,4 @@ api_v1_router.include_router(org_codes_router)
 api_v1_router.include_router(org_reports_router)
 api_v1_router.include_router(qbank_router)
 api_v1_router.include_router(certificates_router)
+api_v1_router.include_router(course_bundles_router)

--- a/backend/app/api/v1/schemas/content.py
+++ b/backend/app/api/v1/schemas/content.py
@@ -30,7 +30,15 @@ class LessonGenerationRequest(BaseModel):
 
 
 class SourceImageRef(BaseModel):
-    """Reference to a source image extracted from a reference PDF."""
+    """Reference to a source image extracted from a reference PDF.
+
+    The frontend fetches the actual image bytes via
+    ``/api/v1/source-images/{id}/data?lang=<locale>`` — the ``id`` field is
+    the only locator needed.  Internal MinIO storage URLs are intentionally
+    absent from this schema so they never reach the browser (#1610).
+    """
+
+    model_config = {"extra": "ignore"}
 
     id: str = Field(..., description="UUID of the source image")
     figure_number: str | None = Field(None, description="Figure number e.g. '1.3'")
@@ -40,13 +48,6 @@ class SourceImageRef(BaseModel):
     attribution: str | None = Field(None, description="Source attribution text")
     image_type: str = Field(
         ..., description="Image type: diagram, photo, chart, formula, icon, unknown"
-    )
-    storage_url: str | None = Field(
-        None, description="CDN URL to the default (usually English) image"
-    )
-    storage_url_fr: str | None = Field(
-        None,
-        description="CDN URL to the French-variant image, when Phase 2 has produced one. NULL means the backend /data endpoint will fall back to storage_url for fr requests.",
     )
     alt_text_fr: str | None = Field(None, description="French alt text")
     alt_text_en: str | None = Field(None, description="English alt text")

--- a/backend/app/api/v1/tutor_voice.py
+++ b/backend/app/api/v1/tutor_voice.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
 
 import httpx
 import structlog
@@ -22,6 +23,9 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.ai.prompts.tutor import get_socratic_system_prompt
+
+if TYPE_CHECKING:
+    from app.ai.prompts.tutor import TutorContext
 from app.api.deps import get_db_session
 from app.api.deps_local_auth import AuthenticatedUser, get_current_user
 from app.api.v1.schemas.tutor_voice import (
@@ -192,7 +196,40 @@ async def _minutes_used_today(user_id: uuid.UUID, db: AsyncSession) -> int:
     return (int(seconds) + 59) // 60
 
 
-_VOICE_MODE_SUFFIX = """
+def _get_voice_mode_suffix(context: TutorContext) -> str:
+    """Build the voice-call suffix injected after the main system prompt.
+
+    The text tutor is grounded by RAG chunks + conversation history, so the
+    country-context line ("Focus paludisme, méningite, malnutrition") is just
+    background colour.  The voice tutor has NEITHER — it gets only the system
+    prompt — so the model latches onto the specific topics it names.  This
+    suffix explicitly anchors the session to the current course/module and
+    blocks country-topic drift (#1960).
+    """
+    course_label = context.course_title or "la formation en cours"
+    if context.module_title:
+        module_ref = (
+            f"Module {context.module_number}: {context.module_title}"
+            if context.module_number
+            else context.module_title
+        )
+        opening_directive = (
+            f"Open by welcoming the learner and asking one Socratic question "
+            f"grounded in {module_ref} of the course «{course_label}»."
+            if context.user_language != "fr"
+            else f"Commence par accueillir l'apprenant et pose une question "
+            f"socratique ancrée dans le {module_ref} du cours «{course_label}»."
+        )
+    else:
+        opening_directive = (
+            f"Open by welcoming the learner and asking which topic within "
+            f"«{course_label}» they'd like to explore today."
+            if context.user_language != "fr"
+            else f"Commence par accueillir l'apprenant et demande-lui quel "
+            f"sujet du cours «{course_label}» il souhaite explorer aujourd'hui."
+        )
+
+    return f"""
 
 ## Voice-call mode (spoken output)
 
@@ -201,7 +238,17 @@ You are now in a **live voice call** with the learner. Adapt your responses:
 - Use natural spoken phrasing. Do not use markdown, bullet points, or source_image markers.
 - Still follow the Socratic pedagogy above: ask probing questions, guide rather than lecture.
 - If you'd normally cite a source, say it briefly in speech ("as covered in Chapter 4") rather than a formal citation.
-- If the learner asks you to speak louder / slower / in a different language, acknowledge and comply."""
+- If the learner asks you to speak louder / slower / in a different language, acknowledge and comply.
+
+## Voice-call anchoring (CRITICAL — override country-context drift)
+
+{opening_directive}
+
+- **Every reply MUST stay anchored in «{course_label}»** and what the learner just said.
+- The "Pays" line above (e.g. "Focus paludisme, méningite, malnutrition") is BACKGROUND COLOUR ONLY. \
+Do NOT bring up country-specific health priorities, diseases, or statistics unless the learner \
+explicitly asks about them. Treat them as reference material, not a conversation starter.
+- If the learner's message is off-topic, gently redirect to the course content with a question."""
 
 
 @router.post("/voice-session", response_model=VoiceSessionResponse)
@@ -249,7 +296,7 @@ async def create_voice_session(
         locale=body.locale,
         session=db,
     )
-    instructions = get_socratic_system_prompt(context, []) + _VOICE_MODE_SUFFIX
+    instructions = get_socratic_system_prompt(context, []) + _get_voice_mode_suffix(context)
 
     voice = "alloy" if body.locale == "en" else "shimmer"
     openai_payload: dict[str, object] = {

--- a/backend/app/domain/models/__init__.py
+++ b/backend/app/domain/models/__init__.py
@@ -6,6 +6,7 @@ from app.domain.models.certificate import Certificate, CertificateTemplate
 from app.domain.models.content import GeneratedContent
 from app.domain.models.conversation import TutorConversation, TutorMessage
 from app.domain.models.course import Course, UserCourseEnrollment
+from app.domain.models.course_bundle import CourseBundle
 from app.domain.models.course_quality import (
     CourseGlossaryTerm,
     CourseQualityRun,
@@ -70,6 +71,7 @@ __all__ = [
     "Certificate",
     "CertificateTemplate",
     "Course",
+    "CourseBundle",
     "CourseGlossaryTerm",
     "CoursePreAssessment",
     "CourseQualityRun",

--- a/backend/app/domain/services/lesson_service.py
+++ b/backend/app/domain/services/lesson_service.py
@@ -442,8 +442,6 @@ class LessonGenerationService:
                     caption_en=db_img.caption_en or caption,
                     attribution=db_img.attribution or ref.attribution,
                     image_type=db_img.image_type or ref.image_type,
-                    storage_url=db_img.storage_url or ref.storage_url,
-                    storage_url_fr=db_img.storage_url_fr or ref.storage_url_fr,
                     alt_text_fr=db_img.alt_text_fr or ref.alt_text_fr,
                     alt_text_en=db_img.alt_text_en or ref.alt_text_en,
                 )
@@ -895,8 +893,6 @@ class LessonGenerationService:
                         caption_en=img.get("caption_en") or img.get("caption"),
                         attribution=img.get("attribution"),
                         image_type=img.get("image_type") or "unknown",
-                        storage_url=img.get("storage_url"),
-                        storage_url_fr=img.get("storage_url_fr"),
                         alt_text_fr=img.get("alt_text_fr"),
                         alt_text_en=img.get("alt_text_en"),
                     )

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -2224,6 +2224,14 @@ class TutorService:
                     }
                 )
 
+        # Strip trailing orphaned user turns — messages persisted before a
+        # failed API call that never received an assistant reply (#2385).
+        # Anthropic requires strictly alternating user/assistant turns; leaving
+        # these in causes a 400 on the next request and creates an infinite
+        # retry cascade where every subsequent attempt also fails.
+        while claude_messages and claude_messages[-1]["role"] == "user":
+            claude_messages.pop()
+
         return claude_messages
 
     async def _persist_user_message(

--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -31,6 +31,7 @@ celery_app = Celery(
         "app.tasks.syllabus_generation",
         "app.tasks.subscription",
         "app.tasks.sms_relay",
+        "app.tasks.course_bundle",
     ],
 )
 

--- a/backend/scripts/backfill_chunk_pages.py
+++ b/backend/scripts/backfill_chunk_pages.py
@@ -1,0 +1,234 @@
+"""Backfill ``document_chunks.page`` for legacy RAG collections (#2058).
+
+Chunks indexed before per-page chunking (#2039) have ``page=NULL``.  The
+contextual image linker (``image_linker._build_contextual_pairs``) joins on
+``chunk.page == image.page_number``; without page values that path yields zero
+pairs regardless of how many images exist.
+
+Approach (Option A — position-matched rewrite):
+  For each PDF on disk, extract text per page (``extract_pages_from_pdf``),
+  re-chunk each page with the same ``TextChunker`` settings, then match each
+  new chunk back to an existing DB row by content-prefix fingerprint and write
+  the page number.  Content and embeddings are never changed.
+
+Usage:
+    cd backend
+    python scripts/backfill_chunk_pages.py                      # dry-run ALL
+    python scripts/backfill_chunk_pages.py --apply              # apply ALL
+    python scripts/backfill_chunk_pages.py --rag-collection-id <id>
+    python scripts/backfill_chunk_pages.py --rag-collection-id <id> --apply
+
+Idempotent: only processes chunks with ``page IS NULL``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+UPLOAD_DIR = Path("uploads/course_resources")
+_FINGERPRINT_LEN = 150
+_WHITESPACE = re.compile(r"\s+")
+
+
+def _fingerprint(content: str) -> str:
+    """Normalised prefix used for fuzzy content matching."""
+    normalised = _WHITESPACE.sub(" ", content.lower()).strip()
+    return normalised[:_FINGERPRINT_LEN]
+
+
+async def _backfill_collection(
+    session: AsyncSession,
+    course_id: str,
+    rag_collection_id: str,
+    apply: bool,
+) -> dict[str, int]:
+    """Backfill page values for chunks in one RAG collection.
+
+    Returns a stats dict: rewritten / unmatched / skipped.
+    """
+    stats = {"rewritten": 0, "unmatched": 0, "skipped": 0}
+
+    # Only act on NULL-page chunks.
+    chunk_rows = (
+        await session.execute(
+            text(
+                "SELECT id, content FROM document_chunks "
+                "WHERE source = :src AND page IS NULL "
+                "ORDER BY id"
+            ),
+            {"src": rag_collection_id},
+        )
+    ).all()
+
+    if not chunk_rows:
+        return stats
+
+    stats["skipped"] = len(chunk_rows)  # will subtract matched below
+
+    course_dir = UPLOAD_DIR / course_id
+    pdf_files = sorted(course_dir.glob("*.pdf")) if course_dir.exists() else []
+
+    if not pdf_files:
+        # No PDFs on disk — cannot determine page numbers.  Report all as unmatched.
+        stats["skipped"] = 0
+        stats["unmatched"] = len(chunk_rows)
+        return stats
+
+    # Build fingerprint → page map from all PDFs in the course directory.
+    from app.ai.rag.chunker import TextChunker, extract_pages_from_pdf
+
+    chunker = TextChunker()
+    fingerprint_to_page: dict[str, int] = {}
+
+    for pdf_path in pdf_files:
+        try:
+            pages = extract_pages_from_pdf(str(pdf_path))
+        except Exception as exc:
+            print(f"    WARN: cannot read {pdf_path.name}: {exc}")
+            continue
+
+        for page_num, page_text in pages:
+            if not page_text.strip():
+                continue
+            for chunk in chunker.chunk_document(
+                text=page_text,
+                source=rag_collection_id,
+                page=page_num,
+            ):
+                fp = _fingerprint(chunk.content)
+                if fp and fp not in fingerprint_to_page:
+                    fingerprint_to_page[fp] = page_num
+
+    if not fingerprint_to_page:
+        stats["skipped"] = 0
+        stats["unmatched"] = len(chunk_rows)
+        return stats
+
+    # Match existing chunks to pages.
+    updates: dict[int, list[str]] = {}  # page_num -> [chunk_id, ...]
+    unmatched_ids: list[str] = []
+
+    for chunk_id, content in chunk_rows:
+        fp = _fingerprint(content)
+        page = fingerprint_to_page.get(fp)
+        if page is not None:
+            updates.setdefault(page, []).append(str(chunk_id))
+        else:
+            unmatched_ids.append(str(chunk_id))
+
+    stats["rewritten"] = sum(len(ids) for ids in updates.values())
+    stats["unmatched"] = len(unmatched_ids)
+    stats["skipped"] = 0
+
+    if apply and updates:
+        for page_num, chunk_ids in updates.items():
+            await session.execute(
+                text(
+                    "UPDATE document_chunks SET page = :page WHERE id = ANY(:ids) AND page IS NULL"
+                ),
+                {"page": page_num, "ids": chunk_ids},
+            )
+        await session.commit()
+
+    return stats
+
+
+async def main(rag_collection_filter: str | None, apply: bool) -> int:
+    database_url = os.environ.get(
+        "DATABASE_URL",
+        "postgresql+asyncpg://postgres:postgres@localhost:5432/santepublique",
+    )
+    if database_url.startswith("postgresql://"):
+        database_url = database_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+
+    engine = create_async_engine(database_url)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    mode = "APPLY" if apply else "DRY-RUN"
+    print(f"backfill_chunk_pages — {mode}")
+    print("-" * 60)
+
+    totals = {"rewritten": 0, "unmatched": 0, "skipped": 0}
+
+    async with async_session() as session:
+        if rag_collection_filter:
+            # Single collection — find its course_id.
+            row = (
+                await session.execute(
+                    text("SELECT id FROM courses WHERE rag_collection_id = :rag LIMIT 1"),
+                    {"rag": rag_collection_filter},
+                )
+            ).first()
+            if row is None:
+                print(f"No course found for rag_collection_id={rag_collection_filter!r}")
+                return 1
+            collections = [(str(row[0]), rag_collection_filter)]
+        else:
+            # All courses that have any NULL-page chunks.
+            rows = (
+                await session.execute(
+                    text(
+                        "SELECT DISTINCT c.id, c.rag_collection_id "
+                        "FROM courses c "
+                        "JOIN document_chunks dc ON dc.source = c.rag_collection_id "
+                        "WHERE c.rag_collection_id IS NOT NULL AND dc.page IS NULL"
+                    )
+                )
+            ).all()
+            collections = [(str(r[0]), r[1]) for r in rows]
+
+    print(f"Collections to process: {len(collections)}")
+    print()
+
+    for course_id, rag_collection_id in collections:
+        print(f"  course={course_id}  collection={rag_collection_id}")
+        async with async_session() as session:
+            stats = await _backfill_collection(session, course_id, rag_collection_id, apply)
+        print(
+            f"    rewritten={stats['rewritten']}  "
+            f"unmatched={stats['unmatched']}  "
+            f"skipped={stats['skipped']}"
+        )
+        for key in totals:
+            totals[key] += stats[key]
+
+    print()
+    print("-" * 60)
+    print(
+        f"TOTAL  rewritten={totals['rewritten']}  "
+        f"unmatched={totals['unmatched']}  "
+        f"skipped={totals['skipped']}"
+    )
+    if not apply:
+        print()
+        print("Dry-run complete. Re-run with --apply to write changes.")
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--rag-collection-id",
+        help="Process only this RAG collection (default: all collections with NULL-page chunks)",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        default=False,
+        help="Write changes to DB (default is dry-run)",
+    )
+    args = parser.parse_args()
+    sys.exit(asyncio.run(main(args.rag_collection_id, args.apply)))

--- a/backend/tests/test_no_minio_leaks_in_schemas.py
+++ b/backend/tests/test_no_minio_leaks_in_schemas.py
@@ -4,30 +4,25 @@ MinIO is private in prod (no Traefik route). Any field containing a raw
 storage URL or storage key serializes an internal Docker hostname to the
 browser. The fix pattern is to expose proxy URLs via /api/v1/.../data
 endpoints instead. This test fails any future schema that re-introduces
-the leak.
+the leak (#1610).
+
+Two rules enforced statically:
+1. No field named ``storage_url``, ``storage_key``, or ``minio_url``.
+2. No field whose *default* is a string matching ``http(s)?://.*minio``.
 """
 
 from __future__ import annotations
 
 import importlib
 import pkgutil
+import re
 
 import pydantic
 
 import app.api.v1.schemas as schemas_pkg
 
-FORBIDDEN_FIELD_NAMES = {"storage_url", "storage_key", "minio_url"}
-
-# Intentionally-allowed carry-overs: schemas where the field is kept on purpose.
-# Keyed by "module.ClassName" and accompanied by a comment explaining why. New
-# entries should be rare; prefer dropping the field and routing through a
-# /api/v1/.../data proxy endpoint (the pattern that closed #1603/#1628).
-ALLOWED_LEAKS: dict[str, set[str]] = {
-    # Retained per owner decision 2026-04-18: lesson output carries a CDN URL
-    # reference via SourceImageRef that the frontend renderer may consume
-    # directly. Byte streams still flow through /api/v1/source-images/{id}/data.
-    "app.api.v1.schemas.content.SourceImageRef": {"storage_url"},
-}
+FORBIDDEN_FIELD_NAMES = frozenset({"storage_url", "storage_key", "minio_url"})
+_MINIO_URL_RE = re.compile(r"https?://.*minio", re.IGNORECASE)
 
 
 def _walk_response_models() -> list[type[pydantic.BaseModel]]:
@@ -47,17 +42,35 @@ def _walk_response_models() -> list[type[pydantic.BaseModel]]:
 
 
 def test_no_storage_url_or_key_field_in_v1_schemas():
+    """No response schema should expose raw storage_url / storage_key / minio_url.
+
+    All known violations have been cleaned up:
+    - SourceImageRef.storage_url / storage_url_fr removed (#1610): frontend
+      uses /api/v1/source-images/{id}/data proxy URL via the ``id`` field.
+
+    If you need to add a truly exceptional allow-list entry, add it here with
+    a comment and owner sign-off.
+    """
     offenders = []
     for model in _walk_response_models():
         leaked = set(model.model_fields) & FORBIDDEN_FIELD_NAMES
-        key = f"{model.__module__}.{model.__name__}"
-        leaked -= ALLOWED_LEAKS.get(key, set())
         if leaked:
-            offenders.append(f"{key}: {sorted(leaked)}")
+            offenders.append(f"{model.__module__}.{model.__name__}: {sorted(leaked)}")
     assert not offenders, (
         "Response schemas must not expose internal storage URLs or keys. "
-        "Use /api/v1/.../data proxy endpoints instead. If a field is "
-        "intentionally retained, add it to ALLOWED_LEAKS with a comment "
-        "explaining why.\n"
+        "Use /api/v1/.../data proxy endpoints instead.\n"
         "Offenders:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_no_minio_url_as_default():
+    """No field default may hard-code an internal http://minio URL."""
+    offenders = []
+    for model in _walk_response_models():
+        for field_name, field_info in model.model_fields.items():
+            default = field_info.default
+            if isinstance(default, str) and _MINIO_URL_RE.search(default):
+                offenders.append(f"{model.__module__}.{model.__name__}.{field_name}: {default!r}")
+    assert not offenders, (
+        "Schema fields must not have internal MinIO URLs as defaults:\n  " + "\n  ".join(offenders)
     )

--- a/backend/tests/test_source_image_injection.py
+++ b/backend/tests/test_source_image_injection.py
@@ -158,7 +158,6 @@ class TestSourceImageRefSchema:
         ref = SourceImageRef(id=str(uuid.uuid4()), image_type="photo")
         assert ref.figure_number is None
         assert ref.caption is None
-        assert ref.storage_url is None
         assert ref.alt_text_fr is None
         assert ref.alt_text_en is None
 
@@ -276,7 +275,6 @@ class TestExtractSourceImageRefs:
         assert result[0].figure_number == "3.1"
         assert result[0].caption == "A diagram"
         assert result[0].image_type == "diagram"
-        assert result[0].storage_url == "https://cdn.example.com/x.webp"
         assert result[0].alt_text_fr == "Diag FR"
         assert result[0].alt_text_en == "Diag EN"
 
@@ -461,63 +459,3 @@ class TestRehydrateSourceImageRefs:
         session = _FakeSession([])
         out = await LessonGenerationService._rehydrate_source_image_refs(cached, session)
         assert len(out) == 2  # second entry skipped entirely; third parsed but no DB overlay
-
-    async def test_overlays_storage_url_fr_from_db(self):
-        img_id = uuid.uuid4()
-        cached = [
-            {
-                "id": str(img_id),
-                "caption": "English caption",
-                "image_type": "diagram",
-                "storage_url": "https://cdn.example.com/default.webp",
-                "storage_url_fr": None,
-            }
-        ]
-        db_row = _make_db_image(
-            img_id,
-            storage_url="https://cdn.example.com/default.webp",
-            storage_url_fr="https://cdn.example.com/fr.webp",
-        )
-        session = _FakeSession([db_row])
-        out = await LessonGenerationService._rehydrate_source_image_refs(cached, session)
-        assert out[0].storage_url_fr == "https://cdn.example.com/fr.webp"
-
-    async def test_storage_url_fr_null_when_no_french_variant(self):
-        img_id = uuid.uuid4()
-        cached = [
-            {
-                "id": str(img_id),
-                "caption": "English caption",
-                "image_type": "diagram",
-                "storage_url": "https://cdn.example.com/default.webp",
-            }
-        ]
-        db_row = _make_db_image(img_id, storage_url_fr=None)
-        session = _FakeSession([db_row])
-        out = await LessonGenerationService._rehydrate_source_image_refs(cached, session)
-        assert out[0].storage_url_fr is None
-
-
-class TestExtractSourceImageRefsStorageUrlFr:
-    async def test_storage_url_fr_passed_through_from_img_meta(self):
-        img_id = str(uuid.uuid4())
-        text = f"{{{{source_image:{img_id}}}}}"
-        img_meta = _make_image_meta(
-            img_id=uuid.UUID(img_id),
-            storage_url="https://cdn.example.com/default.webp",
-            storage_url_fr="https://cdn.example.com/fr.webp",
-        )
-        linked = {uuid.uuid4(): [img_meta]}
-        result = await LessonGenerationService._extract_source_image_refs(text, linked)
-        assert result[0].storage_url_fr == "https://cdn.example.com/fr.webp"
-
-    async def test_storage_url_fr_null_when_not_in_meta(self):
-        img_id = str(uuid.uuid4())
-        text = f"{{{{source_image:{img_id}}}}}"
-        img_meta = _make_image_meta(
-            img_id=uuid.UUID(img_id),
-            storage_url="https://cdn.example.com/default.webp",
-        )
-        linked = {uuid.uuid4(): [img_meta]}
-        result = await LessonGenerationService._extract_source_image_refs(text, linked)
-        assert result[0].storage_url_fr is None

--- a/backend/tests/test_tutor_compaction.py
+++ b/backend/tests/test_tutor_compaction.py
@@ -126,10 +126,12 @@ async def test_compact_summarize_up_to_constant():
 
 
 async def test_prepare_history_no_compact_returns_all_when_short(tutor_service, sample_user):
-    """With no compacted_context and a conversation under the cap, all messages are returned."""
-    conv = _make_conversation(sample_user.id, n_messages=15)
+    """With no compacted_context and a healthy conversation under the cap, all messages are
+    returned. Uses an even message count so the last turn is assistant (no orphaned user turn
+    to strip — see #2385)."""
+    conv = _make_conversation(sample_user.id, n_messages=14)
     history = await tutor_service._prepare_conversation_history(conv)
-    assert len(history) == 15
+    assert len(history) == 14
 
 
 async def test_prepare_history_no_compact_caps_long_conversation(tutor_service, sample_user):

--- a/backend/tests/test_tutor_service.py
+++ b/backend/tests/test_tutor_service.py
@@ -552,3 +552,80 @@ async def test_persist_user_message_commit_durability_invariant(tutor_service, s
 
     # commit() — not just flush() — is required for cross-session visibility.
     assert mock_session.commit.await_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# _prepare_conversation_history — orphaned user-turn guard (#2385)
+# ---------------------------------------------------------------------------
+
+
+async def test_prepare_conversation_history_strips_trailing_orphaned_user_turn(
+    tutor_service, sample_conversation
+):
+    """Orphaned user turn at the end (from a prior failed API call) must be
+    dropped so the Anthropic API never receives consecutive user messages."""
+    sample_conversation.messages = [
+        {"role": "user", "content": "Q1", "timestamp": "t0"},
+        {"role": "assistant", "content": "A1", "timestamp": "t1"},
+        # Orphaned: persisted before the API call that failed, no reply saved.
+        {"role": "user", "content": "Q2", "timestamp": "t2"},
+    ]
+    sample_conversation.compacted_context = None
+
+    result = await tutor_service._prepare_conversation_history(sample_conversation)
+
+    assert result[-1]["role"] == "assistant", (
+        "History must end with assistant turn so a new user message can be appended "
+        "without producing consecutive user messages (Anthropic 400)."
+    )
+    assert result[-1]["content"] == "A1"
+
+
+async def test_prepare_conversation_history_strips_multiple_trailing_orphaned_user_turns(
+    tutor_service, sample_conversation
+):
+    """Multiple orphaned user turns (from N failed retries) are all stripped."""
+    sample_conversation.messages = [
+        {"role": "user", "content": "Q1", "timestamp": "t0"},
+        {"role": "assistant", "content": "A1", "timestamp": "t1"},
+        {"role": "user", "content": "Q2_retry1", "timestamp": "t2"},
+        {"role": "user", "content": "Q2_retry2", "timestamp": "t3"},
+        {"role": "user", "content": "Q2_retry3", "timestamp": "t4"},
+    ]
+    sample_conversation.compacted_context = None
+
+    result = await tutor_service._prepare_conversation_history(sample_conversation)
+
+    assert result[-1]["role"] == "assistant"
+    assert result[-1]["content"] == "A1"
+    # Only the valid exchange survives
+    assert len(result) == 2
+
+
+async def test_prepare_conversation_history_empty_conversation(tutor_service, sample_conversation):
+    """Brand-new conversation with no messages returns empty list (not an error)."""
+    sample_conversation.messages = []
+    sample_conversation.compacted_context = None
+
+    result = await tutor_service._prepare_conversation_history(sample_conversation)
+
+    assert result == []
+
+
+async def test_prepare_conversation_history_preserves_healthy_history(
+    tutor_service, sample_conversation
+):
+    """Healthy alternating history is returned unchanged."""
+    sample_conversation.messages = [
+        {"role": "user", "content": "Q1", "timestamp": "t0"},
+        {"role": "assistant", "content": "A1", "timestamp": "t1"},
+        {"role": "user", "content": "Q2", "timestamp": "t2"},
+        {"role": "assistant", "content": "A2", "timestamp": "t3"},
+    ]
+    sample_conversation.compacted_context = None
+
+    result = await tutor_service._prepare_conversation_history(sample_conversation)
+
+    assert len(result) == 4
+    assert result[-1]["role"] == "assistant"
+    assert result[-1]["content"] == "A2"

--- a/backend/tests/test_tutor_voice_session.py
+++ b/backend/tests/test_tutor_voice_session.py
@@ -4,6 +4,9 @@ Uses a mocked async session because the integration db_session fixture is
 blocked on #554 (Base.metadata.create_all vs Alembic-managed enum types).
 The interesting logic here is the round-up-to-minutes rule and the cap
 clamp formula; both are pure arithmetic once the DB returns a seconds sum.
+
+Also covers _get_voice_mode_suffix (#1960) — verifies the dynamic suffix
+anchors to course/module and suppresses country-topic drift.
 """
 
 from __future__ import annotations
@@ -63,6 +66,62 @@ class TestMinutesUsedToday:
 
         session = _session_returning_seconds(None)
         assert await _minutes_used_today(uuid.uuid4(), session) == 0
+
+
+class TestVoiceModeSuffix:
+    """_get_voice_mode_suffix anchors to course/module and blocks country drift (#1960)."""
+
+    def _make_context(self, **kwargs):
+        from app.ai.prompts.tutor import TutorContext
+
+        defaults = {
+            "user_level": 2,
+            "user_language": "fr",
+            "user_country": "BF",
+        }
+        defaults.update(kwargs)
+        return TutorContext(**defaults)
+
+    def test_contains_anti_drift_instruction(self):
+        from app.api.v1.tutor_voice import _get_voice_mode_suffix
+
+        ctx = self._make_context(course_title="Santé Publique en Afrique de l'Ouest")
+        suffix = _get_voice_mode_suffix(ctx)
+        assert "BACKGROUND COLOUR ONLY" in suffix
+        assert "Do NOT bring up country-specific" in suffix or "ne pas" in suffix.lower()
+
+    def test_no_module_asks_for_topic(self):
+        from app.api.v1.tutor_voice import _get_voice_mode_suffix
+
+        ctx = self._make_context(course_title="Marketing Digital", module_title=None)
+        suffix = _get_voice_mode_suffix(ctx)
+        assert "Marketing Digital" in suffix
+
+    def test_with_module_anchors_to_module(self):
+        from app.api.v1.tutor_voice import _get_voice_mode_suffix
+
+        ctx = self._make_context(
+            course_title="Santé Publique",
+            module_title="Épidémiologie",
+            module_number=3,
+        )
+        suffix = _get_voice_mode_suffix(ctx)
+        assert "Épidémiologie" in suffix
+        assert "Santé Publique" in suffix
+
+    def test_en_suffix_uses_english_phrases(self):
+        from app.api.v1.tutor_voice import _get_voice_mode_suffix
+
+        ctx = self._make_context(user_language="en", course_title="Public Health")
+        suffix = _get_voice_mode_suffix(ctx)
+        assert "Public Health" in suffix
+
+    def test_fallback_course_label_when_no_title(self):
+        from app.api.v1.tutor_voice import _get_voice_mode_suffix
+
+        ctx = self._make_context(course_title=None)
+        suffix = _get_voice_mode_suffix(ctx)
+        assert "la formation en cours" in suffix
 
 
 class TestDurationClamp:

--- a/frontend/app/[locale]/admin/courses/[courseId]/quality/page.tsx
+++ b/frontend/app/[locale]/admin/courses/[courseId]/quality/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { getTranslations } from "next-intl/server";
+import { BundleTrigger } from "@/components/admin/bundle-trigger";
 import { QualityClient } from "@/components/admin/quality/quality-client";
 
 export async function generateMetadata({
@@ -34,8 +35,15 @@ export default async function AdminCourseQualityPage({
           <ArrowLeft className="size-4" />
           {t("backToCourses")}
         </Link>
-        <h1 className="text-2xl font-bold">{t("pageTitle")}</h1>
-        <p className="text-muted-foreground mt-1">{t("pageDescription")}</p>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold">{t("pageTitle")}</h1>
+            <p className="text-muted-foreground mt-1">
+              {t("pageDescription")}
+            </p>
+          </div>
+          <BundleTrigger courseId={courseId} />
+        </div>
       </div>
       <QualityClient courseId={courseId} />
     </div>

--- a/frontend/components/admin/admin-nav.tsx
+++ b/frontend/components/admin/admin-nav.tsx
@@ -50,6 +50,7 @@ export function AdminNav() {
     { href: `/${locale}/admin/users`, label: t("users.title"), adminOnly: false, badge: 0 },
     { href: `/${locale}/admin/courses`, label: t("courses.title"), adminOnly: false, badge: 0 },
     { href: `/${locale}/admin/quality`, label: t("quality.title"), adminOnly: false, badge: attentionCount },
+    { href: `/${locale}/admin/bundles`, label: t("bundles.nav"), adminOnly: false, badge: 0 },
     { href: `/${locale}/admin/curricula`, label: t("curricula.title"), adminOnly: false, badge: 0 },
     { href: `/${locale}/admin/groups`, label: t("groups.title"), adminOnly: false, badge: 0 },
     { href: `/${locale}/admin/taxonomy`, label: t("taxonomy.title"), adminOnly: false, badge: 0 },

--- a/frontend/components/admin/bundle-trigger.tsx
+++ b/frontend/components/admin/bundle-trigger.tsx
@@ -80,7 +80,6 @@ export function BundleTrigger({ courseId, onSuccess }: BundleTriggerProps) {
             </div>
 
             <form onSubmit={handleSubmit} className="space-y-4">
-              {/* Language */}
               <div className="space-y-2">
                 <label className="text-sm font-medium">{t("language")}</label>
                 <div className="flex gap-3">
@@ -103,7 +102,6 @@ export function BundleTrigger({ courseId, onSuccess }: BundleTriggerProps) {
                 </div>
               </div>
 
-              {/* Level */}
               <div className="space-y-2">
                 <label className="text-sm font-medium">{t("level")}</label>
                 <select
@@ -119,9 +117,7 @@ export function BundleTrigger({ courseId, onSuccess }: BundleTriggerProps) {
                 </select>
               </div>
 
-              {error && (
-                <p className="text-sm text-destructive">{error}</p>
-              )}
+              {error && <p className="text-sm text-destructive">{error}</p>}
 
               <div className="flex justify-end gap-2 pt-2">
                 <Button

--- a/frontend/components/admin/bundles-client.tsx
+++ b/frontend/components/admin/bundles-client.tsx
@@ -2,12 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
-import {
-  Download,
-  Loader2,
-  Package,
-  Trash2,
-} from "lucide-react";
+import { Download, Loader2, Package, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   type BundleListItem,
@@ -51,8 +46,6 @@ export function BundlesClient() {
   const load = useCallback(async () => {
     try {
       const data = await listBundles({ limit: 100 });
-
-      // Detect transitions to "ready" or "failed" for notifications
       const prev = prevStatusRef.current;
       for (const b of data) {
         const was = prev[b.bundle_id];
@@ -64,7 +57,6 @@ export function BundlesClient() {
       prevStatusRef.current = Object.fromEntries(
         data.map((b) => [b.bundle_id, b.status]),
       );
-
       setBundles(data);
       setError(null);
     } catch {
@@ -78,7 +70,6 @@ export function BundlesClient() {
     load();
   }, [load]);
 
-  // Auto-poll every 3s while any bundle is generating or pending
   useEffect(() => {
     const hasActive = bundles.some(
       (b) => b.status === "generating" || b.status === "pending",
@@ -96,8 +87,10 @@ export function BundlesClient() {
   async function handleDownload(b: BundleListItem) {
     setDownloading(b.bundle_id);
     try {
-      const filename = `${b.course_title}_${b.language}.zip`
-        .replace(/[^a-zA-Z0-9_.-]/g, "_");
+      const filename = `${b.course_title}_${b.language}.zip`.replace(
+        /[^a-zA-Z0-9_.-]/g,
+        "_",
+      );
       await downloadBundle(b.bundle_id, filename);
     } catch {
       showToast(t("error"));
@@ -119,11 +112,10 @@ export function BundlesClient() {
     }
   }
 
-  function statusBadge(status: string) {
-    const label = t(`status.${status}` as Parameters<typeof t>[0]);
+  function statusBadge(bundleStatus: string) {
+    const label = t(`status.${bundleStatus}` as Parameters<typeof t>[0]);
     const cls: Record<string, string> = {
-      pending:
-        "bg-muted text-muted-foreground",
+      pending: "bg-muted text-muted-foreground",
       generating:
         "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
       ready:
@@ -133,9 +125,9 @@ export function BundlesClient() {
     };
     return (
       <span
-        className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${cls[status] ?? cls.pending}`}
+        className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${cls[bundleStatus] ?? cls.pending}`}
       >
-        {status === "generating" && (
+        {bundleStatus === "generating" && (
           <Loader2 className="size-3 animate-spin" />
         )}
         {label}
@@ -160,7 +152,6 @@ export function BundlesClient() {
         </div>
       )}
 
-      {/* Delete confirmation overlay */}
       {confirmDelete && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
           <div className="w-full max-w-sm rounded-lg bg-background p-6 shadow-xl">
@@ -208,12 +199,16 @@ export function BundlesClient() {
             <thead className="border-b bg-muted/50 text-xs font-medium text-muted-foreground">
               <tr>
                 <th className="px-4 py-3 text-left">{t("table.course")}</th>
-                <th className="px-4 py-3 text-left">{t("table.language")}</th>
+                <th className="px-4 py-3 text-left">
+                  {t("table.language")}
+                </th>
                 <th className="px-4 py-3 text-left">{t("table.level")}</th>
                 <th className="px-4 py-3 text-left">{t("table.status")}</th>
                 <th className="px-4 py-3 text-left">{t("table.size")}</th>
                 <th className="px-4 py-3 text-left">{t("table.created")}</th>
-                <th className="px-4 py-3 text-right">{t("table.actions")}</th>
+                <th className="px-4 py-3 text-right">
+                  {t("table.actions")}
+                </th>
               </tr>
             </thead>
             <tbody className="divide-y">
@@ -222,7 +217,7 @@ export function BundlesClient() {
                   <td className="px-4 py-3 font-medium">
                     {b.course_title}
                     {b.error_message && b.status === "failed" && (
-                      <p className="mt-0.5 text-xs text-destructive/80 truncate max-w-[200px]">
+                      <p className="mt-0.5 max-w-[200px] truncate text-xs text-destructive/80">
                         {b.error_message}
                       </p>
                     )}

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslations, useLocale } from 'next-intl';
 import { track } from '@/lib/analytics';
 import { Link } from '@/i18n/routing';
-import { X, MoreVertical, Trash2, Menu, HelpCircle, BookOpen, GraduationCap, ChevronDown, Globe } from 'lucide-react';
+import { X, MoreVertical, Trash2, Menu, HelpCircle, BookOpen, GraduationCap, ChevronDown, Globe, Phone } from 'lucide-react';
 import { getMyEnrollments, type CourseWithEnrollment, API_BASE } from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import {
@@ -595,9 +595,15 @@ export function ChatPanel({
                 {activeCourseLabel}
               </span>
             ) : null}
-            {/* Voice-call button hidden until voice tutor has proper RAG
-                grounding (#1960). Backend endpoints stay live so existing
-                in-flight sessions complete cleanly. */}
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setShowVoiceCall(true)}
+              className="h-11 w-11"
+              title={t('voiceCall')}
+            >
+              <Phone className="h-4 w-4" />
+            </Button>
             <Button
               variant={tutorMode === 'socratic' ? 'default' : 'outline'}
               size="sm"

--- a/frontend/lib/api-bundles.ts
+++ b/frontend/lib/api-bundles.ts
@@ -84,9 +84,10 @@ export async function downloadBundle(
   filename: string,
 ): Promise<void> {
   const headers = await getAuthHeaders();
-  const res = await fetch(`${API_BASE}/api/v1/admin/bundles/${bundleId}/download`, {
-    headers,
-  });
+  const res = await fetch(
+    `${API_BASE}/api/v1/admin/bundles/${bundleId}/download`,
+    { headers },
+  );
   if (!res.ok) throw new Error(`Download failed: ${res.status}`);
   const blob = await res.blob();
   const url = URL.createObjectURL(blob);

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -437,6 +437,7 @@
     "modeExplanatory": "Explanatory Mode",
     "modeSocraticTooltip": "Guided questions",
     "modeExplanatoryTooltip": "Direct answers",
+    "voiceCall": "Voice call",
     "fileUpload": {
       "attach": "Attach a file",
       "attachAriaLabel": "Attach a file",
@@ -1520,6 +1521,51 @@
     },
     "quality": {
       "title": "Quality"
+    },
+    "bundles": {
+      "pageTitle": "Course Packages",
+      "pageDescription": "Download a course as a flat ZIP of self-contained HTML files for offline use.",
+      "backToCourses": "Back to courses",
+      "newBundle": "New Package",
+      "nav": "Packages",
+      "table": {
+        "course": "Course",
+        "language": "Language",
+        "level": "Level",
+        "status": "Status",
+        "size": "Size",
+        "created": "Created",
+        "actions": "Actions"
+      },
+      "status": {
+        "pending": "Queued",
+        "generating": "Generating…",
+        "ready": "Ready",
+        "failed": "Failed"
+      },
+      "download": "Download",
+      "delete": "Delete",
+      "deleteConfirm": "Delete this bundle? This cannot be undone.",
+      "empty": "No packages yet. Trigger one from the course quality page.",
+      "loading": "Loading packages…",
+      "error": "Could not load packages.",
+      "toastReady": "Package ready — click Download.",
+      "toastFailed": "Package generation failed.",
+      "trigger": {
+        "title": "Package course",
+        "description": "Generate an offline ZIP archive. Missing content will be created automatically.",
+        "language": "Language",
+        "level": "Content level",
+        "submit": "Generate package",
+        "submitting": "Starting…",
+        "successToast": "Package generation started — visit Packages to download when ready."
+      },
+      "levelLabels": {
+        "1": "Beginner",
+        "2": "Intermediate",
+        "3": "Advanced",
+        "4": "Expert"
+      }
     }
   },
   "Courses": {

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -437,6 +437,7 @@
     "modeExplanatory": "Mode Explicatif",
     "modeSocraticTooltip": "Guidage par questions",
     "modeExplanatoryTooltip": "Réponses directes",
+    "voiceCall": "Appel vocal",
     "fileUpload": {
       "attach": "Joindre un fichier",
       "attachAriaLabel": "Joindre un fichier",
@@ -1520,6 +1521,51 @@
     },
     "quality": {
       "title": "Qualité"
+    },
+    "bundles": {
+      "pageTitle": "Packages de cours",
+      "pageDescription": "Téléchargez un cours sous forme d'archive ZIP de fichiers HTML autonomes pour une utilisation hors-ligne.",
+      "backToCourses": "Retour aux cours",
+      "newBundle": "Nouveau package",
+      "nav": "Packages",
+      "table": {
+        "course": "Cours",
+        "language": "Langue",
+        "level": "Niveau",
+        "status": "Statut",
+        "size": "Taille",
+        "created": "Créé le",
+        "actions": "Actions"
+      },
+      "status": {
+        "pending": "En attente",
+        "generating": "Génération…",
+        "ready": "Prêt",
+        "failed": "Échoué"
+      },
+      "download": "Télécharger",
+      "delete": "Supprimer",
+      "deleteConfirm": "Supprimer ce package ? Cette action est irréversible.",
+      "empty": "Aucun package. Lancez-en un depuis la page qualité d'un cours.",
+      "loading": "Chargement des packages…",
+      "error": "Impossible de charger les packages.",
+      "toastReady": "Package prêt — cliquez sur Télécharger.",
+      "toastFailed": "La génération du package a échoué.",
+      "trigger": {
+        "title": "Packager le cours",
+        "description": "Générez une archive ZIP hors-ligne. Le contenu manquant sera créé automatiquement.",
+        "language": "Langue",
+        "level": "Niveau de contenu",
+        "submit": "Générer le package",
+        "submitting": "Démarrage…",
+        "successToast": "Génération démarrée — consultez les Packages pour télécharger quand c'est prêt."
+      },
+      "levelLabels": {
+        "1": "Débutant",
+        "2": "Intermédiaire",
+        "3": "Avancé",
+        "4": "Expert"
+      }
     }
   },
   "Courses": {


### PR DESCRIPTION
Squash-merge of dev into main (phantom-conflict resolution via cherry branch).

Includes:
- fix(tutor): strip trailing orphaned user turns — cascade failure fix (#2385)
- fix(schemas): remove storage_url from SourceImageRef call sites (#2388)
- fix(rag): backfill_chunk_pages.py for legacy NULL-page chunks (#2058)
- chore(schemas): MinIO URL leak guardrail on SourceImageRef (#1610)
- fix(tutor): anchor voice-call to course/module (#1960)
- feat(bundles): course ZIP export (#2363)
- fix(quiz): forceRegenerate ref fix + infinite useEffect fix
- feat(quality): auto-trigger QA sweep after course publish (#2358)
- fix(migration): idempotent bundlestatus enum in 097
- fix(ci): deploy.yml heredoc + ruff formatting fixes
- fix(ux): inline markdown images fill lesson column width (#2094)

🤖 Generated with [Claude Code](https://claude.com/claude-code)