### PR TITLE
Promote dev → main: Moonshot content fix — moonshot-v1-128k + forced-tool emulation (#2446)

### DIFF
--- a/backend/app/ai/providers/openai_compat_provider.py
+++ b/backend/app/ai/providers/openai_compat_provider.py
@@ -10,6 +10,10 @@ Normalizes the OpenAI surface to the provider interface:
   * Anthropic tool schema → ``{"type": "function", "function": {...}}``;
   * ``tool_calls`` (arguments JSON string) → :class:`ToolCall`;
   * ``prompt_tokens`` / ``completion_tokens`` → ``input_tokens`` / ``output_tokens``.
+
+Backends that reject a forced single-tool ``tool_choice`` (Moonshot accepts only
+``none``/``auto``) set ``supports_forced_tool_choice=False``; ``complete()`` then
+emulates the forced tool with JSON mode and returns a synthetic ``ToolCall``.
 """
 
 from __future__ import annotations
@@ -58,8 +62,17 @@ class OpenAICompatLLMProvider:
     supports_cache_control = False
     is_anthropic = False
 
-    def __init__(self, *, api_key: str, base_url: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str | None = None,
+        supports_forced_tool_choice: bool = True,
+    ) -> None:
         self._client = AsyncOpenAI(api_key=api_key, base_url=base_url, timeout=_TIMEOUT_SECONDS)
+        # Moonshot accepts only tool_choice none/auto — never a forced single
+        # tool. When False, complete() emulates a forced tool via JSON mode.
+        self._supports_forced_tool_choice = supports_forced_tool_choice
 
     async def complete(
         self,
@@ -73,14 +86,32 @@ class OpenAICompatLLMProvider:
         tool_choice: dict[str, Any] | None = None,
         json_object: bool = False,
     ) -> LLMResult:
-        msgs = [{"role": "system", "content": flatten_system(system)}, *messages]
+        system_text = flatten_system(system)
+
+        # A forced single-tool call the backend can't express (Moonshot) is
+        # emulated with JSON mode: ask for a JSON object matching the tool's
+        # input_schema, then surface the parsed object as a synthetic ToolCall
+        # so call sites keep reading result.tool_calls[0] unchanged.
+        forced_name = (
+            tool_choice.get("name") if tool_choice and tool_choice.get("type") == "tool" else None
+        )
+        emulate_tool = bool(forced_name and tools and not self._supports_forced_tool_choice)
+
         kwargs: dict[str, Any] = {
             "model": model,
             "max_tokens": max_tokens,
             "temperature": temperature,
-            "messages": msgs,
         }
-        if tools:
+        if emulate_tool:
+            forced_tool = next((t for t in tools if t.get("name") == forced_name), tools[0])
+            schema = forced_tool.get("input_schema", {"type": "object", "properties": {}})
+            system_text += (
+                f"\n\nRespond with ONLY a single JSON object — no prose, no markdown — that "
+                f"conforms to this JSON schema for `{forced_name}`:\n"
+                f"{json.dumps(schema, ensure_ascii=False)}"
+            )
+            kwargs["response_format"] = {"type": "json_object"}
+        elif tools:
             kwargs["tools"] = _to_openai_tools(tools)
             if tool_choice:
                 kwargs["tool_choice"] = _to_openai_tool_choice(tool_choice)
@@ -89,29 +120,11 @@ class OpenAICompatLLMProvider:
             # forced tool already constrains the output shape.
             kwargs["response_format"] = {"type": "json_object"}
 
+        kwargs["messages"] = [{"role": "system", "content": system_text}, *messages]
+
         response = await self._client.chat.completions.create(**kwargs)
-        choice = response.choices[0]
-        msg = choice.message
-
-        tool_calls: list[ToolCall] = []
-        for tc in msg.tool_calls or []:
-            try:
-                args = json.loads(tc.function.arguments or "{}")
-            except json.JSONDecodeError:
-                logger.warning("tool_call arguments not valid JSON", name=tc.function.name)
-                args = {}
-            tool_calls.append(ToolCall(id=tc.id, name=tc.function.name, input=args))
-
-        assistant_message: dict[str, Any] = {"role": "assistant", "content": msg.content or ""}
-        if msg.tool_calls:
-            assistant_message["tool_calls"] = [
-                {
-                    "id": tc.id,
-                    "type": "function",
-                    "function": {"name": tc.function.name, "arguments": tc.function.arguments},
-                }
-                for tc in msg.tool_calls
-            ]
+        msg = response.choices[0].message
+        content = msg.content or ""
 
         usage = getattr(response, "usage", None)
         cached = 0
@@ -124,8 +137,60 @@ class OpenAICompatLLMProvider:
             "cache_creation_input_tokens": 0,
             "cache_read_input_tokens": cached,
         }
+
+        if emulate_tool:
+            try:
+                parsed = json.loads(content)
+            except json.JSONDecodeError:
+                logger.warning("emulated forced-tool JSON not parseable", name=forced_name)
+                return LLMResult(
+                    text=content,
+                    tool_calls=[],
+                    stop_reason="end_turn",
+                    usage=usage_dict,
+                    assistant_message={"role": "assistant", "content": content},
+                )
+            synthetic = ToolCall(id=f"call_{forced_name}", name=forced_name, input=parsed)
+            return LLMResult(
+                text="",
+                tool_calls=[synthetic],
+                stop_reason="tool_use",
+                usage=usage_dict,
+                assistant_message={
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": synthetic.id,
+                            "type": "function",
+                            "function": {"name": forced_name, "arguments": content},
+                        }
+                    ],
+                },
+            )
+
+        tool_calls: list[ToolCall] = []
+        for tc in msg.tool_calls or []:
+            try:
+                args = json.loads(tc.function.arguments or "{}")
+            except json.JSONDecodeError:
+                logger.warning("tool_call arguments not valid JSON", name=tc.function.name)
+                args = {}
+            tool_calls.append(ToolCall(id=tc.id, name=tc.function.name, input=args))
+
+        assistant_message: dict[str, Any] = {"role": "assistant", "content": content}
+        if msg.tool_calls:
+            assistant_message["tool_calls"] = [
+                {
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {"name": tc.function.name, "arguments": tc.function.arguments},
+                }
+                for tc in msg.tool_calls
+            ]
+
         return LLMResult(
-            text=msg.content or "",
+            text=content,
             tool_calls=tool_calls,
             stop_reason="tool_use" if tool_calls else "end_turn",
             usage=usage_dict,

--- a/backend/app/ai/providers/pricing.py
+++ b/backend/app/ai/providers/pricing.py
@@ -17,8 +17,10 @@ _PRICING: dict[str, dict[str, int]] = {
     "claude-sonnet-4-6": {"input": 300, "output": 1500, "cache_write": 375, "cache_read": 30},
     "claude-haiku-4-5": {"input": 100, "output": 500, "cache_write": 125, "cache_read": 10},
     "claude-opus-4-6": {"input": 500, "output": 2500, "cache_write": 625, "cache_read": 50},
-    # Moonshot Kimi K2.6 — $0.95 / $4.00 per 1M; auto prefix-cache ~$0.16/M input.
-    "kimi-k2.6": {"input": 95, "output": 400, "cache_write": 0, "cache_read": 16},
+    # Moonshot moonshot-v1-128k — $2.00 / $5.00 per 1M; auto context-cache hit
+    # billed lower (cache_read ~$0.20/M, re-verify). Standard chat model: honors
+    # arbitrary temperature + json_object (unlike the kimi-k2.6 reasoning model).
+    "moonshot-v1-128k": {"input": 200, "output": 500, "cache_write": 0, "cache_read": 20},
 }
 
 _DEFAULT = {"input": 300, "output": 1500, "cache_write": 375, "cache_read": 30}

--- a/backend/app/ai/providers/registry.py
+++ b/backend/app/ai/providers/registry.py
@@ -37,6 +37,9 @@ def resolve_provider(model: str) -> LLMProvider:
         return OpenAICompatLLMProvider(
             api_key=settings.moonshot_api_key,
             base_url=settings.moonshot_base_url,
+            # Moonshot's API rejects a forced single-tool tool_choice on every
+            # model — the provider emulates it via JSON mode instead.
+            supports_forced_tool_choice=False,
         )
 
     if m.startswith("gpt") or m.startswith("openai"):

--- a/backend/app/domain/services/quality_agent_service.py
+++ b/backend/app/domain/services/quality_agent_service.py
@@ -123,7 +123,7 @@ class CourseQualityService:
         self.claude_service = claude_service
         self.semantic_retriever = semantic_retriever
         # Auditor model is config-driven; defaults to Sonnet. Switching to a
-        # cheaper model (e.g. claude-haiku-4-5 / kimi-k2.6) is opt-in pending a
+        # cheaper model (e.g. claude-haiku-4-5 / moonshot-v1-128k) is opt-in pending a
         # detection-accuracy benchmark; cost_cents uses the per-model pricing
         # table, so the recorded cost stays correct after a switch.
         from app.domain.services.platform_settings_service import SettingsCache

--- a/backend/app/infrastructure/config/platform_defaults.py
+++ b/backend/app/infrastructure/config/platform_defaults.py
@@ -375,10 +375,10 @@ SETTING_DEFINITIONS: list[SettingDef] = [
         "Model — content generation",
         "Model for lessons, quizzes, flashcards, case studies, pre-assessments, "
         "course syllabi and video scripts. Resolved to a provider by prefix "
-        "(claude-* → Anthropic; kimi-* → Moonshot). NOTE: kimi-k2.6 runs on "
-        "China-based servers — confirm data-residency compliance before using it "
-        "for production user content.",
-        allowed_options=["claude-sonnet-4-6", "claude-haiku-4-5", "kimi-k2.6"],
+        "(claude-* → Anthropic; moonshot-* → Moonshot). NOTE: moonshot-v1-128k "
+        "runs on China-based servers — data-residency compliance was cleared "
+        "2026-06-08; default stays Claude.",
+        allowed_options=["claude-sonnet-4-6", "claude-haiku-4-5", "moonshot-v1-128k"],
     ),
     SettingDef(
         "ai-model-quality",

--- a/backend/tests/test_llm_providers.py
+++ b/backend/tests/test_llm_providers.py
@@ -148,6 +148,7 @@ class _FakeOpenAI:
 
 
 async def test_openai_compat_complete_parses_tool_calls_and_flattens_system():
+    # Native forced-tool path: backend supports a forced tool_choice (default).
     response = SimpleNamespace(
         choices=[
             SimpleNamespace(
@@ -164,7 +165,7 @@ async def test_openai_compat_complete_parses_tool_calls_and_flattens_system():
         ],
         usage=SimpleNamespace(prompt_tokens=20, completion_tokens=8, prompt_tokens_details=None),
     )
-    provider = OpenAICompatLLMProvider(api_key="sk-test", base_url="https://api.moonshot.ai/v1")
+    provider = OpenAICompatLLMProvider(api_key="sk-test")
     provider._client = _FakeOpenAI(response)
 
     result = await provider.complete(
@@ -172,7 +173,7 @@ async def test_openai_compat_complete_parses_tool_calls_and_flattens_system():
         messages=[{"role": "user", "content": "hi"}],
         max_tokens=100,
         temperature=0.5,
-        model="kimi-k2.6",
+        model="gpt-4o-mini",
         tools=[_TOOL],
         tool_choice={"type": "tool", "name": "save"},
     )
@@ -188,8 +189,67 @@ async def test_openai_compat_complete_parses_tool_calls_and_flattens_system():
     assert sent["messages"][0] == {"role": "system", "content": "sys"}
     assert sent["tools"][0]["type"] == "function"
     assert sent["tool_choice"] == {"type": "function", "function": {"name": "save"}}
+    # arbitrary temperature forwarded on a non-reasoning chat model.
+    assert sent["temperature"] == 0.5
     # assistant_message carries OpenAI-shaped tool_calls for the next turn.
     assert result.assistant_message["tool_calls"][0]["function"]["name"] == "save"
+
+
+async def test_openai_compat_emulates_forced_tool_via_json_mode():
+    # Moonshot rejects forced tool_choice → emulate via JSON mode and surface a
+    # synthetic ToolCall so call sites keep reading result.tool_calls[0].
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content='{"x": 7}', tool_calls=None))],
+        usage=SimpleNamespace(prompt_tokens=12, completion_tokens=4, prompt_tokens_details=None),
+    )
+    provider = OpenAICompatLLMProvider(api_key="sk-test", supports_forced_tool_choice=False)
+    provider._client = _FakeOpenAI(response)
+
+    result = await provider.complete(
+        system="sys",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=100,
+        temperature=0.7,
+        model="moonshot-v1-128k",
+        tools=[_TOOL],
+        tool_choice={"type": "tool", "name": "save"},
+    )
+
+    assert result.stop_reason == "tool_use"
+    assert result.tool_calls[0].name == "save"
+    assert result.tool_calls[0].input == {"x": 7}
+
+    sent = provider._client.chat.completions.kwargs
+    # No tools/tool_choice sent; JSON mode requested instead.
+    assert "tools" not in sent and "tool_choice" not in sent
+    assert sent["response_format"] == {"type": "json_object"}
+    # The tool's input_schema is injected into the system prompt.
+    assert "save" in sent["messages"][0]["content"]
+    assert "input_schema" not in sent["messages"][0]["content"]  # schema body, not the key
+    # Synthetic assistant tool_call for any follow-up turn.
+    assert result.assistant_message["tool_calls"][0]["function"]["name"] == "save"
+
+
+async def test_openai_compat_emulated_tool_bad_json_returns_no_tool_call():
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="not json", tool_calls=None))],
+        usage=SimpleNamespace(prompt_tokens=5, completion_tokens=2, prompt_tokens_details=None),
+    )
+    provider = OpenAICompatLLMProvider(api_key="sk-test", supports_forced_tool_choice=False)
+    provider._client = _FakeOpenAI(response)
+
+    result = await provider.complete(
+        system="sys",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=50,
+        temperature=0.7,
+        model="moonshot-v1-128k",
+        tools=[_TOOL],
+        tool_choice={"type": "tool", "name": "save"},
+    )
+    assert result.tool_calls == []
+    assert result.stop_reason == "end_turn"
+    assert result.text == "not json"
 
 
 async def test_openai_compat_json_object_without_tools():
@@ -205,7 +265,7 @@ async def test_openai_compat_json_object_without_tools():
         messages=[{"role": "user", "content": "hi"}],
         max_tokens=50,
         temperature=0.0,
-        model="kimi-k2.6",
+        model="moonshot-v1-128k",
         json_object=True,
     )
     assert result.text == '{"ok": true}'
@@ -239,15 +299,23 @@ def _fake_settings(monkeypatch):
 
 def test_resolve_provider_by_prefix(_fake_settings):
     assert isinstance(resolve_provider("claude-sonnet-4-6"), AnthropicLLMProvider)
-    assert isinstance(resolve_provider("kimi-k2.6"), OpenAICompatLLMProvider)
+    assert isinstance(resolve_provider("moonshot-v1-128k"), OpenAICompatLLMProvider)
     assert isinstance(resolve_provider("gpt-4o-mini"), OpenAICompatLLMProvider)
     assert isinstance(resolve_provider("moonshotai/kimi-k2.6"), OpenAICompatLLMProvider)
+
+
+def test_resolve_provider_moonshot_disables_forced_tool_choice(_fake_settings):
+    # Moonshot can't force a single tool — the provider must emulate it.
+    moonshot = resolve_provider("moonshot-v1-128k")
+    assert moonshot._supports_forced_tool_choice is False
+    # Other OpenAI-compatible backends keep native forced tool_choice.
+    assert resolve_provider("gpt-4o-mini")._supports_forced_tool_choice is True
 
 
 def test_resolve_provider_missing_key_raises(_fake_settings, monkeypatch):
     monkeypatch.setattr(_fake_settings, "moonshot_api_key", "")
     with pytest.raises(ValueError, match="MOONSHOT_API_KEY"):
-        resolve_provider("kimi-k2.6")
+        resolve_provider("moonshot-v1-128k")
 
 
 def test_resolve_provider_unknown_model_raises(_fake_settings):
@@ -262,7 +330,7 @@ def test_pricing_per_model():
     usage = {"input_tokens": 1_000_000, "output_tokens": 1_000_000}
     # Sonnet: $3 in + $15 out = 1800 cents.
     assert calculate_cost_cents("claude-sonnet-4-6", usage) == 1800
-    # Kimi K2.6: $0.95 in + $4.00 out = 495 cents.
-    assert calculate_cost_cents("kimi-k2.6", usage) == 495
+    # moonshot-v1-128k: $2.00 in + $5.00 out = 700 cents.
+    assert calculate_cost_cents("moonshot-v1-128k", usage) == 700
     # Unknown model falls back to the default (Sonnet) table.
     assert calculate_cost_cents("mystery", usage) == 1800


### PR DESCRIPTION
Promotes the Moonshot content-generation fix from `dev` to `main` (staging rollout). Cherry-picked from `dev` (PR #2447) onto a fresh release branch off `main`.

Fixes #2446

## What ships
- Swaps the `ai-model-content` Kimi option `kimi-k2.6` → **`moonshot-v1-128k`** (standard chat model: arbitrary temperature + json_object; the reasoning model 400'd on both).
- `OpenAICompatLLMProvider` emulates a forced single-tool `tool_choice` via JSON mode for backends that can't express it (Moonshot), returning a synthetic `ToolCall` so call sites are unchanged.
- Pricing `moonshot-v1-128k` $2/$5 per 1M.

Default model stays Claude Sonnet; Moonshot is opt-in. Data-residency review cleared 2026-06-08.

## Verification
- `uv run pytest` → 1469 passed, 45 skipped; ruff clean.
- Post-deploy staging smoke pending: set `ai-model-content=moonshot-v1-128k`, generate lesson/quiz/case-study + course-structure/video, confirm no 400s, switch back to Sonnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)