### PR TITLE
fix(figures): restore localized "Figure N" tag, fix NULL FR captions on deduped courses, drop orphan markers (#2428)

### DIFF
--- a/backend/app/ai/rag/pipeline.py
+++ b/backend/app/ai/rag/pipeline.py
@@ -299,6 +299,59 @@ class RAGPipeline:
                 pdf_path, source, rag_collection_id, session, progress_callback
             )
 
+    async def _translate_figure_locales(
+        self,
+        *,
+        caption: str | None,
+        surrounding_text: str | None,
+        figure_number: str | None,
+        image_type: str,
+        source: str,
+    ) -> tuple[str | None, str | None, str | None, str | None]:
+        """Translate a figure caption into FR/EN captions + alt text.
+
+        Mirrors the #2272 fallback chain (caption → surrounding_text →
+        figure_number) so caption-less figures still get usable locale text.
+        Returns ``(None, None, None, None)`` when there is nothing to translate
+        or translation fails after a bounded retry.
+        """
+        # Broader gate than "caption is non-empty" (#2272): figures whose
+        # caption block didn't survive extraction still have a figure number +
+        # surrounding text, and that's enough for Claude to write a usable
+        # FR/EN caption + alt text. Without this fallback the locale columns
+        # stayed NULL and the frontend dropped to the English caption.
+        translator_input = (caption or "").strip()
+        if not translator_input and surrounding_text:
+            translator_input = surrounding_text.strip()[:200]
+        if not translator_input and figure_number:
+            translator_input = figure_number
+        if not translator_input:
+            return None, None, None, None
+
+        last_exc: Exception | None = None
+        for _ in range(2):
+            try:
+                translation = await translate_figure_caption(
+                    caption=translator_input,
+                    image_type=image_type,
+                    figure_number=figure_number,
+                )
+                return (
+                    translation.caption_fr,
+                    translation.caption_en,
+                    translation.alt_text_fr,
+                    translation.alt_text_en,
+                )
+            except Exception as exc:
+                last_exc = exc
+        logger.warning(
+            "Failed to translate figure caption after retry; storing NULL locales",
+            source=source,
+            figure_number=figure_number,
+            error=str(last_exc),
+        )
+        return None, None, None, None
+
     async def _process_images(
         self,
         pdf_path: Path,
@@ -329,7 +382,13 @@ class RAGPipeline:
             # Cross-course image dedup: reuse existing storage + computed fields.
             if img.image_hash:
                 donor_result = await session.execute(
-                    select(SourceImage).where(SourceImage.image_hash == img.image_hash).limit(1)
+                    select(SourceImage)
+                    .where(SourceImage.image_hash == img.image_hash)
+                    # Prefer a donor that already carries a French caption so we
+                    # don't clone NULL locales (which silently fall back to the
+                    # English caption on the frontend). NULLs sort last. (#2428)
+                    .order_by(SourceImage.caption_fr.is_(None))
+                    .limit(1)
                 )
                 donor_img = donor_result.scalar_one_or_none()
                 if donor_img is not None:
@@ -364,6 +423,22 @@ class RAGPipeline:
                         caption=img.caption,
                         attribution=img.attribution,
                     )
+                    # If even the best donor lacked FR/EN captions, translate
+                    # now rather than persisting NULL locales — otherwise the
+                    # frontend shows the English caption to FR learners (#2428).
+                    if cloned_img.caption_fr is None or cloned_img.caption_en is None:
+                        (
+                            cloned_img.caption_fr,
+                            cloned_img.caption_en,
+                            cloned_img.alt_text_fr,
+                            cloned_img.alt_text_en,
+                        ) = await self._translate_figure_locales(
+                            caption=cloned_img.caption,
+                            surrounding_text=cloned_img.surrounding_text,
+                            figure_number=cloned_img.figure_number,
+                            image_type=cloned_img.image_type,
+                            source=source,
+                        )
                     session.add(cloned_img)
                     await session.commit()
                     stored_count += 1
@@ -410,45 +485,13 @@ class RAGPipeline:
                         error=str(exc),
                     )
 
-            caption_fr: str | None = None
-            caption_en: str | None = None
-            alt_text_fr: str | None = None
-            alt_text_en: str | None = None
-            # Broader gate than "caption is non-empty" (#2272): figures whose
-            # caption block didn't survive extraction still have a figure
-            # number + surrounding text, and that's enough for Claude to
-            # write a usable FR/EN caption + alt text. Without this fallback
-            # locale columns stayed NULL and the frontend dropped to the
-            # English caption (or just "Figure X.Y" when even that was empty).
-            translator_input = (img.caption or "").strip()
-            if not translator_input and img.surrounding_text:
-                translator_input = img.surrounding_text.strip()[:200]
-            if not translator_input and img.figure_number:
-                translator_input = img.figure_number
-            if translator_input:
-                last_exc: Exception | None = None
-                for _ in range(2):
-                    try:
-                        translation = await translate_figure_caption(
-                            caption=translator_input,
-                            image_type=img.image_type,
-                            figure_number=img.figure_number,
-                        )
-                        caption_fr = translation.caption_fr
-                        caption_en = translation.caption_en
-                        alt_text_fr = translation.alt_text_fr
-                        alt_text_en = translation.alt_text_en
-                        last_exc = None
-                        break
-                    except Exception as exc:
-                        last_exc = exc
-                if last_exc is not None:
-                    logger.warning(
-                        "Failed to translate figure caption after retry; storing NULL locales",
-                        source=source,
-                        figure_number=img.figure_number,
-                        error=str(last_exc),
-                    )
+            caption_fr, caption_en, alt_text_fr, alt_text_en = await self._translate_figure_locales(
+                caption=img.caption,
+                surrounding_text=img.surrounding_text,
+                figure_number=img.figure_number,
+                image_type=img.image_type,
+                source=source,
+            )
 
             figure_kind: str | None = None
             try:

