### PR TITLE
feat(figures): read real caption from image + reject body-text crops; vision on Gemini Flash-Lite (#2435)

### DIFF
--- a/backend/app/ai/rag/image_extractor.py
+++ b/backend/app/ai/rag/image_extractor.py
@@ -38,6 +38,13 @@ VECTOR_CLUSTER_GAP_PT = 10
 VECTOR_MIN_REGION_PX = 100
 HIGH_DRAWING_COUNT_THRESHOLD = 2000
 RASTERIZE_DPI = 200
+# Body-text rejection for the few-drawings full-page fallback (#2435). A page
+# that merely opens with "Figure 4.2 shows…" plus a stray rule must not become
+# a full-page "figure". Reject when text dominates the page AND the vector/visual
+# region is negligible — that's prose, not an illustration. A genuine full-page
+# figure (chart/diagram) has low text coverage, so it clears this gate.
+TEXT_DENSITY_REJECT_FRACTION = 0.45
+MIN_DRAWING_COVERAGE_FRACTION = 0.10
 
 
 def _avg_hash_hex(image_bytes: bytes) -> str | None:
@@ -701,6 +708,48 @@ class PDFImageExtractor:
 
         return results
 
+    def _text_coverage_fraction(self, page: pymupdf.Page) -> float:
+        """Fraction of the page area covered by text blocks (#2435).
+
+        Text blocks don't overlap, so the summed block area is a good proxy.
+        High values mean a prose page; genuine figures sit well below.
+        """
+        try:
+            page_dict = page.get_text("dict")
+        except Exception:
+            return 0.0
+        page_area = abs(page.rect.get_area()) or 1.0
+        text_area = 0.0
+        for block in page_dict.get("blocks", []):
+            if block.get("type") != 0:
+                continue
+            bbox = block.get("bbox")
+            if bbox:
+                text_area += abs(pymupdf.Rect(bbox).get_area())
+        return min(text_area / page_area, 1.0)
+
+    def _drawings_coverage_fraction(self, page: pymupdf.Page) -> float:
+        """Fraction of the page covered by the bounding box of all vector drawings (#2435).
+
+        A real chart/diagram clusters drawings into a substantial region; a prose
+        page's drawings are thin rules with negligible area.
+        """
+        try:
+            drawings = page.get_drawings()
+        except Exception:
+            return 0.0
+        page_area = abs(page.rect.get_area()) or 1.0
+        union: pymupdf.Rect | None = None
+        for drawing in drawings:
+            rect = drawing.get("rect")
+            if rect is None:
+                continue
+            r = pymupdf.Rect(rect)
+            union = r if union is None else (union | r)
+        if union is None:
+            return 0.0
+        return min(abs(union.get_area()) / page_area, 1.0)
+
     def _rasterize_full_page_as_figure(
         self,
         page: pymupdf.Page,
@@ -717,6 +766,25 @@ class PDFImageExtractor:
         page (#2272). The caller from the high-drawing-count path passes
         None and keeps legacy behaviour.
         """
+        # The few-drawings fallback (caption_bbox set) is where body-text pages
+        # leak in (#2435/#2272). Reject a page dominated by prose with negligible
+        # visual area before rasterizing it as a figure. The high-drawing path
+        # (caption_bbox is None) keeps its legacy behaviour.
+        if caption_bbox is not None:
+            text_cov = self._text_coverage_fraction(page)
+            draw_cov = self._drawings_coverage_fraction(page)
+            if (
+                text_cov >= TEXT_DENSITY_REJECT_FRACTION
+                and draw_cov < MIN_DRAWING_COVERAGE_FRACTION
+            ):
+                logger.info(
+                    "Skipping full-page raster — body-text page, not a figure",
+                    page=page_number,
+                    text_coverage=round(text_cov, 2),
+                    drawing_coverage=round(draw_cov, 2),
+                )
+                return None
+
         try:
             pixmap = page.get_pixmap(dpi=RASTERIZE_DPI)
             png_bytes = pixmap.tobytes("png")

--- a/backend/app/ai/rag/pipeline.py
+++ b/backend/app/ai/rag/pipeline.py
@@ -22,6 +22,7 @@ from app.ai.translation import (
     classify_figure,
     extract_flowchart_structure,
     extract_label_positions,
+    read_figure_caption,
     render_overlay_svg,
     render_svg,
     translate_figure_caption,
@@ -473,6 +474,28 @@ class RAGPipeline:
                 )
                 continue
 
+            # Read the real caption from the image + detect body-text crops
+            # (#2435). The PyMuPDF extractor often leaves caption empty (the
+            # translator then echoes the bare figure number, e.g. "Figure 4.2")
+            # or rasterizes a page of body text as a figure. A cheap vision call
+            # recovers the printed caption and flags non-figures.
+            vision_body_text = False
+            try:
+                cap_read = await read_figure_caption(image_bytes=img.image_bytes)
+                if cap_read.is_body_text:
+                    vision_body_text = True
+                elif cap_read.caption:
+                    img.caption = cap_read.caption
+            except RuntimeError:
+                pass  # vision disabled (kill-switch) — keep the heuristic caption
+            except Exception as exc:
+                logger.warning(
+                    "Failed to read figure caption via vision, keeping heuristic",
+                    source=source,
+                    figure_number=img.figure_number,
+                    error=str(exc),
+                )
+
             caption_text = " ".join(filter(None, [img.caption, img.surrounding_text]))
             embedding: list[float] | None = None
             if caption_text.strip():
@@ -494,16 +517,23 @@ class RAGPipeline:
             )
 
             figure_kind: str | None = None
-            try:
-                classification = await classify_figure(image_bytes=img.image_bytes)
-                figure_kind = classification.kind
-            except Exception as exc:
-                logger.warning(
-                    "Failed to classify figure, storing without figure_kind",
-                    source=source,
-                    figure_number=img.figure_number,
-                    error=str(exc),
-                )
+            if vision_body_text:
+                # The caption reader already determined this crop is page text,
+                # not a figure (#2435). Tag it so the retriever excludes it and
+                # purge_body_text_figures (#2431) can remove it; skip the extra
+                # classification call.
+                figure_kind = "body_text"
+            else:
+                try:
+                    classification = await classify_figure(image_bytes=img.image_bytes)
+                    figure_kind = classification.kind
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to classify figure, storing without figure_kind",
+                        source=source,
+                        figure_number=img.figure_number,
+                        error=str(exc),
+                    )
 
             storage_key_fr: str | None = None
             storage_url_fr: str | None = None

--- a/backend/app/ai/translation/__init__.py
+++ b/backend/app/ai/translation/__init__.py
@@ -7,6 +7,10 @@ from app.ai.translation.complex_overlay import (
     render_overlay_svg,
     translate_labels,
 )
+from app.ai.translation.figure_caption_reader import (
+    FigureCaptionRead,
+    read_figure_caption,
+)
 from app.ai.translation.figure_classifier import (
     FigureClassification,
     FigureKind,
@@ -28,6 +32,7 @@ from app.ai.translation.svg_rederiver import (
 __all__ = [
     "DiagramLabel",
     "DiagramLabels",
+    "FigureCaptionRead",
     "FigureClassification",
     "FigureKind",
     "FigureTranslation",
@@ -37,6 +42,7 @@ __all__ = [
     "classify_figure",
     "extract_flowchart_structure",
     "extract_label_positions",
+    "read_figure_caption",
     "render_overlay_svg",
     "render_svg",
     "translate_figure_caption",

--- a/backend/app/ai/translation/figure_caption_reader.py
+++ b/backend/app/ai/translation/figure_caption_reader.py
@@ -1,0 +1,105 @@
+"""Read a figure's real caption from its image, and flag body-text crops (#2435).
+
+The PyMuPDF extractor derives captions from page geometry, which fails two ways:
+it leaves the caption empty (so the pipeline falls back to echoing the bare
+figure number — "Figure 4.2"), and it sometimes rasterizes a whole page of body
+text as a "figure". A cheap vision call fixes both at the source: it reads the
+caption printed in the image and tells us whether the crop is actually a figure.
+
+Runs on whichever provider ``settings.figure_vision_provider`` selects (default
+Gemini 2.5 Flash-Lite). Gated by the same ``enable_figure_vision`` kill-switch.
+"""
+
+from __future__ import annotations
+
+import json
+
+import structlog
+from pydantic import BaseModel, Field
+
+from app.ai.translation.figure_classifier import _extract_json_object
+from app.ai.translation.vision_provider import VisionProvider, get_vision_provider
+from app.infrastructure.config.settings import get_settings
+
+logger = structlog.get_logger(__name__)
+
+_MAX_TOKENS = 300
+
+_SYSTEM_PROMPT = (
+    "You extract metadata from a single image cropped out of an academic "
+    "textbook PDF. Reply with one JSON object and nothing else — no prose, no "
+    "markdown fences."
+)
+
+_USER_PROMPT = (
+    "This image was extracted as a figure from a textbook page. Return JSON with "
+    "exactly two fields:\n"
+    '  "caption": the figure\'s own caption sentence as printed in the image, '
+    'VERBATIM but WITHOUT the leading label (drop any "Figure 4.2", "Fig. 1", '
+    '"Table 3", "Schéma 2" prefix). If no descriptive caption text is visible, '
+    "or the only text is the figure number itself, use null.\n"
+    '  "is_body_text": true if this image is NOT a figure at all — i.e. it is a '
+    "screenshot of running paragraph or multi-column body text, a page "
+    "header/footer, or a block of references. false if it is a genuine figure, "
+    "chart, diagram, table, photo, or formula.\n\n"
+    'Reply with: {"caption": <string|null>, "is_body_text": <boolean>}'
+)
+
+
+class FigureCaptionRead(BaseModel):
+    """Validated caption-reader output."""
+
+    caption: str | None = Field(
+        None, description="Caption text, label prefix removed; None if absent"
+    )
+    is_body_text: bool = Field(
+        False, description="True when the image is page body-text, not a figure"
+    )
+
+
+async def read_figure_caption(
+    image_bytes: bytes,
+    image_media_type: str = "image/webp",
+    provider: VisionProvider | None = None,
+) -> FigureCaptionRead:
+    """Read the real caption + body-text flag from a figure image.
+
+    Args:
+        image_bytes: Raw bytes of the figure asset (WebP as stored in MinIO).
+        image_media_type: MIME type for the vision payload.
+        provider: Optional injected provider (tests). Defaults to the configured one.
+
+    Raises:
+        ValueError: empty input or malformed model output.
+        RuntimeError: figure vision disabled via the cost kill-switch.
+    """
+    if not image_bytes:
+        raise ValueError("image_bytes must be non-empty")
+
+    settings = get_settings()
+    if not settings.enable_figure_vision:
+        raise RuntimeError("figure vision is disabled (ENABLE_FIGURE_VISION=false)")
+
+    if provider is None:
+        provider = get_vision_provider()
+
+    text = await provider.complete_json(
+        image_bytes=image_bytes,
+        image_media_type=image_media_type,
+        system=_SYSTEM_PROMPT,
+        user_prompt=_USER_PROMPT,
+        max_tokens=_MAX_TOKENS,
+    )
+    if not text.strip():
+        raise ValueError("empty caption-reader response")
+
+    try:
+        payload = json.loads(_extract_json_object(text))
+    except json.JSONDecodeError as exc:
+        logger.warning("Caption reader produced invalid JSON", preview=text[:200], error=str(exc))
+        raise ValueError(f"caption reader returned invalid JSON: {exc}") from exc
+
+    raw_caption = payload.get("caption") if isinstance(payload, dict) else None
+    caption = raw_caption.strip() if isinstance(raw_caption, str) and raw_caption.strip() else None
+    is_body_text = bool(payload.get("is_body_text")) if isinstance(payload, dict) else False
+    return FigureCaptionRead(caption=caption, is_body_text=is_body_text)

--- a/backend/app/ai/translation/figure_classifier.py
+++ b/backend/app/ai/translation/figure_classifier.py
@@ -27,6 +27,7 @@ import anthropic
 import structlog
 from pydantic import BaseModel, Field, ValidationError
 
+from app.ai.translation.vision_provider import get_vision_provider
 from app.infrastructure.config.settings import get_settings
 
 logger = structlog.get_logger(__name__)
@@ -156,42 +157,43 @@ async def classify_figure(
         # Cost kill-switch (#1928). Caller catches and treats as a skip.
         raise RuntimeError("figure vision is disabled (ENABLE_FIGURE_VISION=false)")
 
-    if client is None:
-        if not settings.anthropic_api_key:
-            raise ValueError("ANTHROPIC_API_KEY is required to classify figures")
-        client = anthropic.AsyncAnthropic(
-            api_key=settings.anthropic_api_key,
-            timeout=60.0,
+    if client is not None:
+        # Injected Anthropic client (tests / explicit override): use it directly.
+        encoded = base64.standard_b64encode(image_bytes).decode("ascii")
+        response = await client.messages.create(
+            model=_CLASSIFIER_MODEL,
+            max_tokens=_MAX_TOKENS,
+            system=_SYSTEM_PROMPT,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": image_media_type,
+                                "data": encoded,
+                            },
+                        },
+                        {"type": "text", "text": _USER_PROMPT},
+                    ],
+                }
+            ],
+            temperature=0.0,
+        )
+        text = "".join(block.text for block in response.content if hasattr(block, "text"))
+    else:
+        # Production path: whichever vision provider is configured (#2435).
+        provider = get_vision_provider()
+        text = await provider.complete_json(
+            image_bytes=image_bytes,
+            image_media_type=image_media_type,
+            system=_SYSTEM_PROMPT,
+            user_prompt=_USER_PROMPT,
+            max_tokens=_MAX_TOKENS,
         )
 
-    encoded = base64.standard_b64encode(image_bytes).decode("ascii")
-    response = await client.messages.create(
-        model=_CLASSIFIER_MODEL,
-        max_tokens=_MAX_TOKENS,
-        system=_SYSTEM_PROMPT,
-        messages=[
-            {
-                "role": "user",
-                "content": [
-                    {
-                        "type": "image",
-                        "source": {
-                            "type": "base64",
-                            "media_type": image_media_type,
-                            "data": encoded,
-                        },
-                    },
-                    {"type": "text", "text": _USER_PROMPT},
-                ],
-            }
-        ],
-        temperature=0.0,
-    )
-
-    text = ""
-    for block in response.content:
-        if hasattr(block, "text"):
-            text += block.text
     if not text.strip():
         raise ValueError("empty classifier response")
 

--- a/backend/app/ai/translation/vision_provider.py
+++ b/backend/app/ai/translation/vision_provider.py
@@ -1,0 +1,155 @@
+"""Provider-agnostic vision interface for figure tasks (#2435).
+
+The figure classifier and caption reader send one image + a JSON-only prompt to
+a vision model. Which model runs is config-selectable
+(``settings.figure_vision_provider``) so we can use the cheapest accurate VLM —
+Gemini 2.5 Flash-Lite (~$0.10/$0.40 per 1M; a figure image bills ~258 tokens) —
+without locking the codebase to one vendor.
+
+Gemini is reached through its OpenAI-compatible endpoint, so it reuses the same
+``AsyncOpenAI`` client the embeddings service already depends on — no extra
+package. ``anthropic`` (Haiku) and ``openai`` (GPT-4o-mini) remain available by
+flipping one setting.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Protocol, runtime_checkable
+
+import anthropic
+import structlog
+from openai import AsyncOpenAI
+
+from app.infrastructure.config.settings import get_settings
+
+logger = structlog.get_logger(__name__)
+
+_TIMEOUT_SECONDS = 60.0
+
+
+@runtime_checkable
+class VisionProvider(Protocol):
+    """Sends one image + a JSON-only prompt and returns the raw text response."""
+
+    model: str
+
+    async def complete_json(
+        self,
+        *,
+        image_bytes: bytes,
+        image_media_type: str,
+        system: str,
+        user_prompt: str,
+        max_tokens: int,
+    ) -> str: ...
+
+
+class AnthropicVisionProvider:
+    """Claude vision via the Anthropic Messages API."""
+
+    def __init__(self, *, api_key: str, model: str) -> None:
+        self._client = anthropic.AsyncAnthropic(api_key=api_key, timeout=_TIMEOUT_SECONDS)
+        self.model = model
+
+    async def complete_json(
+        self,
+        *,
+        image_bytes: bytes,
+        image_media_type: str,
+        system: str,
+        user_prompt: str,
+        max_tokens: int,
+    ) -> str:
+        encoded = base64.standard_b64encode(image_bytes).decode("ascii")
+        response = await self._client.messages.create(
+            model=self.model,
+            max_tokens=max_tokens,
+            system=system,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": image_media_type,
+                                "data": encoded,
+                            },
+                        },
+                        {"type": "text", "text": user_prompt},
+                    ],
+                }
+            ],
+            temperature=0.0,
+        )
+        return "".join(block.text for block in response.content if hasattr(block, "text"))
+
+
+class OpenAICompatVisionProvider:
+    """OpenAI Chat Completions vision — also serves Gemini via its
+    OpenAI-compatible endpoint (different ``base_url`` + key + model)."""
+
+    def __init__(self, *, api_key: str, model: str, base_url: str | None = None) -> None:
+        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url, timeout=_TIMEOUT_SECONDS)
+        self.model = model
+
+    async def complete_json(
+        self,
+        *,
+        image_bytes: bytes,
+        image_media_type: str,
+        system: str,
+        user_prompt: str,
+        max_tokens: int,
+    ) -> str:
+        encoded = base64.standard_b64encode(image_bytes).decode("ascii")
+        data_uri = f"data:{image_media_type};base64,{encoded}"
+        response = await self._client.chat.completions.create(
+            model=self.model,
+            max_tokens=max_tokens,
+            response_format={"type": "json_object"},
+            messages=[
+                {"role": "system", "content": system},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": data_uri}},
+                        {"type": "text", "text": user_prompt},
+                    ],
+                },
+            ],
+            temperature=0.0,
+        )
+        return response.choices[0].message.content or ""
+
+
+def get_vision_provider(provider: str | None = None) -> VisionProvider:
+    """Build the configured vision provider. Raises if its key is missing."""
+    settings = get_settings()
+    provider = provider or settings.figure_vision_provider
+
+    if provider == "anthropic":
+        if not settings.anthropic_api_key:
+            raise ValueError("ANTHROPIC_API_KEY required for figure_vision_provider=anthropic")
+        return AnthropicVisionProvider(
+            api_key=settings.anthropic_api_key,
+            model=settings.figure_vision_anthropic_model,
+        )
+    if provider == "openai":
+        if not settings.openai_api_key:
+            raise ValueError("OPENAI_API_KEY required for figure_vision_provider=openai")
+        return OpenAICompatVisionProvider(
+            api_key=settings.openai_api_key,
+            model=settings.figure_vision_openai_model,
+        )
+    if provider == "gemini":
+        if not settings.google_api_key:
+            raise ValueError("GOOGLE_API_KEY required for figure_vision_provider=gemini")
+        return OpenAICompatVisionProvider(
+            api_key=settings.google_api_key,
+            model=settings.figure_vision_gemini_model,
+            base_url=settings.gemini_openai_base_url,
+        )
+    raise ValueError(f"unknown figure_vision_provider: {provider!r}")

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -59,7 +59,19 @@ class Settings(BaseSettings):
     # Issue #1928 — staging burned ~$30 in 4 hours of repeated backfills.
     enable_figure_vision: bool = True
 
