### PR TITLE
fix(auth): scope free-unit gate's unit lookup to its module (#2459)

### DIFF
--- a/backend/app/api/deps_local_auth.py
+++ b/backend/app/api/deps_local_auth.py
@@ -155,6 +155,32 @@ async def require_active_subscription(
     )
 
 
+async def _resolve_module_uuid(module_id: str | None, session) -> uuid.UUID | None:
+    """Best-effort resolution of a path ``module_id`` to its UUID.
+
+    Accepts a UUID string or a module code (``M01``). Returns ``None`` when the
+    value is absent or unresolvable — callers treat that as "couldn't scope".
+    """
+    if not module_id:
+        return None
+    try:
+        return uuid.UUID(module_id)
+    except (ValueError, AttributeError):
+        pass
+
+    import re
+
+    from ..domain.models.module import Module
+
+    code = re.match(r"^M(\d{2})$", module_id.upper())
+    if not code:
+        return None
+    result = await session.execute(
+        select(Module.id).where(Module.module_number == int(code.group(1)))
+    )
+    return result.scalars().first()
+
+
 async def require_subscription_or_first_unit(
     request: Request,
     user: AuthenticatedUser = Depends(get_current_user),
@@ -177,6 +203,7 @@ async def require_subscription_or_first_unit(
         return user
 
     unit_id = request.path_params.get("unit_id") or request.path_params.get("unitId")
+    module_id = request.path_params.get("module_id") or request.path_params.get("moduleId")
 
     free_count = SettingsCache.instance().get("subscription-free-units-count", 2)
     m = re.match(r"^\d+\.(\d+)$", unit_id) if unit_id else None
@@ -189,12 +216,19 @@ async def require_subscription_or_first_unit(
         if sub is not None:
             return user
 
-        # No subscription — fall back to DB order_index check
+        # No subscription — fall back to DB order_index check.
+        # Scope by module: a unit number like "1.3" is shared across many modules,
+        # so an unscoped lookup matches multiple rows and used to crash the request
+        # with MultipleResultsFound → unhandled 500 for learners (#2459). We resolve
+        # the module from the path and use .first() so the gate degrades to a clean
+        # 403 even if the module can't be resolved.
         if unit_id:
-            result = await session.execute(
-                select(ModuleUnit.order_index).where(ModuleUnit.unit_number == unit_id)
-            )
-            order = result.scalar_one_or_none()
+            unit_query = select(ModuleUnit.order_index).where(ModuleUnit.unit_number == unit_id)
+            module_uuid = await _resolve_module_uuid(module_id, session)
+            if module_uuid is not None:
+                unit_query = unit_query.where(ModuleUnit.module_id == module_uuid)
+            result = await session.execute(unit_query.limit(1))
+            order = result.scalars().first()
             if order is not None and order < free_count:
                 return user
         break

--- a/backend/tests/test_subscription_gate_unit_lookup.py
+++ b/backend/tests/test_subscription_gate_unit_lookup.py
@@ -1,0 +1,111 @@
+"""Regression tests for the free-unit subscription gate (#2459).
+
+`require_subscription_or_first_unit` used to run an unscoped
+`select(ModuleUnit.order_index).where(unit_number == unit_id)` and call
+`scalar_one_or_none()`. Because a unit number like "1.3" exists in many
+modules, that matched multiple rows and raised MultipleResultsFound, which
+escaped the route handler as an unhandled 500 — but only for learners (admins
+bypass the gate). These tests lock in the module-scoped, crash-proof lookup.
+"""
+
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.exc import MultipleResultsFound
+
+from app.api.deps_local_auth import (
+    AuthenticatedUser,
+    require_subscription_or_first_unit,
+)
+
+
+def _learner(role: str = "user") -> AuthenticatedUser:
+    return AuthenticatedUser({"sub": str(uuid.uuid4()), "email": "n@sira.app", "role": role})
+
+
+def _request(unit_id: str = "1.3", module_id: str | None = None) -> MagicMock:
+    req = MagicMock()
+    req.path_params = {"unit_id": unit_id}
+    if module_id is not None:
+        req.path_params["module_id"] = module_id
+    return req
+
+
+@asynccontextmanager
+async def _patched(session, *, sub):
+    """Patch the gate's lazily-imported collaborators around one call."""
+
+    async def _fake_get_db_session():
+        yield session
+
+    sub_service = MagicMock()
+    sub_service.get_active_subscription = AsyncMock(return_value=sub)
+
+    settings_cache = MagicMock()
+    settings_cache.get.return_value = 2  # free-units-count
+
+    with (
+        patch(
+            "app.infrastructure.persistence.database.get_db_session",
+            _fake_get_db_session,
+        ),
+        patch(
+            "app.domain.services.subscription_service.SubscriptionService",
+            return_value=sub_service,
+        ),
+        patch("app.domain.services.platform_settings_service.SettingsCache") as cache_cls,
+    ):
+        cache_cls.instance.return_value = settings_cache
+        yield
+
+
+async def test_admin_bypasses_without_db():
+    # Admins never touch the DB lookup at all.
+    user = _learner(role="admin")
+    result = await require_subscription_or_first_unit(_request(), user)
+    assert result is user
+
+
+async def test_paid_unit_no_sub_returns_403_not_500():
+    # Unit "1.3" is paid (3 > free_count 2). A learner without a subscription must
+    # get a clean 403 — never MultipleResultsFound, even though the lookup would
+    # match a shared unit number. We make scalar_one_or_none() blow up to prove the
+    # gate doesn't rely on it.
+    result_obj = MagicMock()
+    result_obj.scalars.return_value.first.return_value = 2  # order_index >= free_count
+    result_obj.scalar_one_or_none.side_effect = MultipleResultsFound("must not be called")
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=result_obj)
+
+    async with _patched(session, sub=None):
+        with pytest.raises(HTTPException) as exc:
+            await require_subscription_or_first_unit(
+                _request(module_id=str(uuid.uuid4())), _learner()
+            )
+
+    assert exc.value.status_code == 403
+    result_obj.scalar_one_or_none.assert_not_called()
+
+
+async def test_free_unit_short_circuits_before_db():
+    # Unit "1.2" is within the free window — granted without any subscription check.
+    result = await require_subscription_or_first_unit(_request(unit_id="1.2"), _learner())
+    assert result.role == "user"
+
+
+async def test_low_order_index_grants_access():
+    # A unit whose number doesn't parse but resolves to an early order_index is free.
+    result_obj = MagicMock()
+    result_obj.scalars.return_value.first.return_value = 0  # order_index < free_count
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=result_obj)
+
+    async with _patched(session, sub=None):
+        granted = await require_subscription_or_first_unit(
+            _request(unit_id="intro", module_id=str(uuid.uuid4())), _learner()
+        )
+
+    assert granted.role == "user"


### PR DESCRIPTION
## Problem
Opening a lesson returned **HTTP 500** from `GET /api/v1/content/lessons/{module_id}/{unit_id}` for a regular learner (`nandi`), while the **same lesson loaded for an admin**.

## Root cause (confirmed from the staging traceback)
```
File "app/api/deps_local_auth.py", line 197, in require_subscription_or_first_unit
    order = result.scalar_one_or_none()
sqlalchemy.exc.MultipleResultsFound: Multiple rows were found when one or none was required
```
The free-unit gate's subscription fallback ran an **unscoped** `select(ModuleUnit.order_index).where(unit_number == unit_id)` and called `scalar_one_or_none()`. A unit number like `"1.3"` exists in **26 modules**, so the query matched many rows and raised `MultipleResultsFound`, which **escaped the route handler's try/except** as an unhandled 500.

Admins bypass the gate via an early `return`, so only **learners without an active subscription** hit it — exactly the "loads for admin, 500s for nandi" symptom. The `country=CI` (200) vs `country=burkina-faso` (500) split in the logs was **spurious**: the admin browses with country `CI`, the affected learner with `burkina-faso`. Country was never causal; the user **role** is.

> Note: an earlier revision of this PR hardened the lesson cache-read path on a mistaken theory. That has been reverted — the cache rows for this unit are valid, so there was nothing to purge. This PR is now scoped to the actual cause.

## Fix — `app/api/deps_local_auth.py`
- Resolve the module from the request path and **scope the unit lookup by `module_id`**.
- Use `.first()` (with `.limit(1)`) so the gate degrades to a clean **403** even when the module can't be resolved — it can never raise `MultipleResultsFound` again.
- Add `_resolve_module_uuid` helper (accepts a UUID or an `M01`-style code).

## Tests — `tests/test_subscription_gate_unit_lookup.py`
- admin bypass (no DB touch)
- paid unit + no subscription → **403**, and asserts `scalar_one_or_none()` is **never called**
- free unit short-circuits before the DB
- low `order_index` grants access

`pytest tests/test_subscription_gate_unit_lookup.py` → 4 passed; adjacent `test_subscription_service` + `test_rbac` → 40 passed total. `ruff check`/`format` clean.

## Out of scope / follow-up
The staging logs show `POST /api/v1/quiz/generate` also 500ing with the same `MultipleResultsFound`. Likely the same unscoped-`unit_number` pattern in the quiz path — worth a **separate issue** rather than widening this PR.

Fixes #2459

🤖 Generated with [Claude Code](https://claude.com/claude-code)