### PR TITLE
Promote dev → main: nullable QA run_id (#2456) + prefetch quiz num_questions (#2457)

### DIFF
--- a/backend/app/domain/models/course_quality.py
+++ b/backend/app/domain/models/course_quality.py
@@ -147,8 +147,8 @@ class UnitQualityAssessment(Base):
     __tablename__ = "unit_quality_assessments"
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
-    run_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("course_quality_runs.id", ondelete="CASCADE"), index=True
+    run_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("course_quality_runs.id", ondelete="CASCADE"), nullable=True, index=True
     )
     generated_content_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("generated_content.id", ondelete="CASCADE")
@@ -168,7 +168,7 @@ class UnitQualityAssessment(Base):
     )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    run: Mapped[CourseQualityRun] = relationship(back_populates="assessments")
+    run: Mapped[CourseQualityRun | None] = relationship(back_populates="assessments")
 
 
 class CourseGlossaryTerm(Base):

--- a/backend/app/tasks/content_generation.py
+++ b/backend/app/tasks/content_generation.py
@@ -1350,8 +1350,15 @@ def prefetch_next_lessons_task(
                                 )
 
                         elif content_type == "quiz":
+                            from app.domain.services.platform_settings_service import (
+                                PlatformSettingsService,
+                            )
                             from app.domain.services.quiz_service import QuizService
 
