### PR TITLE
fix: re-hide voice-call button — feature not yet complete (Fixes #2400)

### DIFF
--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslations, useLocale } from 'next-intl';
 import { track } from '@/lib/analytics';
 import { Link } from '@/i18n/routing';
-import { X, MoreVertical, Trash2, Menu, HelpCircle, BookOpen, GraduationCap, ChevronDown, Globe, Phone } from 'lucide-react';
+import { X, MoreVertical, Trash2, Menu, HelpCircle, BookOpen, GraduationCap, ChevronDown, Globe } from 'lucide-react';
 import { getMyEnrollments, type CourseWithEnrollment, API_BASE } from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import {
@@ -26,7 +26,6 @@ import {
 import { ChatMessage as ChatMessageComponent, type ChatMessage } from './chat-message';
 import { ChatInput } from './chat-input';
 import { ChatSuggestions } from './chat-suggestions';
-import { VoiceCallModal } from './voice-call-modal';
 import { TypingIndicator } from './typing-indicator';
 import { UsageCounter } from './usage-counter';
 import { ChatSkeleton } from './chat-skeleton';
@@ -81,7 +80,6 @@ export function ChatPanel({
   const [isHistoryLoading, setIsHistoryLoading] = useState(false);
   const [isTyping, setIsTyping] = useState(false);
   const [showClearDialog, setShowClearDialog] = useState(false);
-  const [showVoiceCall, setShowVoiceCall] = useState(false);
   const [currentUsage, setCurrentUsage] = useState(0);
   const [maxDailyUsage, setMaxDailyUsage] = useState(200);
   const [limitReached, setLimitReached] = useState(false);
@@ -599,15 +597,9 @@ export function ChatPanel({
                 {activeCourseLabel}
               </span>
             ) : null}
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => setShowVoiceCall(true)}
-              className="h-11 w-11"
-              title={t('voiceCall')}
-            >
-              <Phone className="h-4 w-4" />
-            </Button>
+            {/* Voice-call button hidden — feature not yet complete (#1960).
+                Backend endpoints stay live so in-flight sessions close cleanly.
+                Re-enable once voice RAG grounding and UX are finalized. */}
             <Button
               variant={tutorMode === 'socratic' ? 'default' : 'outline'}
               size="sm"
@@ -710,14 +702,6 @@ export function ChatPanel({
           />
         </div>
       </div>
-
-      {/* Voice Call Modal */}
-      <VoiceCallModal
-        open={showVoiceCall}
-        onOpenChange={setShowVoiceCall}
-        courseId={activeCourseId}
-        moduleId={moduleId ?? null}
-      />
 
       {/* Clear History Dialog */}
       <AlertDialog open={showClearDialog} onOpenChange={setShowClearDialog}>

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -438,7 +438,6 @@
     "modeExplanatory": "Explanatory Mode",
     "modeSocraticTooltip": "Guided questions",
     "modeExplanatoryTooltip": "Direct answers",
-    "voiceCall": "Voice call",
     "fileUpload": {
       "attach": "Attach a file",
       "attachAriaLabel": "Attach a file",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -438,7 +438,6 @@
     "modeExplanatory": "Mode Explicatif",
     "modeSocraticTooltip": "Guidage par questions",
     "modeExplanatoryTooltip": "Réponses directes",
-    "voiceCall": "Appel vocal",
     "fileUpload": {
       "attach": "Joindre un fichier",
       "attachAriaLabel": "Joindre un fichier",


### PR DESCRIPTION
## Problem

PR #2382 merged the backend voice-call prompt fix but also re-enabled the voice call button in `chat-panel.tsx`. The button was intentionally hidden in #1960 because the voice feature (voice RAG grounding + UX) is not ready.

## Changes

| File | Change |
|------|--------|
| `frontend/components/chat/chat-panel.tsx` | Remove `Phone` import, `VoiceCallModal`, `showVoiceCall` state; restore hidden-button comment |
| `frontend/messages/fr.json` | Remove `"voiceCall": "Appel vocal"` |
| `frontend/messages/en.json` | Remove `"voiceCall": "Voice call"` |

**Not changed:** `backend/app/api/v1/tutor_voice.py` (`_get_voice_mode_suffix`) and its tests remain intact.

## Test plan

- [ ] Chat panel renders without Phone button in toolbar
- [ ] No console errors about missing `voiceCall` i18n key
- [ ] Socratic mode toggle still works normally
- [ ] Backend voice endpoints still reachable (in-flight session cleanup path unchanged)

Fixes #2400

🤖 Generated with [Claude Code](https://claude.com/claude-code)