### PR TITLE
fix(figures): wrong image binary under a correct caption — dedup linking + body_text purge (#2431)

### DIFF
--- a/backend/app/ai/rag/image_linker.py
+++ b/backend/app/ai/rag/image_linker.py
@@ -42,6 +42,25 @@ _PAGE_ADJACENCY = 1
 _SEMANTIC_TOP_K = 3
 _SEMANTIC_DIST_MAX = 0.35  # cosine distance; ~0.65 cosine similarity
 
+# When several images share a figure_number, an explicit "Figure X" citation
+# must resolve to the *real* figure — not a mis-extracted body-text crop or a
+# decorative element. Lower rank = preferred. NULL/unknown kinds rank between
+# photo and decorative so an unclassified-but-plausible figure still beats a
+# known body-text crop. (#2431)
+_FIGURE_KIND_RANK = {
+    "complex_diagram": 0,
+    "clean_flowchart": 0,
+    "chart": 0,
+    "table": 0,
+    "formula": 0,
+    "micrograph": 0,
+    "photo_with_callouts": 0,
+    "photo": 1,
+    "decorative": 3,
+    "body_text": 4,
+}
+_DEFAULT_KIND_RANK = 2  # NULL / not-yet-classified
+
 
 def _normalize_figure_number(raw: str) -> str:
     """Normalise figure numbers so that '1-3' and '1.3' compare equal."""
@@ -147,19 +166,43 @@ class ImageLinker:
         chunks = chunks_result.all()
 
         images_result = await session.execute(
-            select(SourceImage.id, SourceImage.figure_number).where(
+            select(
+                SourceImage.id,
+                SourceImage.figure_number,
+                SourceImage.figure_kind,
+                SourceImage.width,
+                SourceImage.height,
+                SourceImage.file_size_bytes,
+            ).where(
                 SourceImage.source == source,
                 SourceImage.figure_number.isnot(None),
             )
         )
-        figure_map: dict[str, object] = {}
-        for image_id, figure_number in images_result.all():
-            if figure_number:
-                # Extract just the number from "Figure 1.2" -> "1.2"
-                num_match = _FIGURE_RE.search(figure_number)
-                raw = num_match.group(1) if num_match else figure_number
-                key = _normalize_figure_number(raw)
-                figure_map[key] = image_id
+        # Group images by normalised figure number, then keep the BEST one per
+        # number instead of last-writer-wins: real figures beat photos beat
+        # unclassified beat decorative/body-text crops; ties break on larger
+        # rendered area then file size. Stops an explicit "Figure X" citation
+        # resolving to a mis-extracted body-text crop when a real figure with
+        # the same number exists. (#2431)
+        candidates: dict[str, list] = {}
+        for image_id, figure_number, figure_kind, width, height, file_size in images_result.all():
+            if not figure_number:
+                continue
+            # Extract just the number from "Figure 1.2" -> "1.2"
+            num_match = _FIGURE_RE.search(figure_number)
+            raw = num_match.group(1) if num_match else figure_number
+            key = _normalize_figure_number(raw)
+            candidates.setdefault(key, []).append((image_id, figure_kind, width, height, file_size))
+
+        def _rank(cand: tuple) -> tuple:
+            _id, kind, width, height, file_size = cand
+            kind_rank = _FIGURE_KIND_RANK.get(kind, _DEFAULT_KIND_RANK)
+            area = (width or 0) * (height or 0)
+            return (kind_rank, -area, -(file_size or 0))
+
+        figure_map: dict[str, object] = {
+            key: min(cands, key=_rank)[0] for key, cands in candidates.items()
+        }
 
         existing_pairs = await self._get_existing_pairs(source, session)
 

--- a/backend/app/ai/rag/retriever.py
+++ b/backend/app/ai/rag/retriever.py
@@ -23,6 +23,9 @@ logger = structlog.get_logger()
 # at retrieval time so the lesson generator never sees them as candidates.
 _STOCK_THUMB_MAX_WIDTH = 200
 _STOCK_THUMB_KINDS = ("photo", "decorative")
+# Kinds that are never figures and must never surface in a lesson/tutor, even
+# at full size — mis-extracted page text. (#2431)
+_EXCLUDED_KINDS = ("body_text",)
 
 # High-precision SourceImageChunk reference types. PR #2066 added
 # `semantic` (caption-vs-chunk cosine similarity) which expanded the
@@ -326,6 +329,13 @@ class SemanticRetriever:
                             SourceImage.width <= _STOCK_THUMB_MAX_WIDTH,
                         ),
                     )
