### PR TITLE
fix(auth): refresh expired access token via cookie so mark-complete/submit-quiz stop 401ing

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -318,20 +318,43 @@ export async function apiFetch<T>(
     ...(options?.headers as Record<string, string>),
   };
 
+  let authed = false;
   if (typeof window !== "undefined") {
     try {
       const { authClient } = await import("./auth");
       const token = await authClient.getValidToken();
       headers["Authorization"] = `Bearer ${token}`;
+      authed = true;
     } catch {
       // No valid token — proceed without auth header (unauthenticated call)
     }
   }
 
-  const res = await fetch(`${API_BASE}${path}`, {
+  let res = await fetch(`${API_BASE}${path}`, {
     ...options,
     headers,
   });
+
+  // Self-heal a single 401 by refreshing via the HttpOnly cookie and retrying,
+  // covering tokens that lapse between getValidToken() and the request or are
+  // rejected for clock skew. Request bodies here are JSON strings, safe to reuse.
+  if (res.status === 401 && authed && typeof window !== "undefined") {
+    try {
+      const { authClient } = await import("./auth");
+      await authClient.refreshAccessToken();
+      const token = authClient.getAccessToken();
+      if (token) {
+        headers["Authorization"] = `Bearer ${token}`;
+        res = await fetch(`${API_BASE}${path}`, {
+          ...options,
+          headers,
+        });
+      }
+    } catch {
+      // Refresh failed — fall through to the normal error handling below.
+    }
+  }
+
   if (!res.ok) {
     let message = `API error: ${res.status}`;
     let code: string | undefined;

--- a/frontend/lib/auth.test.ts
+++ b/frontend/lib/auth.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Builds a JWT-shaped token whose payload carries an `exp` claim.
+function makeToken(expSecondsFromNow: number): string {
+  const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const payload = btoa(
+    JSON.stringify({ exp: Math.floor(Date.now() / 1000) + expSecondsFromNow }),
+  );
+  return `${header}.${payload}.sig`;
+}
+
+describe("authClient.getValidToken", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // Fresh singleton per test: the constructor reads tokens from localStorage,
+    // so an empty store reproduces the post-page-load state (refreshToken null).
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("refreshes via the cookie when no refresh token is held in memory (regression #2112)", async () => {
+    const fresh = makeToken(900);
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        access_token: fresh,
+        token_type: "bearer",
+        expires_in: 900,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { authClient } = await import("./auth");
+    const token = await authClient.getValidToken();
+
+    // It must attempt the cookie-based refresh rather than throwing 401.
+    expect(token).toBe(fresh);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/api/v1/auth/refresh");
+  });
+
+  it("throws a clean session-expired error when the cookie refresh fails", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ detail: "Refresh token required" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { authClient, AuthError } = await import("./auth");
+
+    await expect(authClient.getValidToken()).rejects.toMatchObject({
+      name: "AuthError",
+      status: 401,
+    });
+    // One refresh attempt, no retry loop.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(AuthError).toBeDefined();
+  });
+});

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -349,12 +349,16 @@ class AuthClient {
       return this.accessToken;
     }
 
-    if (!this.refreshToken) {
+    // Access token missing/expired: refresh via the HttpOnly refresh_token
+    // cookie. Do NOT gate on this.refreshToken — it is null after any page
+    // load since the refresh token is never persisted to localStorage (#2112),
+    // so gating here permanently blocked recovery once the access token aged out.
+    try {
+      await this.refreshAccessToken();
+    } catch {
       this.clearTokens();
       throw new AuthError('Session expired. Please log in again.', 401);
     }
-
-    await this.refreshAccessToken();
 
     if (!this.accessToken) {
       this.clearTokens();


### PR DESCRIPTION
## Summary

Fixes the "session token continuously expiring" bug where **Mark unit complete** and **End/submit quiz** throw a 401 once the access token ages out, and only recover after a full page refresh.

- `getValidToken()` (`frontend/lib/auth.ts`) gated its refresh on the in‑memory `this.refreshToken`, which is **always null after a page load** since the refresh token lives only in an HttpOnly cookie (#2112). So once the 15‑min access token expired, `apiFetch`‑based calls threw 401 without ever attempting the cookie‑based refresh that would have succeeded. A page reload masked it because `AuthGuard` refreshes on mount. Now `getValidToken()` always attempts the cookie refresh and only throws if that fails.
- `apiFetch()` (`frontend/lib/api.ts`) gains a single 401 refresh‑and‑retry (mirroring `authenticatedFetch`) as defense in depth for tokens that lapse mid‑flight or are rejected for clock skew, instead of silently sending an unauthenticated request.
- Added `frontend/lib/auth.test.ts` with regression coverage.

This one change also fixes every other `getValidToken()` caller (tutor‑api, syllabus‑editor, course‑form, payments, etc.).

Closes #2403

## Test plan

- [x] `frontend/lib/auth.test.ts` passes (2/2, vitest): refresh‑via‑cookie path + clean session‑expired failure (single attempt, no loop)
- [x] ESLint clean on changed files
- [x] `tsc --noEmit` adds no new errors (only pre‑existing `e2e/production-uat.spec.ts` issues remain)
- [ ] Manual: with an expired access token, click Mark complete / Submit quiz once → network shows `POST /api/v1/auth/refresh` then `200` on the original request, no page reload

https://claude.ai/code/session_01JAVwKtUL6SGroJjxze3Nuh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAVwKtUL6SGroJjxze3Nuh)_