### PR TITLE
ci(sync): end recurring dev→main orphan-history conflicts

### DIFF
--- a/.github/workflows/dev-to-main.yml
+++ b/.github/workflows/dev-to-main.yml
@@ -16,26 +16,62 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Create or enable auto-merge on dev→main PR
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Sync dev → main
         env:
           GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin main dev
+
+          # Nothing to promote if the two branches already have identical trees.
+          # (Also stops the back-merge below from re-triggering itself forever.)
+          if git diff --quiet origin/dev origin/main; then
+            echo "dev and main trees are identical — nothing to sync."
+            exit 0
+          fi
+
+          # The main ruleset requires SQUASH merges, and a squash commit never
+          # records dev as a parent — so after each sync dev and main re-orphan
+          # and the next dev→main PR shows phantom "unrelated-history" conflicts
+          # across every file. Re-link them first: merge main into dev with
+          # `-s ours` (keeps dev's tree byte-for-byte, just records main as a
+          # parent) so the PR has a real merge base and shows only the true diff.
+          # The push re-triggers this workflow, which then opens/merges the PR.
+          if ! git merge-base --is-ancestor origin/main origin/dev; then
+            echo "main is not an ancestor of dev — linking histories to avoid phantom conflicts."
+            git checkout -B dev origin/dev
+            git merge -s ours --allow-unrelated-histories origin/main \
+              -m "chore(sync): link main history into dev (keeps dev tree)"
+            git push origin dev
+            echo "Pushed link commit to dev; the resulting push re-runs this workflow to open the PR."
+            exit 0
+          fi
+
+          # Histories are linked and a real diff exists: open (or reuse) the
+          # dev→main PR and enable squash auto-merge.
           PR_NUMBER=$(gh pr list \
             --base main --head dev \
             --state open \
             --json number \
             --jq '.[0].number' \
-            --repo "${{ github.repository }}")
+            --repo "$GITHUB_REPOSITORY")
 
           if [ -z "$PR_NUMBER" ]; then
             PR_URL=$(gh pr create \
               --base main --head dev \
               --title "sync: dev → main" \
               --body "Automated sync: squash-merges dev into main." \
-              --repo "${{ github.repository }}")
+              --repo "$GITHUB_REPOSITORY")
             PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
           fi
 
           # Squash merge required by main ruleset.
           gh pr merge "$PR_NUMBER" --auto --squash \
-            --repo "${{ github.repository }}"
+            --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
## Summary

Permanently fixes the recurring **dev→main sync block**. The `main` ruleset requires **squash** merges, but a squash commit never records `dev` as a parent — so `dev` and `main` re-orphan after every sync. The next `dev→main` PR then has **no merge base** and GitHub reports phantom "unrelated-history" conflicts across *every* file, blocking the sync. This most recently blocked PR #2402 for ~5 days; it was only unblocked by manually back-merging `main` into `dev`.

This change automates that repair inside `.github/workflows/dev-to-main.yml`:

- Before opening the sync PR, if `main` is **not** already an ancestor of `dev`, back-merge it with `git merge -s ours` — this keeps `dev`'s tree **byte-for-byte identical** and only records `main` as a parent, giving the PR a real merge base so it shows the **true diff** instead of phantom conflicts.
- A **no-diff guard** (`git diff --quiet origin/dev origin/main`) exits early when the trees already match, which also prevents the back-merge push from re-triggering the workflow indefinitely.
- The PR open/auto-squash-merge logic is otherwise unchanged (still squash, per the `main` ruleset).

### Loop safety
Per real feature: one back-merge push to `dev` (main not yet an ancestor) → workflow re-runs → main is now an ancestor → opens/auto-merges the PR → squash lands on `main`; trees then match → guard stops. Bounded, no infinite loop. `concurrency: dev-to-main` continues to serialize runs.

### Notes / alternatives
- Requires `secrets.PAT_TOKEN` to be able to push to `dev` (same token the workflow already uses; a manual direct push to `dev` succeeded during the #2402 repair).
- Simpler long-term option (not done here, needs a repo settings change): allow **merge commits** on `main` and switch `--squash` → `--merge`; a merge commit inherently keeps the histories linked.
- This is a deploy-pipeline change, so it's intentionally a **separate follow-up PR** for review rather than bundled with the auth fix.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML valid
- [x] `bash -n` on the embedded run script — syntax valid
- [ ] On first merge to `dev`, confirm the workflow back-merges, re-runs, and opens a clean `dev→main` PR with only the real diff (validates end-to-end against the live ruleset)

https://claude.ai/code/session_01JAVwKtUL6SGroJjxze3Nuh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAVwKtUL6SGroJjxze3Nuh)_