--- a/backend/tests/test_rag_pipeline_images.py
+++ b/backend/tests/test_rag_pipeline_images.py
@@ -477,6 +477,139 @@ class TestRAGPipelineProcessPDFImages:
         assert added_image.rag_collection_id == "rag-col-123"
 
 
+class TestRAGPipelineDedupTranslation:
+    """#2428: cross-course dedup must not persist NULL FR/EN captions.
+
+    The dedup branch clones computed fields from an ``image_hash`` donor and
+    skips the normal translation block. When the donor itself lacked
+    ``caption_fr``/``caption_en`` the clone inherited NULLs, and the frontend
+    silently fell back to the English caption for FR learners.
+    """
+
+    def setup_method(self):
+        self.embedding_service = AsyncMock()
+        self.embedding_service.generate_embedding = AsyncMock(return_value=[0.1] * 1536)
+        self.pipeline = RAGPipeline(self.embedding_service)
+        self.temp_dir = tempfile.mkdtemp()
+
+    def teardown_method(self):
+        import shutil
+
+        shutil.rmtree(self.temp_dir)
+
+    def _donor(self, **overrides):
+        from app.domain.models.source_image import SourceImage
+
+        defaults = dict(
+            source="scutchfield",
+            page_number=1,
+            image_hash="hash123",
+            storage_key="source-images/scutchfield/1_Figure_1.webp",
+            storage_url="http://minio/key.webp",
+            embedding=[0.2] * 1536,
+            caption_fr=None,
+            caption_en=None,
+            alt_text_fr=None,
+            alt_text_en=None,
+            figure_kind="photo",
+            image_type="diagram",
+            width=300,
+            height=200,
+        )
+        defaults.update(overrides)
+        return SourceImage(**defaults)
+
+    @pytest.mark.asyncio
+    async def test_dedup_translates_when_donor_has_null_captions(self):
+        from app.ai.translation.figure_translator import FigureTranslation
+
+        pdf_path = Path(self.temp_dir) / "Donaldson_test.pdf"
+        pdf_path.touch()
+
+        fake_image = _make_extracted_image(image_hash="hash123")
+        donor = self._donor(caption_fr=None, caption_en=None)
+
+        donor_result = MagicMock()
+        donor_result.scalar_one_or_none = MagicMock(return_value=donor)
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=donor_result)
+
+        translation_stub = FigureTranslation(
+            caption_fr="Légende française",
+            caption_en="English caption",
+            alt_text_fr="Texte alternatif",
+            alt_text_en="Alt text",
+        )
+
+        with (
+            patch(
+                "app.ai.rag.pipeline.PDFImageExtractor.extract_images_from_pdf",
+                return_value=[fake_image],
+            ),
+            patch(
+                "app.ai.rag.pipeline.translate_figure_caption",
+                new_callable=AsyncMock,
+                return_value=translation_stub,
+            ) as mock_translate,
+            patch.object(
+                ImageLinker, "link_images_to_chunks", new_callable=AsyncMock, return_value=0
+            ),
+        ):
+            count = await self.pipeline.process_pdf_images(
+                pdf_path=str(pdf_path),
+                source="donaldson",
+                session=mock_session,
+            )
+
+        assert count == 1
+        mock_translate.assert_called_once()
+        cloned = mock_session.add.call_args[0][0]
+        assert cloned.caption_fr == "Légende française"
+        assert cloned.caption_en == "English caption"
+
+    @pytest.mark.asyncio
+    async def test_dedup_reuses_donor_captions_without_retranslating(self):
+        pdf_path = Path(self.temp_dir) / "Donaldson_test.pdf"
+        pdf_path.touch()
+
+        fake_image = _make_extracted_image(image_hash="hash123")
+        donor = self._donor(caption_fr="Déjà traduit", caption_en="Already translated")
+
+        donor_result = MagicMock()
+        donor_result.scalar_one_or_none = MagicMock(return_value=donor)
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=donor_result)
+
+        with (
+            patch(
+                "app.ai.rag.pipeline.PDFImageExtractor.extract_images_from_pdf",
+                return_value=[fake_image],
+            ),
+            patch(
+                "app.ai.rag.pipeline.translate_figure_caption",
+                new_callable=AsyncMock,
+            ) as mock_translate,
+            patch.object(
+                ImageLinker, "link_images_to_chunks", new_callable=AsyncMock, return_value=0
+            ),
+        ):
+            count = await self.pipeline.process_pdf_images(
+                pdf_path=str(pdf_path),
+                source="donaldson",
+                session=mock_session,
+            )
+
+        assert count == 1
+        mock_translate.assert_not_called()
+        cloned = mock_session.add.call_args[0][0]
+        assert cloned.caption_fr == "Déjà traduit"
+        assert cloned.caption_en == "Already translated"
+
+
 class TestRAGPipelineClearSourceImages:
     def setup_method(self):
         self.embedding_service = AsyncMock()