-    # Google AI (Gemini TTS)
+    # Figure-vision provider selection (#2435). The classifier + caption reader
+    # call whichever provider is configured here. Gemini 2.5 Flash-Lite is the
+    # cheapest accurate VLM (~$0.10/$0.40 per 1M; a figure image bills ~258
+    # tokens) and is reached through its OpenAI-compatible endpoint, so it
+    # reuses the OpenAI client and needs no extra dependency. Switch to
+    # "anthropic" (Haiku) or "openai" without code changes.
+    figure_vision_provider: str = "gemini"  # gemini | anthropic | openai
+    figure_vision_gemini_model: str = "gemini-2.5-flash-lite"
+    figure_vision_anthropic_model: str = "claude-haiku-4-5"
+    figure_vision_openai_model: str = "gpt-4o-mini"
+    gemini_openai_base_url: str = "https://generativelanguage.googleapis.com/v1beta/openai/"
+
+    # Google AI (Gemini TTS + figure vision)
     google_api_key: str = ""
 
     # OpenAI Embeddings

--- a/backend/app/tasks/image_translation.py
+++ b/backend/app/tasks/image_translation.py
@@ -31,6 +31,7 @@ from app.ai.translation import (
     classify_figure,
     extract_flowchart_structure,
     extract_label_positions,
+    read_figure_caption,
     render_overlay_svg,
     render_svg,
     translate_figure_caption,
@@ -437,6 +438,196 @@ async def _run_kind_backfill_with_factory(
             "status": "complete",
             "eligible": total,
             "classified": classified,
+            "failed": failed,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Caption recovery via vision (#2435)
+# ---------------------------------------------------------------------------
+#
+# Existing rows where the extractor never captured a caption show the bare
+# figure number ("Figure 4.2") because the translator was fed the figure number
+# as a fallback. Re-read the real caption from the stored image, then re-translate.
+# A row the model says is body-text gets tagged figure_kind=body_text (feeds the
+# #2431 purge). Mirrors backfill_figure_kinds (per-task engine, kill-switch,
+# batched HTTP-GET under a semaphore).
+
+
+@celery_app.task(
+    bind=True,
+    base=FigureClassificationTask,
+    time_limit=3600,
+    soft_time_limit=3300,
+    ignore_result=True,
+    acks_late=False,
+)
+def backfill_figure_captions(
+    self,
+    rag_collection_id: str | None = None,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """Recover real captions for rows whose caption is missing or equals the figure number."""
+    return asyncio.run(
+        _run_caption_backfill(
+            task=self,
+            rag_collection_id=rag_collection_id,
+            limit=limit,
+            dry_run=dry_run,
+        )
+    )
+
+
+async def _run_caption_backfill(
+    task: Task,
+    rag_collection_id: str | None,
+    limit: int | None,
+    dry_run: bool,
+) -> dict:
+    engine = create_async_engine(settings.database_url, pool_pre_ping=True)
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        return await _run_caption_backfill_with_factory(
+            task=task,
+            rag_collection_id=rag_collection_id,
+            limit=limit,
+            dry_run=dry_run,
+            session_factory=session_factory,
+        )
+    finally:
+        await engine.dispose()
+
+
+async def _run_caption_backfill_with_factory(
+    task: Task,
+    rag_collection_id: str | None,
+    limit: int | None,
+    dry_run: bool,
+    session_factory: async_sessionmaker[AsyncSession],
+) -> dict:
+    if not settings.enable_figure_vision:
+        logger.info("caption backfill short-circuit: vision disabled")
+        return {"status": "disabled", "eligible": 0, "recovered": 0, "body_text": 0, "failed": 0}
+    async with session_factory() as session:
+        # Rows whose caption is missing or is just the figure number — exactly
+        # the degenerate "Figure 4.2" case — and that still have a fetchable image.
+        stmt = select(SourceImage).where(
+            SourceImage.storage_url.is_not(None),
+            or_(
+                SourceImage.caption.is_(None),
+                func.btrim(SourceImage.caption) == "",
+                SourceImage.caption == SourceImage.figure_number,
+            ),
+        )
+        if rag_collection_id is not None:
+            stmt = stmt.where(SourceImage.rag_collection_id == rag_collection_id)
+        if limit is not None:
+            stmt = stmt.limit(limit)
+
+        rows = (await session.execute(stmt)).scalars().all()
+        total = len(rows)
+        logger.info(
+            "Caption backfill: eligible rows",
+            total=total,
+            rag_collection_id=rag_collection_id,
+            dry_run=dry_run,
+        )
+        task.update_state(
+            state="READING_CAPTIONS",
+            meta={"step": "reading", "total": total, "processed": 0, "recovered": 0, "failed": 0},
+        )
+        if dry_run or total == 0:
+            return {
+                "status": "dry_run" if dry_run else "noop",
+                "eligible": total,
+                "recovered": 0,
+                "body_text": 0,
+                "failed": 0,
+            }
+
+        recovered = 0
+        body_text = 0
+        failed = 0
+        sem = asyncio.Semaphore(_CONCURRENCY)
+
+        async with httpx.AsyncClient(timeout=30.0) as http:
+
+            async def _read_one(img):
+                async with sem:
+                    try:
+                        upstream = await http.get(img.storage_url)
+                        upstream.raise_for_status()
+                        image_bytes = upstream.content
+                    except Exception as exc:  # noqa: BLE001
+                        return img, None, ("fetch", exc)
+                    try:
+                        result = await read_figure_caption(image_bytes=image_bytes)
+                        return img, result, None
+                    except Exception as exc:  # noqa: BLE001
+                        return img, None, ("read", exc)
+
+            processed = 0
+            for batch_start in range(0, total, _BATCH_SIZE):
+                batch = rows[batch_start : batch_start + _BATCH_SIZE]
+                outcomes = await asyncio.gather(*(_read_one(img) for img in batch))
+                for img, result, err in outcomes:
+                    if err is not None:
+                        stage, exc = err
+                        failed += 1
+                        logger.warning(
+                            "Caption %s failed for source image, skipping",
+                            stage,
+                            source_image_id=str(img.id),
+                            figure_number=img.figure_number,
+                            error=str(exc),
+                        )
+                        continue
+                    if result.is_body_text:
+                        img.figure_kind = "body_text"
+                        session.add(img)
+                        body_text += 1
+                        continue
+                    if not result.caption:
+                        continue
+                    img.caption = result.caption
+                    try:
+                        translation = await translate_figure_caption(
+                            caption=result.caption,
+                            image_type=img.image_type,
+                            figure_number=img.figure_number,
+                        )
+                        img.caption_fr = translation.caption_fr
+                        img.caption_en = translation.caption_en
+                        img.alt_text_fr = translation.alt_text_fr
+                        img.alt_text_en = translation.alt_text_en
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            "Re-translate after caption recovery failed; stored raw caption only",
+                            source_image_id=str(img.id),
+                            error=str(exc),
+                        )
+                    session.add(img)
+                    recovered += 1
+                await session.commit()
+                processed = batch_start + len(batch)
+                task.update_state(
+                    state="READING_CAPTIONS",
+                    meta={
+                        "step": "reading",
+                        "total": total,
+                        "processed": processed,
+                        "recovered": recovered,
+                        "body_text": body_text,
+                        "failed": failed,
+                    },
+                )
+
+        return {
+            "status": "complete",
+            "eligible": total,
+            "recovered": recovered,
+            "body_text": body_text,
             "failed": failed,
         }
 

--- a/backend/tests/test_figure_caption_reader.py
+++ b/backend/tests/test_figure_caption_reader.py
@@ -1,0 +1,83 @@
+"""Unit tests for read_figure_caption (#2435)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.ai.translation import figure_caption_reader as fcr
+from app.ai.translation.figure_caption_reader import read_figure_caption
+
+
+class _FakeProvider:
+    def __init__(self, text: str):
+        self._text = text
+        self.model = "fake"
+
+    async def complete_json(self, **kwargs) -> str:
+        return self._text
+
+
+def _enabled():
+    return MagicMock(enable_figure_vision=True)
+
+
+@pytest.mark.asyncio
+async def test_reads_real_caption():
+    provider = _FakeProvider(
+        json.dumps(
+            {"caption": "The Learning Curve and the Cost of Production", "is_body_text": False}
+        )
+    )
+    with patch.object(fcr, "get_settings", return_value=_enabled()):
+        result = await read_figure_caption(b"webp", provider=provider)
+    assert result.caption == "The Learning Curve and the Cost of Production"
+    assert result.is_body_text is False
+
+
+@pytest.mark.asyncio
+async def test_body_text_flagged_with_null_caption():
+    provider = _FakeProvider(json.dumps({"caption": None, "is_body_text": True}))
+    with patch.object(fcr, "get_settings", return_value=_enabled()):
+        result = await read_figure_caption(b"webp", provider=provider)
+    assert result.is_body_text is True
+    assert result.caption is None
+
+
+@pytest.mark.asyncio
+async def test_blank_caption_normalised_to_none():
+    provider = _FakeProvider(json.dumps({"caption": "   ", "is_body_text": False}))
+    with patch.object(fcr, "get_settings", return_value=_enabled()):
+        result = await read_figure_caption(b"webp", provider=provider)
+    assert result.caption is None
+
+
+@pytest.mark.asyncio
+async def test_markdown_fenced_json_parsed():
+    provider = _FakeProvider('```json\n{"caption": "A bar chart", "is_body_text": false}\n```')
+    with patch.object(fcr, "get_settings", return_value=_enabled()):
+        result = await read_figure_caption(b"webp", provider=provider)
+    assert result.caption == "A bar chart"
+
+
+@pytest.mark.asyncio
+async def test_disabled_raises():
+    with (
+        patch.object(fcr, "get_settings", return_value=MagicMock(enable_figure_vision=False)),
+        pytest.raises(RuntimeError, match="disabled"),
+    ):
+        await read_figure_caption(b"webp", provider=_FakeProvider("{}"))
+
+
+@pytest.mark.asyncio
+async def test_empty_bytes_raises():
+    with pytest.raises(ValueError, match="non-empty"):
+        await read_figure_caption(b"", provider=_FakeProvider("{}"))
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_raises():
+    with patch.object(fcr, "get_settings", return_value=_enabled()), pytest.raises(ValueError):
+        await read_figure_caption(b"webp", provider=_FakeProvider("not json at all"))

--- a/backend/tests/test_rag_pipeline_images.py
+++ b/backend/tests/test_rag_pipeline_images.py
@@ -717,3 +717,122 @@ class TestRAGPipelineClearSourceImages:
 
         assert count == 3
         assert mock_delete.call_count == 3
+
+
+class TestRAGPipelineVisionCaption:
+    """#2435: vision reads the real caption + flags body-text crops at ingest."""
+
+    def setup_method(self):
+        self.embedding_service = AsyncMock()
+        self.embedding_service.generate_embedding = AsyncMock(return_value=[0.1] * 1536)
+        self.pipeline = RAGPipeline(self.embedding_service)
+        self.temp_dir = tempfile.mkdtemp()
+
+    def teardown_method(self):
+        import shutil
+
+        shutil.rmtree(self.temp_dir)
+
+    @pytest.mark.asyncio
+    async def test_vision_caption_feeds_translator_not_figure_number(self):
+        from app.ai.translation.figure_caption_reader import FigureCaptionRead
+        from app.ai.translation.figure_translator import FigureTranslation
+
+        pdf_path = Path(self.temp_dir) / "test.pdf"
+        pdf_path.touch()
+        # Extractor left caption empty; only the figure number is known.
+        fake_image = _make_extracted_image(caption=None, figure_number="Figure 4.2")
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=MagicMock())
+
+        translation_stub = FigureTranslation(
+            caption_fr="La courbe d'apprentissage",
+            caption_en="The learning curve",
+            alt_text_fr="courbe",
+            alt_text_en="curve",
+        )
+
+        with (
+            patch(
+                "app.ai.rag.pipeline.PDFImageExtractor.extract_images_from_pdf",
+                return_value=[fake_image],
+            ),
+            patch(
+                "app.ai.rag.pipeline.S3StorageService.upload_bytes",
+                new_callable=AsyncMock,
+                return_value="http://minio/k.webp",
+            ),
+            patch(
+                "app.ai.rag.pipeline.read_figure_caption",
+                new_callable=AsyncMock,
+                return_value=FigureCaptionRead(
+                    caption="The Learning Curve and the Cost of Production", is_body_text=False
+                ),
+            ),
+            patch(
+                "app.ai.rag.pipeline.translate_figure_caption",
+                new_callable=AsyncMock,
+                return_value=translation_stub,
+            ) as mock_translate,
+            patch("app.ai.rag.pipeline.classify_figure", new_callable=AsyncMock) as mock_classify,
+            patch.object(
+                ImageLinker, "link_images_to_chunks", new_callable=AsyncMock, return_value=0
+            ),
+        ):
+            mock_classify.return_value = MagicMock(kind="chart")
+            count = await self.pipeline.process_pdf_images(
+                pdf_path=str(pdf_path), source="donaldson", session=mock_session
+            )
+
+        assert count == 1
+        # The real caption (not "Figure 4.2") was fed to translation.
+        assert (
+            mock_translate.call_args.kwargs["caption"]
+            == "The Learning Curve and the Cost of Production"
+        )
+        added = mock_session.add.call_args[0][0]
+        assert added.caption == "The Learning Curve and the Cost of Production"
+
+    @pytest.mark.asyncio
+    async def test_body_text_crop_tagged_and_classification_skipped(self):
+        from app.ai.translation.figure_caption_reader import FigureCaptionRead
+
+        pdf_path = Path(self.temp_dir) / "test.pdf"
+        pdf_path.touch()
+        fake_image = _make_extracted_image(figure_number="Figure 4.1")
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=MagicMock())
+
+        with (
+            patch(
+                "app.ai.rag.pipeline.PDFImageExtractor.extract_images_from_pdf",
+                return_value=[fake_image],
+            ),
+            patch(
+                "app.ai.rag.pipeline.S3StorageService.upload_bytes",
+                new_callable=AsyncMock,
+                return_value="http://minio/k.webp",
+            ),
+            patch(
+                "app.ai.rag.pipeline.read_figure_caption",
+                new_callable=AsyncMock,
+                return_value=FigureCaptionRead(caption=None, is_body_text=True),
+            ),
+            patch("app.ai.rag.pipeline.translate_figure_caption", new_callable=AsyncMock),
+            patch("app.ai.rag.pipeline.classify_figure", new_callable=AsyncMock) as mock_classify,
+            patch.object(
+                ImageLinker, "link_images_to_chunks", new_callable=AsyncMock, return_value=0
+            ),
+        ):
+            count = await self.pipeline.process_pdf_images(
+                pdf_path=str(pdf_path), source="donaldson", session=mock_session
+            )
+
+        assert count == 1
+        added = mock_session.add.call_args[0][0]
+        assert added.figure_kind == "body_text"
+        mock_classify.assert_not_called()

--- a/backend/tests/test_vision_provider.py
+++ b/backend/tests/test_vision_provider.py
@@ -1,0 +1,69 @@
+"""Unit tests for the figure-vision provider factory (#2435)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.ai.translation import vision_provider as vp
+
+
+def _settings(provider="gemini", anthropic="", openai="", google=""):
+    s = MagicMock()
+    s.figure_vision_provider = provider
+    s.anthropic_api_key = anthropic
+    s.openai_api_key = openai
+    s.google_api_key = google
+    s.figure_vision_anthropic_model = "claude-haiku-4-5"
+    s.figure_vision_openai_model = "gpt-4o-mini"
+    s.figure_vision_gemini_model = "gemini-2.5-flash-lite"
+    s.gemini_openai_base_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
+    return s
+
+
+def test_default_is_gemini_via_openai_compat():
+    with patch.object(vp, "get_settings", return_value=_settings(provider="gemini", google="k")):
+        provider = vp.get_vision_provider()
+    assert isinstance(provider, vp.OpenAICompatVisionProvider)
+    assert provider.model == "gemini-2.5-flash-lite"
+
+
+def test_anthropic_provider_selected():
+    with patch.object(
+        vp, "get_settings", return_value=_settings(provider="anthropic", anthropic="k")
+    ):
+        provider = vp.get_vision_provider()
+    assert isinstance(provider, vp.AnthropicVisionProvider)
+    assert provider.model == "claude-haiku-4-5"
+
+
+def test_openai_provider_selected():
+    with patch.object(vp, "get_settings", return_value=_settings(provider="openai", openai="k")):
+        provider = vp.get_vision_provider()
+    assert isinstance(provider, vp.OpenAICompatVisionProvider)
+    assert provider.model == "gpt-4o-mini"
+
+
+def test_explicit_override_beats_config():
+    with patch.object(
+        vp, "get_settings", return_value=_settings(provider="gemini", anthropic="k", google="k")
+    ):
+        provider = vp.get_vision_provider("anthropic")
+    assert isinstance(provider, vp.AnthropicVisionProvider)
+
+
+def test_missing_key_raises():
+    with (
+        patch.object(vp, "get_settings", return_value=_settings(provider="gemini", google="")),
+        pytest.raises(ValueError, match="GOOGLE_API_KEY"),
+    ):
+        vp.get_vision_provider()
+
+
+def test_unknown_provider_raises():
+    with (
+        patch.object(vp, "get_settings", return_value=_settings(provider="grok")),
+        pytest.raises(ValueError, match="unknown figure_vision_provider"),
+    ):
+        vp.get_vision_provider()


### PR DESCRIPTION
Fixes #2435

## Problem
Figures rendered with **degenerate captions** ("Figure 4.2" — the real caption was printed in the image but never read) and **whole-page body-text crops**. Both stem from caption + crop being PyMuPDF heuristics, never vision.

## Brainstorm verdict (3 agents)
- **GPT-4o mini rejected** — it bills images ~33× (a full page ≈25.5k tokens vs ~1.6k on Haiku), pricier than today.
- **Gemini 2.5 Flash-Lite** ($0.10/$0.40; ~258 tokens/image) is the cheapest accurate VLM; **3.1 Flash-Lite is more expensive** ($0.25/$1.50), so 2.5 is the default.
- **No chat VLM should emit crop boxes** — coordinate precision is unreliable. Region detection stays deterministic.
- Access verified end-to-end before coding (vision + JSON mode through the OpenAI-compat endpoint).

## Changes
- **WS1** `vision_provider.py` — `VisionProvider` protocol + `get_vision_provider()` factory (config `figure_vision_provider`, default `gemini`). Gemini via its **OpenAI-compatible endpoint**, reusing the existing `AsyncOpenAI` client → **no new dependency**. `classify_figure()` routes through it (injected-client path kept for tests).
- **WS2** `figure_caption_reader.py` — `read_figure_caption() -> {caption, is_body_text}`. Pipeline calls it before translation: a real caption replaces the empty/number caption (translator stops echoing "Figure 4.2"); `is_body_text` tags `figure_kind=body_text` and skips classification (feeds #2431 purge + retriever exclusion).
- **WS3** `image_extractor.py` — the few-drawings full-page fallback now **rejects text-dominated pages with negligible vector area** instead of rasterizing body text as a figure.
- **WS4** `backfill_figure_captions` task (mirrors `backfill_figure_kinds`) — re-reads captions for rows where caption is NULL or equals the figure number, then re-translates; body-text rows retagged.

## Config / secrets
Reuses existing `google_api_key` + `enable_figure_vision` kill-switch; adds `figure_vision_provider`, `figure_vision_gemini_model=gemini-2.5-flash-lite`, `gemini_openai_base_url`. **`deploy.yml` already provisions `GOOGLE_API_KEY`** (validate-secrets + server env) — it must be set as a repo Actions secret.

## Tests / checks
**204 image-suite tests pass**, ruff clean. New: provider factory selection; caption-reader parsing + body-text flag + kill-switch; pipeline feeds the real caption (not the figure number) and tags body-text.

## Compliance
Gemini is a new third-party processor (figure images leave to Google) — confirm DPA / data-residency (GDPR / NDPR / Senegal Loi 2008-12) before enabling on prod. Key stays server-side only.

## Staging verification (after deploy)
Set `figure_vision_provider=gemini` + `enable_figure_vision=true`; run `backfill_figure_captions` (dry-run → real) on collection `620088af…`; reload the Figure 4.1 / 4.2 lessons — 4.2 shows its real caption, 4.1 reclassifies `body_text`.

## Out of scope
GPT-4o mini (cost); self-hosted GPU layout models; VLM-produced bounding boxes.

Related: builds on #2429 (#2428) and #2432 (#2431), both shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)