### PR TITLE
Promote dev → main: pluggable LLM provider + admin model switch (Kimi K2.6) (#2443)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -282,6 +282,9 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Kimi K2.6 content generation (#2443), OpenAI-compatible. Optional —
+          # only used when ai-model-content is set to a kimi-* model.
+          MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
@@ -302,7 +305,7 @@ jobs:
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           command_timeout: 30m
-          envs: GHCR_USER,GHCR_TOKEN,POSTGRES_PASSWORD,ANTHROPIC_API_KEY,OPENAI_API_KEY,GOOGLE_API_KEY,SENTRY_DSN,NEXT_PUBLIC_SENTRY_DSN,NEXT_PUBLIC_POSTHOG_KEY,NEXT_PUBLIC_POSTHOG_HOST,SMS_RELAY_API_KEY,SMS_RELAY_TRUSTED_SENDERS,MINIO_ACCESS_KEY,MINIO_SECRET_KEY,HEYGEN_API_KEY,DEPLOY_SHA
+          envs: GHCR_USER,GHCR_TOKEN,POSTGRES_PASSWORD,ANTHROPIC_API_KEY,MOONSHOT_API_KEY,OPENAI_API_KEY,GOOGLE_API_KEY,SENTRY_DSN,NEXT_PUBLIC_SENTRY_DSN,NEXT_PUBLIC_POSTHOG_KEY,NEXT_PUBLIC_POSTHOG_HOST,SMS_RELAY_API_KEY,SMS_RELAY_TRUSTED_SENDERS,MINIO_ACCESS_KEY,MINIO_SECRET_KEY,HEYGEN_API_KEY,DEPLOY_SHA
           script: |
             set -e
             cd ~/etutor
@@ -320,6 +323,7 @@ jobs:
             printf '%s\n' \
               "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}" \
               "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" \
+              "MOONSHOT_API_KEY=${MOONSHOT_API_KEY}" \
               "OPENAI_API_KEY=${OPENAI_API_KEY}" \
               "GOOGLE_API_KEY=${GOOGLE_API_KEY}" \
               "SENTRY_DSN=${SENTRY_DSN}" \
@@ -490,6 +494,9 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           POSTGRES_PASSWORD: ${{ secrets.PROD_POSTGRES_PASSWORD || secrets.POSTGRES_PASSWORD }}
           ANTHROPIC_API_KEY: ${{ secrets.PROD_ANTHROPIC_API_KEY || secrets.ANTHROPIC_API_KEY }}
+          # Kimi K2.6 content generation (#2443). Optional — only used when
+          # ai-model-content is a kimi-* model (gated on compliance review).
+          MOONSHOT_API_KEY: ${{ secrets.PROD_MOONSHOT_API_KEY || secrets.MOONSHOT_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.PROD_OPENAI_API_KEY || secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.PROD_GOOGLE_API_KEY || secrets.GOOGLE_API_KEY }}
           SENTRY_DSN: ${{ secrets.PROD_SENTRY_DSN || secrets.SENTRY_DSN }}
@@ -511,7 +518,7 @@ jobs:
           # (staging DEPLOY_SSH_KEY won't have access to 94.250.201.110).
           key: ${{ secrets.PROD_DEPLOY_SSH_KEY }}
           command_timeout: 30m
-          envs: GHCR_USER,GHCR_TOKEN,POSTGRES_PASSWORD,ANTHROPIC_API_KEY,OPENAI_API_KEY,GOOGLE_API_KEY,SENTRY_DSN,NEXT_PUBLIC_SENTRY_DSN,NEXT_PUBLIC_POSTHOG_KEY,NEXT_PUBLIC_POSTHOG_HOST,SMS_RELAY_API_KEY,SMS_RELAY_TRUSTED_SENDERS,MINIO_ACCESS_KEY,MINIO_SECRET_KEY,HEYGEN_API_KEY,DEPLOY_SHA
+          envs: GHCR_USER,GHCR_TOKEN,POSTGRES_PASSWORD,ANTHROPIC_API_KEY,MOONSHOT_API_KEY,OPENAI_API_KEY,GOOGLE_API_KEY,SENTRY_DSN,NEXT_PUBLIC_SENTRY_DSN,NEXT_PUBLIC_POSTHOG_KEY,NEXT_PUBLIC_POSTHOG_HOST,SMS_RELAY_API_KEY,SMS_RELAY_TRUSTED_SENDERS,MINIO_ACCESS_KEY,MINIO_SECRET_KEY,HEYGEN_API_KEY,DEPLOY_SHA
           script: |
             set -e
             cd ~/etutor
@@ -522,6 +529,7 @@ jobs:
             printf '%s\n' \
               "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}" \
               "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" \
+              "MOONSHOT_API_KEY=${MOONSHOT_API_KEY}" \
               "OPENAI_API_KEY=${OPENAI_API_KEY}" \
               "GOOGLE_API_KEY=${GOOGLE_API_KEY}" \
               "SENTRY_DSN=${SENTRY_DSN}" \

--- a/backend/app/ai/claude_service.py
+++ b/backend/app/ai/claude_service.py
@@ -3,26 +3,55 @@
 import json
 import re
 from collections.abc import AsyncGenerator
+from dataclasses import dataclass
 from typing import Any
 
 import anthropic
 import structlog
-from anthropic.types import Message
 
+from app.ai.providers import resolve_provider
+from app.ai.providers.base import LLMProvider
 from app.domain.services.platform_settings_service import SettingsCache
 from app.infrastructure.config.settings import get_settings
 
 logger = structlog.get_logger()
 
 
+@dataclass
+class _TextBlock:
+    text: str
+    type: str = "text"
+
+
+@dataclass
+class _ContentMessage:
+    """Minimal provider-neutral stand-in for an Anthropic ``Message``.
+
+    Content-generation callers only read ``.content`` (a list of blocks with
+    ``.text``); this lets ``generate_lesson_content`` return the same shape
+    whether the active provider is Anthropic or OpenAI-compatible.
+    """
+
+    content: list[_TextBlock]
+    stop_reason: str
+    usage: dict[str, Any]
+
+
 class ClaudeService:
-    """Service for interacting with Claude API for content generation."""
+    """Service for content generation, routed through a pluggable provider.
+
+    The active model is the admin-selected ``ai-model-content`` setting; it is
+    resolved to a provider (Anthropic, or an OpenAI-compatible backend such as
+    Moonshot Kimi) at call time. The class name is retained for compatibility
+    with existing call sites.
+    """
 
     def __init__(self):
         self.settings = get_settings()
         if not self.settings.anthropic_api_key:
             raise ValueError("ANTHROPIC_API_KEY is required")
 
+        # Retained for callers that still reach the raw Anthropic client directly.
         self.client = anthropic.AsyncAnthropic(
             api_key=self.settings.anthropic_api_key,
             timeout=600.0,
@@ -32,6 +61,10 @@ class ClaudeService:
         self._max_tokens = _cache.get("ai-max-tokens-content", 64000)
         self._temperature = _cache.get("ai-temperature-content", 0.7)
         self._model = _cache.get("ai-model-content", "claude-sonnet-4-6")
+
+    def _provider(self) -> LLMProvider:
+        """Resolve the provider for the configured content model."""
+        return resolve_provider(self._model)
 
     async def generate_lesson_content_stream(
         self,
@@ -49,45 +82,48 @@ class ClaudeService:
             AsyncGenerator for streaming text chunks
         """
         try:
-            async with self.client.messages.stream(
-                model=self._model,
-                max_tokens=self._max_tokens,
+            async for chunk in self._provider().stream(
                 system=system_prompt,
-                messages=[{"role": "user", "content": user_message}],
+                user_message=user_message,
+                max_tokens=self._max_tokens,
                 temperature=self._temperature,
-            ) as stream_manager:
-                async for event in stream_manager:
-                    if event.type == "content_block_delta" and event.delta.type == "text_delta":
-                        yield event.delta.text
+                model=self._model,
+            ):
+                yield chunk
 
         except Exception as e:
-            logger.error("Claude API streaming call failed", error=str(e))
+            logger.error("LLM streaming call failed", model=self._model, error=str(e))
             raise
 
     async def generate_lesson_content(
         self,
         system_prompt: str,
         user_message: str,
-    ) -> Message:
+    ) -> _ContentMessage:
         """
-        Generate lesson content using Claude API without streaming.
+        Generate lesson content (non-streaming) via the active provider.
 
         Args:
             system_prompt: System prompt for pedagogical context
             user_message: User message with RAG context and requirements
 
         Returns:
-            Message object from Claude API
+            A message-like object whose ``.content`` is a single text block
+            (provider-neutral; callers accumulate ``block.text``).
         """
         try:
-            response = await self.client.messages.create(
-                model=self._model,
-                max_tokens=self._max_tokens,
+            result = await self._provider().complete(
                 system=system_prompt,
                 messages=[{"role": "user", "content": user_message}],
+                max_tokens=self._max_tokens,
                 temperature=self._temperature,
+                model=self._model,
             )
-            return response
+            return _ContentMessage(
+                content=[_TextBlock(text=result.text)],
+                stop_reason=result.stop_reason,
+                usage=result.usage,
+            )
 
         except Exception as e:
             logger.error("Claude API call failed", error=str(e))
@@ -139,12 +175,13 @@ class ClaudeService:
                 )
 
             try:
-                response = await self.client.messages.create(
-                    model=self._model,
-                    max_tokens=self._max_tokens,
+                result = await self._provider().complete(
                     system=system_prompt,
                     messages=[{"role": "user", "content": effective_user_message}],
+                    max_tokens=self._max_tokens,
                     temperature=self._temperature,
+                    model=self._model,
+                    json_object=True,
                 )
             except Exception as e:
                 logger.error(
@@ -154,21 +191,17 @@ class ClaudeService:
                 )
                 raise
 
-            if not response.content or len(response.content) == 0:
-                raise ValueError("Empty response from Claude API")
+            content_text = result.text
+            if not content_text:
+                raise ValueError("Empty response from LLM provider")
 
-            is_truncated = response.stop_reason == "max_tokens"
+            is_truncated = result.stop_reason == "max_tokens"
             if is_truncated:
                 logger.warning(
-                    "Claude response truncated at max_tokens",
+                    "LLM response truncated at max_tokens",
                     content_type=content_type,
-                    usage_output=getattr(response.usage, "output_tokens", None),
+                    usage_output=result.usage.get("output_tokens"),
                 )
-
-            content_text = ""
-            for block in response.content:
-                if hasattr(block, "text"):
-                    content_text += block.text
 
             last_content_text = content_text
 
@@ -286,44 +319,38 @@ class ClaudeService:
                 )
 
             try:
-                response = await self.client.messages.create(
-                    model=eff_model,
-                    max_tokens=eff_max_tokens,
+                # Provider resolved from eff_model (the auditor may run a
+                # different model than the content path). Non-Anthropic providers
+                # strip cache_control from the system blocks automatically.
+                result = await resolve_provider(eff_model).complete(
                     system=system_blocks,
                     messages=[{"role": "user", "content": effective_user_message}],
+                    max_tokens=eff_max_tokens,
                     temperature=eff_temperature,
+                    model=eff_model,
+                    json_object=True,
                 )
             except Exception as e:
                 logger.error(
-                    "Claude cached call failed",
+                    "Cached structured call failed",
                     content_type=content_type,
                     error=str(e),
                 )
                 raise
 
-            usage = getattr(response, "usage", None)
-            last_usage = {
-                "input_tokens": getattr(usage, "input_tokens", None),
-                "output_tokens": getattr(usage, "output_tokens", None),
-                "cache_creation_input_tokens": getattr(usage, "cache_creation_input_tokens", None),
-                "cache_read_input_tokens": getattr(usage, "cache_read_input_tokens", None),
-            }
+            last_usage = result.usage
 
-            if not response.content or len(response.content) == 0:
-                raise ValueError("Empty response from Claude API")
+            content_text = result.text
+            if not content_text:
+                raise ValueError("Empty response from LLM provider")
 
-            is_truncated = response.stop_reason == "max_tokens"
+            is_truncated = result.stop_reason == "max_tokens"
             if is_truncated:
                 logger.warning(
-                    "Claude cached response truncated at max_tokens",
+                    "Cached response truncated at max_tokens",
                     content_type=content_type,
                     usage=last_usage,
                 )
-
-            content_text = ""
-            for block in response.content:
-                if hasattr(block, "text"):
-                    content_text += block.text
             last_content_text = content_text
 
             try:

--- a/backend/app/ai/providers/__init__.py
+++ b/backend/app/ai/providers/__init__.py
@@ -1,0 +1,14 @@
+"""Pluggable LLM provider layer for content generation (#2443)."""
+
+from app.ai.providers.base import LLMProvider, LLMResult, ToolCall
+from app.ai.providers.pricing import calculate_cost_cents, get_pricing
+from app.ai.providers.registry import resolve_provider
+
+__all__ = [
+    "LLMProvider",
+    "LLMResult",
+    "ToolCall",
+    "resolve_provider",
+    "calculate_cost_cents",
+    "get_pricing",
+]

--- a/backend/app/ai/providers/anthropic_provider.py
+++ b/backend/app/ai/providers/anthropic_provider.py
@@ -1,0 +1,117 @@
+"""Anthropic Claude provider (#2443).
+
+Wraps ``anthropic.AsyncAnthropic``. Preserves every Anthropic-native feature the
+codebase already relies on: ``cache_control`` ephemeral system blocks, ``tool_use``
+structured output, and streamed text. ``complete()`` always goes through
+``messages.stream`` + ``get_final_message`` so large ``max_tokens`` requests (e.g.
+64k syllabus generation) don't trip the SDK's non-streaming timeout guard.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import anthropic
+import structlog
+
+from app.ai.providers.base import LLMResult, ToolCall
+
+logger = structlog.get_logger(__name__)
+
+_TIMEOUT_SECONDS = 600.0
+
+
+class AnthropicLLMProvider:
+    """Claude via the Anthropic Messages API."""
+
+    supports_cache_control = True
+    is_anthropic = True
+
+    def __init__(self, *, api_key: str) -> None:
+        self._client = anthropic.AsyncAnthropic(api_key=api_key, timeout=_TIMEOUT_SECONDS)
+
+    async def complete(
+        self,
+        *,
+        system: str | list[dict[str, Any]],
+        messages: list[dict[str, Any]],
+        max_tokens: int,
+        temperature: float,
+        model: str,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: dict[str, Any] | None = None,
+        json_object: bool = False,  # noqa: ARG002 — Anthropic uses prompt-driven JSON
+    ) -> LLMResult:
+        kwargs: dict[str, Any] = {
+            "model": model,
+            "max_tokens": max_tokens,
+            "system": system,
+            "messages": messages,
+            "temperature": temperature,
+        }
+        if tools:
+            kwargs["tools"] = tools
+        if tool_choice:
+            kwargs["tool_choice"] = tool_choice
+
+        async with self._client.messages.stream(**kwargs) as stream:
+            message = await stream.get_final_message()
+
+        text = "".join(b.text for b in message.content if getattr(b, "type", None) == "text")
+        tool_calls = [
+            ToolCall(id=b.id, name=b.name, input=dict(b.input or {}))
+            for b in message.content
+            if getattr(b, "type", None) == "tool_use"
+        ]
+        usage = getattr(message, "usage", None)
+        usage_dict = {
+            "input_tokens": getattr(usage, "input_tokens", None),
+            "output_tokens": getattr(usage, "output_tokens", None),
+            "cache_creation_input_tokens": getattr(usage, "cache_creation_input_tokens", None),
+            "cache_read_input_tokens": getattr(usage, "cache_read_input_tokens", None),
+        }
+        return LLMResult(
+            text=text,
+            tool_calls=tool_calls,
+            stop_reason="tool_use" if tool_calls else (message.stop_reason or "end_turn"),
+            usage=usage_dict,
+            assistant_message={"role": "assistant", "content": message.content},
+        )
+
+    async def stream(
+        self,
+        *,
+        system: str | list[dict[str, Any]],
+        user_message: str,
+        max_tokens: int,
+        temperature: float,
+        model: str,
+    ) -> AsyncGenerator[str, None]:
+        async with self._client.messages.stream(
+            model=model,
+            max_tokens=max_tokens,
+            system=system,
+            messages=[{"role": "user", "content": user_message}],
+            temperature=temperature,
+        ) as stream_manager:
+            async for event in stream_manager:
+                if event.type == "content_block_delta" and event.delta.type == "text_delta":
+                    yield event.delta.text
+
+    def build_tool_result_messages(
+        self, results: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": r["tool_call_id"],
+                        "content": r["content"],
+                    }
+                    for r in results
+                ],
+            }
+        ]

--- a/backend/app/ai/providers/anthropic_provider.py
+++ b/backend/app/ai/providers/anthropic_provider.py
@@ -99,9 +99,7 @@ class AnthropicLLMProvider:
                 if event.type == "content_block_delta" and event.delta.type == "text_delta":
                     yield event.delta.text
 
-    def build_tool_result_messages(
-        self, results: list[dict[str, Any]]
-    ) -> list[dict[str, Any]]:
+    def build_tool_result_messages(self, results: list[dict[str, Any]]) -> list[dict[str, Any]]:
         return [
             {
                 "role": "user",

--- a/backend/app/ai/providers/base.py
+++ b/backend/app/ai/providers/base.py
@@ -1,0 +1,99 @@
+"""Provider-agnostic LLM interface for content generation (#2443).
+
+Mirrors the figure ``vision_provider.py`` (#2435) pattern: a ``Protocol`` plus
+concrete provider classes. Lets content generation (lessons, quizzes, case
+studies, syllabi, video scripts) run on Anthropic Claude OR any OpenAI-compatible
+model (Moonshot Kimi, OpenRouter, OpenAI) behind one interface, selected at
+runtime from the ``ai-model-content`` setting.
+
+The interface normalizes the two things that differ across providers:
+  * **tool use** — Anthropic ``tool_use`` blocks vs OpenAI ``tool_calls``; both
+    surface as :class:`LLMResult.tool_calls`, and each provider knows how to
+    re-encode an assistant turn + tool results back into its own message shape
+    (so a multi-turn agent loop stays provider-agnostic).
+  * **prompt caching** — Anthropic ``cache_control`` ephemeral blocks have no
+    OpenAI equivalent; non-Anthropic providers strip them. ``supports_cache_control``
+    lets callers keep the cache path on Anthropic and fall back elsewhere.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+
+@dataclass
+class ToolCall:
+    """One tool invocation requested by the model."""
+
+    id: str
+    name: str
+    input: dict[str, Any]
+
+
+@dataclass
+class LLMResult:
+    """Normalized result of one ``complete()`` call.
+
+    ``assistant_message`` is the provider-native message dict to append to the
+    running ``messages`` history before sending tool results back — opaque to
+    callers, consumed only by the same provider's ``build_tool_result_messages``.
+    """
+
+    text: str
+    tool_calls: list[ToolCall] = field(default_factory=list)
+    stop_reason: str = "end_turn"  # normalized: "tool_use" | "end_turn" | "max_tokens"
+    usage: dict[str, Any] = field(default_factory=dict)
+    assistant_message: dict[str, Any] | None = None
+
+
+@runtime_checkable
+class LLMProvider(Protocol):
+    """One LLM backend. Implementations: Anthropic, OpenAI-compatible."""
+
+    supports_cache_control: bool
+    is_anthropic: bool
+
+    async def complete(
+        self,
+        *,
+        system: str | list[dict[str, Any]],
+        messages: list[dict[str, Any]],
+        max_tokens: int,
+        temperature: float,
+        model: str,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: dict[str, Any] | None = None,
+        json_object: bool = False,
+    ) -> LLMResult: ...
+
+    def stream(
+        self,
+        *,
+        system: str | list[dict[str, Any]],
+        user_message: str,
+        max_tokens: int,
+        temperature: float,
+        model: str,
+    ) -> AsyncGenerator[str, None]: ...
+
+    def build_tool_result_messages(
+        self, results: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Encode ``[{"tool_call_id": str, "content": str}, ...]`` as the
+        next-turn message(s) in this provider's native shape."""
+        ...
+
+
+def flatten_system(system: str | list[dict[str, Any]]) -> str:
+    """Collapse Anthropic cache_control system blocks into a plain string.
+
+    Used by OpenAI-compatible providers, which take the system prompt as a
+    single ``{"role": "system"}`` message and have no ``cache_control`` concept.
+    """
+    if isinstance(system, str):
+        return system
+    return "\n\n".join(
+        block.get("text", "") for block in system if isinstance(block, dict)
+    )

--- a/backend/app/ai/providers/base.py
+++ b/backend/app/ai/providers/base.py
@@ -78,9 +78,7 @@ class LLMProvider(Protocol):
         model: str,
     ) -> AsyncGenerator[str, None]: ...
 
-    def build_tool_result_messages(
-        self, results: list[dict[str, Any]]
-    ) -> list[dict[str, Any]]:
+    def build_tool_result_messages(self, results: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Encode ``[{"tool_call_id": str, "content": str}, ...]`` as the
         next-turn message(s) in this provider's native shape."""
         ...
@@ -94,6 +92,4 @@ def flatten_system(system: str | list[dict[str, Any]]) -> str:
     """
     if isinstance(system, str):
         return system
-    return "\n\n".join(
-        block.get("text", "") for block in system if isinstance(block, dict)
-    )
+    return "\n\n".join(block.get("text", "") for block in system if isinstance(block, dict))

--- a/backend/app/ai/providers/openai_compat_provider.py
+++ b/backend/app/ai/providers/openai_compat_provider.py
@@ -1,0 +1,167 @@
+"""OpenAI-compatible provider (#2443).
+
+Serves Moonshot Kimi (``base_url=https://api.moonshot.ai/v1``), OpenRouter, and
+OpenAI behind the Chat Completions API — same ``AsyncOpenAI`` client the
+embeddings service and ``vision_provider`` already depend on (no new package).
+
+Normalizes the OpenAI surface to the provider interface:
+  * system blocks (incl. Anthropic ``cache_control``) → one ``system`` message,
+    cache_control stripped (these providers do their own automatic prefix caching);
+  * Anthropic tool schema → ``{"type": "function", "function": {...}}``;
+  * ``tool_calls`` (arguments JSON string) → :class:`ToolCall`;
+  * ``prompt_tokens`` / ``completion_tokens`` → ``input_tokens`` / ``output_tokens``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import structlog
+from openai import AsyncOpenAI
+
+from app.ai.providers.base import LLMResult, ToolCall, flatten_system
+
+logger = structlog.get_logger(__name__)
+
+_TIMEOUT_SECONDS = 600.0
+
+
+def _to_openai_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Anthropic ``{name, description, input_schema}`` → OpenAI function tool."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": t["name"],
+                "description": t.get("description", ""),
+                "parameters": t.get("input_schema", {"type": "object", "properties": {}}),
+            },
+        }
+        for t in tools
+    ]
+
+
+def _to_openai_tool_choice(tool_choice: dict[str, Any]) -> Any:
+    """Anthropic ``{"type": "tool", "name": X}`` → OpenAI forced-function choice."""
+    if tool_choice.get("type") == "tool" and tool_choice.get("name"):
+        return {"type": "function", "function": {"name": tool_choice["name"]}}
+    if tool_choice.get("type") == "any":
+        return "required"
+    return "auto"
+
+
+class OpenAICompatLLMProvider:
+    """Any OpenAI Chat Completions backend (Moonshot / OpenRouter / OpenAI)."""
+
+    supports_cache_control = False
+    is_anthropic = False
+
+    def __init__(self, *, api_key: str, base_url: str | None = None) -> None:
+        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url, timeout=_TIMEOUT_SECONDS)
+
+    async def complete(
+        self,
+        *,
+        system: str | list[dict[str, Any]],
+        messages: list[dict[str, Any]],
+        max_tokens: int,
+        temperature: float,
+        model: str,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: dict[str, Any] | None = None,
+        json_object: bool = False,
+    ) -> LLMResult:
+        msgs = [{"role": "system", "content": flatten_system(system)}, *messages]
+        kwargs: dict[str, Any] = {
+            "model": model,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "messages": msgs,
+        }
+        if tools:
+            kwargs["tools"] = _to_openai_tools(tools)
+            if tool_choice:
+                kwargs["tool_choice"] = _to_openai_tool_choice(tool_choice)
+        elif json_object:
+            # response_format and forced-tool calls are mutually exclusive; the
+            # forced tool already constrains the output shape.
+            kwargs["response_format"] = {"type": "json_object"}
+
+        response = await self._client.chat.completions.create(**kwargs)
+        choice = response.choices[0]
+        msg = choice.message
+
+        tool_calls: list[ToolCall] = []
+        for tc in msg.tool_calls or []:
+            try:
+                args = json.loads(tc.function.arguments or "{}")
+            except json.JSONDecodeError:
+                logger.warning("tool_call arguments not valid JSON", name=tc.function.name)
+                args = {}
+            tool_calls.append(ToolCall(id=tc.id, name=tc.function.name, input=args))
+
+        assistant_message: dict[str, Any] = {"role": "assistant", "content": msg.content or ""}
+        if msg.tool_calls:
+            assistant_message["tool_calls"] = [
+                {
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {"name": tc.function.name, "arguments": tc.function.arguments},
+                }
+                for tc in msg.tool_calls
+            ]
+
+        usage = getattr(response, "usage", None)
+        cached = 0
+        details = getattr(usage, "prompt_tokens_details", None)
+        if details is not None:
+            cached = getattr(details, "cached_tokens", 0) or 0
+        usage_dict = {
+            "input_tokens": getattr(usage, "prompt_tokens", None),
+            "output_tokens": getattr(usage, "completion_tokens", None),
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": cached,
+        }
+        return LLMResult(
+            text=msg.content or "",
+            tool_calls=tool_calls,
+            stop_reason="tool_use" if tool_calls else "end_turn",
+            usage=usage_dict,
+            assistant_message=assistant_message,
+        )
+
+    async def stream(
+        self,
+        *,
+        system: str | list[dict[str, Any]],
+        user_message: str,
+        max_tokens: int,
+        temperature: float,
+        model: str,
+    ) -> AsyncGenerator[str, None]:
+        stream = await self._client.chat.completions.create(
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            messages=[
+                {"role": "system", "content": flatten_system(system)},
+                {"role": "user", "content": user_message},
+            ],
+            stream=True,
+        )
+        async for chunk in stream:
+            if not chunk.choices:
+                continue
+            delta = chunk.choices[0].delta
+            if delta and delta.content:
+                yield delta.content
+
+    def build_tool_result_messages(
+        self, results: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        return [
+            {"role": "tool", "tool_call_id": r["tool_call_id"], "content": r["content"]}
+            for r in results
+        ]

--- a/backend/app/ai/providers/openai_compat_provider.py
+++ b/backend/app/ai/providers/openai_compat_provider.py
@@ -158,9 +158,7 @@ class OpenAICompatLLMProvider:
             if delta and delta.content:
                 yield delta.content
 
-    def build_tool_result_messages(
-        self, results: list[dict[str, Any]]
-    ) -> list[dict[str, Any]]:
+    def build_tool_result_messages(self, results: list[dict[str, Any]]) -> list[dict[str, Any]]:
         return [
             {"role": "tool", "tool_call_id": r["tool_call_id"], "content": r["content"]}
             for r in results

--- a/backend/app/ai/providers/pricing.py
+++ b/backend/app/ai/providers/pricing.py
@@ -1,0 +1,48 @@
+"""Per-model pricing for generation cost accounting (#2443).
+
+Replaces the Sonnet-hardcoded constants in ``quality_agent_service``. Cents per
+million tokens. ``cache_write`` / ``cache_read`` apply only to Anthropic prompt
+caching; OpenAI-compatible providers report cached input under ``cache_read`` at
+their own (lower) rate, or 0 when unsupported.
+
+Re-verify against each vendor's official pricing when it changes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# cents per 1M tokens: (input, output, cache_write, cache_read)
+_PRICING: dict[str, dict[str, int]] = {
+    "claude-sonnet-4-6": {"input": 300, "output": 1500, "cache_write": 375, "cache_read": 30},
+    "claude-haiku-4-5": {"input": 100, "output": 500, "cache_write": 125, "cache_read": 10},
+    "claude-opus-4-6": {"input": 500, "output": 2500, "cache_write": 625, "cache_read": 50},
+    # Moonshot Kimi K2.6 — $0.95 / $4.00 per 1M; auto prefix-cache ~$0.16/M input.
+    "kimi-k2.6": {"input": 95, "output": 400, "cache_write": 0, "cache_read": 16},
+}
+
+_DEFAULT = {"input": 300, "output": 1500, "cache_write": 375, "cache_read": 30}
+
+
+def get_pricing(model: str) -> dict[str, int]:
+    return _PRICING.get(model, _DEFAULT)
+
+
+def calculate_cost_cents(model: str, usage: dict[str, Any]) -> int:
+    """Cost of one call in integer cents, using ``model``'s pricing table.
+
+    ``usage`` keys: ``input_tokens``, ``output_tokens``,
+    ``cache_creation_input_tokens``, ``cache_read_input_tokens``.
+    """
+    p = get_pricing(model)
+    inp = int(usage.get("input_tokens") or 0)
+    out = int(usage.get("output_tokens") or 0)
+    cwrite = int(usage.get("cache_creation_input_tokens") or 0)
+    cread = int(usage.get("cache_read_input_tokens") or 0)
+    cents = (
+        inp * p["input"]
+        + out * p["output"]
+        + cwrite * p["cache_write"]
+        + cread * p["cache_read"]
+    ) / 1_000_000
+    return int(round(cents))

--- a/backend/app/ai/providers/pricing.py
+++ b/backend/app/ai/providers/pricing.py
@@ -40,9 +40,6 @@ def calculate_cost_cents(model: str, usage: dict[str, Any]) -> int:
     cwrite = int(usage.get("cache_creation_input_tokens") or 0)
     cread = int(usage.get("cache_read_input_tokens") or 0)
     cents = (
-        inp * p["input"]
-        + out * p["output"]
-        + cwrite * p["cache_write"]
-        + cread * p["cache_read"]
+        inp * p["input"] + out * p["output"] + cwrite * p["cache_write"] + cread * p["cache_read"]
     ) / 1_000_000
     return int(round(cents))

--- a/backend/app/ai/providers/registry.py
+++ b/backend/app/ai/providers/registry.py
@@ -1,0 +1,55 @@
+"""Model → provider resolution (#2443).
+
+Mirrors ``vision_provider.get_vision_provider``: maps a model string to a built
+provider, raising a clear error when the required API key is unset. Prefix-based
+dispatch keeps it open for new OpenAI-compatible backends without touching call
+sites — only the registry and a settings key change.
+"""
+
+from __future__ import annotations
+
+from app.ai.providers.anthropic_provider import AnthropicLLMProvider
+from app.ai.providers.base import LLMProvider
+from app.ai.providers.openai_compat_provider import OpenAICompatLLMProvider
+from app.infrastructure.config.settings import get_settings
+
+
+def resolve_provider(model: str) -> LLMProvider:
+    """Build the provider that serves ``model``.
+
+    Dispatch:
+      * ``claude-*`` / ``anthropic-*`` → Anthropic
+      * ``kimi-*`` / ``moonshot-*``    → Moonshot (OpenAI-compatible)
+      * ``gpt-*``                      → OpenAI
+      * contains ``/`` (e.g. ``moonshotai/kimi-k2.6``) → OpenRouter
+    """
+    settings = get_settings()
+    m = (model or "").lower()
+
+    if m.startswith("claude") or m.startswith("anthropic"):
+        if not settings.anthropic_api_key:
+            raise ValueError(f"ANTHROPIC_API_KEY required for model {model!r}")
+        return AnthropicLLMProvider(api_key=settings.anthropic_api_key)
+
+    if m.startswith("kimi") or m.startswith("moonshot"):
+        if not settings.moonshot_api_key:
+            raise ValueError(f"MOONSHOT_API_KEY required for model {model!r}")
+        return OpenAICompatLLMProvider(
+            api_key=settings.moonshot_api_key,
+            base_url=settings.moonshot_base_url,
+        )
+
+    if m.startswith("gpt") or m.startswith("openai"):
+        if not settings.openai_api_key:
+            raise ValueError(f"OPENAI_API_KEY required for model {model!r}")
+        return OpenAICompatLLMProvider(api_key=settings.openai_api_key)
+
+    if "/" in m:  # OpenRouter-style "vendor/model"
+        if not settings.openrouter_api_key:
+            raise ValueError(f"OPENROUTER_API_KEY required for model {model!r}")
+        return OpenAICompatLLMProvider(
+            api_key=settings.openrouter_api_key,
+            base_url=settings.openrouter_base_url,
+        )
+
+    raise ValueError(f"No provider mapping for model {model!r}")

--- a/backend/app/api/v1/schemas/settings.py
+++ b/backend/app/api/v1/schemas/settings.py
@@ -16,6 +16,7 @@ class SettingResponse(BaseModel):
     validation_rules: dict | None = None
     is_sensitive: bool = False
     is_default: bool = True
+    allowed_options: list[str] | None = None
 
 
 class SettingUpdateRequest(BaseModel):

--- a/backend/app/domain/services/course_agent_service.py
+++ b/backend/app/domain/services/course_agent_service.py
@@ -1,12 +1,12 @@
 """Course content creator agent — generates full course structure via Claude API."""
 
-import os
 import uuid
 from typing import Any
 
 import structlog
 
 from app.ai.model_registry import get_model_caps
+from app.ai.providers import resolve_provider
 
 # ── Tool-use schema for structured syllabus output ──────────────────
 # Claude is forced to call this tool, ensuring every unit has an
@@ -444,19 +444,7 @@ class CourseAgentService:
         estimated_hours, bloom_level, and a sequential module_number.
         Falls back to 2 placeholder modules if ANTHROPIC_API_KEY is not set.
         """
-        api_key = os.getenv("ANTHROPIC_API_KEY", "")
-        if not api_key:
-            logger.warning(
-                "ANTHROPIC_API_KEY not set — returning placeholder modules",
-                course=title_en,
-            )
-            return _PLACEHOLDER_MODULES
-
         try:
-            import anthropic
-
-            client = anthropic.AsyncAnthropic(api_key=api_key)
-
             domains_str = ", ".join(course_domain) if course_domain else "General"
             levels_str = ", ".join(course_level) if course_level else "All levels"
             audience_str = ", ".join(audience_type) if audience_type else "Professionals"
@@ -516,38 +504,36 @@ class CourseAgentService:
                     audience_type=audience_type,
                 )
 
-            # Use tool_use to enforce structured JSON output
-            async with client.messages.stream(
-                model=_model,
-                max_tokens=64000,
+            # Force structured output via the save_syllabus tool, through the
+            # provider resolved from the active content model (Anthropic or an
+            # OpenAI-compatible backend such as Moonshot Kimi).
+            provider = resolve_provider(_model)
+            result = await provider.complete(
+                system="",
                 messages=[{"role": "user", "content": prompt}],
+                max_tokens=64000,
+                temperature=0.7,
+                model=_model,
                 tools=[SYLLABUS_TOOL],
                 tool_choice={"type": "tool", "name": "save_syllabus"},
-            ) as stream:
-                message = await stream.get_final_message()
+            )
 
-            # Extract modules from tool_use block
+            # Extract modules from the tool call
             modules_raw = None
-            for block in message.content:
-                if block.type == "tool_use" and block.name == "save_syllabus":
-                    modules_raw = block.input.get("modules", [])
-                    break
+            if result.tool_calls:
+                modules_raw = result.tool_calls[0].input.get("modules", [])
 
-            # Fallback: if tool_use failed, try raw text parsing
+            # Fallback: if the tool call failed, try raw text parsing
             if not modules_raw:
                 logger.warning(
                     "tool_use extraction failed, falling back to text",
                     course=title_en,
-                    stop_reason=message.stop_reason,
+                    stop_reason=result.stop_reason,
                 )
-                for block in message.content:
-                    if hasattr(block, "text") and block.text:
-                        raw = block.text.strip()
-                        if raw.startswith("```"):
-                            raw = raw.split("\n", 1)[1].rsplit("```", 1)[0].strip()
-                        modules_raw = _try_parse_modules(raw)
-                        if modules_raw:
-                            break
+                raw = (result.text or "").strip()
+                if raw.startswith("```"):
+                    raw = raw.split("\n", 1)[1].rsplit("```", 1)[0].strip()
+                modules_raw = _try_parse_modules(raw)
 
             if not modules_raw:
                 raise ValueError("Failed to extract modules from tool_use or text")

--- a/backend/app/domain/services/lesson_video_service.py
+++ b/backend/app/domain/services/lesson_video_service.py
@@ -40,6 +40,7 @@ from sqlalchemy.orm import selectinload
 
 from app.ai.claude_service import ClaudeService
 from app.ai.prompts.audience import detect_audience
+from app.ai.providers import resolve_provider
 from app.domain.models.generated_audio import GeneratedAudio
 from app.domain.models.module import Module
 from app.domain.services.platform_settings_service import SettingsCache
@@ -621,23 +622,20 @@ class LessonVideoService:
         system_prompt: str,
         user_message: str,
     ) -> tuple[str, dict]:
-        anthropic_client = self._claude.client
-        async with anthropic_client.messages.stream(
-            model=SettingsCache.instance().get("ai-model-content", "claude-sonnet-4-6"),
-            max_tokens=4000,
+        model = SettingsCache.instance().get("ai-model-content", "claude-sonnet-4-6")
+        result = await resolve_provider(model).complete(
             system=system_prompt,
             messages=[{"role": "user", "content": user_message}],
+            max_tokens=4000,
+            temperature=0.7,
+            model=model,
             tools=[VIDEO_SCRIPT_TOOL],
             tool_choice={"type": "tool", "name": "save_video_script"},
-        ) as stream:
-            message = await stream.get_final_message()
+        )
 
-        for block in message.content:
-            if (
-                getattr(block, "type", None) == "tool_use"
-                and getattr(block, "name", None) == "save_video_script"
-            ):
-                payload = block.input or {}
+        for call in result.tool_calls:
+            if call.name == "save_video_script":
+                payload = call.input or {}
                 scenes = payload.get("scenes") or []
                 narration_parts: list[str] = []
                 for scene in scenes:
@@ -651,10 +649,10 @@ class LessonVideoService:
                     "scenes": scenes,
                 }
                 if not script:
-                    raise ValueError("Claude returned empty video script")
+                    raise ValueError("LLM returned empty video script")
                 return script, metadata
 
-        raise ValueError("Claude did not invoke the save_video_script tool")
+        raise ValueError("LLM did not invoke the save_video_script tool")
 
     def _heygen_callback_url(self) -> str | None:
         base = (settings.heygen_callback_base_url or "").rstrip("/")

--- a/backend/app/domain/services/platform_settings_service.py
+++ b/backend/app/domain/services/platform_settings_service.py
@@ -53,6 +53,8 @@ def _validate_value(defn: SettingDef, raw: Any) -> Any:
             raise ValueError(f"'{defn.key}' must be >= {lo}")
         if hi is not None and isinstance(val, (int, float)) and val > hi:
             raise ValueError(f"'{defn.key}' must be <= {hi}")
+    if defn.allowed_options is not None and val not in defn.allowed_options:
+        raise ValueError(f"'{defn.key}' must be one of {defn.allowed_options}")
     return val
 
 
@@ -208,6 +210,7 @@ class PlatformSettingsService:
             "validation_rules": defn.validation,
             "is_sensitive": defn.is_sensitive,
             "is_default": current == defn.default,
+            "allowed_options": defn.allowed_options,
         }
 
     @staticmethod

--- a/backend/app/domain/services/quality_agent_service.py
+++ b/backend/app/domain/services/quality_agent_service.py
@@ -82,6 +82,7 @@ COURSE_PASSING_RATIO = 0.92  # for early exit
 DEFAULT_BUDGET_FULL = 200
 DEFAULT_BUDGET_TARGETED = 50
 
+
 def normalize_term(text: str) -> str:
     """Lowercase + strip accents + collapse whitespace.
 

--- a/backend/app/domain/services/quality_agent_service.py
+++ b/backend/app/domain/services/quality_agent_service.py
@@ -82,14 +82,6 @@ COURSE_PASSING_RATIO = 0.92  # for early exit
 DEFAULT_BUDGET_FULL = 200
 DEFAULT_BUDGET_TARGETED = 50
 
-# Approximate Claude Sonnet 4.6 pricing (cents per million tokens)
-# Used for cost_cents accounting; refresh when pricing changes.
-PRICING_INPUT_CENTS_PER_M = 300  # $3 / M
-PRICING_OUTPUT_CENTS_PER_M = 1500  # $15 / M
-PRICING_CACHE_WRITE_CENTS_PER_M = 375  # ~25% premium on writes
-PRICING_CACHE_READ_CENTS_PER_M = 30  # ~10% of input
-
-
 def normalize_term(text: str) -> str:
     """Lowercase + strip accents + collapse whitespace.
 
@@ -103,25 +95,17 @@ def normalize_term(text: str) -> str:
     return s
 
 
-def calculate_cost_cents(usage: dict[str, Any]) -> int:
-    """Compute the cost of one Claude call in integer cents.
+def calculate_cost_cents(usage: dict[str, Any], model: str = "claude-sonnet-4-6") -> int:
+    """Compute the cost of one LLM call in integer cents for ``model``.
 
-    ``usage`` keys: ``input_tokens``, ``output_tokens``,
+    Delegates to the per-model pricing table (``app.ai.providers.pricing``).
+    ``model`` defaults to Sonnet so existing single-argument callers are
+    unchanged. ``usage`` keys: ``input_tokens``, ``output_tokens``,
     ``cache_creation_input_tokens``, ``cache_read_input_tokens``.
-    Anthropic reports cache reads + cache writes SEPARATELY from the
-    main ``input_tokens`` field (which is then the *uncached* portion).
     """
-    inp = int(usage.get("input_tokens") or 0)
-    out = int(usage.get("output_tokens") or 0)
-    cwrite = int(usage.get("cache_creation_input_tokens") or 0)
-    cread = int(usage.get("cache_read_input_tokens") or 0)
-    cents = (
-        inp * PRICING_INPUT_CENTS_PER_M
-        + out * PRICING_OUTPUT_CENTS_PER_M
-        + cwrite * PRICING_CACHE_WRITE_CENTS_PER_M
-        + cread * PRICING_CACHE_READ_CENTS_PER_M
-    ) / 1_000_000
-    return int(round(cents))
+    from app.ai.providers.pricing import calculate_cost_cents as _calc
+
+    return _calc(model, usage)
 
 
 # ---- Service ------------------------------------------------------------
@@ -138,8 +122,9 @@ class CourseQualityService:
         self.claude_service = claude_service
         self.semantic_retriever = semantic_retriever
         # Auditor model is config-driven; defaults to Sonnet. Switching to a
-        # cheaper model (e.g. claude-haiku-4-5) is opt-in pending a detection-
-        # accuracy benchmark — note calculate_cost_cents() assumes Sonnet pricing.
+        # cheaper model (e.g. claude-haiku-4-5 / kimi-k2.6) is opt-in pending a
+        # detection-accuracy benchmark; cost_cents uses the per-model pricing
+        # table, so the recorded cost stays correct after a switch.
         from app.domain.services.platform_settings_service import SettingsCache
 
         self._model = SettingsCache.instance().get("ai-model-quality", "claude-sonnet-4-6")
@@ -499,7 +484,7 @@ class CourseQualityService:
         gc.quality_status = "passing" if not needs_regen else "needs_review"
 
         # Persist the assessment row.
-        cost = calculate_cost_cents(usage)
+        cost = calculate_cost_cents(usage, self._model)
         assessment = UnitQualityAssessment(
             run_id=run_id,
             generated_content_id=content_id,

--- a/backend/app/domain/services/syllabus_agent_service.py
+++ b/backend/app/domain/services/syllabus_agent_service.py
@@ -23,6 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.ai.prompts.syllabus_agent import get_syllabus_agent_system_prompt, get_tool_definitions
+from app.ai.providers import resolve_provider
 from app.ai.rag.embeddings import EmbeddingService
 from app.ai.rag.retriever import SemanticRetriever
 from app.domain.models.course import Course
@@ -142,55 +143,52 @@ class SyllabusAgentService:
 
         max_iterations = 5
         model = SettingsCache.instance().get("ai-model-content", "claude-sonnet-4-6")
+        provider = resolve_provider(model)
 
         for _ in range(max_iterations):
-            response = await self._client.messages.create(
-                model=model,
-                max_tokens=8192,
+            result = await provider.complete(
                 system=self._system_prompt,
-                tools=self._tools,
                 messages=messages,
+                max_tokens=8192,
+                temperature=0.7,
+                model=model,
+                tools=self._tools,
             )
 
-            if response.stop_reason == "tool_use":
-                tool_results = []
-                tool_use_blocks = []
+            if result.stop_reason == "tool_use":
+                if result.text.strip():
+                    payload = {"type": "content", "data": {"text": result.text}}
+                    yield f"data: {json.dumps(payload)}\n\n"
 
-                for block in response.content:
-                    if block.type == "text" and block.text.strip():
-                        yield f"data: {json.dumps({'type': 'content', 'data': {'text': block.text}})}\n\n"
-                    elif block.type == "tool_use":
-                        tool_use_blocks.append(block)
-                        tool_result = await self._execute_tool(
-                            tool_name=block.name,
-                            tool_input=block.input,
-                            admin_id=admin_id,
-                            admin_email=admin_email,
-                            session=session,
-                            module_id=module_id,
-                        )
-                        yield f"data: {json.dumps({'type': 'tool_call', 'data': {'tool': block.name, 'result_summary': self._summarize_tool_result(block.name, tool_result)}})}\n\n"
-                        tool_results.append(
-                            {
-                                "type": "tool_result",
-                                "tool_use_id": block.id,
-                                "content": json.dumps(tool_result),
-                            }
-                        )
+                tool_results = []
+                for call in result.tool_calls:
+                    tool_result = await self._execute_tool(
+                        tool_name=call.name,
+                        tool_input=call.input,
+                        admin_id=admin_id,
+                        admin_email=admin_email,
+                        session=session,
+                        module_id=module_id,
+                    )
+                    summary = self._summarize_tool_result(call.name, tool_result)
+                    event = {
+                        "type": "tool_call",
+                        "data": {"tool": call.name, "result_summary": summary},
+                    }
+                    yield f"data: {json.dumps(event)}\n\n"
+                    tool_results.append(
+                        {"tool_call_id": call.id, "content": json.dumps(tool_result)}
+                    )
 
                 messages = [
                     *messages,
-                    {"role": "assistant", "content": response.content},
-                    {"role": "user", "content": tool_results},
+                    result.assistant_message,
+                    *provider.build_tool_result_messages(tool_results),
                 ]
 
             else:
-                full_text = ""
-                for block in response.content:
-                    if hasattr(block, "text"):
-                        full_text += block.text
-
-                yield f"data: {json.dumps({'type': 'content', 'data': {'text': full_text}})}\n\n"
+                payload = {"type": "content", "data": {"text": result.text}}
+                yield f"data: {json.dumps(payload)}\n\n"
                 yield f"data: {json.dumps({'type': 'done', 'data': {}})}\n\n"
                 return
 

--- a/backend/app/infrastructure/config/platform_defaults.py
+++ b/backend/app/infrastructure/config/platform_defaults.py
@@ -21,6 +21,9 @@ class SettingDef:
     description: str = ""
     validation: dict | None = None
     is_sensitive: bool = False
+    # When set, the value must be one of these; the admin UI renders a
+    # single-select dropdown instead of a free-text field (#2443).
+    allowed_options: list[str] | None = None
 
 
 SETTING_DEFINITIONS: list[SettingDef] = [
@@ -370,8 +373,12 @@ SETTING_DEFINITIONS: list[SettingDef] = [
         "claude-sonnet-4-6",
         "string",
         "Model — content generation",
-        "Claude model for lessons, quizzes, flashcards, case studies, "
-        "pre-assessments, course syllabi and video scripts.",
+        "Model for lessons, quizzes, flashcards, case studies, pre-assessments, "
+        "course syllabi and video scripts. Resolved to a provider by prefix "
+        "(claude-* → Anthropic; kimi-* → Moonshot). NOTE: kimi-k2.6 runs on "
+        "China-based servers — confirm data-residency compliance before using it "
+        "for production user content.",
+        allowed_options=["claude-sonnet-4-6", "claude-haiku-4-5", "kimi-k2.6"],
     ),
     SettingDef(
         "ai-model-quality",

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -51,6 +51,16 @@ class Settings(BaseSettings):
     # Anthropic Claude API
     anthropic_api_key: str = ""
 
+    # Pluggable content-generation providers (#2443). The active model is the
+    # admin-selected `ai-model-content` setting; the registry resolves it to a
+    # provider by prefix. Keys are server-side only (never exposed to clients).
+    # Kimi K2.6 is served over Moonshot's OpenAI-compatible endpoint — keep prod
+    # use gated on a data-residency compliance review (China-based servers).
+    moonshot_api_key: str = ""
+    moonshot_base_url: str = "https://api.moonshot.ai/v1"
+    openrouter_api_key: str = ""
+    openrouter_base_url: str = "https://openrouter.ai/api/v1"
+
     # Cost kill-switch for Vision-backed figure tasks (classifier, flowchart
     # SVG re-deriver, complex_diagram overlay extractor). Set to False in an
     # environment that shouldn't spend on Claude Vision — backfills and the

--- a/backend/tests/test_claude_service.py
+++ b/backend/tests/test_claude_service.py
@@ -4,6 +4,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.ai.providers.base import LLMResult
+
 
 def _make_response(text: str, stop_reason: str = "end_turn"):
     """Build a mock Claude API response."""
@@ -38,6 +40,25 @@ def claude_service():
 
                 service = ClaudeService()
                 service.client = AsyncMock()
+
+                # ClaudeService now routes through a provider (#2443). Keep the
+                # existing tests' `client.messages.create` mocking intact by
+                # making the fake provider's complete() call it and adapt the
+                # Anthropic-style mock response into an LLMResult.
+                async def _fake_complete(**kwargs):
+                    resp = await service.client.messages.create(**kwargs)
+                    text = "".join(
+                        b.text for b in resp.content if getattr(b, "type", None) == "text"
+                    )
+                    return LLMResult(
+                        text=text,
+                        stop_reason=resp.stop_reason,
+                        usage={"output_tokens": getattr(resp.usage, "output_tokens", None)},
+                    )
+
+                fake_provider = MagicMock()
+                fake_provider.complete = AsyncMock(side_effect=_fake_complete)
+                service._provider = lambda: fake_provider
                 return service
 
 

--- a/backend/tests/test_llm_providers.py
+++ b/backend/tests/test_llm_providers.py
@@ -1,0 +1,268 @@
+"""Tests for the pluggable LLM provider layer (#2443).
+
+No network: the SDK clients on each provider are replaced with fakes so we can
+assert request translation, response normalization, and tool-message shaping.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.ai.providers import resolve_provider
+from app.ai.providers.anthropic_provider import AnthropicLLMProvider
+from app.ai.providers.base import flatten_system
+from app.ai.providers.openai_compat_provider import (
+    OpenAICompatLLMProvider,
+    _to_openai_tool_choice,
+    _to_openai_tools,
+)
+from app.ai.providers.pricing import calculate_cost_cents
+
+_TOOL = {
+    "name": "save",
+    "description": "Save it",
+    "input_schema": {"type": "object", "properties": {"x": {"type": "integer"}}},
+}
+
+
+# ── flatten_system / tool translation ─────────────────────────────
+
+
+def test_flatten_system_strips_cache_control():
+    blocks = [
+        {"type": "text", "text": "A", "cache_control": {"type": "ephemeral"}},
+        {"type": "text", "text": "B"},
+    ]
+    assert flatten_system(blocks) == "A\n\nB"
+    assert flatten_system("plain") == "plain"
+
+
+def test_to_openai_tools_and_choice():
+    tools = _to_openai_tools([_TOOL])
+    assert tools[0]["type"] == "function"
+    assert tools[0]["function"]["name"] == "save"
+    assert tools[0]["function"]["parameters"] == _TOOL["input_schema"]
+
+    assert _to_openai_tool_choice({"type": "tool", "name": "save"}) == {
+        "type": "function",
+        "function": {"name": "save"},
+    }
+    assert _to_openai_tool_choice({"type": "any"}) == "required"
+    assert _to_openai_tool_choice({"type": "auto"}) == "auto"
+
+
+# ── Anthropic provider ────────────────────────────────────────────
+
+
+class _FakeStreamCtx:
+    def __init__(self, message):
+        self._m = message
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def get_final_message(self):
+        return self._m
+
+
+class _FakeAnthropic:
+    def __init__(self, message):
+        self.message = message
+        self.messages = SimpleNamespace(stream=self._stream)
+
+    def _stream(self, **kwargs):
+        self.last_kwargs = kwargs
+        return _FakeStreamCtx(self.message)
+
+
+async def test_anthropic_complete_parses_tool_use_and_usage():
+    message = SimpleNamespace(
+        content=[
+            SimpleNamespace(type="text", text="hello"),
+            SimpleNamespace(type="tool_use", id="tu_1", name="save", input={"x": 1}),
+        ],
+        stop_reason="tool_use",
+        usage=SimpleNamespace(
+            input_tokens=10,
+            output_tokens=5,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=2,
+        ),
+    )
+    provider = AnthropicLLMProvider(api_key="sk-test")
+    provider._client = _FakeAnthropic(message)
+
+    result = await provider.complete(
+        system=[{"type": "text", "text": "sys", "cache_control": {"type": "ephemeral"}}],
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=100,
+        temperature=0.3,
+        model="claude-sonnet-4-6",
+        tools=[_TOOL],
+        tool_choice={"type": "tool", "name": "save"},
+    )
+
+    assert result.text == "hello"
+    assert result.stop_reason == "tool_use"
+    assert result.tool_calls[0].name == "save"
+    assert result.tool_calls[0].input == {"x": 1}
+    assert result.usage["input_tokens"] == 10
+    assert result.usage["cache_read_input_tokens"] == 2
+    # cache_control blocks pass through untouched on Anthropic.
+    assert provider._client.last_kwargs["system"][0]["cache_control"] == {"type": "ephemeral"}
+    assert result.assistant_message == {"role": "assistant", "content": message.content}
+
+
+def test_anthropic_tool_result_messages_shape():
+    provider = AnthropicLLMProvider(api_key="sk-test")
+    msgs = provider.build_tool_result_messages([{"tool_call_id": "tu_1", "content": "out"}])
+    assert msgs == [
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "tu_1", "content": "out"}],
+        }
+    ]
+    assert provider.supports_cache_control is True
+
+
+# ── OpenAI-compatible provider ────────────────────────────────────
+
+
+class _FakeChatCompletions:
+    def __init__(self, response):
+        self._r = response
+
+    async def create(self, **kwargs):
+        self.kwargs = kwargs
+        return self._r
+
+
+class _FakeOpenAI:
+    def __init__(self, response):
+        self.chat = SimpleNamespace(completions=_FakeChatCompletions(response))
+
+
+async def test_openai_compat_complete_parses_tool_calls_and_flattens_system():
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content=None,
+                    tool_calls=[
+                        SimpleNamespace(
+                            id="call_1",
+                            function=SimpleNamespace(name="save", arguments='{"x": 1}'),
+                        )
+                    ],
+                )
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=20, completion_tokens=8, prompt_tokens_details=None),
+    )
+    provider = OpenAICompatLLMProvider(api_key="sk-test", base_url="https://api.moonshot.ai/v1")
+    provider._client = _FakeOpenAI(response)
+
+    result = await provider.complete(
+        system=[{"type": "text", "text": "sys", "cache_control": {"type": "ephemeral"}}],
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=100,
+        temperature=0.5,
+        model="kimi-k2.6",
+        tools=[_TOOL],
+        tool_choice={"type": "tool", "name": "save"},
+    )
+
+    assert result.tool_calls[0].input == {"x": 1}
+    assert result.stop_reason == "tool_use"
+    assert result.usage["input_tokens"] == 20
+    assert result.usage["output_tokens"] == 8
+    assert result.usage["cache_creation_input_tokens"] == 0
+
+    sent = provider._client.chat.completions.kwargs
+    # system flattened to a leading system message, cache_control stripped.
+    assert sent["messages"][0] == {"role": "system", "content": "sys"}
+    assert sent["tools"][0]["type"] == "function"
+    assert sent["tool_choice"] == {"type": "function", "function": {"name": "save"}}
+    # assistant_message carries OpenAI-shaped tool_calls for the next turn.
+    assert result.assistant_message["tool_calls"][0]["function"]["name"] == "save"
+
+
+async def test_openai_compat_json_object_without_tools():
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content='{"ok": true}', tool_calls=None))],
+        usage=SimpleNamespace(prompt_tokens=5, completion_tokens=3, prompt_tokens_details=None),
+    )
+    provider = OpenAICompatLLMProvider(api_key="sk-test")
+    provider._client = _FakeOpenAI(response)
+
+    result = await provider.complete(
+        system="sys",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=50,
+        temperature=0.0,
+        model="kimi-k2.6",
+        json_object=True,
+    )
+    assert result.text == '{"ok": true}'
+    assert result.stop_reason == "end_turn"
+    assert provider._client.chat.completions.kwargs["response_format"] == {"type": "json_object"}
+
+
+def test_openai_tool_result_messages_shape():
+    provider = OpenAICompatLLMProvider(api_key="sk-test")
+    msgs = provider.build_tool_result_messages([{"tool_call_id": "call_1", "content": "out"}])
+    assert msgs == [{"role": "tool", "tool_call_id": "call_1", "content": "out"}]
+    assert provider.supports_cache_control is False
+
+
+# ── registry resolution ───────────────────────────────────────────
+
+
+@pytest.fixture
+def _fake_settings(monkeypatch):
+    settings = SimpleNamespace(
+        anthropic_api_key="sk-anthropic",
+        moonshot_api_key="sk-moonshot",
+        moonshot_base_url="https://api.moonshot.ai/v1",
+        openai_api_key="sk-openai",
+        openrouter_api_key="sk-openrouter",
+        openrouter_base_url="https://openrouter.ai/api/v1",
+    )
+    monkeypatch.setattr("app.ai.providers.registry.get_settings", lambda: settings)
+    return settings
+
+
+def test_resolve_provider_by_prefix(_fake_settings):
+    assert isinstance(resolve_provider("claude-sonnet-4-6"), AnthropicLLMProvider)
+    assert isinstance(resolve_provider("kimi-k2.6"), OpenAICompatLLMProvider)
+    assert isinstance(resolve_provider("gpt-4o-mini"), OpenAICompatLLMProvider)
+    assert isinstance(resolve_provider("moonshotai/kimi-k2.6"), OpenAICompatLLMProvider)
+
+
+def test_resolve_provider_missing_key_raises(_fake_settings, monkeypatch):
+    monkeypatch.setattr(_fake_settings, "moonshot_api_key", "")
+    with pytest.raises(ValueError, match="MOONSHOT_API_KEY"):
+        resolve_provider("kimi-k2.6")
+
+
+def test_resolve_provider_unknown_model_raises(_fake_settings):
+    with pytest.raises(ValueError, match="No provider mapping"):
+        resolve_provider("llama-3")
+
+
+# ── pricing ───────────────────────────────────────────────────────
+
+
+def test_pricing_per_model():
+    usage = {"input_tokens": 1_000_000, "output_tokens": 1_000_000}
+    # Sonnet: $3 in + $15 out = 1800 cents.
+    assert calculate_cost_cents("claude-sonnet-4-6", usage) == 1800
+    # Kimi K2.6: $0.95 in + $4.00 out = 495 cents.
+    assert calculate_cost_cents("kimi-k2.6", usage) == 495
+    # Unknown model falls back to the default (Sonnet) table.
+    assert calculate_cost_cents("mystery", usage) == 1800