--- a/frontend/components/learning/source-image.tsx
+++ b/frontend/components/learning/source-image.tsx
@@ -32,8 +32,15 @@ export function SourceImage({
     ? (alt_text_fr ?? caption_fr ?? captionFallback ?? t('defaultAlt'))
     : (alt_text_en ?? caption_en ?? captionFallback ?? t('defaultAlt'));
 
-  const figureLabel = figure_number
-    ? `${figure_number}${caption ? ` — ${caption}` : ''}`
+  // Strip any leading figure-word already baked into figure_number (extraction
+  // stores mixed formats: "1.3", "Figure 1.3", "Fig. 2-8", "Schéma 3"), then
+  // prefix the localized label — restores the "Figure N" tag dropped in #844
+  // without re-introducing the double-prefix it fixed.
+  const bareNumber = figure_number
+    ?.replace(/^(figures?|fig\.?|schémas?|tableaux?|graphiques?|diagrammes?|encadrés?|illustrations?)\s*/i, '')
+    .trim();
+  const figureLabel = bareNumber
+    ? `${t('figure')} ${bareNumber}${caption ? ` — ${caption}` : ''}`
     : caption ?? '';
 
   return (

--- a/frontend/lib/source-image-utils.ts
+++ b/frontend/lib/source-image-utils.ts
@@ -22,8 +22,11 @@ export function splitWithSourceImageMarkers(
     const meta = imageMap.get(match[1]);
     if (meta) {
       parts.push({ type: 'source_image', meta });
-    } else {
-      parts.push({ type: 'markdown', text: text.slice(match.index, SOURCE_IMAGE_RE.lastIndex) });
+    } else if (process.env.NODE_ENV !== 'production') {
+      // Orphan marker: model cited an image whose ref was dropped (e.g. by the
+      // max-5 cap during lesson generation). Skip it so the literal
+      // {{source_image:…}} string never leaks into rendered text.
+      console.debug('Dropping orphan source_image marker', match[1]);
     }
     lastIndex = SOURCE_IMAGE_RE.lastIndex;
   }


### PR DESCRIPTION
Fixes #2428

## Problem
French learners saw **English figure captions** and a **bare figure number** instead of a localized `Figure 1.3 — <légende française>` tag — in both lessons and the AI tutor (shared `SourceImage` component). Three distinct regressions:

1. **Numbered tag lost** — `0f304fd9` (#844) stripped the `t('figure')` prefix from the figure label; today it renders bare `1.3 — …`. The `SourceImage.figure` i18n key still exists but went unused.
2. **English caption for FR users** — the cross-course dedup branch (`9e4c7121`) cloned `caption_fr`/`caption_en` from an arbitrary `image_hash` donor and `continue`d, skipping translation. NULL donor locales propagated, and the frontend silently fell back to the English `caption`.
3. **Orphan markers leak** — a `{{source_image:UUID}}` marker with no matching ref was re-emitted as literal text.

## Changes
- **WS1 — `frontend/components/learning/source-image.tsx`:** re-add the localized `t('figure')` prefix, guarded by a leading-figure-word strip (`figure|fig.|schéma|tableau|graphique|diagramme|encadré|illustration`) so mixed `figure_number` formats never double-prefix. Covers lessons **and** tutor (shared component).
- **WS2 — `backend/app/ai/rag/pipeline.py`:** donor lookup now prefers a translated row (`ORDER BY caption_fr IS NULL`); when the clone still lacks FR/EN it translates via a new shared `_translate_figure_locales()` helper (also replaces the duplicated inline block on the normal path).
- **WS3 — `frontend/lib/source-image-utils.ts`:** orphan markers are skipped (dev-only `console.debug`) instead of leaking literal text.

## Tests / checks
- Backend: `ruff check` + `ruff format` clean; **19/19** `test_rag_pipeline_images.py` pass (incl. 2 new dedup cases: NULL-donor → translates; FR-donor → reuses without re-translating).
- Frontend: `eslint` clean on both changed files; `tsc --noEmit` shows only pre-existing, unrelated errors in `e2e/production-uat.spec.ts` (missing `speakeasy` dep).

## Follow-up (post-deploy, not in this PR)
Run `backfill_image_translations(rag_collection_id=…)` on affected courses to repair existing rows whose `caption_fr` is already NULL (the dedup fix only prevents *new* NULLs). Then spot-check a FR lesson + tutor.

## Notes / edge case
A `figure_number` like `"Schéma 2"` will render as `Figure 2 — …` (single, generic localized prefix). Accepted per scope; per-type prefixes (Table/Diagram) are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)