### PR TITLE
fix(quality,extraction): greenlet lazy-load in quality sweep + .PDF case mismatch

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -1688,7 +1688,13 @@ async def upload_course_resource(
     file_hash = hashlib.sha256(data).hexdigest()
 
     safe_name = re.sub(r"[^\w.\-]", "_", Path(file.filename or "resource.pdf").name)
-    if not safe_name.lower().endswith(".pdf"):
+    # Normalise the extension to a lowercase ".pdf". Files uploaded with an
+    # uppercase ".PDF" were written verbatim, but extract_course_resource looks
+    # for "<stem>.pdf" and globs "*.pdf" — both case-sensitive on Linux — so the
+    # source was silently dropped ("PDF file not found on disk").
+    if safe_name.lower().endswith(".pdf"):
+        safe_name = safe_name[: -len(".pdf")] + ".pdf"
+    else:
         safe_name += ".pdf"
 
     # File-hash dedup: if an identical PDF was already extracted for any course,

--- a/backend/app/domain/services/quality_agent_service.py
+++ b/backend/app/domain/services/quality_agent_service.py
@@ -42,6 +42,7 @@ import structlog
 from sqlalchemy import and_, func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.ai.claude_service import ClaudeService
 from app.ai.prompts.quality import (
@@ -184,11 +185,16 @@ class CourseQualityService:
             summary_parts.append(f"### {r.filename}\n{r.summary_text.strip()[:6000]}")
         source_summaries_block = "\n\n".join(summary_parts) or "(no source summaries available)"
 
-        # Glossary
+        # Glossary. Eager-load first_unit: the loop below reads
+        # ``t.first_unit.unit_number``, and a lazy relationship access on an
+        # AsyncSession raises "greenlet_spawn has not been called". This runs
+        # in the Celery sweep (assess_course_task) outside any per-unit
+        # try/except, so the lazy load would fail the whole run.
         gloss_result = await session.execute(
             select(CourseGlossaryTerm)
             .where(CourseGlossaryTerm.course_id == course_id)
             .where(CourseGlossaryTerm.language == language)
+            .options(selectinload(CourseGlossaryTerm.first_unit))
         )
         terms = list(gloss_result.scalars().all())
         glossary_parts: list[str] = []

--- a/backend/app/tasks/quality_assessment.py
+++ b/backend/app/tasks/quality_assessment.py
@@ -533,6 +533,7 @@ def assess_course_task(
                                 content_id=str(gc.id),
                                 run_id=run_id,
                                 error=str(e),
+                                exc_info=True,
                             )
                             # Roll back the failed unit's tx but keep the sweep going.
                             await session.rollback()
@@ -565,5 +566,6 @@ def assess_course_task(
             run_id=run_id,
             exception=str(exc),
             task_id=self.request.id,
+            exc_info=True,
         )
         return {"status": "failed", "error": str(exc), "run_id": run_id}

--- a/backend/app/tasks/resource_extraction.py
+++ b/backend/app/tasks/resource_extraction.py
@@ -92,8 +92,12 @@ def extract_course_resource(self, resource_id: str) -> dict:
         pdf_path = course_dir / f"{original_filename}.pdf"
 
         if not pdf_path.exists():
-            for candidate in course_dir.glob("*.pdf"):
-                if candidate.stem == original_filename:
+            # Case-insensitive fallback: files uploaded with an uppercase ".PDF"
+            # were written verbatim, and the lowercase lookup + "*.pdf" glob
+            # above are case-sensitive on Linux. Match on the extension lowercased
+            # so existing ".PDF" uploads are recovered without re-uploading.
+            for candidate in course_dir.glob("*"):
+                if candidate.suffix.lower() == ".pdf" and candidate.stem == original_filename:
                     pdf_path = candidate
                     break
 

--- a/backend/tests/test_quality_agent.py
+++ b/backend/tests/test_quality_agent.py
@@ -515,3 +515,53 @@ def test_dimension_scores_rejects_negative():
             pedagogical_fit=80,
             structural_completeness=80,
         )
+
+
+# ---- build_quality_context eager-loads first_unit (greenlet regression) ----
+
+
+async def test_build_quality_context_eager_loads_glossary_first_unit():
+    """Regression: the glossary loop reads ``t.first_unit.unit_number``. On an
+    AsyncSession a lazy relationship access raises ``greenlet_spawn has not
+    been called``, failing the whole assess_course_task sweep. The query must
+    eager-load ``first_unit`` via selectinload.
+    """
+    import uuid
+    from unittest.mock import AsyncMock, MagicMock
+
+    from app.domain.models.course import Course
+    from app.domain.models.course_quality import CourseGlossaryTerm
+    from app.domain.services.quality_agent_service import CourseQualityService
+
+    captured: list = []
+
+    course = MagicMock()
+    course.syllabus_context = None
+    course.syllabus_json = None
+    course.objectives_json = None
+
+    def _result_for(stmt):
+        captured.append(stmt)
+        result = MagicMock()
+        entity = stmt.column_descriptions[0]["entity"]
+        if entity is Course:
+            result.scalar_one_or_none.return_value = course
+        else:
+            scalars = MagicMock()
+            scalars.all.return_value = []
+            result.scalars.return_value = scalars
+        return result
+
+    session = MagicMock()
+    session.execute = AsyncMock(side_effect=_result_for)
+
+    service = CourseQualityService(MagicMock(), MagicMock())
+    await service.build_quality_context(course_id=uuid.uuid4(), language="fr", session=session)
+
+    gloss_stmts = [s for s in captured if s.column_descriptions[0]["entity"] is CourseGlossaryTerm]
+    assert gloss_stmts, "glossary query was not executed"
+    option_paths = " ".join(str(o.path) for o in gloss_stmts[0]._with_options)
+    assert "first_unit" in option_paths, (
+        "glossary query must selectinload(CourseGlossaryTerm.first_unit) to "
+        "avoid a lazy-load greenlet error in the Celery sweep"
+    )

--- a/backend/tests/test_resource_extraction.py
+++ b/backend/tests/test_resource_extraction.py
@@ -121,6 +121,70 @@ class TestExtractCourseResourceTask:
         assert mock_resource.extraction_status == EXTRACTION_STATUS_DONE
         assert mock_resource.raw_text
 
+    def test_task_finds_uppercase_pdf_extension(self, tmp_path):
+        """Regression: a file uploaded with an uppercase ``.PDF`` extension is
+        written verbatim, but the lookup builds ``<stem>.pdf`` and globs
+        ``*.pdf`` — both case-sensitive on Linux — so the source was silently
+        dropped. The fallback must match the extension case-insensitively.
+        """
+        from app.tasks.resource_extraction import extract_course_resource
+
+        course_id = uuid.uuid4()
+        resource_id = uuid.uuid4()
+
+        pdf_dir = tmp_path / str(course_id)
+        pdf_dir.mkdir(parents=True)
+        # Uppercase extension on disk; DB stores the bare stem.
+        (pdf_dir / "Donor_Alignment.PDF").write_bytes(_make_minimal_pdf())
+
+        mock_resource = MagicMock()
+        mock_resource.id = resource_id
+        mock_resource.course_id = course_id
+        mock_resource.filename = "Donor_Alignment"
+        mock_resource.extraction_status = EXTRACTION_STATUS_PENDING
+
+        mock_course = MagicMock()
+        mock_course.id = course_id
+        mock_course.creation_mode = "legacy"
+        mock_course.rag_collection_id = None
+        mock_course.indexation_task_id = None
+
+        class MockSession:
+            def get(self, model, pk):
+                from app.domain.models.course import Course
+                from app.domain.models.course_resource import CourseResource
+
+                if model is CourseResource:
+                    return mock_resource
+                if model is Course:
+                    return mock_course
+                return None
+
+            def add(self, _obj):
+                pass
+
+            def commit(self):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                pass
+
+        with (
+            patch("app.tasks.resource_extraction.UPLOAD_DIR", tmp_path),
+            patch(
+                "app.tasks.resource_extraction.Session",
+                side_effect=lambda *a, **k: MockSession(),
+            ),
+        ):
+            result = extract_course_resource(str(resource_id))
+
+        assert result["status"] == "done"
+        assert mock_resource.extraction_status == EXTRACTION_STATUS_DONE
+        assert mock_resource.raw_text
+
     def test_task_marks_failed_when_pdf_missing(self, tmp_path):
         from app.tasks.resource_extraction import extract_course_resource
 


### PR DESCRIPTION
## Summary

Two independent, pre-existing bugs surfaced from the demo-tenant celery logs (separate from the indexation soft-timeout fix in #2422).

### #2423 — `assess_course_task` always fails with `greenlet_spawn has not been called`
`build_quality_context` reads `t.first_unit.unit_number` on glossary terms loaded **without** eager-loading. A lazy relationship access on an `AsyncSession` raises `greenlet_spawn`, and the call sits **outside** the per-unit `try/except`, so it fails the entire course quality sweep. Only fires once a glossary has terms with `first_unit` set — which is why `assess_course_structure_task` succeeds but the full sweep doesn't.

**Fix:** `selectinload(CourseGlossaryTerm.first_unit)` on the glossary query; add `exc_info=True` to the failure logs (the throw site was invisible — only `str(exc)` was logged).

### #2424 — Course resource silently dropped (`extract_course_resource: PDF file not found on disk`)
Confirmed via read-only `ls` on the prod container: the file is on disk as `…Health.PDF` (uppercase). The upload sanitizer preserves `.PDF`; extraction reconstructs a hardcoded lowercase `<stem>.pdf` and globs `*.pdf` — both case-sensitive on Linux → not found, source never enters RAG.

**Fix:** normalize the extension to lowercase `.pdf` on upload (going forward) + make the extraction fallback glob case-insensitive (recovers existing `.PDF` files without re-upload).

## Test plan
- [x] Regression test: `build_quality_context` glossary query carries `selectinload(first_unit)`
- [x] Regression test: `extract_course_resource` locates a file written as `.PDF`
- [x] `ruff check` + `ruff format` clean; `pytest` green for quality + extraction + upload + admin suites (83 passed)

## Follow-up (noted in #2424)
Surface stranded `file_not_found`/failed resources in the admin/recap UI so a dropped source is noticed rather than silently missing from RAG.

Closes #2423
Closes #2424

🤖 Generated with [Claude Code](https://claude.com/claude-code)