--- a/docker-compose.prod.sira-donnia.yml
+++ b/docker-compose.prod.sira-donnia.yml
@@ -81,6 +81,7 @@ services:
       APP_ENV: production
       CORS_ORIGINS: https://app.sira-donnia.org
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      MOONSHOT_API_KEY: ${MOONSHOT_API_KEY}
       # Cost kill-switch for Vision-backed figure tasks (#1928). Default
       # true preserves behaviour; flip to false in .env + recreate the
       # worker to stop Claude Vision spend on backfills + ingest.
@@ -192,6 +193,7 @@ services:
       APP_ENV: production
       CORS_ORIGINS: https://app.sira-donnia.org
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      MOONSHOT_API_KEY: ${MOONSHOT_API_KEY}
       # Cost kill-switch for Vision-backed figure tasks (#1928). Default
       # true preserves behaviour; flip to false in .env + recreate the
       # worker to stop Claude Vision spend on backfills + ingest.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -81,6 +81,7 @@ services:
       APP_ENV: production
       CORS_ORIGINS: https://etutor.elearning.portfolio2.kimbetien.com
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      MOONSHOT_API_KEY: ${MOONSHOT_API_KEY}
       # Cost kill-switch for Vision-backed figure tasks (#1928). Default
       # true preserves behaviour; flip to false in .env + recreate the
       # worker to stop Claude Vision spend on backfills + ingest.
