### PR TITLE
fix(country): unify ECOWAS + AES + Others list across all selectors

### DIFF
--- a/backend/app/ai/prompts/flashcard.py
+++ b/backend/app/ai/prompts/flashcard.py
@@ -24,6 +24,10 @@ COUNTRY_NAMES_FR = {
     "NG": "Nigéria",
     "BJ": "Bénin",
     "TG": "Togo",
+    # Catch-all options ("Other West African" / "Other") have no single country;
+    # fall back to the regional name so prompts stay grammatical and on-domain.
+    "OWA": "Afrique de l'Ouest",
+    "OTH": "Afrique de l'Ouest",
 }
 
 COUNTRY_NAMES_EN = {
@@ -42,6 +46,10 @@ COUNTRY_NAMES_EN = {
     "NG": "Nigeria",
     "BJ": "Benin",
     "TG": "Togo",
+    # Catch-all options ("Other West African" / "Other") have no single country;
+    # fall back to the regional name so prompts stay grammatical and on-domain.
+    "OWA": "West Africa",
+    "OTH": "West Africa",
 }
 
 

--- a/backend/app/ai/prompts/lesson.py
+++ b/backend/app/ai/prompts/lesson.py
@@ -44,6 +44,10 @@ COUNTRY_NAMES_FR = {
     "NG": "Nigéria",
     "BJ": "Bénin",
     "TG": "Togo",
+    # Catch-all options ("Other West African" / "Other") have no single country;
+    # fall back to the regional name so prompts stay grammatical and on-domain.
+    "OWA": "Afrique de l'Ouest",
+    "OTH": "Afrique de l'Ouest",
 }
 
 COUNTRY_NAMES_EN = {
@@ -62,6 +66,10 @@ COUNTRY_NAMES_EN = {
     "NG": "Nigeria",
     "BJ": "Benin",
     "TG": "Togo",
+    # Catch-all options ("Other West African" / "Other") have no single country;
+    # fall back to the regional name so prompts stay grammatical and on-domain.
+    "OWA": "West Africa",
+    "OTH": "West Africa",
 }
 
 

--- a/backend/app/ai/prompts/tutor.py
+++ b/backend/app/ai/prompts/tutor.py
@@ -528,6 +528,10 @@ def _get_country_context(country: str, course_domain: str | None = None) -> str:
         "TG": "Togo",
         "CV": "Cap-Vert",
         "GM": "Gambie",
+        # Catch-all options ("Other West African" / "Other") have no single
+        # country; fall back to the regional name.
+        "OWA": "Afrique de l'Ouest",
+        "OTH": "Afrique de l'Ouest",
     }
     country_name = country_names.get(country, country)
 

--- a/backend/app/domain/services/placement_service.py
+++ b/backend/app/domain/services/placement_service.py
@@ -415,12 +415,4 @@ class PlacementService:
         if "level_3" in weak_levels:
             recommendations.append("Reinforce biostatistics and data analysis skills")
 
-        country = context.get("country", "").lower()
-        if country in ["senegal", "mali", "burkina faso", "guinea"]:
-            recommendations.append("Focus on Sahel-specific health challenges")
-        elif country in ["ghana", "nigeria", "benin", "togo"]:
-            recommendations.append("Emphasize coastal disease patterns and urban health")
-        elif country in ["cote d'ivoire", "liberia", "sierra leone"]:
-            recommendations.append("Focus on tropical disease burden in your region")
-
         return recommendations[:5]

--- a/backend/migrations/versions/099_country_kebab_to_iso.py
+++ b/backend/migrations/versions/099_country_kebab_to_iso.py
@@ -1,0 +1,59 @@
+"""Normalize users.country from kebab slugs to ISO 3166-1 alpha-2 codes
+
+The onboarding flow historically stored country as kebab slugs ("senegal",
+"burkina-faso", "other-west-african", "other") while registration/profile and
+the AI content pipeline use ISO codes ("SN", "BF", "OWA", "OTH"). The selectors
+are now unified on ISO codes (see frontend/lib/countries.ts), so this migration
+converts any already-stored kebab values to their ISO equivalents. Rows already
+holding ISO codes (or NULL) are untouched.
+
+Revision ID: 099_country_kebab_to_iso
+Revises: 098_payment_provider_columns
+Create Date: 2026-06-10
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "099_country_kebab_to_iso"
+down_revision: str | None = "098_payment_provider_columns"
+branch_labels = None
+depends_on = None
+
+
+# kebab slug -> ISO 3166-1 alpha-2 code (OWA/OTH are the catch-all options)
+KEBAB_TO_ISO = {
+    "benin": "BJ",
+    "burkina-faso": "BF",
+    "cabo-verde": "CV",
+    "cote-divoire": "CI",
+    "gambia": "GM",
+    "ghana": "GH",
+    "guinea": "GN",
+    "guinea-bissau": "GW",
+    "liberia": "LR",
+    "mali": "ML",
+    "niger": "NE",
+    "nigeria": "NG",
+    "senegal": "SN",
+    "sierra-leone": "SL",
+    "togo": "TG",
+    "other-west-african": "OWA",
+    "other": "OTH",
+}
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    stmt = sa.text("UPDATE users SET country = :iso WHERE country = :kebab")
+    for kebab, iso in KEBAB_TO_ISO.items():
+        conn.execute(stmt, {"iso": iso, "kebab": kebab})
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    stmt = sa.text("UPDATE users SET country = :kebab WHERE country = :iso")
+    for kebab, iso in KEBAB_TO_ISO.items():
+        conn.execute(stmt, {"kebab": kebab, "iso": iso})

--- a/backend/tests/test_placement_service.py
+++ b/backend/tests/test_placement_service.py
@@ -226,11 +226,6 @@ class TestGenerateRecommendations:
         recs = service._generate_recommendations(4, {}, {})
         assert any("1-12" in r or "Module 13" in r for r in recs)
 
-    def test_country_recommendation_senegal(self):
-        service = PlacementService(_make_user_repo())
-        recs = service._generate_recommendations(2, {}, {"country": "senegal"})
-        assert any("Sahel" in r for r in recs)
-
     def test_max_5_recommendations_returned(self):
         service = PlacementService(_make_user_repo())
         recs = service._generate_recommendations(

--- a/frontend/app/[locale]/(app)/profile/profile-client.tsx
+++ b/frontend/app/[locale]/(app)/profile/profile-client.tsx
@@ -25,6 +25,7 @@ import { PlacementResultsHistory } from "@/components/placement/placement-result
 import { Upload, User as UserIcon, AlertTriangle, CheckCircle, ClipboardList, LogOut, ArrowLeft } from "lucide-react";
 import { authClient } from "@/lib/auth";
 import { API_BASE } from "@/lib/api";
+import { COUNTRIES } from "@/lib/countries";
 
 const fetchUserProfile = async () => {
   const response = await fetch(`${API_BASE}/api/v1/users/me`, {
@@ -73,26 +74,6 @@ const profileSchema = z.object({
 
 type ProfileFormData = z.infer<typeof profileSchema>;
 
-const WEST_AFRICAN_COUNTRIES = [
-  { code: "BJ", name: "Benin" },
-  { code: "BF", name: "Burkina Faso" },
-  { code: "CV", name: "Cape Verde" },
-  { code: "CI", name: "Côte d'Ivoire" },
-  { code: "GM", name: "Gambia" },
-  { code: "GH", name: "Ghana" },
-  { code: "GN", name: "Guinea" },
-  { code: "GW", name: "Guinea-Bissau" },
-  { code: "LR", name: "Liberia" },
-  { code: "ML", name: "Mali" },
-  { code: "NE", name: "Niger" },
-  { code: "NG", name: "Nigeria" },
-  { code: "SN", name: "Senegal" },
-  { code: "SL", name: "Sierra Leone" },
-  { code: "TG", name: "Togo" },
-  { code: "OWA", name: "Other West African" },
-  { code: "OTH", name: "Other" },
-];
-
 const PROFESSIONAL_ROLES = [
   "doctor",
   "nurse",
@@ -110,6 +91,7 @@ const PROFESSIONAL_ROLES = [
 export function ProfileClient() {
   const t = useTranslations("Profile");
   const tPrivacy = useTranslations("Privacy");
+  const tCountries = useTranslations("Countries");
   const [isEditing, setIsEditing] = useState(false);
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
   const [showRecontextAlert, setShowRecontextAlert] = useState(false);
@@ -262,7 +244,10 @@ export function ProfileClient() {
                 <Badge variant="outline">{profile.preferred_language.toUpperCase()}</Badge>
                 {profile.country && (
                   <Badge variant="outline">
-                    {WEST_AFRICAN_COUNTRIES.find(c => c.code === profile.country)?.name || profile.country}
+                    {(() => {
+                      const c = COUNTRIES.find((c) => c.code === profile.country);
+                      return c ? tCountries(c.key) : profile.country;
+                    })()}
                   </Badge>
                 )}
               </div>
@@ -383,9 +368,12 @@ export function ProfileClient() {
                         </SelectTrigger>
                       </FormControl>
                       <SelectContent>
-                        {WEST_AFRICAN_COUNTRIES.map((country) => (
+                        {COUNTRIES.map((country) => (
                           <SelectItem key={country.code} value={country.code}>
-                            {country.name}
+                            <span className="flex items-center gap-2">
+                              <span>{country.flag}</span>
+                              <span>{tCountries(country.key)}</span>
+                            </span>
                           </SelectItem>
                         ))}
                       </SelectContent>

--- a/frontend/components/admin/lesson-preview-step.tsx
+++ b/frontend/components/admin/lesson-preview-step.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/select";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { COUNTRIES } from "@/lib/countries";
 import {
   type SyllabusModule,
   type LessonPreviewResponse,
@@ -52,6 +53,7 @@ interface PreviewState {
 
 export function LessonPreviewStep({ courseId }: LessonPreviewStepProps) {
   const t = useTranslations("AdminCourses.lessonPreview");
+  const tCountries = useTranslations("Countries");
   const locale = useLocale();
 
   const [modules, setModules] = useState<SyllabusModule[]>([]);
@@ -206,12 +208,14 @@ export function LessonPreviewStep({ courseId }: LessonPreviewStepProps) {
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="SN">S\u00e9n\u00e9gal</SelectItem>
-              <SelectItem value="ML">Mali</SelectItem>
-              <SelectItem value="BF">Burkina Faso</SelectItem>
-              <SelectItem value="CI">C\u00f4te d&apos;Ivoire</SelectItem>
-              <SelectItem value="GH">Ghana</SelectItem>
-              <SelectItem value="NG">Nigeria</SelectItem>
+              {COUNTRIES.map((c) => (
+                <SelectItem key={c.code} value={c.code}>
+                  <span className="flex items-center gap-2">
+                    <span>{c.flag}</span>
+                    <span>{tCountries(c.key)}</span>
+                  </span>
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>

--- a/frontend/components/auth/email-otp-register-form.tsx
+++ b/frontend/components/auth/email-otp-register-form.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/ui/card';
 import { OTPInput, OTPInputRef } from './otp-input';
 import { authClient, RegisterEmailOTPResponse, AuthError } from '@/lib/auth';
+import { COUNTRIES } from '@/lib/countries';
 
 // Step 1: Registration form schema
 const createRegistrationSchema = (t: (key: string) => string) => z.object({
@@ -41,6 +42,7 @@ type OTPForm = z.infer<ReturnType<typeof createOTPSchema>>;
 export function EmailOTPRegisterForm() {
   const t = useTranslations('Auth');
   const tCommon = useTranslations('Common');
+  const tCountries = useTranslations('Countries');
   const router = useRouter();
   const locale = useLocale();
   
@@ -282,21 +284,11 @@ export function EmailOTPRegisterForm() {
                 className="flex h-11 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <option value="">{t('selectCountry')}</option>
-                <option value="SN">Sénégal</option>
-                <option value="GH">Ghana</option>
-                <option value="NG">Nigeria</option>
-                <option value="CI">Côte d&apos;Ivoire</option>
-                <option value="BF">Burkina Faso</option>
-                <option value="ML">Mali</option>
-                <option value="NE">Niger</option>
-                <option value="GN">Guinée</option>
-                <option value="SL">Sierra Leone</option>
-                <option value="LR">Liberia</option>
-                <option value="GW">Guinée-Bissau</option>
-                <option value="CV">Cap-Vert</option>
-                <option value="GM">Gambie</option>
-                <option value="TG">Togo</option>
-                <option value="BJ">Bénin</option>
+                {COUNTRIES.map((c) => (
+                  <option key={c.code} value={c.code}>
+                    {c.flag} {tCountries(c.key)}
+                  </option>
+                ))}
               </select>
               {errors.country && (
                 <p className="text-sm text-red-600">{errors.country.message}</p>

--- a/frontend/components/auth/totp-register-form.tsx
+++ b/frontend/components/auth/totp-register-form.tsx
@@ -16,6 +16,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { authClient, RegisterResponse, AuthError } from '@/lib/auth';
+import { COUNTRIES } from '@/lib/countries';
 
 // Step 1: Registration form schema
 const createRegistrationSchema = (t: (key: string) => string) => z.object({
@@ -40,6 +41,7 @@ type TOTPForm = z.infer<ReturnType<typeof createTOTPSchema>>;
 export function TOTPRegisterForm() {
   const t = useTranslations('Auth');
   const tCommon = useTranslations('Common');
+  const tCountries = useTranslations('Countries');
   const router = useRouter();
   const locale = useLocale();
   
@@ -206,21 +208,11 @@ export function TOTPRegisterForm() {
                 className="flex h-11 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <option value="">{t('selectCountry')}</option>
-                <option value="SN">Sénégal</option>
-                <option value="GH">Ghana</option>
-                <option value="NG">Nigeria</option>
-                <option value="CI">Côte d&apos;Ivoire</option>
-                <option value="BF">Burkina Faso</option>
-                <option value="ML">Mali</option>
-                <option value="NE">Niger</option>
-                <option value="GN">Guinée</option>
-                <option value="SL">Sierra Leone</option>
-                <option value="LR">Liberia</option>
-                <option value="GW">Guinée-Bissau</option>
-                <option value="CV">Cap-Vert</option>
-                <option value="GM">Gambie</option>
-                <option value="TG">Togo</option>
-                <option value="BJ">Bénin</option>
+                {COUNTRIES.map((c) => (
+                  <option key={c.code} value={c.code}>
+                    {c.flag} {tCountries(c.key)}
+                  </option>
+                ))}
               </select>
               {errors.country && (
                 <p className="text-sm text-red-600">{errors.country.message}</p>

--- a/frontend/components/onboarding/steps/country-step.tsx
+++ b/frontend/components/onboarding/steps/country-step.tsx
@@ -8,54 +8,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { COUNTRIES } from '@/lib/countries';
 
 interface CountryStepProps {
   value: string;
   onChange: (value: string) => void;
 }
 
-const countries = [
-  'benin',
-  'burkina-faso',
-  'cabo-verde',
-  'cote-divoire',
-  'gambia',
-  'ghana',
-  'guinea',
-  'guinea-bissau',
-  'liberia',
-  'mali',
-  'niger',
-  'nigeria',
-  'senegal',
-  'sierra-leone',
-  'togo',
-  'other-west-african',
-  'other'
-];
-
-const countryFlags: { [key: string]: string } = {
-  'benin': '🇧🇯',
-  'burkina-faso': '🇧🇫',
-  'cabo-verde': '🇨🇻',
-  'cote-divoire': '🇨🇮',
-  'gambia': '🇬🇲',
-  'ghana': '🇬🇭',
-  'guinea': '🇬🇳',
-  'guinea-bissau': '🇬🇼',
-  'liberia': '🇱🇷',
-  'mali': '🇲🇱',
-  'niger': '🇳🇪',
-  'nigeria': '🇳🇬',
-  'senegal': '🇸🇳',
-  'sierra-leone': '🇸🇱',
-  'togo': '🇹🇬',
-  'other-west-african': '🌍',
-  'other': '🌐'
-};
-
 export function CountryStep({ value, onChange }: CountryStepProps) {
   const t = useTranslations('Onboarding.step2');
+  const tCountries = useTranslations('Countries');
 
   return (
     <div className="space-y-6">
@@ -70,11 +32,11 @@ export function CountryStep({ value, onChange }: CountryStepProps) {
             <SelectValue placeholder={t('selectCountry')} />
           </SelectTrigger>
           <SelectContent>
-            {countries.map((country) => (
-              <SelectItem key={country} value={country}>
+            {COUNTRIES.map((country) => (
+              <SelectItem key={country.code} value={country.code}>
                 <div className="flex items-center gap-2">
-                  <span>{countryFlags[country]}</span>
-                  <span>{t(`countries.${country}`)}</span>
+                  <span>{country.flag}</span>
+                  <span>{tCountries(country.key)}</span>
                 </div>
               </SelectItem>
             ))}

--- a/frontend/lib/countries.ts
+++ b/frontend/lib/countries.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared country list — the single source of truth for every country selector
+ * (registration, onboarding, profile, admin course creation).
+ *
+ * Values are stored as ISO 3166-1 alpha-2 codes, which is the encoding the backend
+ * AI prompts (lesson/flashcard/tutor) and content pipeline key on. `OWA` / `OTH` are
+ * non-standard codes for the two catch-all options.
+ *
+ * Covers all 15 ECOWAS members (which include the 3 AES states: Mali, Burkina Faso,
+ * Niger) plus "Other West African" and "Other".
+ *
+ * `key` indexes the `Countries` i18n namespace in messages/{fr,en}.json.
+ */
+export interface CountryOption {
+  code: string;
+  key: string;
+  flag: string;
+}
+
+export const COUNTRIES: CountryOption[] = [
+  { code: 'BJ', key: 'benin', flag: '🇧🇯' },
+  { code: 'BF', key: 'burkina-faso', flag: '🇧🇫' },
+  { code: 'CV', key: 'cabo-verde', flag: '🇨🇻' },
+  { code: 'CI', key: 'cote-divoire', flag: '🇨🇮' },
+  { code: 'GM', key: 'gambia', flag: '🇬🇲' },
+  { code: 'GH', key: 'ghana', flag: '🇬🇭' },
+  { code: 'GN', key: 'guinea', flag: '🇬🇳' },
+  { code: 'GW', key: 'guinea-bissau', flag: '🇬🇼' },
+  { code: 'LR', key: 'liberia', flag: '🇱🇷' },
+  { code: 'ML', key: 'mali', flag: '🇲🇱' },
+  { code: 'NE', key: 'niger', flag: '🇳🇪' },
+  { code: 'NG', key: 'nigeria', flag: '🇳🇬' },
+  { code: 'SN', key: 'senegal', flag: '🇸🇳' },
+  { code: 'SL', key: 'sierra-leone', flag: '🇸🇱' },
+  { code: 'TG', key: 'togo', flag: '🇹🇬' },
+  { code: 'OWA', key: 'other-west-african', flag: '🌍' },
+  { code: 'OTH', key: 'other', flag: '🌐' },
+];

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1,4 +1,23 @@
 {
+  "Countries": {
+    "benin": "Benin",
+    "burkina-faso": "Burkina Faso",
+    "cabo-verde": "Cabo Verde",
+    "cote-divoire": "Côte d'Ivoire",
+    "gambia": "Gambia",
+    "ghana": "Ghana",
+    "guinea": "Guinea",
+    "guinea-bissau": "Guinea-Bissau",
+    "liberia": "Liberia",
+    "mali": "Mali",
+    "niger": "Niger",
+    "nigeria": "Nigeria",
+    "senegal": "Senegal",
+    "sierra-leone": "Sierra Leone",
+    "togo": "Togo",
+    "other-west-african": "Other West African",
+    "other": "Other"
+  },
   "Common": {
     "appName": "Sira",
     "loading": "Loading...",
@@ -564,26 +583,7 @@
     "step2": {
       "title": "Select Your Country",
       "description": "Choose your country for localized content",
-      "selectCountry": "Select your country",
-      "countries": {
-        "benin": "Benin",
-        "burkina-faso": "Burkina Faso",
-        "cabo-verde": "Cabo Verde",
-        "cote-divoire": "Côte d'Ivoire",
-        "gambia": "Gambia",
-        "ghana": "Ghana",
-        "guinea": "Guinea",
-        "guinea-bissau": "Guinea-Bissau",
-        "liberia": "Liberia",
-        "mali": "Mali",
-        "niger": "Niger",
-        "nigeria": "Nigeria",
-        "senegal": "Senegal",
-        "sierra-leone": "Sierra Leone",
-        "togo": "Togo",
-        "other-west-african": "Other West African",
-        "other": "Other"
-      }
+      "selectCountry": "Select your country"
     },
     "step3": {
       "title": "Professional Role",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1,4 +1,23 @@
 {
+  "Countries": {
+    "benin": "Bénin",
+    "burkina-faso": "Burkina Faso",
+    "cabo-verde": "Cabo Verde",
+    "cote-divoire": "Côte d'Ivoire",
+    "gambia": "Gambie",
+    "ghana": "Ghana",
+    "guinea": "Guinée",
+    "guinea-bissau": "Guinée-Bissau",
+    "liberia": "Libéria",
+    "mali": "Mali",
+    "niger": "Niger",
+    "nigeria": "Nigeria",
+    "senegal": "Sénégal",
+    "sierra-leone": "Sierra Leone",
+    "togo": "Togo",
+    "other-west-african": "Autre pays ouest-africain",
+    "other": "Autre"
+  },
   "Common": {
     "appName": "Sira",
     "loading": "Chargement...",
@@ -564,26 +583,7 @@
     "step2": {
       "title": "Sélectionnez Votre Pays",
       "description": "Choisissez votre pays pour un contenu localisé",
-      "selectCountry": "Sélectionnez votre pays",
-      "countries": {
-        "benin": "Bénin",
-        "burkina-faso": "Burkina Faso",
-        "cabo-verde": "Cabo Verde",
-        "cote-divoire": "Côte d'Ivoire",
-        "gambia": "Gambie",
-        "ghana": "Ghana",
-        "guinea": "Guinée",
-        "guinea-bissau": "Guinée-Bissau",
-        "liberia": "Libéria",
-        "mali": "Mali",
-        "niger": "Niger",
-        "nigeria": "Nigeria",
-        "senegal": "Sénégal",
-        "sierra-leone": "Sierra Leone",
-        "togo": "Togo",
-        "other-west-african": "Autre pays ouest-africain",
-        "other": "Autre"
-      }
+      "selectCountry": "Sélectionnez votre pays"
     },
     "step3": {
       "title": "Rôle Professionnel",


### PR DESCRIPTION
Fixes #2461

## Problem

The country list regressed and drifted out of sync across **five** selectors, each with a different country set **and** a different value encoding — so a user's country could not round-trip between register → onboarding → profile, and the AI content pipeline (which keys on ISO codes) often got a value it couldn't match. The admin course-creation lesson-preview selector was the worst, down to **6** countries.

| Where | Before | Now |
|---|---|---|
| Course creation (lesson preview) | 6, ISO, hardcoded | 17, shared, i18n |
| Register (TOTP + Email-OTP) | 15, ISO, no "Others", hardcoded FR | 17, shared, i18n |
| Onboarding | 17, **kebab** slugs, i18n | 17, **ISO codes**, shared i18n |
| Profile | 17, ISO, hardcoded EN | 17, shared, i18n |

## Changes

- **`frontend/lib/countries.ts`** (new) — single source of truth: 15 ECOWAS members (incl. the 3 AES states) + `OWA` (Other West African) + `OTH` (Other), as ISO 3166-1 alpha-2 codes.
- **Shared `Countries` i18n namespace** (FR/EN) — replaces the per-component hardcoded names and the old nested `Onboarding.step2.countries` block; reused by all five selectors.
- **Canonical encoding = ISO codes everywhere.** Onboarding now stores codes instead of kebab slugs, so values round-trip and match the backend AI prompts.
- **Backend AI prompts** (`lesson`/`flashcard`/`tutor`) handle `OWA`/`OTH` with a regional fallback so the catch-all codes never leak into generated content.
- **Removed the stale public-health country→disease branch** from placement recommendations (the platform is now generalist). Follow-up #2464 tracks generalizing the remaining hardcoded health module/weak-area strings.
- **Migration `099_country_kebab_to_iso`** converts existing `users.country` kebab values to ISO (reversible).

## Verification

- Frontend production build (Node 20): clean ✅
- tsc + eslint on changed files: 0 errors ✅
- `pytest tests/test_placement_service.py`: 28 passed (removed obsolete country-rec test) ✅
- Migration up/down verified on a scratch DB (kebab→ISO and reverse) ✅
- ruff check/format: clean; alembic single head ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)