### PR TITLE
feat(courses): surface which sources are really used (extracted + indexed)

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -1613,7 +1613,15 @@ async def list_course_resources(
     current_user: AuthenticatedUser = Depends(require_role(UserRole.admin, UserRole.sub_admin)),
     db=Depends(get_db_session),
 ) -> dict:
-    """List uploaded resource files for a course."""
+    """List a course's uploaded resources with their real extraction + indexation status.
+
+    DB-driven (CourseResource is the source of truth), not disk-driven: a resource
+    whose file is missing/failed (#2424), deduped (no file on disk), or saved with an
+    uppercase ``.PDF`` would otherwise be invisible. Each entry carries
+    ``chunks_indexed`` — the count of DocumentChunk rows tied to this resource via
+    ``course_resource_id`` — which is the definitive "this source is actually used in
+    RAG" signal admins need (>0 = used, 0 = not used).
+    """
     result = await db.execute(select(Course).where(Course.id == course_id))
     course = result.scalar_one_or_none()
     if not course:
@@ -1622,25 +1630,54 @@ async def list_course_resources(
     from app.domain.models.course_resource import CourseResource
 
     db_resources_result = await db.execute(
-        select(CourseResource).where(CourseResource.course_id == course_id)
+        select(CourseResource)
+        .where(CourseResource.course_id == course_id)
+        .order_by(CourseResource.extracted_at)
     )
-    db_resources = {r.filename: r for r in db_resources_result.scalars().all()}
+    db_resources = list(db_resources_result.scalars().all())
+
+    # Per-resource indexed-chunk counts in one grouped query (mirrors the
+    # aggregate count in /index-status). Chunks carry course_resource_id since
+    # #2186; legacy chunks with NULL are simply uncounted.
+    chunks_by_resource: dict[uuid.UUID, int] = {}
+    if course.rag_collection_id:
+        counts_result = await db.execute(
+            select(DocumentChunk.course_resource_id, func.count())
+            .where(DocumentChunk.source == course.rag_collection_id)
+            .where(DocumentChunk.course_resource_id.isnot(None))
+            .group_by(DocumentChunk.course_resource_id)
+        )
+        chunks_by_resource = {rid: n for rid, n in counts_result.all()}
 
     course_dir = UPLOAD_DIR / str(course_id)
-    if not course_dir.exists():
-        return {"course_id": str(course_id), "files": []}
+
+    def _disk_file(stem: str):
+        # Case-insensitive: files uploaded as ".PDF" were written verbatim (#2424).
+        if not course_dir.exists():
+            return None
+        for candidate in course_dir.glob("*"):
+            if candidate.suffix.lower() == ".pdf" and candidate.stem == stem:
+                return candidate
+        return None
 
     files = []
-    for f in sorted(course_dir.glob("*.pdf")):
-        stat = f.stat()
-        stem = f.stem
-        db_res = db_resources.get(stem)
+    for r in db_resources:
+        disk = _disk_file(r.filename)
+        stat = disk.stat() if disk else None
         files.append(
             {
-                "name": f.name,
-                "size_bytes": stat.st_size,
-                "uploaded_at": datetime.fromtimestamp(stat.st_mtime, tz=UTC).isoformat(),
-                "extraction_status": db_res.extraction_status if db_res else "done",
+                "resource_id": str(r.id),
+                "name": disk.name if disk else f"{r.filename}.pdf",
+                "size_bytes": stat.st_size if stat else None,
+                "uploaded_at": (
+                    datetime.fromtimestamp(stat.st_mtime, tz=UTC).isoformat()
+                    if stat
+                    else r.extracted_at.isoformat()
+                ),
+                "extraction_status": r.extraction_status,
+                "char_count": r.char_count,
+                "chunks_indexed": chunks_by_resource.get(r.id, 0),
+                "on_disk": disk is not None,
             }
         )
 

--- a/backend/tests/test_admin_courses_helpers.py
+++ b/backend/tests/test_admin_courses_helpers.py
@@ -330,3 +330,82 @@ def test_diagnose_pointer_returns_live_for_pending_with_meta(monkeypatch):
     course = SimpleNamespace(indexation_task_id="t-1")
     verdict, _state, _meta = _diagnose_indexation_pointer(course, require_progress=False)
     assert verdict == "live"
+
+
+# ---- list_course_resources: per-source "really used" status (DB-driven) ----
+
+
+class _ResourcesResult:
+    """Scriptable stand-in for a SQLAlchemy Result across the endpoint's queries."""
+
+    def __init__(self, *, scalar=None, scalars_all=None, rows=None):
+        self._scalar = scalar
+        self._scalars_all = scalars_all
+        self._rows = rows
+
+    def scalar_one_or_none(self):
+        return self._scalar
+
+    def scalars(self):
+        from unittest.mock import MagicMock
+
+        inner = MagicMock()
+        inner.all.return_value = self._scalars_all
+        return inner
+
+    def all(self):
+        return self._rows
+
+
+async def test_list_course_resources_reports_per_source_chunk_counts(tmp_path, monkeypatch):
+    """DB-driven listing: resources missing from disk still appear, and each
+    carries chunks_indexed (the "used in RAG" signal). A failed source shows
+    chunks_indexed=0; an indexed source shows its count.
+    """
+    import uuid as _uuid
+    from datetime import UTC, datetime
+    from unittest.mock import AsyncMock
+
+    from app.api.v1 import admin_courses
+    from app.api.v1.admin_courses import list_course_resources
+
+    course_id = _uuid.uuid4()
+    used = SimpleNamespace(
+        id=_uuid.uuid4(),
+        filename="indexed_source",
+        char_count=4200,
+        extraction_status="done",
+        extracted_at=datetime(2026, 6, 6, tzinfo=UTC),
+    )
+    dropped = SimpleNamespace(
+        id=_uuid.uuid4(),
+        filename="Donor_Alignment",  # uploaded as .PDF / file_not_found → not on disk
+        char_count=None,
+        extraction_status="failed",
+        extracted_at=datetime(2026, 6, 6, tzinfo=UTC),
+    )
+
+    course = SimpleNamespace(id=course_id, rag_collection_id="rag-collection-1")
+
+    db = SimpleNamespace()
+    db.execute = AsyncMock(
+        side_effect=[
+            _ResourcesResult(scalar=course),  # SELECT Course
+            _ResourcesResult(scalars_all=[used, dropped]),  # SELECT CourseResource
+            _ResourcesResult(rows=[(used.id, 12)]),  # grouped chunk counts
+        ]
+    )
+
+    # No files on disk → both resources still listed (DB-driven), on_disk False.
+    monkeypatch.setattr(admin_courses, "UPLOAD_DIR", tmp_path)
+
+    resp = await list_course_resources(course_id=course_id, current_user=None, db=db)
+
+    by_id = {f["resource_id"]: f for f in resp["files"]}
+    assert by_id[str(used.id)]["chunks_indexed"] == 12
+    assert by_id[str(used.id)]["extraction_status"] == "done"
+    assert by_id[str(dropped.id)]["chunks_indexed"] == 0
+    assert by_id[str(dropped.id)]["extraction_status"] == "failed"
+    assert by_id[str(dropped.id)]["on_disk"] is False
+    # The dropped source is visible even though it has no file on disk.
+    assert len(resp["files"]) == 2

--- a/frontend/app/[locale]/admin/courses/[courseId]/sources/page.tsx
+++ b/frontend/app/[locale]/admin/courses/[courseId]/sources/page.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+import { CourseSourcesClient } from "@/components/admin/course-sources-client";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string; courseId: string }>;
+}) {
+  await params;
+  const t = await getTranslations("AdminCourses.sourcesPage");
+  return {
+    title: t("pageTitle"),
+    description: t("pageDescription"),
+  };
+}
+
+export default async function AdminCourseSourcesPage({
+  params,
+}: {
+  params: Promise<{ locale: string; courseId: string }>;
+}) {
+  const { courseId } = await params;
+  const t = await getTranslations("AdminCourses.sourcesPage");
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <div className="border-b bg-background p-4 shrink-0">
+        <Link
+          href="/admin/courses"
+          className="mb-2 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="size-4" />
+          {t("backToCourses")}
+        </Link>
+        <h1 className="text-2xl font-bold">{t("pageTitle")}</h1>
+        <p className="text-muted-foreground mt-1">{t("pageDescription")}</p>
+      </div>
+      <div className="p-4">
+        <CourseSourcesClient courseId={courseId} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -65,6 +65,8 @@ import {
   CourseResourceUploadStep,
   useCourseResourceUpload,
 } from "@/components/admin/course-resource-upload-step";
+import { SourceStatusBadge } from "@/components/admin/source-status-badge";
+import { CourseSourcesUsage } from "@/components/admin/course-sources-usage";
 
 const EXTRACTING_STATUSES = new Set(["pending", "extracting"]);
 
@@ -150,6 +152,7 @@ function AttachedResources({
                 <p className="truncate text-xs font-medium">{f.name}</p>
                 <p className="text-xs text-muted-foreground">{formatBytes(f.size_bytes)}</p>
               </div>
+              <SourceStatusBadge status={f.extraction_status} chunks={f.chunks_indexed} />
             </div>
           ))}
         </div>
