### PR TITLE
fix(content): stop case-study unit page crashing on undefined content (#2471)

### DIFF
--- a/frontend/components/learning/case-study-viewer.tsx
+++ b/frontend/components/learning/case-study-viewer.tsx
@@ -190,6 +190,14 @@ export function CaseStudyViewer({
               `/api/v1/content/cases/${moduleId}/${unitId}?language=${language}&level=${level}&country=${resolvedCountry}`
             );
             if (cancelled) return;
+            // The completion re-fetch can still return a 202 "generating"
+            // envelope (no content field) when the row was stored under a
+            // fallback country the exact-country cache query misses. Committing
+            // it would crash on content.aof_context — keep polling instead.
+            if ('status' in caseRes && (caseRes as unknown as GeneratingResponse).status === 'generating') {
+              pollStatus(taskId, startTime);
+              return;
+            }
             setCaseStudyData(caseRes);
             setIsGenerating(false);
             setIsLoading(false);
@@ -411,6 +419,31 @@ export function CaseStudyViewer({
 
   if (!caseStudyData) {
     return <LessonSkeleton />;
+  }
+
+  // Defensive guard: caseStudyData may have been set from a non-case response
+  // (e.g. a 202 generating envelope with no content field). Never let a
+  // malformed payload white-screen the page on content.aof_context.
+  if (!caseStudyData.content) {
+    return (
+      <div className="container mx-auto max-w-4xl px-4 py-6">
+        <Card className="border-red-200">
+          <CardContent className="p-6 text-center">
+            <AlertTriangle className="w-8 h-8 text-red-500 mx-auto mb-3" />
+            <div className="text-red-600 font-medium mb-2">{t('error')}</div>
+            <p className="text-gray-600 mb-4">{t('loadError')}</p>
+            <Button
+              variant="outline"
+              onClick={handleRefresh}
+              className="min-h-11"
+            >
+              <RefreshCw className="w-4 h-4 mr-2" />
+              {t('retry')}
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
   }
 
   const { content } = caseStudyData;


### PR DESCRIPTION
## Problem

Opening a case-study unit (e.g. `/fr/modules/<id>/units/1.4`) white-screened with **"Une erreur est survenue / An error occurred"** and a console `TypeError: Cannot read properties of undefined (reading 'aof_context')`. A hard block for the learner.

## Root cause

`CaseStudyViewer` could set `caseStudyData` to a **202 "generating" envelope** (`{ status, task_id, message }` — no `content` field) and then crash at `content.aof_context`. This happens when the poll status says `complete` but the immediate re-fetch of `/cases/...` still returns a 202 — the generated row was stored under a *fallback* country that the exact-country cache query misses.

`LessonViewer` already guards both failure modes; `CaseStudyViewer` guarded neither.

## Fix (mirrors LessonViewer, single file)

1. **Re-poll guard** in the poll-completion path — if the re-fetch returns a generating envelope, keep polling instead of committing it (the timeout path already handles a genuinely stuck task).
2. **Render-time `!caseStudyData.content` guard** — render the existing error/Retry card instead of crashing, for any malformed payload from any source (poll race, stale IndexedDB fallback, unexpected response).

No new i18n keys — reuses `t('error')`, `t('loadError')`, `t('retry')`.

## Out of scope

The backend country-fallback cache-miss that triggers the stray 202 is a separate, larger follow-up. The re-poll guard makes it non-fatal (resolves once the row lands, or surfaces `generationTimeout` gracefully, matching lessons).

## Verification

- `npx tsc --noEmit` clean for the changed file (pre-existing e2e spec errors unrelated); `eslint` clean.
- Manual: open the affected unit → no crash; open a known-good case study → renders normally.

Fixes #2471

🤖 Generated with [Claude Code](https://claude.com/claude-code)