### PR TITLE
perf(ai): config-driven Claude models + right-size low-stakes calls (#2440)

### DIFF
--- a/backend/app/ai/claude_service.py
+++ b/backend/app/ai/claude_service.py
@@ -31,6 +31,7 @@ class ClaudeService:
         _cache = SettingsCache.instance()
         self._max_tokens = _cache.get("ai-max-tokens-content", 64000)
         self._temperature = _cache.get("ai-temperature-content", 0.7)
+        self._model = _cache.get("ai-model-content", "claude-sonnet-4-6")
 
     async def generate_lesson_content_stream(
         self,
@@ -49,7 +50,7 @@ class ClaudeService:
         """
         try:
             async with self.client.messages.stream(
-                model="claude-sonnet-4-6",
+                model=self._model,
                 max_tokens=self._max_tokens,
                 system=system_prompt,
                 messages=[{"role": "user", "content": user_message}],
@@ -80,7 +81,7 @@ class ClaudeService:
         """
         try:
             response = await self.client.messages.create(
-                model="claude-sonnet-4-6",
+                model=self._model,
                 max_tokens=self._max_tokens,
                 system=system_prompt,
                 messages=[{"role": "user", "content": user_message}],
@@ -139,7 +140,7 @@ class ClaudeService:
 
             try:
                 response = await self.client.messages.create(
-                    model="claude-sonnet-4-6",
+                    model=self._model,
                     max_tokens=self._max_tokens,
                     system=system_prompt,
                     messages=[{"role": "user", "content": effective_user_message}],
@@ -240,6 +241,7 @@ class ClaudeService:
         max_retries: int = 1,
         max_tokens: int | None = None,
         temperature: float | None = None,
+        model: str | None = None,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Generate structured JSON with cache-aware system blocks.
 
@@ -267,6 +269,7 @@ class ClaudeService:
 
         eff_max_tokens = max_tokens if max_tokens is not None else self._max_tokens
         eff_temperature = temperature if temperature is not None else self._temperature
+        eff_model = model if model is not None else self._model
 
         for attempt in range(max_retries + 1):
             if attempt == 0:
@@ -284,7 +287,7 @@ class ClaudeService:
 
             try:
                 response = await self.client.messages.create(
-                    model="claude-sonnet-4-6",
+                    model=eff_model,
                     max_tokens=eff_max_tokens,
                     system=system_blocks,
                     messages=[{"role": "user", "content": effective_user_message}],

--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -717,15 +717,20 @@ Respond with ONLY this JSON object, no other text:
 
     from anthropic import Anthropic
 
+    from app.domain.services.platform_settings_service import SettingsCache
+
     api_key = os.getenv("ANTHROPIC_API_KEY", "")
     if not api_key:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="AI service not configured",
         )
+    # Was hardcoded to the deprecated claude-sonnet-4-20250514 (retires
+    # 2026-06-15). Use the config-driven content model (default Sonnet 4.6).
+    model = SettingsCache.instance().get("ai-model-content", "claude-sonnet-4-6")
     client = Anthropic(api_key=api_key)
     response = client.messages.create(
-        model="claude-sonnet-4-20250514",
+        model=model,
         max_tokens=1024,
         system=(
             "You are a curriculum design expert. You propose clear, accurate, "

--- a/backend/app/domain/services/course_agent_service.py
+++ b/backend/app/domain/services/course_agent_service.py
@@ -489,7 +489,9 @@ class CourseAgentService:
                 objectives_json=objectives_json,
             )
 
-            _model = "claude-sonnet-4-6"
+            from app.domain.services.platform_settings_service import SettingsCache
+
+            _model = SettingsCache.instance().get("ai-model-content", "claude-sonnet-4-6")
             caps = get_model_caps(_model)
             prompt_tokens_est = len(prompt) / caps["chars_per_token"]
             available = caps["context_window_tokens"] - caps["max_output_tokens"] - 5_000

--- a/backend/app/domain/services/image_service.py
+++ b/backend/app/domain/services/image_service.py
@@ -205,7 +205,10 @@ class ImageGenerationService:
         """Use Claude API to extract key concept, DALL-E prompt, and semantic tags."""
         import anthropic
 
+        from app.domain.services.platform_settings_service import SettingsCache
+
         client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key, timeout=600.0)
+        model = SettingsCache.instance().get("ai-model-image-metadata", "claude-haiku-4-5")
 
         language_name = "French" if language == "fr" else "English"
 
@@ -262,7 +265,7 @@ class ImageGenerationService:
         )
 
         message = await client.messages.create(
-            model="claude-sonnet-4-6",
+            model=model,
             max_tokens=400,
             messages=[
                 {
@@ -381,10 +384,13 @@ class ImageGenerationService:
         """Generate bilingual alt-text for the image."""
         import anthropic
 
+        from app.domain.services.platform_settings_service import SettingsCache
+
         client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key, timeout=600.0)
+        model = SettingsCache.instance().get("ai-model-image-metadata", "claude-haiku-4-5")
 
         message = await client.messages.create(
-            model="claude-sonnet-4-6",
+            model=model,
             max_tokens=100,
             messages=[
                 {

--- a/backend/app/domain/services/lesson_video_service.py
+++ b/backend/app/domain/services/lesson_video_service.py
@@ -623,7 +623,7 @@ class LessonVideoService:
     ) -> tuple[str, dict]:
         anthropic_client = self._claude.client
         async with anthropic_client.messages.stream(
-            model="claude-sonnet-4-6",
+            model=SettingsCache.instance().get("ai-model-content", "claude-sonnet-4-6"),
             max_tokens=4000,
             system=system_prompt,
             messages=[{"role": "user", "content": user_message}],

--- a/backend/app/domain/services/quality_agent_service.py
+++ b/backend/app/domain/services/quality_agent_service.py
@@ -137,6 +137,12 @@ class CourseQualityService:
     ):
         self.claude_service = claude_service
         self.semantic_retriever = semantic_retriever
+        # Auditor model is config-driven; defaults to Sonnet. Switching to a
+        # cheaper model (e.g. claude-haiku-4-5) is opt-in pending a detection-
+        # accuracy benchmark — note calculate_cost_cents() assumes Sonnet pricing.
+        from app.domain.services.platform_settings_service import SettingsCache
+
+        self._model = SettingsCache.instance().get("ai-model-quality", "claude-sonnet-4-6")
 
     # ---- Context builder (cached prefix) ----------------------------
 
@@ -305,6 +311,7 @@ class CourseQualityService:
             ],
             user_message=user_message,
             content_type="glossary_extraction",
+            model=self._model,
         )
         if parsed.get("raw_response"):
             logger.error(
@@ -453,6 +460,7 @@ class CourseQualityService:
             system_blocks=cached_blocks,
             user_message=user_message,
             content_type=f"quality_audit_{gc.content_type}",
+            model=self._model,
         )
 
         if parsed.get("raw_response"):
@@ -499,7 +507,7 @@ class CourseQualityService:
             score=Decimal(final_score),
             dimension_scores=report.dimension_scores.model_dump(),
             flags=[f.model_dump() for f in report.flags],
-            model="claude-sonnet-4-6",
+            model=self._model,
             tokens_in=usage.get("input_tokens"),
             tokens_out=usage.get("output_tokens"),
             cache_read_tokens=usage.get("cache_read_input_tokens"),

--- a/backend/app/domain/services/syllabus_agent_service.py
+++ b/backend/app/domain/services/syllabus_agent_service.py
@@ -138,11 +138,14 @@ class SyllabusAgentService:
         module_id: uuid.UUID | None,
     ) -> AsyncGenerator[str, None]:
         """Run the Claude tool_use agent loop."""
+        from app.domain.services.platform_settings_service import SettingsCache
+
         max_iterations = 5
+        model = SettingsCache.instance().get("ai-model-content", "claude-sonnet-4-6")
 
         for _ in range(max_iterations):
             response = await self._client.messages.create(
-                model="claude-sonnet-4-6",
+                model=model,
                 max_tokens=8192,
                 system=self._system_prompt,
                 tools=self._tools,

--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -1422,10 +1422,11 @@ class TutorService:
             sources_cited: list[dict[str, Any]] = []
             source_image_refs: list[dict[str, Any]] = []
             api_messages: list[MessageParam] = list(conversation_history)
+            tutor_model = _sc().get("tutor-model", "claude-sonnet-4-6")
 
             while tool_call_count <= MAX_TOOL_CALLS:
                 response = await self.anthropic.messages.create(
-                    model="claude-sonnet-4-6",
+                    model=tutor_model,
                     system=system_prompt,
                     messages=api_messages,
                     tools=TOOL_DEFINITIONS,
@@ -1442,7 +1443,7 @@ class TutorService:
                     if usage is not None:
                         logger.info(
                             "tutor_claude_call",
-                            model="claude-sonnet-4-6",
+                            model=tutor_model,
                             input_tokens=getattr(usage, "input_tokens", None),
                             output_tokens=getattr(usage, "output_tokens", None),
                             cache_read=getattr(usage, "cache_read_input_tokens", None),
@@ -2341,7 +2342,7 @@ class TutorService:
                 )
 
                 compact_response = await self.anthropic.messages.create(
-                    model="claude-sonnet-4-6",
+                    model=_sc().get("tutor-model", "claude-sonnet-4-6"),
                     messages=[{"role": "user", "content": prompt}],
                     max_tokens=_sc().get("tutor-compaction-max-tokens", 600),
                     temperature=_sc().get("tutor-compaction-temperature", 0.3),

--- a/backend/app/domain/services/tutor_tools.py
+++ b/backend/app/domain/services/tutor_tools.py
@@ -542,7 +542,7 @@ Respond ONLY with valid JSON in this exact format:
 }}"""
 
         response = await self.anthropic.messages.create(
-            model="claude-sonnet-4-6",
+            model=SettingsCache.instance().get("tutor-suggestions-model", "claude-haiku-4-5"),
             messages=[{"role": "user", "content": prompt}],
             max_tokens=SettingsCache.instance().get("tutor-suggestions-max-tokens", 800),
             temperature=SettingsCache.instance().get("tutor-suggestions-temperature", 0.5),

--- a/backend/app/infrastructure/config/platform_defaults.py
+++ b/backend/app/infrastructure/config/platform_defaults.py
@@ -365,6 +365,34 @@ SETTING_DEFINITIONS: list[SettingDef] = [
         {"min": 0.0, "max": 1.5},
     ),
     SettingDef(
+        "ai-model-content",
+        "ai",
+        "claude-sonnet-4-6",
+        "string",
+        "Model — content generation",
+        "Claude model for lessons, quizzes, flashcards, case studies, "
+        "pre-assessments, course syllabi and video scripts.",
+    ),
+    SettingDef(
+        "ai-model-quality",
+        "ai",
+        "claude-sonnet-4-6",
+        "string",
+        "Model — quality auditor",
+        "Claude model for the course-quality auditor. Haiku is a cheaper "
+        "option once detection accuracy has been benchmarked.",
+    ),
+    SettingDef(
+        "ai-model-image-metadata",
+        "ai",
+        "claude-haiku-4-5",
+        "string",
+        "Model — image metadata",
+        "Claude model for image concept/tag extraction and alt-text "
+        "(low-stakes structured calls). Override to a larger model if "
+        "quality regresses.",
+    ),
+    SettingDef(
         "ai-rag-default-top-k",
         "ai",
         8,
@@ -401,6 +429,23 @@ SETTING_DEFINITIONS: list[SettingDef] = [
         {"min": 600, "max": 7200},
     ),
     # ── Tutor ──────────────────────────────────────────────
+    SettingDef(
+        "tutor-model",
+        "tutor",
+        "claude-sonnet-4-6",
+        "string",
+        "Model — tutor response",
+        "Claude model for the main tutor conversation loop.",
+    ),
+    SettingDef(
+        "tutor-suggestions-model",
+        "tutor",
+        "claude-haiku-4-5",
+        "string",
+        "Model — tutor suggestions / mini-quiz",
+        "Claude model for the tutor mini-quiz tool (bounded structured "
+        "output). Override to a larger model if quality regresses.",
+    ),
     SettingDef(
         "tutor-response-max-tokens",
         "tutor",


### PR DESCRIPTION
## What & why

Cuts Anthropic spend and removes a latent breakage, from a 5-agent review of how the backend spends Claude tokens (verified against source). All Claude model IDs are now **config-driven** via `SettingsCache`, so future model swaps are config, not code.

Fixes #2440

## Changes (safe, in this PR)

- **Fix deprecated admin model** — `admin_courses` suggest-metadata hardcoded `claude-sonnet-4-20250514` (Sonnet **4.0**, retires **2026-06-15**) → `ai-model-content` (default `claude-sonnet-4-6`). Was a future hard failure.
- **Right-size low-stakes calls to Haiku by default** (config-overridable): image concept/alt-text (`ai-model-image-metadata`) and the tutor mini-quiz (`tutor-suggestions-model`).
- **Config-driven models everywhere**: content generation (`ClaudeService` → `ai-model-content`), quality auditor (`ai-model-quality`, default Sonnet), tutor response/compaction (`tutor-model`), course/syllabus/video generation.
- `generate_structured_content_cached` gains an optional `model` arg; the QA auditor now records the **actual** model into `unit_quality_assessments`.

New settings keys: `ai-model-content`, `ai-model-quality`, `ai-model-image-metadata`, `tutor-model`, `tutor-suggestions-model`.

## Deferred to a follow-up (the bigger lever)

The review's #1 item — **prompt caching on the content-generation path** — turned out to need more than a drop-in. The lesson/quiz/etc. system-prompt templates **interleave volatile variables** (`{course_title}`, `{country}`, `{unit_title}`, `{level}`, `{module_title}`, `{bloom_level}`) throughout the body, so the cacheable prefix diverges within ~120 tokens — far below Sonnet's 2048-token cache minimum. Real caching requires restructuring the **admin-customizable** templates so the static instructions+schema lead and all variables move to a trailing user-message block — a change with prod-prompt-migration and content-quality implications that deserves its own focused PR + review. Tracked under #2440.

Also deferred: **image-caption embedding batching** — it's an OpenAI cost (not Anthropic), and the per-image loop is resilience-sensitive (per-image commit for live progress; caption is vision-corrected in-loop), so batching is a riskier refactor off the core ask.

**Dropped:** figure-vision gating — `dev` (#2435) already routes figure vision to **Gemini** by default, so it is no longer primarily an Anthropic cost.

## Notes / risk

- Right-sizing image metadata + mini-quiz to Haiku is **config-overridable** back to Sonnet if quality regresses; a quick spot-check is recommended (these are short, bounded structured tasks well within Haiku's range).
- QA auditor stays **Sonnet by default**; Haiku is opt-in pending a detection-accuracy benchmark (`calculate_cost_cents` assumes Sonnet pricing — revisit if switched).

## Verification

- `cd backend && uv run pytest` on the touched suites: **191 passed** (claude_service, quality_agent, tutor_*, image_generation, admin_courses_helpers).
- `uv run ruff check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
