### PR TITLE
fix(migration): use postgresql.ENUM in 097 to prevent DuplicateObjectError (Fixes #2393)

### DIFF
--- a/backend/migrations/versions/097_add_course_bundles.py
+++ b/backend/migrations/versions/097_add_course_bundles.py
@@ -7,6 +7,7 @@ Create Date: 2026-05-21
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects.postgresql import ENUM as PG_ENUM
 
 revision: str = "097_add_course_bundles"
 down_revision: str | None = "096_add_file_hash_to_course_resources"
@@ -43,7 +44,7 @@ def upgrade() -> None:
         sa.Column("country", sa.String(4), server_default="SN", nullable=False),
         sa.Column(
             "status",
-            sa.Enum(
+            PG_ENUM(
                 "pending",
                 "generating",
                 "ready",


### PR DESCRIPTION
## Summary

- `sa.Enum(create_type=False)` from #2372 is insufficient — SQLAlchemy's `op.create_table()` still emits `CREATE TYPE` via an internal before-create hook regardless of that flag.
- Staging had `bundlestatus` type from a prior partial run but no `course_bundles` table, causing `DuplicateObjectError` on every deploy attempt.
- Fix: switch to `postgresql.ENUM(create_type=False)` (SQLAlchemy's PG-specific dialect type), which reliably suppresses the emission since the dialect type does not fire the generic before-create hook.
- The `DO $$ ... EXCEPTION WHEN duplicate_object THEN NULL $$` guard is kept for safety (handles the case where the type doesn't exist yet).

## Test plan

- [ ] Local: migration imports cleanly
- [ ] CI passes
- [ ] Staging deploy succeeds (no DuplicateObjectError in migration step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)