### PR TITLE
fix(settings): auto-reload SettingsCache so Celery picks up admin changes without restart (#2449)

### DIFF
--- a/backend/app/domain/services/platform_settings_service.py
+++ b/backend/app/domain/services/platform_settings_service.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import threading
+import time
 from pathlib import Path
 from typing import Any
 
@@ -77,10 +78,20 @@ def _write_overrides(data: dict[str, Any]) -> None:
 
 
 class SettingsCache:
-    """Process-local cache for synchronous access."""
+    """Process-local cache for synchronous access.
+
+    Auto-reloads when the backing ``platform_settings.json`` changes on disk, so
+    a separate process (e.g. the Celery worker) picks up admin updates written by
+    the API process without a restart — the file lives on a shared volume. The
+    staleness check is mtime-based and throttled to at most once per
+    ``_CHECK_INTERVAL`` seconds to keep ``get()`` cheap on hot paths.
+    """
 
     _instance: SettingsCache | None = None
     _data: dict[str, Any] = {}
+    _mtime: float | None = None
+    _last_check: float = 0.0
+    _CHECK_INTERVAL = 2.0
 
     @classmethod
     def instance(cls) -> SettingsCache:
@@ -89,11 +100,29 @@ class SettingsCache:
         return cls._instance
 
     def get(self, key: str, default: Any = None) -> Any:
+        self._maybe_refresh()
         return self._data.get(key, default)
+
+    @staticmethod
+    def _file_mtime() -> float | None:
+        try:
+            return _SETTINGS_FILE.stat().st_mtime
+        except OSError:
+            return None
+
+    def _maybe_refresh(self) -> None:
+        """Reload if the settings file changed, checked at most once per interval."""
+        now = time.monotonic()
+        if now - self._last_check < self._CHECK_INTERVAL:
+            return
+        self._last_check = now
+        if self._file_mtime() != self._mtime:
+            self.refresh()
 
     def refresh(self) -> None:
         overrides = _read_overrides()
         self._data = {d.key: overrides.get(d.key, d.default) for d in SETTING_DEFINITIONS}
+        self._mtime = self._file_mtime()
         logger.debug("settings_cache.refreshed", count=len(self._data))
 
 

--- a/backend/tests/test_settings_cache.py
+++ b/backend/tests/test_settings_cache.py
@@ -1,0 +1,62 @@
+"""SettingsCache auto-reload on file change (#2449).
+
+The Celery worker reads platform settings via the synchronous SettingsCache,
+which previously loaded once at process start. These tests assert it now picks
+up a cross-process write to the shared settings file (mtime-gated, throttled)
+without an explicit refresh() — i.e. an admin change in the API process reaches
+the worker without a restart.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app.domain.services import platform_settings_service as pss
+from app.domain.services.platform_settings_service import SettingsCache, _write_overrides
+
+_KEY = "ai-model-content"
+
+
+@pytest.fixture
+def settings_file(tmp_path, monkeypatch):
+    f = tmp_path / "platform_settings.json"
+    monkeypatch.setattr(pss, "_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(pss, "_SETTINGS_FILE", f)
+    return f
+
+
+def _write(model: str, mtime: float) -> None:
+    _write_overrides({_KEY: model})
+    os.utime(pss._SETTINGS_FILE, (mtime, mtime))
+
+
+def test_settings_cache_auto_reloads_on_file_change(settings_file):
+    cache = SettingsCache()
+
+    _write("claude-haiku-4-5", mtime=1_000_000.0)
+    cache.refresh()
+    assert cache.get(_KEY) == "claude-haiku-4-5"
+
+    # Simulate the API process writing a new value (newer mtime).
+    _write("moonshot-v1-128k", mtime=1_000_100.0)
+    cache._last_check = 0.0  # bypass the throttle window
+
+    # get() reloads from the changed file without an explicit refresh().
+    assert cache.get(_KEY) == "moonshot-v1-128k"
+
+
+def test_settings_cache_throttles_stat_checks(settings_file):
+    cache = SettingsCache()
+    _write("claude-sonnet-4-6", mtime=2_000_000.0)
+    cache._last_check = 0.0
+    assert cache.get(_KEY) == "claude-sonnet-4-6"  # primes _last_check ~= now
+
+    # A change within the throttle interval is not yet observed.
+    _write("moonshot-v1-128k", mtime=2_000_100.0)
+    assert cache.get(_KEY) == "claude-sonnet-4-6"
+
+    # Once the throttle is cleared, the new value is picked up.
+    cache._last_check = 0.0
+    assert cache.get(_KEY) == "moonshot-v1-128k"


### PR DESCRIPTION
## What & why

Changing a platform setting (e.g. `ai-model-content`, after #2443/#2446) didn't take effect in content generation until the **Celery worker was restarted**. The worker reads settings via the synchronous `SettingsCache`, which was loaded once at process start (`worker_ready` / `worker_process_init`) and never re-read — no TTL, no pub/sub. `PlatformSettingsService.set()` refreshes only the API process's cache.

Fixes #2449.

## Fix

The override store is a JSON file (`config/platform_settings.json`) on a **shared docker volume** (`./config:/app/config`, mounted by both `backend` and `celery-worker`), so the new value is already visible to the worker. Make `SettingsCache.get()` detect a changed file via **mtime** and reload through the existing `refresh()`/`_read_overrides()`:

- `_maybe_refresh()` stats the file at most once per `_CHECK_INTERVAL` (2s, via `time.monotonic()`); reloads only when mtime differs.
- `stat()` wrapped in try/except — a missing file or transient error never breaks `get()`.
- Relies on the existing atomic write (`tmp` + `os.replace`), so mtime advances atomically and readers never see a partial file.

Result: any process (worker included) picks up admin changes within ~2s, no restart, no new infrastructure. Fixes staleness for **every** worker-read setting, not just the model.

**No call-site changes:** each Celery task constructs `ClaudeService()` fresh and the other model-reading sites read `SettingsCache.instance().get(...)` per call, so a live cache is sufficient. The async `PlatformSettingsService` Redis-TTL path (API reads) is untouched.

## Verification

- `cd backend && uv run pytest` → **1471 passed, 45 skipped**; ruff lint + format clean. New `tests/test_settings_cache.py` covers auto-reload on file change and the throttle window.
- Pending post-deploy: change `ai-model-content` via the admin API while `celery-worker` runs, trigger a generation, confirm the new model is used (worker logs / `generated_content`) **without** restarting the worker; then revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)