### PR TITLE
fix(tutor): sort conversation list by last activity (#2407)

### DIFF
--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -1852,10 +1852,24 @@ class TutorService:
         if isinstance(user_id, str):
             user_id = uuid.UUID(user_id)
 
+        # Sort by last activity, not creation time (#2407). The sidebar shows each
+        # thread's last-message timestamp, so ordering by created_at made threads
+        # look unsorted (a recently-active old thread sat below newer-but-idle ones).
+        # tutor_messages holds a durable row per message (#1978), so MAX(created_at)
+        # is a reliable last-activity key; fall back to created_at for legacy/empty
+        # threads that have no rows there.
+        last_activity = func.coalesce(
+            select(func.max(TutorMessage.created_at))
+            .where(TutorMessage.conversation_id == TutorConversation.id)
+            .correlate(TutorConversation)
+            .scalar_subquery(),
+            TutorConversation.created_at,
+        )
+
         query = (
             select(TutorConversation)
             .where(TutorConversation.user_id == user_id)
-            .order_by(TutorConversation.created_at.desc())
+            .order_by(last_activity.desc())
             .limit(limit)
             .offset(offset)
         )

--- a/backend/tests/test_tutor_service.py
+++ b/backend/tests/test_tutor_service.py
@@ -411,6 +411,32 @@ async def test_list_conversations_returns_required_fields(
     assert "preview" in conv
 
 
+async def test_list_conversations_orders_by_last_activity(tutor_service, sample_user):
+    """Threads must be ordered by last activity, not creation time (#2407).
+
+    DB integration tests in this repo are skipped (conftest's create_all can't
+    emit enum types behind create_type=False), so we assert the invariant on the
+    constructed SELECT: its ORDER BY must reference the last-message timestamp
+    from tutor_messages (via coalesce/max), not plain tutor_conversations.created_at.
+    """
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_count_result = MagicMock()
+    mock_count_result.scalar.return_value = 0
+    mock_session.execute = AsyncMock(side_effect=[mock_result, mock_count_result])
+
+    await tutor_service.list_conversations(user_id=sample_user.id, session=mock_session)
+
+    # First execute() is the list query; compile it to inspect the ORDER BY.
+    list_stmt = mock_session.execute.call_args_list[0].args[0]
+    compiled = str(list_stmt.compile()).lower()
+    order_clause = compiled.split("order by", 1)[1]
+    assert "coalesce" in order_clause
+    assert "tutor_messages.created_at" in order_clause
+    assert "desc" in order_clause
+
+
 async def test_get_conversation_returns_none_for_wrong_user(tutor_service, sample_user):
     """get_conversation must return None when the conversation belongs to another user."""
     mock_session = AsyncMock(spec=AsyncSession)


### PR DESCRIPTION
## Problem

In the AI tutor sidebar, past conversation threads were displayed in the wrong order. Each thread shows a relative timestamp derived from its **last message** ("3d ago", "7d ago", "26d ago"), but the list was **sorted by the conversation's creation time** — so a thread last active "3d ago" sat *below* threads last active "7d ago" because those were *created* more recently. Display and sort key disagreed, so the list looked unsorted.

## Fix

`TutorService.list_conversations` now orders by last activity at the DB level: a correlated subquery over the durable `tutor_messages` table (`MAX(created_at)`, added in #1978), with `COALESCE` fallback to `TutorConversation.created_at` for legacy/empty threads.

This also keeps pagination correct — it fetches the 20 most-recently-*active* threads, not the 20 most-recently-*created*.

- Backend-only. **No migration, no schema change, no write-path change.**
- Frontend unchanged: it already renders the backend order as-is and displays `last_message_at`, so display and sort now agree.

## Tests

- New `test_list_conversations_orders_by_last_activity` asserts the constructed `SELECT`'s `ORDER BY` references `coalesce` / `tutor_messages.created_at` `desc` (mock-based, matching the repo's pattern since DB integration tests are skipped on the conftest enum limitation).
- Existing `list_conversations` field test still passes. Full `test_tutor_service.py`: 16 passed.

Fixes #2407

🤖 Generated with [Claude Code](https://claude.com/claude-code)