### PR TITLE
Promote dev → main: auto-reload SettingsCache for Celery (#2449)

### DIFF
--- a/backend/app/domain/services/platform_settings_service.py
+++ b/backend/app/domain/services/platform_settings_service.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import threading
+import time
 from pathlib import Path
 from typing import Any
 
@@ -77,10 +78,20 @@ def _write_overrides(data: dict[str, Any]) -> None:
 
 
 class SettingsCache:
-    """Process-local cache for synchronous access."""
+    """Process-local cache for synchronous access.
+
+    Auto-reloads when the backing ``platform_settings.json`` changes on disk, so
+    a separate process (e.g. the Celery worker) picks up admin updates written by
+    the API process without a restart — the file lives on a shared volume. The
+    staleness check is mtime-based and throttled to at most once per
+    ``_CHECK_INTERVAL`` seconds to keep ``get()`` cheap on hot paths.
+    """
 
     _instance: SettingsCache | None = None
     _data: dict[str, Any] = {}
+    _mtime: float | None = None
+    _last_check: float = 0.0
+    _CHECK_INTERVAL = 2.0
 
     @classmethod
     def instance(cls) -> SettingsCache:
@@ -89,11 +100,29 @@ class SettingsCache:
         return cls._instance
 
     def get(self, key: str, default: Any = None) -> Any:
+        self._maybe_refresh()
         return self._data.get(key, default)
+
+    @staticmethod
+    def _file_mtime() -> float | None:
+        try:
+            return _SETTINGS_FILE.stat().st_mtime
+        except OSError:
+            return None
+
+    def _maybe_refresh(self) -> None:
+        """Reload if the settings file changed, checked at most once per interval."""
+        now = time.monotonic()
+        if now - self._last_check < self._CHECK_INTERVAL:
+            return
+        self._last_check = now
+        if self._file_mtime() != self._mtime:
+            self.refresh()
 
     def refresh(self) -> None:
         overrides = _read_overrides()
         self._data = {d.key: overrides.get(d.key, d.default) for d in SETTING_DEFINITIONS}
+        self._mtime = self._file_mtime()
         logger.debug("settings_cache.refreshed", count=len(self._data))
 
 

--- a/backend/tests/test_settings_cache.py
+++ b/backend/tests/test_settings_cache.py
@@ -1,0 +1,62 @@
+"""SettingsCache auto-reload on file change (#2449).
+
+The Celery worker reads platform settings via the synchronous SettingsCache,
+which previously loaded once at process start. These tests assert it now picks
+up a cross-process write to the shared settings file (mtime-gated, throttled)
+without an explicit refresh() — i.e. an admin change in the API process reaches
+the worker without a restart.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app.domain.services import platform_settings_service as pss
+from app.domain.services.platform_settings_service import SettingsCache, _write_overrides
+
+_KEY = "ai-model-content"
+
+
+@pytest.fixture
+def settings_file(tmp_path, monkeypatch):
+    f = tmp_path / "platform_settings.json"
+    monkeypatch.setattr(pss, "_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(pss, "_SETTINGS_FILE", f)
+    return f
+
+
+def _write(model: str, mtime: float) -> None:
+    _write_overrides({_KEY: model})
+    os.utime(pss._SETTINGS_FILE, (mtime, mtime))
+
+
+def test_settings_cache_auto_reloads_on_file_change(settings_file):
+    cache = SettingsCache()
+
+    _write("claude-haiku-4-5", mtime=1_000_000.0)
+    cache.refresh()
+    assert cache.get(_KEY) == "claude-haiku-4-5"
+
+    # Simulate the API process writing a new value (newer mtime).
+    _write("moonshot-v1-128k", mtime=1_000_100.0)
+    cache._last_check = 0.0  # bypass the throttle window
+
+    # get() reloads from the changed file without an explicit refresh().
+    assert cache.get(_KEY) == "moonshot-v1-128k"
+
+
+def test_settings_cache_throttles_stat_checks(settings_file):
+    cache = SettingsCache()
+    _write("claude-sonnet-4-6", mtime=2_000_000.0)
+    cache._last_check = 0.0
+    assert cache.get(_KEY) == "claude-sonnet-4-6"  # primes _last_check ~= now
+
+    # A change within the throttle interval is not yet observed.
+    _write("moonshot-v1-128k", mtime=2_000_100.0)
+    assert cache.get(_KEY) == "claude-sonnet-4-6"
+
+    # Once the throttle is cleared, the new value is picked up.
+    cache._last_check = 0.0
+    assert cache.get(_KEY) == "moonshot-v1-128k"


### PR DESCRIPTION
Promotes the SettingsCache auto-reload fix from `dev` to `main` (staging rollout). Cherry-picked from `dev` (PR #2450) onto a fresh release branch off `main`.

Fixes #2449

## What ships
`SettingsCache.get()` now reloads when the shared `config/platform_settings.json` changes (mtime-gated, throttled to once/2s), so the **Celery worker picks up admin setting changes (e.g. `ai-model-content`) without a restart**. No call-site changes; the async Redis-TTL path is untouched.

## Verification
- `uv run pytest` → 1471 passed, 45 skipped; ruff clean. New `tests/test_settings_cache.py`.
- Post-deploy staging check: change `ai-model-content` via admin API while the worker runs, trigger a generation, confirm the new model is used without restarting `celery-worker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)