### PR TITLE
fix(ai): route course suggest-metadata through resolve_provider (#2452)

### DIFF
--- a/backend/app/api/v1/admin_courses.py
+++ b/backend/app/api/v1/admin_courses.py
@@ -713,33 +713,43 @@ Respond with ONLY this JSON object, no other text:
 }}"""
 
     import json as json_module
-    import os
 
-    from anthropic import Anthropic
-
+    from app.ai.providers import resolve_provider
     from app.domain.services.platform_settings_service import SettingsCache
 
-    api_key = os.getenv("ANTHROPIC_API_KEY", "")
-    if not api_key:
+    # Was hardcoded to the deprecated claude-sonnet-4-20250514 (retires
+    # 2026-06-15). Use the config-driven content model (default Sonnet 4.6),
+    # routed through the pluggable provider so non-Anthropic models (e.g.
+    # Moonshot) work too instead of 404ing against the Anthropic SDK.
+    model = SettingsCache.instance().get("ai-model-content", "claude-sonnet-4-6")
+    system_prompt = (
+        "You are a curriculum design expert. You propose clear, accurate, "
+        "and compelling course titles and descriptions based on source materials "
+        "and learning objectives. Always respond with valid JSON only."
+    )
+    try:
+        result = await resolve_provider(model).complete(
+            system=system_prompt,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=1024,
+            temperature=0.7,
+            model=model,
+            json_object=True,
+        )
+    except ValueError as exc:
+        # Registry raises when the configured model's API key is unset.
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="AI service not configured",
-        )
-    # Was hardcoded to the deprecated claude-sonnet-4-20250514 (retires
-    # 2026-06-15). Use the config-driven content model (default Sonnet 4.6).
-    model = SettingsCache.instance().get("ai-model-content", "claude-sonnet-4-6")
-    client = Anthropic(api_key=api_key)
-    response = client.messages.create(
-        model=model,
-        max_tokens=1024,
-        system=(
-            "You are a curriculum design expert. You propose clear, accurate, "
-            "and compelling course titles and descriptions based on source materials "
-            "and learning objectives. Always respond with valid JSON only."
-        ),
-        messages=[{"role": "user", "content": prompt}],
-    )
-    response_text = response.content[0].text.strip()
+        ) from exc
+    except Exception as exc:
+        logger.error("suggest_metadata generation failed", model=model, error=str(exc))
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="AI generation failed",
+        ) from exc
+
+    response_text = (result.text or "").strip()
 
     # Parse JSON from response
     try:

--- a/backend/tests/test_admin_courses_helpers.py
+++ b/backend/tests/test_admin_courses_helpers.py
@@ -7,17 +7,21 @@ pytest-asyncio event-loop conflict that keeps the integration suite skipped
 
 from __future__ import annotations
 
+import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import HTTPException
 
+from app.api.v1 import admin_courses
 from app.api.v1.admin_courses import (
+    SuggestMetadataResponse,
     _diagnose_indexation_pointer,
     _require_extracted_sources,
     _require_indexed_sources,
     _safe_task_meta,
+    suggest_course_metadata,
 )
 
 
@@ -409,3 +413,102 @@ async def test_list_course_resources_reports_per_source_chunk_counts(tmp_path, m
     assert by_id[str(dropped.id)]["on_disk"] is False
     # The dropped source is visible even though it has no file on disk.
     assert len(resp["files"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# #2452 — suggest-metadata routes through the pluggable provider (not the
+# Anthropic SDK), so non-Anthropic content models (e.g. Moonshot) work.
+# ---------------------------------------------------------------------------
+
+
+class _Result:
+    def __init__(self, scalar=None, rows=None):
+        self._scalar = scalar
+        self._rows = rows or []
+
+    def scalar_one_or_none(self):
+        return self._scalar
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+class _QueuedDB:
+    """Async DB stub returning queued execute() results in order."""
+
+    def __init__(self, results):
+        self._results = list(results)
+
+    async def execute(self, *args, **kwargs):
+        return self._results.pop(0)
+
+
+def _fake_course():
+    return SimpleNamespace(
+        languages="fr,en",
+        objectives_json={"fr": ["Comprendre X"], "en": ["Understand X"]},
+        taxonomy_categories=[SimpleNamespace(slug="public_health", type="domain")],
+        estimated_hours=20,
+    )
+
+
+def _patch_model(monkeypatch, model: str):
+    import app.domain.services.platform_settings_service as pss
+
+    monkeypatch.setattr(
+        pss.SettingsCache,
+        "instance",
+        staticmethod(lambda: SimpleNamespace(get=lambda k, d=None: model)),
+    )
+
+
+@pytest.mark.asyncio
+async def test_suggest_metadata_routes_through_resolve_provider(monkeypatch):
+    monkeypatch.setattr(admin_courses, "_require_extracted_sources", AsyncMock(return_value=None))
+    _patch_model(monkeypatch, "moonshot-v1-128k")
+
+    captured: dict = {}
+
+    class _Provider:
+        async def complete(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                text='{"title_fr": "Titre", "title_en": "Title", '
+                '"description_fr": "Desc fr", "description_en": "Desc en"}',
+                stop_reason="end_turn",
+                usage={},
+            )
+
+    def _fake_resolve(model):
+        captured["resolved_model"] = model
+        return _Provider()
+
+    monkeypatch.setattr("app.ai.providers.resolve_provider", _fake_resolve)
+
+    db = _QueuedDB([_Result(scalar=_fake_course()), _Result(rows=[("Some extracted text",)])])
+
+    resp = await suggest_course_metadata(course_id=uuid.uuid4(), db=db)
+
+    assert isinstance(resp, SuggestMetadataResponse)
+    assert resp.title_fr == "Titre" and resp.description_en == "Desc en"
+    # Routed through the configured (non-Anthropic) model via the provider, JSON mode on.
+    assert captured["resolved_model"] == "moonshot-v1-128k"
+    assert captured["model"] == "moonshot-v1-128k"
+    assert captured["json_object"] is True
+
+
+@pytest.mark.asyncio
+async def test_suggest_metadata_missing_provider_key_returns_503(monkeypatch):
+    monkeypatch.setattr(admin_courses, "_require_extracted_sources", AsyncMock(return_value=None))
+    _patch_model(monkeypatch, "moonshot-v1-128k")
+
+    def _raise(model):
+        raise ValueError("MOONSHOT_API_KEY required for model 'moonshot-v1-128k'")
+
+    monkeypatch.setattr("app.ai.providers.resolve_provider", _raise)
+
+    db = _QueuedDB([_Result(scalar=_fake_course()), _Result(rows=[("text",)])])
+
+    with pytest.raises(HTTPException) as exc:
+        await suggest_course_metadata(course_id=uuid.uuid4(), db=db)
+    assert exc.value.status_code == 503


### PR DESCRIPTION
## What & why

With `ai-model-content` set to a non-Anthropic model (e.g. `moonshot-v1-128k`), `POST /admin/courses/{id}/suggest-metadata` returned **500** and hard-blocked the AI-Assisted course-creation wizard at the **AI Proposal** step. `suggest_course_metadata` read the admin-selected model but called the **sync Anthropic SDK directly**, bypassing the pluggable provider layer (#2443) — Anthropic then 404'd on the Moonshot model id. It was the **only** `ai-model-content` consumer bypassing `resolve_provider`.

Fixes #2452.

## Fix

Route through `resolve_provider(model).complete(..., json_object=True)`, mirroring the lesson/quiz path:
- `json_object=True` is a no-op on Anthropic (`# noqa: ARG002 — prompt-driven JSON`) and gives reliable JSON on Moonshot; already used in production by `ClaudeService.generate_structured_content` on the default Sonnet path.
- `await` fixes a blocking sync SDK call inside an async endpoint.
- `ValueError` from the registry (configured model's API key unset) → **503**; other provider errors → **502**; existing JSON fence/brace extraction kept.
- Removed the now-dead `from anthropic import Anthropic` / `os.getenv("ANTHROPIC_API_KEY")` guard.

Default (Sonnet) behavior is unchanged.

## Verification

- `cd backend && uv run pytest` → **1473 passed, 45 skipped**; ruff lint + format clean. New tests in `tests/test_admin_courses_helpers.py` assert the endpoint routes through `resolve_provider` with the configured model + `json_object=True` (not the Anthropic SDK), and that an unset model key → 503.
- Pending post-deploy: with `ai-model-content=moonshot-v1-128k` on staging, exercise suggest-metadata and confirm a 200 proposal (no 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)