@@ -192,6 +193,7 @@ services:
       APP_ENV: production
       CORS_ORIGINS: https://etutor.elearning.portfolio2.kimbetien.com
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      MOONSHOT_API_KEY: ${MOONSHOT_API_KEY}
       # Cost kill-switch for Vision-backed figure tasks (#1928). Default
       # true preserves behaviour; flip to false in .env + recreate the
       # worker to stop Claude Vision spend on backfills + ingest.

--- a/frontend/components/admin/settings-client.tsx
+++ b/frontend/components/admin/settings-client.tsx
@@ -184,6 +184,13 @@ function SettingRow({ setting, saving, onSave, onReset, t }: {
               className="rounded border bg-background px-2 py-1 text-sm">
               <option value="true">true</option><option value="false">false</option>
             </select>
+          ) : setting.allowed_options && setting.allowed_options.length > 0 ? (
+            <select value={draft} onChange={(e) => setDraft(e.target.value)}
+              className="rounded border bg-background px-2 py-1 text-sm">
+              {setting.allowed_options.map((opt) => (
+                <option key={opt} value={opt}>{opt}</option>
+              ))}
+            </select>
           ) : (
             <input type={setting.value_type === "integer" || setting.value_type === "float" ? "number" : "text"}
               step={setting.value_type === "float" ? "0.1" : "1"}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -854,6 +854,7 @@ export interface PlatformSetting {
   validation_rules: { min?: number; max?: number } | null;
   is_sensitive: boolean;
   is_default: boolean;
+  allowed_options?: string[] | null;
 }
 
 export interface SettingsByCategory {


### PR DESCRIPTION
Promotes the pluggable LLM provider work from `dev` to `main` (staging rollout).

Cherry-picked from `dev` (merged via PR #2444) onto a fresh release branch off `main`, per the established per-feature promotion pattern.

Fixes #2443

## What ships
- **Provider layer** (`backend/app/ai/providers/`): `LLMProvider` protocol + `LLMResult`; `AnthropicLLMProvider` and `OpenAICompatLLMProvider` (Moonshot/OpenRouter/OpenAI); `resolve_provider(model)` + per-model `pricing.py`.
- **Routing**: `ClaudeService`'s 4 methods + tool-use generation (`course_agent`, `lesson_video`, `syllabus_agent`) delegate to the resolved provider; signatures unchanged. Tutor stays on Anthropic (deferred).
- **Admin switch**: `ai-model-content` single-select in the admin AI tab — `[claude-sonnet-4-6, claude-haiku-4-5, kimi-k2.6]`, **default stays Sonnet**.
- **Deploy**: `MOONSHOT_API_KEY` wired through `deploy.yml` + prod compose, **optional** (not in required-missing checks).

## Safety / compliance
- Kimi is **opt-in**; default model unchanged. **Do not enable Kimi for production user content** until the data-residency review clears (China-based servers; GDPR / Senegal / Ghana / Nigeria / CIV). Staging A/B is fine.

## Verification
- `uv run pytest` → 1466 passed, 45 skipped; `ruff` lint + format clean (the format fix is included).
- Pending post-deploy: live staging smoke (set `ai-model-content=kimi-k2.6`, generate lesson/quiz/case-study + course-structure/video, confirm structured output + no provider 400s; switch back to Sonnet). Requires `MOONSHOT_API_KEY` in staging backend env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)