### PR TITLE
style: fix ruff import sort for AnthropicBadRequestError

### DIFF
--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -9,7 +9,8 @@ from datetime import datetime
 from typing import Any
 
 import structlog
-from anthropic import AsyncAnthropic, BadRequestError as AnthropicBadRequestError
+from anthropic import AsyncAnthropic
+from anthropic import BadRequestError as AnthropicBadRequestError
 from anthropic.types import MessageParam, ToolResultBlockParam, ToolUseBlock
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine


### PR DESCRIPTION
Fixes the lint failure on dev from PR #2398 — ruff requires separate `from anthropic import` lines for the two symbols.