### PR TITLE
fix(migrations): merge two 099 heads to unblock deploys (#2475)

### DIFF
--- a/backend/migrations/versions/100_merge_099_heads.py
+++ b/backend/migrations/versions/100_merge_099_heads.py
@@ -1,0 +1,33 @@
+"""Merge the two 099 head revisions into a single head
+
+PRs #2456 (099_quality_assessment_run_id_nullable) and #2461
+(099_country_kebab_to_iso) were developed and merged concurrently, each
+branching off 098_payment_provider_columns. That left the migration graph
+with two heads, so `alembic upgrade head` aborts with "Multiple head
+revisions are present" and every deploy fails at the migration step (#2475).
+
+This is a no-op merge migration: it has no schema changes, it only unifies
+the two heads so there is a single linear head again.
+
+Revision ID: 100_merge_099_heads
+Revises: 099_quality_assessment_run_id_nullable, 099_country_kebab_to_iso
+Create Date: 2026-06-10
+"""
+
+from __future__ import annotations
+
+revision: str = "100_merge_099_heads"
+down_revision: tuple[str, str] = (
+    "099_quality_assessment_run_id_nullable",
+    "099_country_kebab_to_iso",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Problem

Every staging/prod deploy since #2456 and #2461 merged fails at the migration step:

```
ERROR [alembic.util.messaging] Multiple head revisions are present for given argument 'head'
FAILED: Multiple head revisions are present...
```

The deploy rolls back, so **staging is frozen on old code** — which is why user-facing fixes (PR #2472 case-study crash, #2471) never reached learners.

## Root cause

`099_quality_assessment_run_id_nullable` (#2456) and `099_country_kebab_to_iso` (#2461) both branch off `098_payment_provider_columns` and are both leaf heads. `alembic upgrade head` cannot choose.

## Fix

A no-op **merge migration** `100_merge_099_heads` with `down_revision = (099_quality..., 099_country...)`. No schema change. Verified locally:

```
$ alembic heads
100_merge_099_heads (head)        # was two heads
```

P0 — unblocks all deploys.

Fixes #2475

🤖 Generated with [Claude Code](https://claude.com/claude-code)