@@ -1693,6 +1696,18 @@ export function AICourseWizard({
                       )}
                       {tAi("linker.retryButton")}
                     </Button>
+                  )}
+
+                  {courseId && (
+                    <div className="space-y-2 pt-1">
+                      <p className="text-sm font-medium">
+                        {t("sourcesUsage.title")}
+                      </p>
+                      <CourseSourcesUsage
+                        courseId={courseId}
+                        refreshKey={indexStatus?.chunks_indexed}
+                      />
+                    </div>
                   )}
                 </div>
               );

--- a/frontend/components/admin/course-resource-upload-step.tsx
+++ b/frontend/components/admin/course-resource-upload-step.tsx
@@ -102,9 +102,10 @@ export function useCourseResourceUpload(
         if (cancelled) return;
         const serverFiles: UploadedFile[] = (data.files ?? []).map((f) => ({
           name: f.name,
-          size_bytes: f.size_bytes,
+          size_bytes: f.size_bytes ?? 0,
           status: "uploaded" as const,
           extraction_status: f.extraction_status,
+          chunks_indexed: f.chunks_indexed,
         }));
         setFiles((prev) => {
           const localNames = new Set(prev.map((f) => f.name));

--- a/frontend/components/admin/course-sources-client.tsx
+++ b/frontend/components/admin/course-sources-client.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { CourseSourcesUsage } from "@/components/admin/course-sources-usage";
+
+/**
+ * Persistent per-course "which sources are really used" panel, reachable from the
+ * course list ("Sources" action). Lets admins audit a published course's sources
+ * — extracted + indexed vs silently dropped — outside the creation wizard.
+ */
+export function CourseSourcesClient({ courseId }: { courseId: string }) {
+  return (
+    <div className="max-w-3xl">
+      <CourseSourcesUsage courseId={courseId} />
+    </div>
+  );
+}

--- a/frontend/components/admin/course-sources-usage.tsx
+++ b/frontend/components/admin/course-sources-usage.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { AlertTriangle, FileText } from "lucide-react";
+import {
+  getCourseResources,
+  type CourseResourceStatus,
+} from "@/lib/api-course-admin";
+import { SourceStatusBadge } from "@/components/admin/source-status-badge";
+
+/**
+ * Per-source "really used in RAG" panel: lists every uploaded source (DB-driven,
+ * so failed/deduped/missing-on-disk sources appear too) with its indexed-chunk
+ * status, and warns prominently when any source was dropped (failed extraction or
+ * 0 chunks). Reused in the creation wizards' indexation recap and the persistent
+ * course Sources page.
+ *
+ * `refreshKey` change → refetch (the wizard passes the live chunk count so the
+ * panel updates as indexation lands).
+ */
+export function CourseSourcesUsage({
+  courseId,
+  refreshKey,
+}: {
+  courseId: string;
+  refreshKey?: unknown;
+}) {
+  const t = useTranslations("AdminCourses.wizard.sourcesUsage");
+  const [sources, setSources] = useState<CourseResourceStatus[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      const data = await getCourseResources(courseId);
+      setSources(data.files);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [courseId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await getCourseResources(courseId);
+        if (!cancelled) setSources(data.files);
+      } catch {
+        if (!cancelled) setError(true);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId, refreshKey]);
+
+  if (loading && sources === null) {
+    return <p className="text-xs text-muted-foreground">{t("loading")}</p>;
+  }
+  if (error) {
+    return (
+      <button
+        type="button"
+        onClick={load}
+        className="text-xs text-destructive underline-offset-2 hover:underline"
+      >
+        {t("error")}
+      </button>
+    );
+  }
+  if (!sources || sources.length === 0) return null;
+
+  const dropped = sources.filter(
+    (s) => s.extraction_status === "failed" || s.chunks_indexed === 0
+  );
+
+  return (
+    <div className="space-y-2">
+      {dropped.length > 0 && (
+        <div className="flex items-start gap-2 rounded-lg border border-amber-300 bg-amber-50 p-3 text-xs text-amber-800 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-300">
+          <AlertTriangle className="h-4 w-4 shrink-0" />
+          <span>{t("droppedWarning", { count: dropped.length })}</span>
+        </div>
+      )}
+      <ul className="divide-y rounded-lg border">
+        {sources.map((s) => (
+          <li
+            key={s.resource_id}
+            className="flex items-center gap-2.5 px-3 py-2"
+          >
+            <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="min-w-0 flex-1 truncate text-xs font-medium">
+              {s.name}
+            </span>
+            <SourceStatusBadge
+              status={s.extraction_status}
+              chunks={s.chunks_indexed}
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/components/admin/course-wizard-client.tsx
+++ b/frontend/components/admin/course-wizard-client.tsx
@@ -40,6 +40,8 @@ import {
   CourseResourceUploadStep,
   useCourseResourceUpload,
 } from "@/components/admin/course-resource-upload-step";
+import { SourceStatusBadge } from "@/components/admin/source-status-badge";
+import { CourseSourcesUsage } from "@/components/admin/course-sources-usage";
 
 type WizardStep = "upload" | "info" | "generate" | "index" | "publish";
 
@@ -153,6 +155,7 @@ function AttachedResources({
                 <p className="truncate text-xs font-medium">{f.name}</p>
                 <p className="text-xs text-muted-foreground">{formatBytes(f.size_bytes)}</p>
               </div>
+              <SourceStatusBadge status={f.extraction_status} chunks={f.chunks_indexed} />
             </div>
           ))}
         </div>
@@ -1498,6 +1501,16 @@ export function CourseWizardClient({
                         </Button>
                       </div>
                     )}
+                  </div>
+                )}
+
+                {courseId && (
+                  <div className="space-y-2">
+                    <p className="text-sm font-medium">{t("sourcesUsage.title")}</p>
+                    <CourseSourcesUsage
+                      courseId={courseId}
+                      refreshKey={indexStatus?.chunks_indexed}
+                    />
                   </div>
                 )}
               </div>

--- a/frontend/components/admin/courses-client.tsx
+++ b/frontend/components/admin/courses-client.tsx
@@ -410,6 +410,7 @@ export function CoursesClient() {
                 onGenerateStructure={(c) => setPendingAction({ type: 'generate', course: c })}
                 onEdit={(c) => { setEditingCourse(c); setFormOpen(true); }}
                 onReviewQuality={(c) => router.push(`/admin/courses/${c.id}/quality`)}
+                onViewSources={(c) => router.push(`/admin/courses/${c.id}/sources`)}
                 onResumeWizard={() => openWizardResume(course)}
               />
             ))}
@@ -562,6 +563,7 @@ function CourseRow({
   onGenerateStructure,
   onEdit,
   onReviewQuality,
+  onViewSources,
   onResumeWizard,
 }: {
   course: AdminCourse;
@@ -572,6 +574,7 @@ function CourseRow({
   onGenerateStructure: (c: AdminCourse) => void;
   onEdit: (c: AdminCourse) => void;
   onReviewQuality: (c: AdminCourse) => void;
+  onViewSources: (c: AdminCourse) => void;
   onResumeWizard: () => void;
 }) {
   const t = useTranslations('AdminCourses');
@@ -676,6 +679,10 @@ function CourseRow({
               <DropdownMenuItem onClick={() => onReviewQuality(course)}>
                 <Activity className="mr-2 h-4 w-4" />
                 {t('reviewQuality')}
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onViewSources(course)}>
+                <Database className="mr-2 h-4 w-4" />
+                {t('viewSources')}
               </DropdownMenuItem>
               {!isPublished && (
                 <DropdownMenuItem

--- a/frontend/components/admin/source-status-badge.tsx
+++ b/frontend/components/admin/source-status-badge.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { CheckCircle2, AlertCircle, AlertTriangle } from "lucide-react";
+import { useTranslations } from "next-intl";
+import type { ExtractionStatus } from "@/lib/api-course-admin";
+
+/**
+ * Per-source "really used in RAG" badge, shared by the wizards' attached-resources
+ * lists, the indexation recap, and the course Sources panel.
+ *
+ * The definitive "used" signal is `chunks_indexed` (DocumentChunk rows tied to the
+ * resource). A source can be extraction_status="done" yet contribute 0 chunks
+ * (e.g. file_not_found #2424, or not indexed yet) — that must read as NOT used.
+ *
+ * `chunks` undefined = count not known yet (pre-indexation); 0 = known-and-empty.
+ */
+export function SourceStatusBadge({
+  status,
+  chunks,
+}: {
+  status?: ExtractionStatus;
+  chunks?: number;
+}) {
+  const t = useTranslations("AdminCourses.wizard.sourceStatus");
+
+  if (status === "failed") {
+    return (
+      <span className="flex items-center gap-1 text-xs font-medium text-destructive">
+        <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+        {t("failed")}
+      </span>
+    );
+  }
+
+  if (status === "pending" || status === "extracting") {
+    return (
+      <span className="flex items-center gap-1 text-xs text-muted-foreground">
+        <div className="h-3 w-3 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
+        {t("extracting")}
+      </span>
+    );
+  }
+
+  // status === "done" (or unknown but uploaded)
+  if (typeof chunks === "number" && chunks > 0) {
+    return (
+      <span className="flex items-center gap-1 text-xs font-medium text-green-700 dark:text-green-400">
+        <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-green-600" />
+        {t("usedChunks", { count: chunks })}
+      </span>
+    );
+  }
+
+  if (chunks === 0) {
+    // Extracted but no chunks in RAG — this source is NOT used. Warn clearly.
+    return (
+      <span className="flex items-center gap-1 text-xs font-medium text-amber-700 dark:text-amber-400">
+        <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+        {t("notIndexed")}
+      </span>
+    );
+  }
+
+  // Extracted, chunk count not yet known (indexation not run / in progress).
+  return (
+    <span className="flex items-center gap-1 text-xs text-muted-foreground">
+      <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
+      {t("extracted")}
+    </span>
+  );
+}

--- a/frontend/lib/api-course-admin.ts
+++ b/frontend/lib/api-course-admin.ts
@@ -22,6 +22,23 @@ export interface UploadedFile {
   status: "queued" | "uploading" | "uploaded" | "error";
   error?: string;
   extraction_status?: ExtractionStatus;
+  // Count of DocumentChunk rows tied to this resource — the definitive
+  // "this source is actually used in RAG" signal (>0 used, 0 not used).
+  chunks_indexed?: number;
+}
+
+// Per-source status as returned by GET /admin/courses/{id}/resources. The
+// endpoint is DB-driven, so failed / deduped / missing-on-disk sources all
+// appear here (they were previously invisible).
+export interface CourseResourceStatus {
+  resource_id: string;
+  name: string;
+  size_bytes: number | null;
+  uploaded_at: string;
+  extraction_status: ExtractionStatus;
+  char_count: number | null;
+  chunks_indexed: number;
+  on_disk: boolean;
 }
 
 export interface CourseInfo {
@@ -152,7 +169,7 @@ export async function deleteCourseResource(
 
 export async function getCourseResources(
   courseId: string
-): Promise<{ files: Array<{ name: string; size_bytes: number; extraction_status?: ExtractionStatus }> }> {
+): Promise<{ course_id: string; files: CourseResourceStatus[] }> {
   return apiFetch(`/api/v1/admin/courses/${courseId}/resources`);
 }
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1723,6 +1723,19 @@
         "hide": "Hide attached files",
         "noFiles": "No resources attached"
       },
+      "sourceStatus": {
+        "failed": "Extraction failed",
+        "extracting": "Extracting…",
+        "usedChunks": "{count, plural, one {# fragment indexed} other {# fragments indexed}}",
+        "notIndexed": "Extracted, not indexed",
+        "extracted": "Extracted"
+      },
+      "sourcesUsage": {
+        "title": "Sources used by the course",
+        "loading": "Loading sources…",
+        "error": "Failed to load sources — retry",
+        "droppedWarning": "{count, plural, one {# source was not indexed and will not be used by the course.} other {# sources were not indexed and will not be used by the course.}}"
+      },
       "generate": {
         "title": "Generate syllabus",
         "description": "The AI agent will analyze your resources and generate the course structure.",
@@ -1973,7 +1986,13 @@
       "generateError": "Failed to generate lesson preview.",
       "noModules": "No modules found. Generate a syllabus first."
     },
-    "reviewQuality": "Review quality"
+    "reviewQuality": "Review quality",
+    "viewSources": "Sources used",
+    "sourcesPage": {
+      "pageTitle": "Course sources",
+      "pageDescription": "Check which sources were extracted and indexed (actually used by the course).",
+      "backToCourses": "Back to courses"
+    }
   },
   "AdminSyllabus": {
     "pageTitle": "Syllabus Management",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1723,6 +1723,19 @@
         "hide": "Masquer les fichiers joints",
         "noFiles": "Aucune ressource jointe"
       },
+      "sourceStatus": {
+        "failed": "Échec extraction",
+        "extracting": "Extraction…",
+        "usedChunks": "{count, plural, one {# fragment indexé} other {# fragments indexés}}",
+        "notIndexed": "Extrait, non indexé",
+        "extracted": "Extrait"
+      },
+      "sourcesUsage": {
+        "title": "Sources utilisées par le cours",
+        "loading": "Chargement des sources…",
+        "error": "Échec du chargement des sources — réessayer",
+        "droppedWarning": "{count, plural, one {# source n'a pas été indexée et ne sera pas utilisée par le cours.} other {# sources n'ont pas été indexées et ne seront pas utilisées par le cours.}}"
+      },
       "generate": {
         "title": "Générer le syllabus",
         "description": "L'agent IA va analyser vos ressources et générer la structure du cours.",
@@ -1973,7 +1986,13 @@
       "generateError": "Échec de la génération de l'aperçu de la leçon.",
       "noModules": "Aucun module trouvé. Générez d'abord un programme."
     },
-    "reviewQuality": "Revue qualité"
+    "reviewQuality": "Revue qualité",
+    "viewSources": "Sources utilisées",
+    "sourcesPage": {
+      "pageTitle": "Sources du cours",
+      "pageDescription": "Vérifiez quelles sources ont été extraites et indexées (réellement utilisées par le cours).",
+      "backToCourses": "Retour aux formations"
+    }
   },
   "AdminSyllabus": {
     "pageTitle": "Gestion du syllabus",


### PR DESCRIPTION
## Summary

Admins had **no reliable way to see which uploaded PDFs actually made it into a course's RAG**. A silently-dropped source (extraction `file_not_found` #2424, parse failure, or extracted-but-not-indexed) left the course answering from a partial source set, with no signal to the admin. The user flagged this as critical: *"user should absolutely know which sources are really used."*

Root of the invisibility: `GET /admin/courses/{id}/resources` was **disk-driven** (case-sensitive `*.pdf` glob), so failed / deduped / uppercase-`.PDF` sources never even appeared in the list.

## The "really used" signal
`DocumentChunk.course_resource_id` (#2186) is populated at indexation. Counting chunks per resource is the definitive "this source's text is in RAG" signal: `>0` = used, `0` = not used.

## Backend
- `list_course_resources` is now **DB-driven** (CourseResource = source of truth). Each entry carries `resource_id`, `extraction_status`, `char_count`, `on_disk`, and **`chunks_indexed`** (one grouped query, mirroring `/index-status`). Disk lookup is case-insensitive so uppercase `.PDF` resolves. Failed/deduped/missing-on-disk sources are now visible.

## Frontend
- **`SourceStatusBadge`** — ✓ N fragments / ⚠ extracted-not-indexed / ✗ extraction failed / extracting.
- **AttachedResources** (both wizards) now shows the per-source badge in every step (previously name+size only).
- **`CourseSourcesUsage`** panel — per-source list + a prominent **dropped-sources banner** — added to the indexation/linker recap of both wizards. This is the moment an admin learns a source was dropped.
- **Persistent course Sources page** `/admin/courses/{id}/sources` + a **"Sources used"** row action, so a published course's sources can be audited later (mirrors the existing quality sub-page pattern).
- i18n (fr + en).

## Test plan
- [x] Backend: new `test_list_course_resources_reports_per_source_chunk_counts` (DB-driven listing includes a not-on-disk/failed source with `chunks_indexed=0`; an indexed source shows its count). `ruff` + `pytest` green (22 passed in the helper suite).
- [x] Frontend: `eslint` (0 errors) + `tsc --noEmit` clean on changed files. JSON locales validated.
- [ ] `npm run build` — not run locally (Node 18 here vs Next's Node ≥20 native-binding requirement); runs in CI.
- [ ] E2E on demo tenant: open the Sources panel for a course with the dropped `…Health.PDF` (#2424) → it shows ✗/not-used while indexed sources show fragment counts.

## Notes
- No DB migration (failures show a generic badge, not the exact reason — remains the #2424 follow-up).
- Per-source **image** counts out of scope (`SourceImage` has no `course_resource_id`).
- The DB-driven `/resources` change also fixes the pre-existing bug where failed/deduped/`.PDF` sources were invisible.

Follows up #2424.

🤖 Generated with [Claude Code](https://claude.com/claude-code)