### PR TITLE
fix(audio): stop unit audio summaries opening with country/region meta-preamble

### DIFF
--- a/backend/app/domain/services/lesson_audio_service.py
+++ b/backend/app/domain/services/lesson_audio_service.py
@@ -71,9 +71,10 @@ Your task is to write a short spoken audio summary script for a single lesson.
 
 Guidelines:
 - Write in {lang_label}
+- Start IMMEDIATELY with the lesson's actual content. Do NOT open with a meta-sentence about the audio summary, the platform, or the listener's country/region (e.g. never say things like "This audio summary lets you review your content whether you are in Burkina Faso or Senegal…")
 - Length: approximately 500 words — about 3-4 minutes of spoken audio
 - Style: {style}
-- Structure: brief intro → key concepts recap → main takeaway
+- Structure: open directly on the first key concept → recap the key concepts → main takeaway
 - Use simple language accessible on 2G/3G with limited bandwidth
 - {context_note}
 - DO NOT include headers, bullet points, or markdown — write plain spoken prose

--- a/backend/tests/test_lesson_audio_service.py
+++ b/backend/tests/test_lesson_audio_service.py
@@ -36,6 +36,15 @@ class TestBuildLessonAudioSystemPrompt:
         prompt = _build_lesson_audio_system_prompt("en")
         assert "Output only the script text" in prompt
 
+    def test_prompt_forbids_meta_preamble(self):
+        # The script must open on lesson content, not a country/region framing
+        # sentence like "...whether you are in Burkina Faso or Senegal".
+        prompt = _build_lesson_audio_system_prompt("en")
+        assert "Start IMMEDIATELY" in prompt
+        assert "country/region" in prompt
+        # And the old "brief intro" framing must be gone.
+        assert "brief intro" not in prompt
+
 
 class TestEstimateDuration:
     def test_minimum_duration_is_one(self):


### PR DESCRIPTION
## Summary

Unit **audio summaries** often opened with a content-free meta-preamble like *"This audio summary allows you to review your course content whether you are in Burkina Faso, Senegal…"* — wasting TTS seconds and adding nothing pedagogically. This makes the summary start directly on lesson content.

## Changes
- `_build_lesson_audio_system_prompt` (`backend/app/domain/services/lesson_audio_service.py`):
  - Added an explicit instruction to **start immediately with lesson content** and never open with a meta-sentence about the summary, platform, or the listener's country/region.
  - Changed the structure guideline from `brief intro → key concepts recap → main takeaway` to `open directly on the first key concept → recap → main takeaway`.
  - Kept the West-African examples reference (examples *within* the content are still wanted).
- Added regression test `test_prompt_forbids_meta_preamble`.

## Scope / notes
- Sibling audio services (`qbank_audio_service.py`, `tutor_audio_service.py`) use different prompts and are unaffected.
- Existing audio is cached per `(module, unit, language)`, so this only affects **newly generated** summaries. Regenerating cached units would re-spend Claude + OpenAI TTS and is out of scope.

## Test
`uv run pytest tests/test_lesson_audio_service.py -q` → 15 passed.

Fixes #2416

🤖 Generated with [Claude Code](https://claude.com/claude-code)