### PR TITLE
feat(tutor): detect Anthropic credit exhaustion and surface specific error

### DIFF
--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from typing import Any
 
 import structlog
-from anthropic import AsyncAnthropic
+from anthropic import AsyncAnthropic, BadRequestError as AnthropicBadRequestError
 from anthropic.types import MessageParam, ToolResultBlockParam, ToolUseBlock
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -1755,6 +1755,13 @@ class TutorService:
                 "finished": True,
             }
 
+        except AnthropicBadRequestError as e:
+            code = "api_quota_exhausted" if "credit balance" in str(e).lower() else "tutor_error"
+            logger.error("Error in tutor chat", error=str(e), user_id=str(user_id))
+            yield {
+                "type": "error",
+                "data": {"code": code, "message": "An error occurred. Please try again."},
+            }
         except Exception as e:
             logger.error("Error in tutor chat", error=str(e), user_id=str(user_id))
             yield {

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -441,7 +441,11 @@ export function ChatPanel({
               } else if (chunk.type === 'error') {
                 const errorCode = chunk.data?.code;
                 fullContent =
-                  errorCode === 'limit_reached' ? t('errorLimitReached') : t('error');
+                  errorCode === 'limit_reached'
+                    ? t('errorLimitReached')
+                    : errorCode === 'api_quota_exhausted'
+                      ? t('errorServiceUnavailable')
+                      : t('error');
                 if (errorCode === 'limit_reached') {
                   setLimitReached(true);
                 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -409,6 +409,7 @@
     "allConversationsCleared": "All conversations deleted",
     "error": "Something went wrong. Please try again.",
     "errorLimitReached": "Daily message limit reached. Come back tomorrow.",
+    "errorServiceUnavailable": "AI service is temporarily unavailable. Please try again later.",
     "upgradePrompt": "Subscribe to continue — 1,000 XOF/month",
     "errorDescription": "Failed to send message. Please try again.",
     "retry": "Retry",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -409,6 +409,7 @@
     "allConversationsCleared": "Toutes les conversations supprimées",
     "error": "Une erreur s'est produite. Veuillez réessayer.",
     "errorLimitReached": "Limite de messages quotidiens atteinte. Revenez demain.",
+    "errorServiceUnavailable": "Le service IA est temporairement indisponible. Veuillez réessayer plus tard.",
     "upgradePrompt": "S'abonner pour continuer — 1 000 FCFA/mois",
     "errorDescription": "Échec de l'envoi du message. Veuillez réessayer.",
     "retry": "Réessayer",


### PR DESCRIPTION
## Summary

- Catches `anthropic.BadRequestError` specifically before the generic `except Exception` in `send_message`
- When the error message contains "credit balance", emits SSE event with `code: "api_quota_exhausted"` instead of `"tutor_error"`
- Frontend maps `api_quota_exhausted` → new `errorServiceUnavailable` i18n key:
  - EN: "AI service is temporarily unavailable. Please try again later."
  - FR: "Le service IA est temporairement indisponible. Veuillez réessayer plus tard."
- Does **not** trigger the Subscribe banner (`setLimitReached`) — this is an infrastructure issue, not a user quota issue

Fixes #2397

## Test plan

- [ ] Restore staging Anthropic credits and send a tutor message — confirm the tutor responds (cascaed fix verification too)
- [ ] To test the new error path without burning credits: mock `AnthropicBadRequestError` with "credit balance" in message and assert `code == "api_quota_exhausted"` in the yielded event
- [ ] Confirm other 400 errors (e.g. invalid requests) still yield `tutor_error` not `api_quota_exhausted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)