### PR TITLE
fix(quality): make unit_quality_assessments.run_id nullable so auto post-gen QA persists

### DIFF
--- a/backend/app/domain/models/course_quality.py
+++ b/backend/app/domain/models/course_quality.py
@@ -147,8 +147,8 @@ class UnitQualityAssessment(Base):
     __tablename__ = "unit_quality_assessments"
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
-    run_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("course_quality_runs.id", ondelete="CASCADE"), index=True
+    run_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("course_quality_runs.id", ondelete="CASCADE"), nullable=True, index=True
     )
     generated_content_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("generated_content.id", ondelete="CASCADE")
@@ -168,7 +168,7 @@ class UnitQualityAssessment(Base):
     )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    run: Mapped[CourseQualityRun] = relationship(back_populates="assessments")
+    run: Mapped[CourseQualityRun | None] = relationship(back_populates="assessments")
 
 
 class CourseGlossaryTerm(Base):

--- a/backend/migrations/versions/099_quality_assessment_run_id_nullable.py
+++ b/backend/migrations/versions/099_quality_assessment_run_id_nullable.py
@@ -1,0 +1,43 @@
+"""Make unit_quality_assessments.run_id nullable
+
+The auto post-generation QA path dispatches assess_and_regenerate_unit_task
+with no run_id (a standalone per-unit score has no course-level run). The
+whole service/task layer already treats run_id as optional, but the column
+was created NOT NULL in migration 090, so every auto QA insert hit a
+NOT NULL violation and the assessment never persisted (#2456). Relaxing the
+constraint aligns the DB with the code's existing run_id-optional intent.
+
+Revision ID: 099_quality_assessment_run_id_nullable
+Revises: 098_payment_provider_columns
+Create Date: 2026-06-09
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "099_quality_assessment_run_id_nullable"
+down_revision: str | None = "098_payment_provider_columns"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "unit_quality_assessments",
+        "run_id",
+        existing_type=sa.UUID(as_uuid=True),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    # Will fail if any run_id IS NULL rows exist (auto-QA assessments) —
+    # expected for a relax-then-tighten migration.
+    op.alter_column(
+        "unit_quality_assessments",
+        "run_id",
+        existing_type=sa.UUID(as_uuid=True),
+        nullable=False,
+    )

--- a/backend/tests/test_quality_agent.py
+++ b/backend/tests/test_quality_agent.py
@@ -565,3 +565,18 @@ async def test_build_quality_context_eager_loads_glossary_first_unit():
         "glossary query must selectinload(CourseGlossaryTerm.first_unit) to "
         "avoid a lazy-load greenlet error in the Celery sweep"
     )
+
+
+# ---- Auto post-generation QA: run_id is optional (#2456) --------------
+
+
+def test_unit_quality_assessment_run_id_is_nullable():
+    """Auto post-generation QA persists a per-unit score with no course run.
+
+    The whole task/service layer already treats run_id as optional, so the
+    column must be nullable — otherwise every auto-QA insert hits a NOT NULL
+    violation and the assessment never persists (#2456).
+    """
+    from app.domain.models.course_quality import UnitQualityAssessment
+
+    assert UnitQualityAssessment.__table__.c.run_id.nullable is True


### PR DESCRIPTION
## What

Auto post-generation QA dispatches `assess_and_regenerate_unit_task` with **no `run_id`** (a standalone per-unit score has no course-level run). The whole task/service layer already treats `run_id` as optional:

- task signatures: `run_id: str | None = None`
- `assess_unit(run_id: uuid.UUID | None)`, `assess_and_regenerate_loop(run_id: uuid.UUID | None)`
- `gc.last_quality_run_id = run_id` where that column **is** nullable

The **only** thing rejecting `None` was the DB column `unit_quality_assessments.run_id`, declared `nullable=False` in migration `090`. So every auto-QA insert hit a `NOT NULL` violation → the assessment never persisted.

## Change

- **Migration `099`** — `ALTER COLUMN run_id ... nullable=True`.
- **Model** (`course_quality.py`) — `run_id: Mapped[uuid.UUID | None]` + `run: Mapped[CourseQualityRun | None]`.
- **Test** — guards that `UnitQualityAssessment.run_id` is nullable.

The admin course-sweep path always supplies a concrete `run_id`; `finalize_run` and the budget query filter by `run_id`, so null-run rows are ignored there — behaviour unchanged.

## Verification

- `uv run ruff format` + `ruff check` — clean.
- `uv run pytest tests/test_quality_agent.py` — 39 passed.
- `uv run alembic heads` / `history` — `099` is the single head, chains cleanly from `098`. (No local Postgres available to run a live `upgrade`/`downgrade` round-trip; the alter is a trivial nullability relax.)

Fixes #2456

🤖 Generated with [Claude Code](https://claude.com/claude-code)