### PR TITLE
fix(quiz): country fallback + envelope crash guards (#2480)

### DIFF
--- a/backend/app/api/v1/quiz.py
+++ b/backend/app/api/v1/quiz.py
@@ -214,6 +214,35 @@ async def generate_quiz(
             cache_result = await session.execute(cached_query)
             cached = cache_result.scalars().first()
 
+            # Country fallback: if no exact-country match, serve any country's
+            # quiz (same unit/language/level) instead of re-dispatching a fresh
+            # generation on every request. Mirrors the lesson/case-study
+            # endpoints so a learner whose country lacks a row (e.g. old-course
+            # content stored under a pre-ISO country value) sees the quiz
+            # immediately while the country-specific version generates in the
+            # background (#2480).
+            is_country_fallback = False
+            if not cached:
+                fallback_query = (
+                    select(GeneratedContent)
+                    .where(GeneratedContent.content_type == "quiz")
+                    .where(GeneratedContent.language == request.language)
+                    .where(GeneratedContent.level == request.level)
+                    .order_by(GeneratedContent.generated_at.desc())
+                )
+                if quiz_unit_uuid is not None:
+                    fallback_query = fallback_query.where(
+                        GeneratedContent.module_unit_id == quiz_unit_uuid
+                    )
+                else:
+                    fallback_query = fallback_query.where(
+                        GeneratedContent.module_id == module_uuid,
+                        GeneratedContent.module_unit_id.is_(None),
+                        GeneratedContent.content["unit_id"].astext == request.unit_id,
+                    )
+                cached = (await session.execute(fallback_query)).scalars().first()
+                is_country_fallback = cached is not None
+
             if cached:
                 from app.api.v1.schemas.quiz import QuizContent as _QuizContent
 
@@ -228,8 +257,25 @@ async def generate_quiz(
                     content=_QuizContent(**content_dict),
                     generated_at=cached.generated_at.isoformat(),
                     cached=True,
+                    country_fallback=is_country_fallback,
                 )
-                logger.info("Quiz cache hit", quiz_id=str(quiz_response.id))
+                logger.info(
+                    "Quiz cache hit",
+                    quiz_id=str(quiz_response.id),
+                    country_fallback=is_country_fallback,
+                )
+                if is_country_fallback:
+                    from app.tasks.content_generation import generate_country_content_task
+
+                    generate_country_content_task.delay(
+                        module_id=str(module_uuid),
+                        unit_id=request.unit_id,
+                        content_type="quiz",
+                        language=request.language,
+                        level=request.level,
+                        country=request.country,
+                        user_id=str(current_user.id) if current_user else "",
+                    )
                 return JSONResponse(
                     content=quiz_response.model_dump(mode="json"),
                     status_code=status.HTTP_200_OK,

--- a/backend/tests/test_quiz_country_fallback.py
+++ b/backend/tests/test_quiz_country_fallback.py
@@ -1,0 +1,143 @@
+"""Tests for country fallback in POST /api/v1/quiz/generate.
+
+Without fallback, a learner whose country has no generated quiz row gets an
+exact-country cache miss → a fresh Celery generation re-dispatched on every
+request → perpetual 202 (and the frontend then crashes on quiz.content.title).
+This mirrors the lesson/case-study endpoints: serve any country's row
+immediately with country_fallback=true and regenerate the country-specific
+version in the background (#2480).
+
+The endpoint function is invoked directly with a mocked session (two queries:
+exact-country, then any-country fallback), so no DB fixture is required.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.api.v1 import quiz as quiz_module
+from app.api.v1.schemas.quiz import QuizGenerationRequest
+
+
+def _fake_cached_quiz(country_context: str):
+    """A GeneratedContent-like row carrying a complete quiz payload."""
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        module_id=uuid.uuid4(),
+        content={
+            "unit_id": "1.5",
+            "title": "Quiz régional",
+            "description": "Instructions",
+            "questions": [
+                {
+                    "id": "q1",
+                    "question": "Question 1?",
+                    "options": ["A", "B", "C", "D"],
+                    "correct_answer": 0,
+                    "explanation": "Parce que A.",
+                    "sources_cited": ["src-1"],
+                    "difficulty": "medium",
+                }
+            ],
+            "time_limit_minutes": None,
+            "passing_score": 70.0,
+        },
+        language="fr",
+        level=1,
+        country_context=country_context,
+        generated_at=datetime.now(tz=UTC),
+    )
+
+
+def _execute_returning(*rows):
+    """async session.execute side_effect yielding one row per call."""
+    results = []
+    for row in rows:
+        result = MagicMock()
+        result.scalars.return_value.first.return_value = row
+        results.append(result)
+    return AsyncMock(side_effect=results)
+
+
+def _request(country: str) -> QuizGenerationRequest:
+    return QuizGenerationRequest(
+        module_id=str(uuid.uuid4()),
+        unit_id="1.5",
+        language="fr",
+        country=country,
+        level=1,
+        num_questions=10,
+    )
+
+
+@pytest.mark.asyncio
+async def test_country_fallback_serves_other_country_and_dispatches():
+    """Exact-country miss + any-country hit => 200, country_fallback=true,
+    and a background country-specific generation is dispatched."""
+    module_uuid = uuid.uuid4()
+    fake_session = MagicMock()
+    # 1st query (exact country "NG") misses; 2nd (fallback) hits "CI".
+    fake_session.execute = _execute_returning(None, _fake_cached_quiz("CI"))
+
+    fake_task = MagicMock()
+
+    with (
+        patch.object(quiz_module, "_check_subscription_or_first_unit", AsyncMock()),
+        patch.object(quiz_module, "_resolve_module_uuid", AsyncMock(return_value=module_uuid)),
+        patch(
+            "app.domain.services._unit_resolution.resolve_module_unit_id",
+            AsyncMock(return_value=uuid.uuid4()),
+        ),
+        patch("app.tasks.content_generation.generate_country_content_task", fake_task),
+    ):
+        response = await quiz_module.generate_quiz(
+            request=_request("NG"),
+            quiz_service=MagicMock(),
+            session=fake_session,
+            current_user=SimpleNamespace(id=uuid.uuid4()),
+        )
+
+    assert response.status_code == 200
+    body = json.loads(response.body.decode())
+    assert body["country_fallback"] is True
+    fake_task.delay.assert_called_once()
+    assert fake_task.delay.call_args.kwargs["content_type"] == "quiz"
+    assert fake_task.delay.call_args.kwargs["country"] == "NG"
+
+
+@pytest.mark.asyncio
+async def test_exact_country_hit_no_fallback_no_dispatch():
+    """Exact-country hit => 200, country_fallback=false, no background regen."""
+    module_uuid = uuid.uuid4()
+    fake_session = MagicMock()
+    # 1st query (exact country "CI") hits; fallback query never runs.
+    fake_session.execute = _execute_returning(_fake_cached_quiz("CI"))
+
+    fake_task = MagicMock()
+
+    with (
+        patch.object(quiz_module, "_check_subscription_or_first_unit", AsyncMock()),
+        patch.object(quiz_module, "_resolve_module_uuid", AsyncMock(return_value=module_uuid)),
+        patch(
+            "app.domain.services._unit_resolution.resolve_module_unit_id",
+            AsyncMock(return_value=uuid.uuid4()),
+        ),
+        patch("app.tasks.content_generation.generate_country_content_task", fake_task),
+    ):
+        response = await quiz_module.generate_quiz(
+            request=_request("CI"),
+            quiz_service=MagicMock(),
+            session=fake_session,
+            current_user=SimpleNamespace(id=uuid.uuid4()),
+        )
+
+    assert response.status_code == 200
+    body = json.loads(response.body.decode())
+    assert body["country_fallback"] is False
+    fake_task.delay.assert_not_called()

--- a/frontend/components/quiz/quiz-container.tsx
+++ b/frontend/components/quiz/quiz-container.tsx
@@ -155,6 +155,17 @@ export function QuizContainer({
               num_questions: unitQuestionsCount,
             });
             if (stale) return;
+            // The completion re-fetch can still return a 202 "generating"
+            // envelope (no content field) — committing it would crash on
+            // quiz.content.title. Keep polling instead (mirrors case study).
+            if (
+              quizData &&
+              'status' in quizData &&
+              (quizData as unknown as GeneratingResponse).status === 'generating'
+            ) {
+              pollStatus(taskId, startTime);
+              return;
+            }
             setQuiz(quizData);
             setState('ready');
           } else if (statusRes.status === 'failed') {
@@ -348,6 +359,30 @@ export function QuizContainer({
     );
   }
   
+  // Defensive guard: quiz may have been set from a non-quiz response (e.g. a
+  // 202 generating envelope with no content field). Never let a malformed
+  // payload white-screen the page on quiz.content.title.
+  if (state === 'ready' && quiz && !quiz.content?.questions) {
+    return (
+      <div className="max-w-4xl mx-auto p-4">
+        <Card className="border-red-200 bg-red-50">
+          <CardContent className="flex flex-col items-center justify-center py-12">
+            <AlertTriangle className="w-8 h-8 text-red-600 mb-4" />
+            <h2 className="text-lg font-semibold text-red-900 mb-2">
+              {t('error')}
+            </h2>
+            <p className="text-red-700 text-center max-w-md mb-6">
+              {error || t('networkError')}
+            </p>
+            <Button onClick={handleRetry} variant="outline">
+              {t('tryAgain')}
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
   // Ready to Start State
   if (state === 'ready' && quiz) {
     return (


### PR DESCRIPTION
## Problem

After #2474 deployed, case-study units load but **quiz units crash** with `cannot read properties of undefined`. Same two-layer bug, never applied to quizzes.

## Root cause

1. **Backend** `/api/v1/quiz/generate` did an exact-country-only cache lookup with no fallback. The `099_country_kebab_to_iso` migration normalized `users.country` to ISO but left content tables untouched, so **old-course** quiz rows (stored under the pre-ISO country value) no longer match the learner's now-ISO country → fresh generation re-dispatched every request → perpetual 202.
2. **Frontend** `quiz-container.tsx` committed a 202 `{status:'generating'}` envelope as quiz data, then crashed on `quiz.content.title` (guard only checked `quiz`, not `quiz.content`).

## Fix (mirrors the shipped case-study fix)

- **Backend**: any-country fallback → serve existing row with `country_fallback=true` + dispatch `generate_country_content_task(content_type="quiz")` for the background country-specific regen.
- **Frontend**: poll-completion guard (keep polling if re-fetch still generating) + render-time `!quiz.content?.questions` guard rendering the existing error/Retry card.

## No regression on recent courses

The fallback runs only on an exact-country **miss**. A recent course whose ISO content matches the learner's ISO country gets an exact hit first → fallback never runs, `country_fallback=false`, identical behavior. Purely additive on the already-broken miss path.

## Tests

`tests/test_quiz_country_fallback.py` (mocked session): fallback-hit → 200 + `country_fallback:true` + `content_type="quiz"` dispatch; exact-hit → 200 + `country_fallback:false` + no dispatch. Pass; ruff + tsc clean.

Fixes #2480

🤖 Generated with [Claude Code](https://claude.com/claude-code)