### PR TITLE
test(e2e): payment-method selector coverage (Orange Money, Wave, Paystack) (#2419)

### DIFF
--- a/frontend/e2e/pages/subscribe-page.ts
+++ b/frontend/e2e/pages/subscribe-page.ts
@@ -1,0 +1,46 @@
+/**
+ * Page object for /[locale]/subscribe — the provider-API payment selector (#2355).
+ *
+ * Thin wrapper — locators only for the payment-method selector, Pay CTA, the
+ * "no methods" empty state, and the inline error. Specs route-mock
+ * /api/v1/payments/* so these assertions stay deterministic (see #2419).
+ */
+
+import type { Locator, Page } from '@playwright/test';
+
+/** Visible method labels (en locale) keyed by provider id. */
+export const METHOD_LABELS = {
+  orange_money: 'Orange Money',
+  wave: 'Wave',
+  paystack: 'Bank card',
+} as const;
+
+export type ProviderId = keyof typeof METHOD_LABELS;
+
+export class SubscribePage {
+  constructor(public readonly page: Page) {}
+
+  async goto(locale: 'fr' | 'en' = 'en'): Promise<void> {
+    await this.page.goto(`/${locale}/subscribe`);
+  }
+
+  /** A payment-method option button by provider id (matched on its visible label). */
+  methodButton(provider: ProviderId): Locator {
+    return this.page.getByRole('button', { name: METHOD_LABELS[provider], exact: true });
+  }
+
+  /** The "Pay …" checkout CTA. */
+  payButton(): Locator {
+    return this.page.getByRole('button', { name: /pay/i });
+  }
+
+  /** Empty state shown when no provider is enabled. */
+  noMethods(): Locator {
+    return this.page.getByText(/no payment method is available/i);
+  }
+
+  /** Inline error surfaced when initialize fails (e.g. provider misconfigured). */
+  paymentError(): Locator {
+    return this.page.getByText(/payment provider error|payment could not be started/i);
+  }
+}

--- a/frontend/e2e/specs/02-learner/subscribe-payments.spec.ts
+++ b/frontend/e2e/specs/02-learner/subscribe-payments.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * Payment-method selector on /subscribe — all three modes (#2419, follow-up to #2355).
+ *
+ * Route-mocked: GET /api/v1/payments/providers and /subscriptions/me are
+ * intercepted so the test is deterministic and never mutates shared staging
+ * platform settings. Service workers are blocked so the PWA's stale-while-
+ * revalidate api-responses cache can't shadow the mocked responses.
+ */
+
+import { expect, test } from '@playwright/test';
+import { SubscribePage } from '../../pages/subscribe-page';
+
+const PROVIDERS_URL = '**/api/v1/payments/providers';
+const INITIALIZE_URL = '**/api/v1/payments/initialize';
+const SUBSCRIPTION_ME = '**/api/v1/subscriptions/me';
+
+const ALL_THREE = ['orange_money', 'wave', 'paystack'];
+
+// Free-tier subscription so isActive=false and the selector renders, regardless
+// of the e2e-learner fixture's real subscription state.
+const FREE_TIER = {
+  has_subscription: false,
+  free_tier: { daily_messages: 5, first_lesson_free: true },
+};
+
+async function mockProviders(page: import('@playwright/test').Page, providers: string[]) {
+  await page.route(PROVIDERS_URL, (route) => route.fulfill({ json: { providers } }));
+}
+
+test.describe('@learner subscribe — payment methods', () => {
+  // Block the service worker so page.route() always intercepts the API calls.
+  test.use({ serviceWorkers: 'block' });
+
+  test.beforeEach(async ({ page }) => {
+    await page.route(SUBSCRIPTION_ME, (route) => route.fulfill({ json: FREE_TIER }));
+  });
+
+  test('renders Orange Money, Wave and Bank card when all are enabled', async ({ page }) => {
+    await mockProviders(page, ALL_THREE);
+    const subscribe = new SubscribePage(page);
+    await subscribe.goto('en');
+
+    await expect(subscribe.methodButton('orange_money')).toBeVisible();
+    await expect(subscribe.methodButton('wave')).toBeVisible();
+    await expect(subscribe.methodButton('paystack')).toBeVisible();
+    await expect(subscribe.payButton()).toBeVisible();
+
+    // First provider is selected by default.
+    await expect(subscribe.methodButton('orange_money')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  test('selecting a method moves the aria-pressed state', async ({ page }) => {
+    await mockProviders(page, ALL_THREE);
+    const subscribe = new SubscribePage(page);
+    await subscribe.goto('en');
+
+    await subscribe.methodButton('wave').click();
+    await expect(subscribe.methodButton('wave')).toHaveAttribute('aria-pressed', 'true');
+    await expect(subscribe.methodButton('orange_money')).toHaveAttribute('aria-pressed', 'false');
+    await expect(subscribe.methodButton('paystack')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  test('shows only the enabled providers (Paystack only → Bank card only)', async ({ page }) => {
+    await mockProviders(page, ['paystack']);
+    const subscribe = new SubscribePage(page);
+    await subscribe.goto('en');
+
+    await expect(subscribe.methodButton('paystack')).toBeVisible();
+    await expect(subscribe.methodButton('orange_money')).toHaveCount(0);
+    await expect(subscribe.methodButton('wave')).toHaveCount(0);
+  });
+
+  test('shows the empty state when no provider is enabled', async ({ page }) => {
+    await mockProviders(page, []);
+    const subscribe = new SubscribePage(page);
+    await subscribe.goto('en');
+
+    await expect(subscribe.noMethods()).toBeVisible();
+    await expect(subscribe.payButton()).toHaveCount(0);
+  });
+
+  test('Pay posts the selected provider to initialize and follows checkout_url', async ({
+    page,
+  }) => {
+    await mockProviders(page, ALL_THREE);
+
+    // Stub the provider's hosted checkout so window.location redirect resolves.
+    await page.route('https://provider.test/**', (route) =>
+      route.fulfill({ contentType: 'text/html', body: 'ok' }),
+    );
+    await page.route(INITIALIZE_URL, (route) => {
+      const body = route.request().postDataJSON();
+      return route.fulfill({
+        json: {
+          checkout_url: 'https://provider.test/checkout/abc',
+          reference: 'sira_test',
+          provider: body.provider,
+        },
+      });
+    });
+
+    const subscribe = new SubscribePage(page);
+    await subscribe.goto('en');
+    await subscribe.methodButton('wave').click();
+
+    const initReq = page.waitForRequest(INITIALIZE_URL);
+    await subscribe.payButton().click();
+    const body = (await initReq).postDataJSON();
+
+    expect(body.provider).toBe('wave');
+    expect(body.payment_type).toBe('access');
+  });
+
+  test('surfaces an inline error when initialize fails', async ({ page }) => {
+    await mockProviders(page, ['paystack']);
+    await page.route(INITIALIZE_URL, (route) =>
+      route.fulfill({ status: 502, json: { detail: 'Payment provider error' } }),
+    );
+
+    const subscribe = new SubscribePage(page);
+    await subscribe.goto('en');
+    await subscribe.payButton().click();
+
+    await expect(subscribe.paymentError()).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Adds e2e coverage for the `/subscribe` payment-method selector shipped in #2355. Route-mocked so it's deterministic and **never mutates shared staging platform settings**.

Fixes #2419

## What's added
- `frontend/e2e/pages/subscribe-page.ts` — page object (method buttons, Pay CTA, empty state, error).
- `frontend/e2e/specs/02-learner/subscribe-payments.spec.ts` — 6 tests:
  1. All three methods render (Orange Money / Wave / Bank card) + first selected by default.
  2. Selecting a method moves the `aria-pressed` state.
  3. Only enabled providers show (Paystack only → Bank card only).
  4. Empty state when no provider is enabled.
  5. **Pay** posts the selected provider + `payment_type` to `/payments/initialize` and follows `checkout_url`.
  6. Inline error surfaced when initialize fails (502).

## Design
- Mocks `GET /api/v1/payments/providers` and `/subscriptions/me` via `page.route()` → deterministic, no global state mutation, no dependency on which providers an admin has enabled.
- `test.use({ serviceWorkers: 'block' })` so the PWA's stale-while-revalidate `api-responses` cache can't shadow the mocked responses (a real gotcha observed during manual testing).
- Runs in the existing **E2E Persona Suite (Playwright vs staging)** CI job under the `02-learner` project (uses the secret-backed setup storageState).

## Verification
- `npx playwright test --project=02-learner subscribe-payments` → **6 passed** against staging.
- `playwright --list` discovers all 6; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)