+                ),
+                # Never surface mis-extracted body-text crops, regardless of
+                # size (they're large, so the stock-thumb filter misses them).
+                # NULL kinds are kept — they're not yet classified. (#2431)
+                or_(
+                    SourceImage.figure_kind.is_(None),
+                    SourceImage.figure_kind.notin_(_EXCLUDED_KINDS),
                 ),
             )
             .order_by(

--- a/backend/app/ai/translation/figure_classifier.py
+++ b/backend/app/ai/translation/figure_classifier.py
@@ -42,6 +42,7 @@ FigureKind = Literal[
     "micrograph",
     "decorative",
     "complex_diagram",
+    "body_text",
 ]
 
 _ALLOWED_KINDS: set[str] = {
@@ -54,6 +55,7 @@ _ALLOWED_KINDS: set[str] = {
     "micrograph",
     "decorative",
     "complex_diagram",
+    "body_text",
 }
 
 _CLASSIFIER_MODEL = "claude-haiku-4-5"
@@ -85,13 +87,19 @@ _USER_PROMPT = (
     "no information.\n"
     "- complex_diagram: anatomical plate, multi-panel figure, dense "
     "labelled illustration with many text annotations. Anything that is "
-    "clearly a diagram but too dense for clean_flowchart.\n\n"
+    "clearly a diagram but too dense for clean_flowchart.\n"
+    "- body_text: NOT a figure at all — a screenshot of running paragraph "
+    "or multi-column body text (sentences/prose), a page header/footer, or "
+    "a block of references. Mis-extracted page text, not an illustration, "
+    "chart, table, or diagram.\n\n"
     "Reply with a JSON object containing exactly one field:\n"
     '  {"kind": "<one of the values above>"}\n\n'
     "Rules:\n"
     "- Pick the single best fit. If torn between two, prefer the more "
     "conservative classification (e.g. complex_diagram over "
     "clean_flowchart when in doubt, photo over photo_with_callouts).\n"
+    "- Use body_text ONLY when the image is essentially prose/page text with "
+    "no figure content; a real table or labelled diagram is NOT body_text.\n"
     "- Do not invent new kinds. Reply with JSON only."
 )
 

--- a/backend/app/tasks/image_indexation.py
+++ b/backend/app/tasks/image_indexation.py
@@ -368,42 +368,177 @@ async def _run_purge_with_factory(
         )
 
         if dry_run:
-            preview = [
-                {
-                    "id": str(img.id),
-                    "rag_collection_id": img.rag_collection_id,
-                    "page_number": img.page_number,
-                    "figure_number": img.figure_number,
-                    "width": img.width,
-                    "height": img.height,
-                    "storage_key": img.storage_key,
-                }
-                for img in rows[:20]
-            ]
-            return {"status": "dry_run", "eligible": total, "preview": preview}
+            return {"status": "dry_run", "eligible": total, "preview": _purge_preview(rows)}
 
-        deleted = 0
-        storage_failed = 0
-        for img in rows:
-            for key in (img.storage_key, img.storage_key_fr):
-                if not key:
-                    continue
-                try:
-                    await storage.delete_object(key)
-                except Exception as exc:  # noqa: BLE001
-                    storage_failed += 1
-                    logger.warning(
-                        "Failed to delete orphan-figure object from storage",
-                        source_image_id=str(img.id),
-                        key=key,
-                        error=str(exc),
-                    )
-            await session.delete(img)
-            deleted += 1
-        await session.commit()
+        deleted, storage_failed = await _delete_image_rows(session, rows, storage)
 
         logger.info(
             "Orphan-figure purge complete",
+            deleted=deleted,
+            storage_failed=storage_failed,
+            rag_collection_id=rag_collection_id,
+        )
+        return {
+            "status": "complete",
+            "eligible": total,
+            "deleted": deleted,
+            "storage_failed": storage_failed,
+        }
+
+
+def _purge_preview(rows: list) -> list[dict]:
+    """First 20 rows summarised for a purge dry-run response."""
+    return [
+        {
+            "id": str(img.id),
+            "rag_collection_id": img.rag_collection_id,
+            "page_number": img.page_number,
+            "figure_number": img.figure_number,
+            "figure_kind": img.figure_kind,
+            "width": img.width,
+            "height": img.height,
+            "storage_key": img.storage_key,
+        }
+        for img in rows[:20]
+    ]
+
+
+async def _delete_image_rows(session, rows: list, storage) -> tuple[int, int]:
+    """Delete source-image rows + their MinIO objects. Returns (deleted, storage_failed).
+
+    A MinIO failure is logged and counted but never blocks the DB delete — the
+    junction rows cascade and any baked-in ``{{source_image:UUID}}`` lesson
+    marker becomes a no-op orphan (dropped client-side, #2428).
+    """
+    deleted = 0
+    storage_failed = 0
+    for img in rows:
+        for key in (img.storage_key, img.storage_key_fr):
+            if not key:
+                continue
+            try:
+                await storage.delete_object(key)
+            except Exception as exc:  # noqa: BLE001
+                storage_failed += 1
+                logger.warning(
+                    "Failed to delete figure object from storage",
+                    source_image_id=str(img.id),
+                    key=key,
+                    error=str(exc),
+                )
+        await session.delete(img)
+        deleted += 1
+    await session.commit()
+    return deleted, storage_failed
+
+
+# ---------------------------------------------------------------------------
+# Cleanup for mis-extracted body-text crops (#2431)
+# ---------------------------------------------------------------------------
+#
+# The vision classifier (figure_classifier `body_text`) flags source_images
+# whose binary is a screenshot of running page text, not a figure. Duplicate
+# figure_numbers used to let an explicit "Figure X" citation resolve to one of
+# these crops (last-writer-wins in the linker, since fixed). Purge them so they
+# never render; lessons that cited a now-deleted image drop the orphan
+# {{source_image:UUID}} marker cleanly client-side (#2428). Unlike the
+# full-page purge above, this keys purely on the classified kind, so it catches
+# captioned, non-full-page crops too. Run `backfill_figure_kinds` first.
+
+
+class PurgeBodyTextFiguresTask(Task):
+    """Celery base for the body-text figure purge."""
+
+    def on_success(self, retval, task_id, args, kwargs):
+        logger.info("Body-text figure purge completed", task_id=task_id, result=retval)
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        logger.error("Body-text figure purge failed", task_id=task_id, exception=str(exc))
+
+
+@celery_app.task(
+    bind=True,
+    base=PurgeBodyTextFiguresTask,
+    time_limit=1800,
+    soft_time_limit=1500,
+    ignore_result=True,
+    acks_late=False,
+)
+def purge_body_text_figures(
+    self,
+    rag_collection_id: str | None = None,
+    limit: int | None = None,
+    dry_run: bool = True,
+) -> dict:
+    """Delete ``source_images`` classified as ``body_text`` (mis-extracted page text).
+
+    Requires ``figure_kind`` to be populated first (run ``backfill_figure_kinds``).
+    Args mirror :func:`purge_orphan_full_page_figures`.
+    """
+    return asyncio.run(
+        _run_body_text_purge(
+            rag_collection_id=rag_collection_id,
+            limit=limit,
+            dry_run=dry_run,
+        )
+    )
+
+
+async def _run_body_text_purge(
+    rag_collection_id: str | None,
+    limit: int | None,
+    dry_run: bool,
+) -> dict:
+    from app.infrastructure.config.settings import settings
+    from app.infrastructure.storage.s3 import S3StorageService
+
+    engine = create_async_engine(settings.database_url, pool_pre_ping=True)
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        return await _run_body_text_purge_with_factory(
+            rag_collection_id=rag_collection_id,
+            limit=limit,
+            dry_run=dry_run,
+            session_factory=session_factory,
+            storage=S3StorageService(),
+        )
+    finally:
+        await engine.dispose()
+
+
+async def _run_body_text_purge_with_factory(
+    rag_collection_id: str | None,
+    limit: int | None,
+    dry_run: bool,
+    session_factory: async_sessionmaker[AsyncSession],
+    storage,
+) -> dict:
+    from app.domain.models.source_image import SourceImage
+
+    async with session_factory() as session:
+        stmt = select(SourceImage).where(SourceImage.figure_kind == "body_text")
+        if rag_collection_id is not None:
+            stmt = stmt.where(SourceImage.rag_collection_id == rag_collection_id)
+        if limit is not None:
+            stmt = stmt.limit(limit)
+
+        rows = (await session.execute(stmt)).scalars().all()
+        total = len(rows)
+
+        logger.info(
+            "Body-text figure purge: eligible rows",
+            total=total,
+            rag_collection_id=rag_collection_id,
+            dry_run=dry_run,
+        )
+
+        if dry_run:
+            return {"status": "dry_run", "eligible": total, "preview": _purge_preview(rows)}
+
+        deleted, storage_failed = await _delete_image_rows(session, rows, storage)
+
+        logger.info(
+            "Body-text figure purge complete",
             deleted=deleted,
             storage_failed=storage_failed,
             rag_collection_id=rag_collection_id,

--- a/backend/tests/test_figure_classifier.py
+++ b/backend/tests/test_figure_classifier.py
@@ -75,6 +75,7 @@ class TestClassifyFigure:
             "micrograph",
             "decorative",
             "complex_diagram",
+            "body_text",
         ],
     )
     async def test_each_allowed_kind_parses(self, kind: str):

--- a/backend/tests/test_image_linker.py
+++ b/backend/tests/test_image_linker.py
@@ -143,7 +143,7 @@ class TestExplicitLinkage:
 
         session.execute.side_effect = [
             _make_execute_result([(chunk_id, "See Figure 1.3 for the diagram.")]),
-            _make_execute_result([(img_id, "1.3")]),
+            _make_execute_result([(img_id, "1.3", None, None, None, None)]),
             _make_execute_result([]),
             _make_execute_result([(img_id, 5, "chapter_1")]),
             _make_execute_result([(chunk_id, 5, "chapter_1")]),
@@ -161,6 +161,38 @@ class TestExplicitLinkage:
         assert explicit_rows[0].document_chunk_id == chunk_id
 
     @pytest.mark.asyncio
+    async def test_explicit_link_prefers_real_figure_over_body_text_dup(self):
+        """Two images share 'Figure 1.4' — the citation must link the real
+        figure, not the (larger, first-listed) mis-extracted body-text crop.
+        Guards the duplicate-figure_number binary-mismatch bug (#2431)."""
+        linker = ImageLinker()
+        session = _mock_session()
+        img_bad = _uuid()  # body_text crop — listed first AND larger
+        img_good = _uuid()  # the real chart
+        chunk_id = _uuid()
+
+        session.execute.side_effect = [
+            _make_execute_result([(chunk_id, "See Figure 1.4 for the data.")]),
+            _make_execute_result(
+                [
+                    (img_bad, "Figure 1.4", "body_text", 1024, 900, 95000),
+                    (img_good, "Figure 1.4", "chart", 800, 600, 30000),
+                ]
+            ),
+            _make_execute_result([]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+            _make_execute_result([]),
+        ]
+
+        await linker.link_images_to_chunks("donaldson", session)
+
+        added = session.add_all.call_args[0][0]
+        explicit_rows = [r for r in added if r.reference_type == "explicit"]
+        assert len(explicit_rows) == 1
+        assert explicit_rows[0].source_image_id == img_good
+
+    @pytest.mark.asyncio
     async def test_explicit_link_dash_figure_number(self):
         """DB stores '1-3', text says 'Figure 1.3' — must still match after normalisation."""
         linker = ImageLinker()
@@ -170,7 +202,7 @@ class TestExplicitLinkage:
 
         session.execute.side_effect = [
             _make_execute_result([(chunk_id, "See Figure 1.3 for the diagram.")]),
-            _make_execute_result([(img_id, "1-3")]),
+            _make_execute_result([(img_id, "1-3", None, None, None, None)]),
             _make_execute_result([]),
             _make_execute_result([(img_id, 5, None)]),
             _make_execute_result([(chunk_id, 5, None)]),
@@ -194,7 +226,7 @@ class TestExplicitLinkage:
 
         session.execute.side_effect = [
             _make_execute_result([(chunk_id, "As shown in Fig. 2.1, the data reveals...")]),
-            _make_execute_result([(img_id, "2.1")]),
+            _make_execute_result([(img_id, "2.1", None, None, None, None)]),
             _make_execute_result([]),
             _make_execute_result([(img_id, 10, None)]),
             _make_execute_result([(chunk_id, 10, None)]),
@@ -216,7 +248,7 @@ class TestExplicitLinkage:
 
         session.execute.side_effect = [
             _make_execute_result([(chunk_id, "No figures mentioned here.")]),
-            _make_execute_result([(img_id, "1.3")]),
+            _make_execute_result([(img_id, "1.3", None, None, None, None)]),
             _make_execute_result([]),
             _make_execute_result([(img_id, 3, None)]),
             _make_execute_result([]),
@@ -255,7 +287,7 @@ class TestExplicitLinkage:
 
         session.execute.side_effect = [
             _make_execute_result([(chunk_id, "Figure 1.3 is important.")]),
-            _make_execute_result([(img_id, "1.3")]),
+            _make_execute_result([(img_id, "1.3", None, None, None, None)]),
             _make_execute_result([(img_id,)]),
             _make_execute_result([(img_id, chunk_id)]),
             _make_execute_result([(img_id, 5, None)]),
@@ -378,7 +410,7 @@ class TestContextualLinkage:
 
         session.execute.side_effect = [
             _make_execute_result([(chunk_id, "See Figure 2.0 here.")]),
-            _make_execute_result([(img_id, "2.0")]),
+            _make_execute_result([(img_id, "2.0", None, None, None, None)]),
             _make_execute_result([]),
             _make_execute_result([(img_id, 10, None)]),
             _make_execute_result([(chunk_id, 10, None)]),
@@ -510,7 +542,12 @@ class TestEdgeCases:
 
         session.execute.side_effect = [
             _make_execute_result([(chunk_id, "See Figure 1.1 and Figure 2.2.")]),
-            _make_execute_result([(img1_id, "1.1"), (img2_id, "2.2")]),
+            _make_execute_result(
+                [
+                    (img1_id, "1.1", None, None, None, None),
+                    (img2_id, "2.2", None, None, None, None),
+                ]
+            ),
             _make_execute_result([]),
             _make_execute_result([(img1_id, 4, None), (img2_id, 9, None)]),
             _make_execute_result([(chunk_id, 4, None)]),
@@ -567,7 +604,7 @@ class TestEdgeCases:
 
         session.execute.side_effect = [
             _make_execute_result([(chunk_id, "Figure 3.0 here.")]),
-            _make_execute_result([(img_id, "3.0")]),
+            _make_execute_result([(img_id, "3.0", None, None, None, None)]),
             _make_execute_result([]),
             _make_execute_result([(img_id, 2, None)]),
             _make_execute_result([(chunk_id, 99, None)]),
@@ -703,7 +740,7 @@ class TestSemanticLinkage:
 
         session.execute.side_effect = [
             _make_execute_result([(chunk_id, "See Figure 1.3 for the diagram.")]),
-            _make_execute_result([(img_id, "1.3")]),
+            _make_execute_result([(img_id, "1.3", None, None, None, None)]),
             _make_execute_result([]),  # no pre-existing pairs
             _make_execute_result([(img_id, 5, None)]),  # contextual images
             _make_execute_result([(chunk_id, 5, None)]),  # contextual chunks

--- a/backend/tests/test_purge_body_text_figures.py
+++ b/backend/tests/test_purge_body_text_figures.py
@@ -1,0 +1,115 @@
+"""Unit tests for the body-text figure purge (#2431).
+
+Covers ``_run_body_text_purge_with_factory`` directly so no engine/DB is
+needed — the SQL ``WHERE figure_kind = 'body_text'`` predicate itself is
+enforced by Postgres; here we verify the dry-run preview and the
+delete-from-storage-then-DB behaviour on the rows the query returns.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.domain.models.source_image import SourceImage
+from app.tasks.image_indexation import _run_body_text_purge_with_factory
+
+
+def _make_row(**overrides) -> MagicMock:
+    img = MagicMock(spec=SourceImage)
+    img.id = overrides.get("id", uuid.uuid4())
+    img.rag_collection_id = overrides.get("rag_collection_id", "col-1")
+    img.page_number = overrides.get("page_number", 97)
+    img.figure_number = overrides.get("figure_number", "Figure 3.2")
+    img.figure_kind = "body_text"
+    img.width = overrides.get("width", 1024)
+    img.height = overrides.get("height", 682)
+    img.storage_key = overrides.get("storage_key", "source-images/col-1/x.webp")
+    img.storage_key_fr = overrides.get("storage_key_fr")
+    return img
+
+
+def _factory_returning(rows: list):
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    session.delete = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = rows
+    session.execute = AsyncMock(return_value=result)
+
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=session)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=cm), session
+
+
+@pytest.mark.asyncio
+async def test_dry_run_counts_without_deleting():
+    rows = [_make_row(), _make_row()]
+    factory, session = _factory_returning(rows)
+    storage = AsyncMock()
+
+    result = await _run_body_text_purge_with_factory(
+        rag_collection_id=None,
+        limit=None,
+        dry_run=True,
+        session_factory=factory,
+        storage=storage,
+    )
+
+    assert result["status"] == "dry_run"
+    assert result["eligible"] == 2
+    assert len(result["preview"]) == 2
+    assert result["preview"][0]["figure_kind"] == "body_text"
+    session.delete.assert_not_called()
+    storage.delete_object.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_real_run_deletes_rows_and_objects():
+    rows = [
+        _make_row(storage_key="a.webp", storage_key_fr="a_fr.svg"),
+        _make_row(storage_key="b.webp", storage_key_fr=None),
+    ]
+    factory, session = _factory_returning(rows)
+    storage = AsyncMock()
+
+    result = await _run_body_text_purge_with_factory(
+        rag_collection_id="col-1",
+        limit=None,
+        dry_run=False,
+        session_factory=factory,
+        storage=storage,
+    )
+
+    assert result["status"] == "complete"
+    assert result["deleted"] == 2
+    assert result["storage_failed"] == 0
+    assert session.delete.await_count == 2
+    # a.webp + a_fr.svg + b.webp = 3 object deletes (b has no FR variant)
+    assert storage.delete_object.await_count == 3
+    session.commit.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_storage_failure_does_not_block_db_delete():
+    rows = [_make_row(storage_key="boom.webp", storage_key_fr=None)]
+    factory, session = _factory_returning(rows)
+    storage = AsyncMock()
+    storage.delete_object = AsyncMock(side_effect=ConnectionError("MinIO down"))
+
+    result = await _run_body_text_purge_with_factory(
+        rag_collection_id=None,
+        limit=None,
+        dry_run=False,
+        session_factory=factory,
+        storage=storage,
+    )
+
+    assert result["deleted"] == 1
+    assert result["storage_failed"] == 1
+    session.delete.assert_awaited_once()
+    session.commit.assert_awaited()


### PR DESCRIPTION
Fixes #2431

## Problem
A FR lesson rendered a **screenshot of unrelated English body text** under the (correct, now-FR via #2428) caption **"Figure 3.2 — Une chaîne de valeur … pétrole"**. The caption is right; the **image binary is wrong**.

Root causes (staging `santepublique_aof`, 12,918 images):
- **Duplicate `figure_number` rows** — `Figure 1.4` ×21, `FIGURE 2` ×15, `Figure 3.2` ×2 (same page 97).
- **Linker last-writer-wins** — `_build_explicit_pairs` set `figure_map[key] = image_id` with no ordering, so an explicit "Figure X" citation resolved to a **random** sibling (often the body-text crop).
- **1,911 unclassified rows** (`figure_kind` NULL) the purge couldn't reach.

## Changes
- **Classifier** (`figure_classifier.py`): add a `body_text` kind so the vision classifier flags page-text screenshots precisely (vs over-deleting legit `decorative`).
- **Linker** (`_build_explicit_pairs`): among images sharing a figure_number, keep the **best** — real figure_kind > photo > unclassified(NULL) > decorative/body_text, tie-break on rendered area then file size.
- **Retriever** (`get_linked_images`): never surface `body_text` regardless of size (NULL kinds kept — not yet classified).
- **Task** (`purge_body_text_figures`): delete `body_text` rows + MinIO objects. Safe for existing lessons — orphaned `{{source_image:UUID}}` markers are dropped client-side (WS3 of #2428, already on staging). Shares delete/preview helpers with the full-page purge.

## Tests / checks
94 passed, ruff clean. New: linker prefers the real figure over a larger, first-listed `body_text` duplicate; classifier accepts `body_text`; purge dry-run / real / storage-failure paths.

## Data ops (separate, on staging after deploy)
`backfill_figure_kinds` (classify the 1,911 NULL rows) → `purge_body_text_figures` (`dry_run` first) → reload the lesson; the body-text Figure 3.2 disappears or shows the correct sibling.

## Out of scope
Full re-extraction; repointing existing baked-in markers to the good sibling (deferred).

## Related
Builds on #2429 (#2428 — FR caption tag + orphan-marker drop), already on staging. FR translation backfill on staging is done (4,106/4,111).

🤖 Generated with [Claude Code](https://claude.com/claude-code)