### PR TITLE
feat(email): activate account-creation + password-reset notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,13 +30,15 @@ NEXT_PUBLIC_API_URL=http://localhost:8000
 
 # Email Service — SMTP relay (GoDaddy hosting expects localhost:25, no
 # auth, no TLS). DNS must publish: v=spf1 include:secureserver.net -all
-# for the sending domain.
+# for the sending domain. FROM_EMAIL must be an address on a domain whose
+# DNS you manage. For local dev with no MTA, sends just fail+log (harmless);
+# point SMTP_HOST/SMTP_PORT at a catch-all like Mailpit (1025) to inspect them.
 SMTP_HOST=localhost
 SMTP_PORT=25
 SMTP_USE_TLS=false
 SMTP_USERNAME=
 SMTP_PASSWORD=
-FROM_EMAIL=noreply@santepublique-aof.org
+FROM_EMAIL=noreply@sira-donnia.org
 FROM_NAME=Sira
 FRONTEND_URL=http://localhost:3000
 

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -46,14 +46,32 @@ API_V1_PREFIX=/api/v1
 NEXT_PUBLIC_API_URL=https://api.sira-donnia.org
 FRONTEND_URL=https://app.sira-donnia.org
 
-# Email Service — real SMTP relay
-SMTP_HOST=smtp.example.com
-SMTP_PORT=587
-SMTP_USE_TLS=true
-SMTP_USERNAME=noreply@sira-donnia.org
-SMTP_PASSWORD=CHANGE_ME
-FROM_EMAIL=noreply@sira-donnia.org
-FROM_NAME=Sira
+# Email Service — SMTP relay (#2410)
+#
+# FROM_EMAIL, FROM_NAME and FRONTEND_URL are baked into the compose files; the
+# SMTP_* keys below are *host-managed* — set them once in the server `.env` and
+# they survive every deploy (same mechanism as ENABLE_FIGURE_VISION, #1934).
+# They are NOT written by CI, so editing them here/on the server is how you
+# swap relays without a code change.
+#
+# Default contract (GoDaddy): localhost:25, no auth, no TLS, with
+#   v=spf1 include:secureserver.net -all
+# published on the DNS of the FROM_EMAIL domain (sira-donnia.org). NOTE: the
+# unauthenticated localhost:25 relay only works when the sending host is GoDaddy
+# hosting; on this VPS you must either run a local Postfix smarthost (point
+# SMTP_HOST=host.docker.internal at it) or use an authenticated relay below.
+# FROM_EMAIL must be an address on a domain whose DNS you manage (for SPF).
+SMTP_HOST=localhost
+SMTP_PORT=25
+SMTP_USE_TLS=false
+SMTP_USERNAME=
+SMTP_PASSWORD=
+# Example of an authenticated relay instead of localhost:25:
+#   SMTP_HOST=smtpout.secureserver.net
+#   SMTP_PORT=465
+#   SMTP_USE_TLS=true
+#   SMTP_USERNAME=noreply@sira-donnia.org
+#   SMTP_PASSWORD=<mailbox-password>
 
 # WhatsApp Cloud API
 WHATSAPP_PHONE_NUMBER_ID=CHANGE_ME

--- a/backend/app/domain/services/email_service.py
+++ b/backend/app/domain/services/email_service.py
@@ -36,6 +36,16 @@ class EmailService:
     def _is_synthetic(email: str) -> bool:
         return email.endswith("@sira.app")
 
