### PR TITLE
feat(content): clear 'subscription required' state with Subscribe link (#2469)

### DIFF
--- a/frontend/components/learning/case-study-viewer.tsx
+++ b/frontend/components/learning/case-study-viewer.tsx
@@ -15,9 +15,10 @@ import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import { LessonSkeleton } from './lesson-skeleton';
 import { SourceCitations } from './source-citations';
-import { apiFetch, getModuleDetailWithProgress } from '@/lib/api';
+import { apiFetch, getModuleDetailWithProgress, ApiError } from '@/lib/api';
 import { useCurrentUser } from '@/lib/hooks/use-current-user';
 import { loadCaseStudy, OfflineContentNotAvailable } from '@/lib/offline/content-loader';
+import { SubscriptionRequired } from '@/components/shared/subscription-required';
 import { addOfflineAction } from '@/lib/offline/db';
 import { OfflineBadge } from '@/components/shared/offline-badge';
 import { useNetworkStatus } from '@/lib/hooks/use-network-status';
@@ -103,6 +104,7 @@ export function CaseStudyViewer({
   const [isLoading, setIsLoading] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [subscriptionRequired, setSubscriptionRequired] = useState(false);
   const [isCompleted, setIsCompleted] = useState(false);
   const [completeError, setCompleteError] = useState<string | null>(null);
   const [correctionVisible, setCorrectionVisible] = useState(false);
@@ -165,6 +167,7 @@ export function CaseStudyViewer({
     const resolvedCountry = frozenCountryRef.current;
 
     let cancelled = false;
+    setSubscriptionRequired(false);
     if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
 
     const pollStatus = (taskId: string, startTime: number) => {
@@ -264,6 +267,12 @@ export function CaseStudyViewer({
         if (cancelled) return;
         if (err instanceof OfflineContentNotAvailable) {
           setError(t('contentNotAvailableOffline'));
+        } else if (
+          err instanceof ApiError &&
+          (err.code === 'subscription_required' || err.status === 403)
+        ) {
+          setSubscriptionRequired(true);
+          setError(t('loadError'));
         } else {
           setError(t('loadError'));
         }
@@ -368,6 +377,10 @@ export function CaseStudyViewer({
       <img src={src} alt={alt ?? ''} className="w-full h-auto rounded-lg my-4" />
     ),
   };
+
+  if (error && subscriptionRequired) {
+    return <SubscriptionRequired />;
+  }
 
   if (error) {
     return (

--- a/frontend/components/learning/lesson-viewer.tsx
+++ b/frontend/components/learning/lesson-viewer.tsx
@@ -25,6 +25,7 @@ import { track } from '@/lib/analytics';
 import { loadLesson, OfflineContentNotAvailable } from '@/lib/offline/content-loader';
 import { addOfflineAction } from '@/lib/offline/db';
 import { OfflineBadge } from '@/components/shared/offline-badge';
+import { SubscriptionRequired } from '@/components/shared/subscription-required';
 import { useNetworkStatus } from '@/lib/hooks/use-network-status';
 
 const POLL_INTERVAL_MS = 3000;
@@ -87,7 +88,7 @@ export function LessonViewer({
   const [isGenerating, setIsGenerating] = useState(false);
   const [isSlowGeneration, setIsSlowGeneration] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [errorType, setErrorType] = useState<'load' | 'generation' | 'timeout' | 'no_content' | 'not_found' | null>(null);
+  const [errorType, setErrorType] = useState<'load' | 'generation' | 'timeout' | 'no_content' | 'not_found' | 'subscription' | null>(null);
   const [forceRegenerate, setForceRegenerate] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [contentSource, setContentSource] = useState<'api' | 'indexeddb'>('api');
@@ -266,6 +267,12 @@ export function LessonViewer({
         } else if (err instanceof ApiError && err.status === 404) {
           setError(t('unitNotFound'));
           setErrorType('not_found');
+        } else if (
+          err instanceof ApiError &&
+          (err.code === 'subscription_required' || err.status === 403)
+        ) {
+          setError(t('loadError'));
+          setErrorType('subscription');
         } else {
           setError(t('loadError'));
           setErrorType('load');
@@ -357,6 +364,22 @@ export function LessonViewer({
     ),
   };
 
+
+  if (error && errorType === 'subscription') {
+    return (
+      <SubscriptionRequired
+        secondaryAction={
+          <Button
+            variant="outline"
+            onClick={() => router.push(`/${locale}/modules/${moduleId}`)}
+            className="min-h-11"
+          >
+            {t('backToModule')}
+          </Button>
+        }
+      />
+    );
+  }
 
   if (error) {
     return (

--- a/frontend/components/quiz/quiz-container.tsx
+++ b/frontend/components/quiz/quiz-container.tsx
@@ -18,6 +18,7 @@ import { loadQuiz, OfflineContentNotAvailable } from '@/lib/offline/content-load
 import { getOfflineContent } from '@/lib/offline/db';
 import { scoreQuizOffline } from '@/lib/offline/offline-quiz-scorer';
 import { OfflineBadge } from '@/components/shared/offline-badge';
+import { SubscriptionRequired } from '@/components/shared/subscription-required';
 import { useNetworkStatus } from '@/lib/hooks/use-network-status';
 
 const POLL_INTERVAL_MS = 3000;
@@ -60,6 +61,7 @@ export function QuizContainer({
   const [quiz, setQuiz] = useState<Quiz | null>(null);
   const [result, setResult] = useState<QuizAttemptResponse | null>(null);
   const [error, setError] = useState<string>('');
+  const [subscriptionRequired, setSubscriptionRequired] = useState(false);
   const [retryCount, setRetryCount] = useState(0);
   // forceRegenerate is tracked via forceRegenerateRef (below) — not state — so
   // that resetting it after a fetch does not re-trigger the main useEffect.
@@ -178,6 +180,7 @@ export function QuizContainer({
       try {
         setState('loading');
         setError('');
+        setSubscriptionRequired(false);
 
         const result = await loadQuiz<Quiz | GeneratingResponse>(
           moduleId, unitId, language, level, country,
@@ -214,6 +217,7 @@ export function QuizContainer({
         } else if (err instanceof ApiError) {
           if (err.code === 'subscription_required' || err.status === 403) {
             errorMessage = t('subscriptionRequired');
+            setSubscriptionRequired(true);
           } else if (err.status === 401) {
             errorMessage = t('authRequired');
           } else {
@@ -319,6 +323,10 @@ export function QuizContainer({
   }
   
   // Error State
+  if (state === 'error' && subscriptionRequired) {
+    return <SubscriptionRequired />;
+  }
+
   if (state === 'error') {
     return (
       <div className="max-w-4xl mx-auto p-4">

--- a/frontend/components/shared/subscription-required.tsx
+++ b/frontend/components/shared/subscription-required.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { Lock } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { Link } from '@/i18n/routing';
+import { Card, CardContent } from '@/components/ui/card';
+
+interface SubscriptionRequiredProps {
+  /** Optional secondary action rendered under the Subscribe CTA (e.g. "back to module"). */
+  secondaryAction?: ReactNode;
+}
+
+/**
+ * Shown when content is gated behind an active subscription (backend 403
+ * `subscription_required`). Replaces the generic "load error" state with a
+ * clear message and a link to the /subscribe page (#2469).
+ */
+export function SubscriptionRequired({ secondaryAction }: SubscriptionRequiredProps) {
+  const t = useTranslations('SubscriptionRequired');
+
+  return (
+    <div className="container mx-auto max-w-4xl px-4 py-6">
+      <Card className="border-primary/20">
+        <CardContent className="p-6 text-center">
+          <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+            <Lock className="h-6 w-6 text-primary" />
+          </div>
+          <div className="mb-2 font-medium text-stone-900">{t('title')}</div>
+          <p className="mx-auto mb-5 max-w-md text-gray-600">{t('description')}</p>
+          <div className="flex flex-col items-center gap-3">
+            <Link
+              href="/subscribe"
+              className="inline-flex min-h-11 items-center justify-center rounded-md bg-primary px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-primary/90"
+            >
+              {t('cta')}
+            </Link>
+            {secondaryAction}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2052,6 +2052,11 @@
     "description": "You must be enrolled in this course to access this content.",
     "cta": "Browse courses"
   },
+  "SubscriptionRequired": {
+    "title": "Subscription required",
+    "description": "A subscription is required to access this content. The first unit of each module is free.",
+    "cta": "Subscribe"
+  },
   "Subscribe": {
     "title": "Subscription",
     "subtitle": "Access all courses and AI tutor",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -2052,6 +2052,11 @@
     "description": "Vous devez être inscrit à ce cours pour accéder à ce contenu.",
     "cta": "Voir les cours"
   },
+  "SubscriptionRequired": {
+    "title": "Abonnement requis",
+    "description": "Un abonnement est requis pour accéder à ce contenu. La première unité de chaque module est gratuite.",
+    "cta": "S'abonner"
+  },
   "Subscribe": {
     "title": "Abonnement",
     "subtitle": "Accédez à tous les cours et au tuteur IA",


### PR DESCRIPTION
## Problem
After #2459 the backend returns a clean **403** `{"code":"subscription_required"}` when a learner without a subscription opens a paid unit. But the UI was misleading: lessons & case studies showed the generic "Erreur lors du chargement de la leçon" + **Retry**, and quizzes showed a message with **no way to subscribe**.

## Fix
A dedicated "subscription required" state across all three content types, with a **Subscribe** button → the existing `/subscribe` page.

- **New** `components/shared/subscription-required.tsx` — lock icon + title/description + localized "S'abonner"/"Subscribe" link (`@/i18n/routing` → `/subscribe`), with an optional secondary action slot.
- **lesson-viewer** / **case-study-viewer** — detect `ApiError && (code==='subscription_required' || status===403)` and render the new component (lesson keeps a "back to module" secondary action). `ApiError` already exposes `.status`/`.code`.
- **quiz-container** — already detected the 403; now renders the component instead of the generic red card.
- **i18n** — new `SubscriptionRequired` namespace (fr/en) mirroring the existing `Quiz.subscriptionRequired` wording.

## Verification
- `tsc --noEmit` clean for all changed files (only pre-existing `e2e/*.spec.ts` errors remain, outside the build). `eslint` clean (0 errors) on changed files.
- Manual (post-deploy): as a learner **without** a subscription, open a paid unit (≥1.3) lesson, case study, and quiz → each shows the subscription state with a working **Subscribe** button to `/{locale}/subscribe`, not the generic error.

Fixes #2469

🤖 Generated with [Claude Code](https://claude.com/claude-code)