### PR TITLE
fix(quiz): final quiz uses connected user's country, not hardcoded "senegal"

### DIFF
--- a/frontend/app/[locale]/(app)/modules/[moduleId]/summative/page.tsx
+++ b/frontend/app/[locale]/(app)/modules/[moduleId]/summative/page.tsx
@@ -27,8 +27,6 @@ export default async function SummativePage({ params }: SummativePageProps) {
       moduleId={moduleId}
       locale={locale}
       language={language}
-      country="senegal"
-      level={1}
     />
   );
 }

--- a/frontend/app/[locale]/(app)/modules/[moduleId]/summative/summative-page-client.tsx
+++ b/frontend/app/[locale]/(app)/modules/[moduleId]/summative/summative-page-client.tsx
@@ -9,16 +9,12 @@ interface SummativePageClientProps {
   moduleId: string;
   locale: string;
   language: string;
-  country: string;
-  level: number;
 }
 
 export function SummativePageClient({
   moduleId,
   locale,
   language,
-  country,
-  level,
 }: SummativePageClientProps) {
   const router = useRouter();
   // Bumping the key remounts the container with fresh state — used to reset
@@ -33,8 +29,6 @@ export function SummativePageClient({
           key={retryKey}
           moduleId={moduleId}
           language={language}
-          country={country}
-          level={level}
           onComplete={() => {
             router.push(`/${locale}/modules`);
           }}

--- a/frontend/components/quiz/summative-assessment-container.tsx
+++ b/frontend/components/quiz/summative-assessment-container.tsx
@@ -19,12 +19,15 @@ import {
   canAttemptSummativeAssessment
 } from '@/lib/api';
 import { useSettings } from '@/lib/settings-context';
+import { useCurrentUser } from '@/lib/hooks/use-current-user';
 
 interface SummativeAssessmentContainerProps {
   moduleId: string;
   language: string;
-  country: string;
-  level: number;
+  /** Optional override; defaults to the connected user's country. */
+  country?: string;
+  /** Optional override; defaults to the connected user's current level. */
+  level?: number;
   onComplete?: () => void;
   onRetry?: () => void;
 }
@@ -42,6 +45,11 @@ export function SummativeAssessmentContainer({
   const t = useTranslations('SummativeAssessment');
   const { getSetting } = useSettings();
   const summativeTimeLimit = getSetting<number>("quiz-summative-time-limit-minutes", 30);
+  // Contextualize the assessment to the connected learner, mirroring the
+  // unit-quiz pattern (quiz-container.tsx). Props act as optional overrides.
+  const { user: currentUser, isHydrated } = useCurrentUser();
+  const resolvedCountry = country || currentUser?.country || 'CI';
+  const resolvedLevel = level || currentUser?.current_level || 1;
   
   const [state, setState] = useState<AssessmentState>('checking');
   const [assessment, setAssessment] = useState<Quiz | null>(null);
@@ -77,8 +85,8 @@ export function SummativeAssessmentContainer({
       const assessmentData = await generateSummativeAssessment({
         module_id: moduleId,
         language,
-        country,
-        level,
+        country: resolvedCountry,
+        level: resolvedLevel,
       });
       
       setAssessment(assessmentData);
@@ -294,6 +302,7 @@ export function SummativeAssessmentContainer({
               onClick={handleStartAssessment}
               size="lg"
               className="min-h-12 px-8"
+              disabled={!isHydrated}
             >
               <PlayCircle className="w-5 h-5 mr-2" />
               {t('startAssessment')}


### PR DESCRIPTION
Fixes #2434

## Problem

The module **final quiz** (summative assessment) was generated and contextualized for **Senegal for every learner**, regardless of who was logged in or which country they selected. The summative page hardcoded `country="senegal"` and `level={1}` and passed them straight through to `POST /api/v1/quiz/summative/generate`; the connected user's country/level were never consulted. Because `"senegal"` isn't an ISO code (`SN`/`CI`), the prompt literally interpolated the string and the cache row was keyed on it.

## Fix

Mirror the existing unit-quiz pattern (`quiz-container.tsx`): resolve country/level from the connected user via `useCurrentUser()` inside `summative-assessment-container.tsx`. Props become optional overrides; the server page and page-client stop injecting constants.

- `components/quiz/summative-assessment-container.tsx` — `useCurrentUser()`; `resolvedCountry = country || currentUser?.country || 'CI'`, `resolvedLevel = level || currentUser?.current_level || 1`; used in `handleStartAssessment`. Start button gated on `isHydrated`.
- `summative-page-client.tsx` — drop `country`/`level` props.
- `summative/page.tsx` — remove `country="senegal"` / `level={1}`.

The `'CI'` / `1` fallbacks match the existing unit-quiz default exactly — no new convention.

## ⚠️ Required follow-up (data) — run before/at deploy

Existing `generated_content` summative rows were all written with `country_context = 'senegal'`. The cache fallback (`quiz_service.py`) would otherwise serve those stale rows to other-country learners on their **first** attempt before background regeneration lands — unacceptable for a graded assessment. Purge them (staging first, then prod, via psql — cache data, not schema, so no Alembic migration):

```sql
-- sanity: should be 0 (summative quizzes don't generate figures)
SELECT count(*) FROM generated_images gi
JOIN generated_content gc ON gi.generated_content_id = gc.id
WHERE gc.content_type = 'quiz' AND gc.content->>'unit_id' = 'summative'
  AND gc.country_context = 'senegal';

DELETE FROM generated_content
WHERE content_type = 'quiz'
  AND module_unit_id IS NULL
  AND content->>'unit_id' = 'summative'
  AND country_context = 'senegal';
```

## Verification

- `tsc --noEmit` clean for touched files; `eslint` clean (only pre-existing, unrelated `e2e/production-uat.spec.ts` errors from a missing `speakeasy` test dep).
- Manual: log in as a non-Senegal learner (e.g. `country = 'CI'`), open a module's final quiz, confirm the `POST /api/v1/quiz/summative/generate` body sends the user's real country + `current_level` (not `senegal`/`1`) and the questions are contextualized to that country.

## Out of scope

The broader audit surfaced related country-default issues (prefetch hardcoding `"CI"`, flashcards not passing country). Those are separate and will be filed on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)