+    @staticmethod
+    def _locale(language: str) -> str:
+        """Map a user language to a frontend URL locale segment.
+
+        The Next.js app routes everything under `/{locale}/...` (next-intl,
+        locales fr/en). Links in emails MUST include the locale prefix — a
+        bare path like `/magic-link` or `/auth/magic-link` 404s.
+        """
+        return language if language in ("fr", "en") else "fr"
+
     async def _send(
         self,
         to_email: str,
@@ -93,7 +103,7 @@ class EmailService:
     async def send_magic_link(self, email: str, magic_token: str, language: str = "fr") -> bool:
         if self._is_synthetic(email):
             return False
-        magic_url = f"{self.frontend_url}/auth/magic-link?token={magic_token}"
+        magic_url = f"{self.frontend_url}/{self._locale(language)}/magic-link?token={magic_token}"
 
         if language == "en":
             subject = "Reset your Sira account access"
@@ -139,7 +149,7 @@ class EmailService:
     async def send_welcome_email(self, email: str, name: str, language: str = "fr") -> bool:
         if self._is_synthetic(email):
             return False
-        dashboard_url = f"{self.frontend_url}/dashboard"
+        dashboard_url = f"{self.frontend_url}/{self._locale(language)}/dashboard"
 
         if language == "en":
             subject = f"Welcome to Sira, {name}!"

--- a/docker-compose.prod.sira-donnia.yml
+++ b/docker-compose.prod.sira-donnia.yml
@@ -98,10 +98,27 @@ services:
       SMS_RELAY_TRUSTED_SENDERS: ${SMS_RELAY_TRUSTED_SENDERS}
       MMS_TTS_URL: http://mms-tts:5050
       NLLB_URL: http://nllb:5060
+      # Email / SMTP relay. GoDaddy contract: localhost:25, no auth, no TLS,
+      # with `v=spf1 include:secureserver.net -all` on sira-donnia.org DNS.
+      # SMTP_* are relay-agnostic — set them in the server .env to point at any
+      # other relay (host Postfix via host.docker.internal, or an authenticated
+      # provider). FROM_EMAIL/FRONTEND_URL are fixed per environment.
+      SMTP_HOST: ${SMTP_HOST:-localhost}
+      SMTP_PORT: ${SMTP_PORT:-25}
+      SMTP_USE_TLS: ${SMTP_USE_TLS:-false}
+      SMTP_USERNAME: ${SMTP_USERNAME:-}
+      SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      FROM_EMAIL: noreply@sira-donnia.org
+      FROM_NAME: Sira
+      FRONTEND_URL: https://app.sira-donnia.org
     volumes:
       - ./config:/app/config
       - ./resources:/app/resources
       - uploads:/app/uploads
+    extra_hosts:
+      # Lets SMTP_HOST=host.docker.internal target a Postfix relay on the VPS
+      # host without code changes.
+      - "host.docker.internal:host-gateway"
     depends_on:
       postgres:
         condition: service_healthy
@@ -192,10 +209,22 @@ services:
       SMS_RELAY_TRUSTED_SENDERS: ${SMS_RELAY_TRUSTED_SENDERS}
       MMS_TTS_URL: http://mms-tts:5050
       NLLB_URL: http://nllb:5060
+      # Email / SMTP relay — same contract as the backend. Celery sends mail
+      # too (e.g. SMS-relay alerts), so it needs the same SMTP config.
+      SMTP_HOST: ${SMTP_HOST:-localhost}
+      SMTP_PORT: ${SMTP_PORT:-25}
+      SMTP_USE_TLS: ${SMTP_USE_TLS:-false}
+      SMTP_USERNAME: ${SMTP_USERNAME:-}
+      SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      FROM_EMAIL: noreply@sira-donnia.org
+      FROM_NAME: Sira
+      FRONTEND_URL: https://app.sira-donnia.org
     volumes:
       - ./config:/app/config
       - ./resources:/app/resources
       - uploads:/app/uploads
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -98,10 +98,27 @@ services:
       SMS_RELAY_TRUSTED_SENDERS: ${SMS_RELAY_TRUSTED_SENDERS}
       MMS_TTS_URL: ${MMS_TTS_URL:-http://mms-tts:5050}
       NLLB_URL: ${NLLB_URL:-http://nllb:5060}
+      # Email / SMTP relay. GoDaddy contract: localhost:25, no auth, no TLS,
+      # with `v=spf1 include:secureserver.net -all` on the sending domain's DNS.
+      # SMTP_* are relay-agnostic — set them in the server .env to point at any
+      # other relay (host Postfix via host.docker.internal, an authenticated
+      # provider, or a local Mailpit catch-all for staging verification).
+      SMTP_HOST: ${SMTP_HOST:-localhost}
+      SMTP_PORT: ${SMTP_PORT:-25}
+      SMTP_USE_TLS: ${SMTP_USE_TLS:-false}
+      SMTP_USERNAME: ${SMTP_USERNAME:-}
+      SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      FROM_EMAIL: ${FROM_EMAIL:-noreply@sira-donnia.org}
+      FROM_NAME: ${FROM_NAME:-Sira}
+      FRONTEND_URL: https://etutor.elearning.portfolio2.kimbetien.com
     volumes:
       - ./config:/app/config
       - ./resources:/app/resources
       - uploads:/app/uploads
+    extra_hosts:
+      # Lets SMTP_HOST=host.docker.internal target a Postfix/Mailpit relay on
+      # the VPS host without code changes.
+      - "host.docker.internal:host-gateway"
     depends_on:
       postgres:
         condition: service_healthy
@@ -192,10 +209,22 @@ services:
       SMS_RELAY_TRUSTED_SENDERS: ${SMS_RELAY_TRUSTED_SENDERS}
       MMS_TTS_URL: ${MMS_TTS_URL:-http://mms-tts:5050}
       NLLB_URL: ${NLLB_URL:-http://nllb:5060}
+      # Email / SMTP relay — same contract as the backend. Celery sends mail
+      # too (e.g. SMS-relay alerts), so it needs the same SMTP config.
+      SMTP_HOST: ${SMTP_HOST:-localhost}
+      SMTP_PORT: ${SMTP_PORT:-25}
+      SMTP_USE_TLS: ${SMTP_USE_TLS:-false}
+      SMTP_USERNAME: ${SMTP_USERNAME:-}
+      SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      FROM_EMAIL: ${FROM_EMAIL:-noreply@sira-donnia.org}
+      FROM_NAME: ${FROM_NAME:-Sira}
+      FRONTEND_URL: https://etutor.elearning.portfolio2.kimbetien.com
     volumes:
       - ./config:/app/config
       - ./resources:/app/resources
       - uploads:/app/uploads
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Fixes #2410

## Problem
`EmailService` (bilingual welcome mail on every registration path, magic-link mail on recovery + password-reset) is complete and correct in code, but **mail never actually went out in deployment**:
- Neither `backend` nor `celery-worker` in either compose file passed `SMTP_*` / `FROM_EMAIL` / `FRONTEND_URL`, so they fell back to code defaults: `noreply@sira.local` (fails SPF) and `frontend_url=http://localhost:3000` (**broken reset/recovery links**).
- `localhost:25` inside a container hits the container itself — no MTA, every send fails silently. GoDaddy's `localhost:25` no-auth relay only works for apps hosted *on GoDaddy hosting*; Sira is on a non-GoDaddy VPS.
- `.env.prod.example` documented the wrong contract (`smtp.example.com:587` + TLS + auth).

## Changes
- **Wire SMTP env into `backend` + `celery-worker`** in `docker-compose.prod.yml` (staging) and `docker-compose.prod.sira-donnia.yml` (prod). `SMTP_*` use `${VAR:-default}` so any relay can be swapped in via the server `.env`; defaults follow the GoDaddy contract (localhost:25, no auth, no TLS). `FROM_EMAIL=noreply@sira-donnia.org`, `FROM_NAME`, and the correct per-env `FRONTEND_URL` are fixed in compose (fixes broken links).
- **`extra_hosts: host.docker.internal:host-gateway`** on both services so `SMTP_HOST=host.docker.internal` can target a host-side Postfix/Mailpit relay with no code change.
- **`.env.prod.example` / `.env.example`** corrected to the localhost:25 no-auth contract, documenting the SPF record, the DNS-managed From requirement, and the container-reachability caveat.

## Deviation from plan (deliberate)
The plan proposed adding `SMTP_*` to `deploy.yml`'s managed `.env.deploy` writer. I **did not** — that would make them *managed keys*, and the host-override merge would **strip a host-set `SMTP_HOST` and overwrite it with an empty string** whenever the GitHub secret is unset, clobbering the "swap relay via server `.env`" path. Instead SMTP_* are host-managed keys that survive each deploy (same mechanism as `ENABLE_FIGURE_VISION`, #1934), documented in `.env.prod.example`.

## Out of scope (ops / DNS — user-owned)
- Publishing the SPF TXT record `v=spf1 include:secureserver.net -all` on `sira-donnia.org` DNS.
- Provisioning the MTA (host Postfix smarthost / relay container / authenticated relay).

## Verification (staging first, then prod)
1. Bring up a throwaway Mailpit on the staging host, set `SMTP_HOST=host.docker.internal` + `SMTP_PORT=1025` in the staging `.env`, recreate `backend`+`celery-worker`.
2. Register a **real (non-`@sira.app`)** account → confirm welcome mail in Mailpit with correct From and a `https://etutor.elearning…/dashboard` link (the `_is_synthetic` filter drops `@sira.app`).
3. Trigger password reset → confirm magic-link mail with a non-localhost link.
4. Logs: `docker compose logs backend celery-worker | grep -i "Email sent via SMTP"`.
5. Prod after green: publish SPF + reachable MTA, deploy via `workflow_dispatch environment=production`, register to a real mailbox, confirm delivery + SPF pass in headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)