### PR TITLE
fix(content): add country fallback to case-study endpoint (#2474)

### DIFF
--- a/backend/app/api/v1/content.py
+++ b/backend/app/api/v1/content.py
@@ -1285,6 +1285,25 @@ async def get_or_generate_case_study(
             cache_result = await session.execute(cached_query)
             cached = cache_result.scalars().first()
 
+            # Country fallback: if no exact-country match, serve any country's
+            # case study (same language/level) instead of re-dispatching a fresh
+            # 3-min generation on every request. Mirrors the lesson endpoint so a
+            # learner whose country lacks a row sees content immediately while the
+            # country-specific version generates in the background (#2474).
+            is_country_fallback = False
+            if not cached:
+                fallback_query = (
+                    select(GeneratedContent)
+                    .where(GeneratedContent.module_unit_id == case_module_unit_uuid)
+                    .where(GeneratedContent.content_type == "case")
+                    .where(GeneratedContent.language == language)
+                    .where(GeneratedContent.level == level)
+                    .order_by(GeneratedContent.generated_at.desc())
+                )
+                fallback_result = await session.execute(fallback_query)
+                cached = fallback_result.scalars().first()
+                is_country_fallback = cached is not None
+
             if cached:
                 from app.api.v1.schemas.content import CaseStudyContent as _CaseStudyContent
 
@@ -1305,6 +1324,7 @@ async def get_or_generate_case_study(
                     content=_CaseStudyContent(**content_dict),
                     generated_at=cached.generated_at.isoformat(),
                     cached=True,
+                    country_fallback=is_country_fallback,
                 )
 
                 if current_user is not None:
@@ -1326,7 +1346,20 @@ async def get_or_generate_case_study(
                 logger.info(
                     "Case study cache hit",
                     case_study_id=str(case_study_response.id),
+                    country_fallback=is_country_fallback,
                 )
+                if is_country_fallback:
+                    from app.tasks.content_generation import generate_country_content_task
+
+                    generate_country_content_task.delay(
+                        module_id=str(resolved_module_id),
+                        unit_id=unit_id,
+                        content_type="case",
+                        language=language,
+                        level=level,
+                        country=country,
+                        user_id=str(current_user.id) if current_user else "",
+                    )
                 _dispatch_content_prefetch(current_user, str(resolved_module_id), unit_id)
                 return JSONResponse(
                     content=case_study_response.model_dump(mode="json"),

--- a/backend/tests/test_case_study_country_fallback.py
+++ b/backend/tests/test_case_study_country_fallback.py
@@ -1,0 +1,150 @@
+"""Tests for country fallback in GET /api/v1/content/cases/{module_id}/{unit_id}.
+
+Without fallback, a learner whose country has no generated case-study row gets
+an exact-country cache miss → a fresh 3-min Celery generation re-dispatched on
+every request → perpetual 202. This mirrors the lesson endpoint: serve any
+country's row immediately with country_fallback=true and regenerate the
+country-specific version in the background (#2474).
+
+The endpoint function is invoked directly with a mocked session (two queries:
+exact-country, then any-country fallback), so no DB fixture is required.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.api.v1 import content as content_module
+
+
+def _fake_cached_case(country_context: str):
+    """A GeneratedContent-like row carrying a complete case-study payload."""
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        module_id=uuid.uuid4(),
+        content={
+            "unit_id": "1.4",
+            "aof_context": "Contexte régional",
+            "real_data": "Données réelles",
+            "guided_questions": ["Q1", "Q2"],
+            "annotated_correction": "Correction",
+            "sources_cited": ["src-1"],
+        },
+        language="fr",
+        level=1,
+        country_context=country_context,
+        generated_at=datetime.now(tz=UTC),
+    )
+
+
+def _execute_returning(*rows):
+    """Build an async session.execute side_effect yielding one row per call.
+
+    Each call returns a result whose .scalars().first() is the next row.
+    """
+    results = []
+    for row in rows:
+        result = MagicMock()
+        result.scalars.return_value.first.return_value = row
+        results.append(result)
+    return AsyncMock(side_effect=results)
+
+
+@pytest.mark.asyncio
+async def test_country_fallback_serves_other_country_and_dispatches():
+    """Exact-country miss + any-country hit => 200, country_fallback=true,
+    and a background country-specific generation is dispatched."""
+    resolved_module_id = uuid.uuid4()
+    fake_session = MagicMock()
+    # 1st query (exact country "NG") misses; 2nd (fallback, any country) hits "CI".
+    fake_session.execute = _execute_returning(None, _fake_cached_case("CI"))
+
+    fake_task = MagicMock()
+
+    with (
+        patch.object(
+            content_module, "_resolve_module_id", AsyncMock(return_value=resolved_module_id)
+        ),
+        patch(
+            "app.domain.services._unit_resolution.resolve_module_unit_id",
+            AsyncMock(return_value=uuid.uuid4()),
+        ),
+        patch.object(
+            content_module,
+            "rewrite_uuid_citations_for_module",
+            AsyncMock(return_value=["src-1"]),
+        ),
+        patch.object(content_module, "ProgressService", MagicMock()),
+        patch.object(content_module, "_dispatch_content_prefetch", MagicMock()),
+        patch("app.tasks.content_generation.generate_country_content_task", fake_task),
+    ):
+        response = await content_module.get_or_generate_case_study(
+            module_id=str(resolved_module_id),
+            unit_id="1.4",
+            language="fr",
+            level=1,
+            country="NG",
+            force_regenerate=False,
+            case_study_service=MagicMock(),
+            session=fake_session,
+            current_user=SimpleNamespace(id=uuid.uuid4()),
+        )
+
+    assert response.status_code == 200
+    body = json.loads(response.body.decode())
+    assert body["country_fallback"] is True
+    # background regen for the learner's actual country was dispatched
+    fake_task.delay.assert_called_once()
+    assert fake_task.delay.call_args.kwargs["content_type"] == "case"
+    assert fake_task.delay.call_args.kwargs["country"] == "NG"
+
+
+@pytest.mark.asyncio
+async def test_exact_country_hit_no_fallback_no_dispatch():
+    """Exact-country hit => 200, country_fallback=false, no background regen."""
+    resolved_module_id = uuid.uuid4()
+    fake_session = MagicMock()
+    # 1st query (exact country "CI") hits; fallback query is never run.
+    fake_session.execute = _execute_returning(_fake_cached_case("CI"))
+
+    fake_task = MagicMock()
+
+    with (
+        patch.object(
+            content_module, "_resolve_module_id", AsyncMock(return_value=resolved_module_id)
+        ),
+        patch(
+            "app.domain.services._unit_resolution.resolve_module_unit_id",
+            AsyncMock(return_value=uuid.uuid4()),
+        ),
+        patch.object(
+            content_module,
+            "rewrite_uuid_citations_for_module",
+            AsyncMock(return_value=["src-1"]),
+        ),
+        patch.object(content_module, "ProgressService", MagicMock()),
+        patch.object(content_module, "_dispatch_content_prefetch", MagicMock()),
+        patch("app.tasks.content_generation.generate_country_content_task", fake_task),
+    ):
+        response = await content_module.get_or_generate_case_study(
+            module_id=str(resolved_module_id),
+            unit_id="1.4",
+            language="fr",
+            level=1,
+            country="CI",
+            force_regenerate=False,
+            case_study_service=MagicMock(),
+            session=fake_session,
+            current_user=SimpleNamespace(id=uuid.uuid4()),
+        )
+
+    assert response.status_code == 200
+    body = json.loads(response.body.decode())
+    assert body["country_fallback"] is False
+    fake_task.delay.assert_not_called()


### PR DESCRIPTION
## Problem ("still failing for nandi")

A learner whose country has no generated case-study row never sees the case study: the `/api/v1/content/cases/...` endpoint did an **exact-country-only** cache lookup, missed, and re-dispatched a fresh 3-min Celery generation on every request → perpetual `202 "generating"` → endless poll (and, on the pre-#2472 bundle, the `aof_context` white-screen).

## Root cause

The lesson endpoint already handles this (`content.py:509-522`); the dedicated case-study endpoint never got the same fallback.

## Fix

Mirror the lesson endpoint in `get_or_generate_case_study`:
1. On an exact-country cache miss, run an **any-country fallback query** and serve that row immediately with `country_fallback=true`.
2. Dispatch `generate_country_content_task(content_type="case", country=<learner country>)` to build the country-specific version in the background (task already supports `"case"`).

No schema change — `CaseStudyResponse.country_fallback` already exists and the frontend already carries the field.

## Tests

`tests/test_case_study_country_fallback.py` (mocked session, no DB fixture):
- exact-country miss + any-country hit → 200, `country_fallback:true`, background regen dispatched for the learner's country.
- exact-country hit → 200, `country_fallback:false`, no dispatch.

Both pass; ruff clean.

> Depends on #2476 (Alembic head merge) to actually deploy — staging deploys are currently failing on multiple migration heads.

Fixes #2474

🤖 Generated with [Claude Code](https://claude.com/claude-code)