+                            settings_svc = PlatformSettingsService()
+                            num_questions = int(
+                                await settings_svc.get("quiz-unit-questions-count") or 10
+                            )
                             quiz_service = QuizService(ClaudeService(), retriever)
                             await quiz_service.get_or_generate_quiz(
                                 module_id=module_uuid,
@@ -1359,6 +1366,7 @@ def prefetch_next_lessons_task(
                                 language=language,
                                 country=country,
                                 level=level,
+                                num_questions=num_questions,
                                 session=session,
                             )
                             prefetched.append(label)

--- a/backend/migrations/versions/099_quality_assessment_run_id_nullable.py
+++ b/backend/migrations/versions/099_quality_assessment_run_id_nullable.py
@@ -1,0 +1,43 @@
+"""Make unit_quality_assessments.run_id nullable
+
+The auto post-generation QA path dispatches assess_and_regenerate_unit_task
+with no run_id (a standalone per-unit score has no course-level run). The
+whole service/task layer already treats run_id as optional, but the column
+was created NOT NULL in migration 090, so every auto QA insert hit a
+NOT NULL violation and the assessment never persisted (#2456). Relaxing the
+constraint aligns the DB with the code's existing run_id-optional intent.
+
+Revision ID: 099_quality_assessment_run_id_nullable
+Revises: 098_payment_provider_columns
+Create Date: 2026-06-09
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "099_quality_assessment_run_id_nullable"
+down_revision: str | None = "098_payment_provider_columns"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "unit_quality_assessments",
+        "run_id",
+        existing_type=sa.UUID(as_uuid=True),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    # Will fail if any run_id IS NULL rows exist (auto-QA assessments) —
+    # expected for a relax-then-tighten migration.
+    op.alter_column(
+        "unit_quality_assessments",
+        "run_id",
+        existing_type=sa.UUID(as_uuid=True),
+        nullable=False,
+    )

--- a/backend/tests/test_prefetch_lessons.py
+++ b/backend/tests/test_prefetch_lessons.py
@@ -288,3 +288,113 @@ class TestDispatchContentPrefetch:
         assert call_kwargs["language"] == "en"
         assert call_kwargs["country"] == "GH"
         assert call_kwargs["level"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: prefetch quiz branch supplies the required num_questions arg (#2457)
+# ---------------------------------------------------------------------------
+
+
+class _FakeSessionCtx:
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class TestPrefetchQuizNumQuestions:
+    """The quiz branch of ``prefetch_next_lessons_task`` must pass the
+    required ``num_questions`` arg to ``get_or_generate_quiz`` — otherwise it
+    raised ``TypeError`` and every quiz prefetch silently landed in ``errors``
+    (#2457). Drives the real task with the DB + service seams mocked so a
+    single quiz unit flows through the branch.
+    """
+
+    def test_quiz_branch_passes_num_questions_from_settings(self, module_id):
+        from app.tasks.content_generation import prefetch_next_lessons_task
+
+        # One quiz unit returned by the units query.
+        quiz_unit = MagicMock()
+        quiz_unit.unit_number = "1.2"
+        quiz_unit.unit_type = "quiz"
+        quiz_unit.order_index = 1
+
+        def _result(scalar_one=None, all_rows=None):
+            r = MagicMock()
+            r.scalar_one_or_none = MagicMock(return_value=scalar_one)
+            scalars = MagicMock()
+            scalars.all = MagicMock(return_value=all_rows or [])
+            r.scalars = MagicMock(return_value=scalars)
+            return r
+
+        # Ordered execute() results: (1) module lookup in _get_next_units,
+        # (2) units query, (3) _is_cached cache query (None = not cached).
+        session = MagicMock()
+        session.execute = AsyncMock(
+            side_effect=[
+                _result(scalar_one=MagicMock()),  # module exists
+                _result(all_rows=[quiz_unit]),  # the quiz unit
+                _result(scalar_one=None),  # not cached
+            ]
+        )
+
+        engine = MagicMock()
+        engine.dispose = AsyncMock()
+
+        quiz_service = MagicMock()
+        quiz_service.get_or_generate_quiz = AsyncMock()
+
+        settings_svc = MagicMock()
+        settings_svc.get = AsyncMock(return_value=7)
+
+        with (
+            patch(
+                "sqlalchemy.ext.asyncio.create_async_engine",
+                return_value=engine,
+            ),
+            patch(
+                "sqlalchemy.ext.asyncio.async_sessionmaker",
+                return_value=lambda: _FakeSessionCtx(session),
+            ),
+            patch("app.ai.claude_service.ClaudeService", MagicMock()),
+            patch("app.ai.rag.embeddings.EmbeddingService", MagicMock()),
+            patch("app.ai.rag.retriever.SemanticRetriever", MagicMock()),
+            patch(
+                "app.domain.services.lesson_service.LessonGenerationService",
+                MagicMock(),
+            ),
+            patch(
+                "app.domain.services.quiz_service.QuizService",
+                return_value=quiz_service,
+            ),
+            patch(
+                "app.domain.services.platform_settings_service.PlatformSettingsService",
+                return_value=settings_svc,
+            ),
+            patch(
+                "app.domain.services._unit_resolution.resolve_module_unit_id",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            result = prefetch_next_lessons_task.run(
+                user_id=str(uuid.uuid4()),
+                module_id=str(module_id),
+                current_unit_id="",
+                language="fr",
+                country="SN",
+                level=1,
+            )
+
+        # The quiz prefetched cleanly (no TypeError → not in errors).
+        assert result["status"] == "complete"
+        assert "1.2:quiz" in result["prefetched"]
+        assert result["errors"] == []
+
+        # And num_questions was supplied, sourced from the platform setting.
+        quiz_service.get_or_generate_quiz.assert_awaited_once()
+        call_kwargs = quiz_service.get_or_generate_quiz.await_args.kwargs
+        assert call_kwargs["num_questions"] == 7

--- a/backend/tests/test_quality_agent.py
+++ b/backend/tests/test_quality_agent.py
@@ -565,3 +565,18 @@ async def test_build_quality_context_eager_loads_glossary_first_unit():
         "glossary query must selectinload(CourseGlossaryTerm.first_unit) to "
         "avoid a lazy-load greenlet error in the Celery sweep"
     )
+
+
+# ---- Auto post-generation QA: run_id is optional (#2456) --------------
+
+
+def test_unit_quality_assessment_run_id_is_nullable():
+    """Auto post-generation QA persists a per-unit score with no course run.
+
+    The whole task/service layer already treats run_id as optional, so the
+    column must be nullable — otherwise every auto-QA insert hits a NOT NULL
+    violation and the assessment never persists (#2456).
+    """
+    from app.domain.models.course_quality import UnitQualityAssessment
+
+    assert UnitQualityAssessment.__table__.c.run_id.nullable is True


### PR DESCRIPTION
Promotes the two content-modules Celery fixes from `dev` to `main` (cherry-picked onto a fresh sync branch off `main` to keep the promotion scoped to exactly these two fixes — avoids the squash-divergence phantom diff of a full dev→main).

- **#2456** — `unit_quality_assessments.run_id` made nullable (migration `099` + model) so auto post-generation QA persists. Merged to dev in #2458.
- **#2457** — prefetch quiz branch now passes the required `num_questions` (from the `quiz-unit-questions-count` setting). Merged to dev in #2460.

Both reviewed PASS; backend/frontend/E2E CI green on the source PRs.

Fixes #2456
Fixes #2457

🤖 Generated with [Claude Code](https://claude.com/claude-code)