### PR TITLE
release: AI tutor model-switchable across providers (#2483) → staging

### DIFF
--- a/backend/app/domain/services/tutor_service.py
+++ b/backend/app/domain/services/tutor_service.py
@@ -11,7 +11,6 @@ from typing import Any
 import structlog
 from anthropic import AsyncAnthropic
 from anthropic import BadRequestError as AnthropicBadRequestError
-from anthropic.types import MessageParam, ToolResultBlockParam, ToolUseBlock
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
@@ -24,6 +23,7 @@ from app.ai.prompts.tutor import (
     get_persona_block_text,
     get_socratic_system_prompt,
 )
+from app.ai.providers import resolve_provider
 from app.ai.rag.embeddings import EmbeddingService
 from app.ai.rag.retriever import SemanticRetriever
 from app.domain.models.content import GeneratedContent
@@ -44,6 +44,10 @@ logger = structlog.get_logger()
 
 _sc = SettingsCache.instance
 MAX_TOOL_CALLS = _sc().get("tutor-max-tool-calls", 3)
+# Image/PDF uploads only work on Anthropic content blocks; when the admin has
+# pointed ``tutor-model`` at a non-Anthropic backend, multimodal turns fall back
+# to this Claude model so uploads keep working (#2483).
+_TUTOR_MULTIMODAL_FALLBACK_MODEL = "claude-sonnet-4-6"
 # Defaults relaxed (#1978) — compaction is non-destructive so we can afford
 # a higher trigger and a much larger verbatim window. Further bumped #1995
 # (50→80, 20→40) after staging feedback that the tutor lost learner-stated
@@ -1421,50 +1425,60 @@ class TutorService:
             all_tool_calls: list[dict[str, Any]] = []
             sources_cited: list[dict[str, Any]] = []
             source_image_refs: list[dict[str, Any]] = []
-            api_messages: list[MessageParam] = list(conversation_history)
+            api_messages: list[dict[str, Any]] = list(conversation_history)
             tutor_model = _sc().get("tutor-model", "claude-sonnet-4-6")
 
+            # Resolve the provider for the configured tutor model (#2483). The id
+            # may now point at a non-Anthropic backend (Moonshot/Kimi, OpenAI,
+            # OpenRouter); resolve_provider dispatches by model prefix.
+            provider = resolve_provider(tutor_model)
+            active_model = tutor_model
+
+            # Multimodal turns (image/PDF uploads) only work on Anthropic — the
+            # OpenAI-compatible providers can't carry Anthropic content blocks.
+            # Fall back to the default Claude model for this turn so uploads keep
+            # working regardless of the admin's tutor-model choice.
+            if file_content_blocks and not provider.is_anthropic:
+                logger.info(
+                    "tutor_multimodal_anthropic_fallback",
+                    requested_model=tutor_model,
+                    fallback_model=_TUTOR_MULTIMODAL_FALLBACK_MODEL,
+                    user_id=str(user_id),
+                )
+                active_model = _TUTOR_MULTIMODAL_FALLBACK_MODEL
+                provider = resolve_provider(active_model)
+
             while tool_call_count <= MAX_TOOL_CALLS:
-                response = await self.anthropic.messages.create(
-                    model=tutor_model,
+                result = await provider.complete(
                     system=system_prompt,
                     messages=api_messages,
                     tools=TOOL_DEFINITIONS,
                     max_tokens=_sc().get("tutor-response-max-tokens", 1500),
                     temperature=_sc().get("tutor-response-temperature", 0.7),
+                    model=active_model,
                 )
 
-                # Prompt-caching telemetry (#1984). Anthropic returns
-                # ``cache_read_input_tokens`` (cache hit) and
-                # ``cache_creation_input_tokens`` (cache write). Watching
+                # Prompt-caching telemetry (#1984). ``usage`` is normalized to a
+                # dict by the provider; ``cache_*`` keys are populated on
+                # Anthropic and zero/None on other providers. Watching
                 # cache_read on turn 2+ tells us caching is actually working.
                 try:
-                    usage = getattr(response, "usage", None)
-                    if usage is not None:
-                        logger.info(
-                            "tutor_claude_call",
-                            model=tutor_model,
-                            input_tokens=getattr(usage, "input_tokens", None),
-                            output_tokens=getattr(usage, "output_tokens", None),
-                            cache_read=getattr(usage, "cache_read_input_tokens", None),
-                            cache_creation=getattr(usage, "cache_creation_input_tokens", None),
-                            user_id=str(user_id),
-                            tool_call_count=tool_call_count,
-                        )
+                    usage = result.usage or {}
+                    logger.info(
+                        "tutor_claude_call",
+                        model=active_model,
+                        input_tokens=usage.get("input_tokens"),
+                        output_tokens=usage.get("output_tokens"),
+                        cache_read=usage.get("cache_read_input_tokens"),
+                        cache_creation=usage.get("cache_creation_input_tokens"),
+                        user_id=str(user_id),
+                        tool_call_count=tool_call_count,
+                    )
                 except Exception:  # pragma: no cover — telemetry must never break the tutor
                     pass
 
-                tool_use_blocks = [
-                    block for block in response.content if isinstance(block, ToolUseBlock)
-                ]
-
-                if not tool_use_blocks:
-                    text_parts = [
-                        block.text
-                        for block in response.content
-                        if hasattr(block, "text") and block.text
-                    ]
-                    full_response = "".join(text_parts)
+                if not result.tool_calls:
+                    full_response = result.text
 
                     for chunk_text in _split_into_chunks(full_response):
                         yield {
@@ -1480,12 +1494,7 @@ class TutorService:
                         user_id=str(user_id),
                         tool_call_count=tool_call_count,
                     )
-                    text_parts = [
-                        block.text
-                        for block in response.content
-                        if hasattr(block, "text") and block.text
-                    ]
-                    full_response = "".join(text_parts)
+                    full_response = result.text
                     if full_response:
                         for chunk_text in _split_into_chunks(full_response):
                             yield {
@@ -1495,11 +1504,12 @@ class TutorService:
                             }
                     break
 
-                assistant_content: list[Any] = list(response.content)
-                api_messages.append({"role": "assistant", "content": assistant_content})
+                # Append the assistant turn in the provider's native shape before
+                # tool results, so the next call sees a well-formed history.
+                api_messages.append(result.assistant_message)
 
-                tool_results: list[ToolResultBlockParam] = []
-                for tool_block in tool_use_blocks:
+                tool_results: list[dict[str, Any]] = []
+                for tool_block in result.tool_calls:
                     tool_call_count += 1
 
                     logger.info(
@@ -1608,13 +1618,12 @@ class TutorService:
 
                     tool_results.append(
                         {
-                            "type": "tool_result",
-                            "tool_use_id": tool_block.id,
+                            "tool_call_id": tool_block.id,
                             "content": tool_result_str,
                         }
                     )
 
-                api_messages.append({"role": "user", "content": tool_results})
+                api_messages.extend(provider.build_tool_result_messages(tool_results))
 
             unique_sources = _deduplicate_sources(sources_cited)
             # Citation surface: swap any rag_collection_id UUID labels for the
@@ -2341,19 +2350,16 @@ class TutorService:
                     language=user_language,
                 )
 
-                compact_response = await self.anthropic.messages.create(
-                    model=_sc().get("tutor-model", "claude-sonnet-4-6"),
+                compact_model = _sc().get("tutor-model", "claude-sonnet-4-6")
+                compact_result = await resolve_provider(compact_model).complete(
+                    system="",
                     messages=[{"role": "user", "content": prompt}],
                     max_tokens=_sc().get("tutor-compaction-max-tokens", 600),
                     temperature=_sc().get("tutor-compaction-temperature", 0.3),
+                    model=compact_model,
                 )
 
-                compact_text_parts = [
-                    block.text
-                    for block in compact_response.content
-                    if hasattr(block, "text") and block.text
-                ]
-                new_compact = "".join(compact_text_parts).strip()
+                new_compact = (compact_result.text or "").strip()
 
                 conversation.compacted_context = new_compact
                 conversation.compacted_at = datetime.utcnow()

--- a/backend/app/domain/services/tutor_tools.py
+++ b/backend/app/domain/services/tutor_tools.py
@@ -10,6 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.ai.providers import resolve_provider
 from app.ai.rag.retriever import SemanticRetriever
 from app.domain.models.content import GeneratedContent
 from app.domain.models.module import Module
@@ -541,14 +542,20 @@ Respond ONLY with valid JSON in this exact format:
   ]
 }}"""
 
-        response = await self.anthropic.messages.create(
-            model=SettingsCache.instance().get("tutor-suggestions-model", "claude-haiku-4-5"),
+        quiz_model = SettingsCache.instance().get("tutor-suggestions-model", "claude-haiku-4-5")
+        # Route through the pluggable provider (#2483) so the mini-quiz honors a
+        # non-Anthropic tutor-suggestions-model. json_object enforces clean JSON
+        # on OpenAI-compatible backends; Anthropic stays prompt-driven.
+        result = await resolve_provider(quiz_model).complete(
+            system="",
             messages=[{"role": "user", "content": prompt}],
             max_tokens=SettingsCache.instance().get("tutor-suggestions-max-tokens", 800),
             temperature=SettingsCache.instance().get("tutor-suggestions-temperature", 0.5),
+            model=quiz_model,
+            json_object=True,
         )
 
-        quiz_text = response.content[0].text.strip()
+        quiz_text = (result.text or "").strip()
 
         try:
             if "```json" in quiz_text:

--- a/backend/app/infrastructure/config/platform_defaults.py
+++ b/backend/app/infrastructure/config/platform_defaults.py
@@ -442,7 +442,12 @@ SETTING_DEFINITIONS: list[SettingDef] = [
         "claude-sonnet-4-6",
         "string",
         "Model — tutor response",
-        "Claude model for the main tutor conversation loop.",
+        "Model for the main tutor conversation loop. Resolved to a provider by "
+        "prefix (claude-* → Anthropic; moonshot-* → Moonshot). NOTE: "
+        "non-Anthropic models lose Anthropic prompt caching (higher cost / "
+        "latency), and turns with image/PDF uploads transparently fall back to "
+        "Claude — multimodal is Anthropic-only.",
+        allowed_options=["claude-sonnet-4-6", "claude-haiku-4-5", "moonshot-v1-128k"],
     ),
     SettingDef(
         "tutor-suggestions-model",
@@ -450,8 +455,10 @@ SETTING_DEFINITIONS: list[SettingDef] = [
         "claude-haiku-4-5",
         "string",
         "Model — tutor suggestions / mini-quiz",
-        "Claude model for the tutor mini-quiz tool (bounded structured "
-        "output). Override to a larger model if quality regresses.",
+        "Model for the tutor mini-quiz tool (bounded structured output). "
+        "Resolved to a provider by prefix (claude-* → Anthropic; moonshot-* → "
+        "Moonshot). Override to a larger model if quality regresses.",
+        allowed_options=["claude-haiku-4-5", "claude-sonnet-4-6", "moonshot-v1-128k"],
     ),
     SettingDef(
         "tutor-response-max-tokens",

--- a/backend/tests/_provider_fakes.py
+++ b/backend/tests/_provider_fakes.py
@@ -1,0 +1,49 @@
+"""Shared fakes for the pluggable LLM provider in tutor tests (#2483).
+
+The tutor send loop, compaction, and mini-quiz now go through
+``resolve_provider(model).complete(...)`` instead of the Anthropic SDK directly.
+These helpers let tests script a provider's ``complete()`` with normalized
+``LLMResult`` objects — no SDK, no network.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from app.ai.providers.base import LLMResult
+
+
+def llm(text="", tool_calls=None, stop_reason=None) -> LLMResult:
+    """Build a normalized LLMResult the way a provider's complete() would."""
+    tcs = tool_calls or []
+    return LLMResult(
+        text=text,
+        tool_calls=tcs,
+        stop_reason=stop_reason or ("tool_use" if tcs else "end_turn"),
+        assistant_message={"role": "assistant", "content": text},
+    )
+
+
+class FakeProvider:
+    """Stand-in for a resolved LLMProvider — no SDK, no network."""
+
+    is_anthropic = True
+    supports_cache_control = True
+
+    def __init__(self):
+        self.complete = AsyncMock()
+        self.build_tool_result_messages = MagicMock(
+            side_effect=lambda results: [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": r["tool_call_id"],
+                            "content": r["content"],
+                        }
+                        for r in results
+                    ],
+                }
+            ]
+        )

--- a/backend/tests/test_tutor_compaction.py
+++ b/backend/tests/test_tutor_compaction.py
@@ -16,6 +16,7 @@ from app.domain.services.tutor_service import (
     SessionContext,
     TutorService,
 )
+from tests._provider_fakes import FakeProvider, llm
 
 
 @pytest.fixture(autouse=True)
@@ -240,13 +241,8 @@ async def test_compact_conversation_async_is_non_destructive(tutor_service, samp
     conv.compacted_through_position = 0
     conversation_id = conv.id
 
-    class FakeTextBlock:
-        def __init__(self, text):
-            self.text = text
-
-    mock_compact_response = MagicMock()
-    mock_compact_response.content = [FakeTextBlock("Résumé compact généré")]
-    tutor_service.anthropic.messages.create = AsyncMock(return_value=mock_compact_response)
+    provider = FakeProvider()
+    provider.complete.return_value = llm(text="Résumé compact généré")
 
     mock_session = AsyncMock(spec=AsyncSession)
 
@@ -265,6 +261,7 @@ async def test_compact_conversation_async_is_non_destructive(tutor_service, samp
     mock_session_factory.return_value = mock_session
 
     with (
+        patch("app.domain.services.tutor_service.resolve_provider", return_value=provider),
         patch("app.domain.services.tutor_service.create_async_engine", return_value=mock_engine),
         patch(
             "app.domain.services.tutor_service.async_sessionmaker",
@@ -302,13 +299,8 @@ async def test_compaction_does_not_decrement_counters(tutor_service, sample_user
     pre_messages = list(conv.messages)
     conversation_id = conv.id
 
-    class FakeTextBlock:
-        def __init__(self, text):
-            self.text = text
-
-    mock_compact_response = MagicMock()
-    mock_compact_response.content = [FakeTextBlock("Résumé")]
-    tutor_service.anthropic.messages.create = AsyncMock(return_value=mock_compact_response)
+    provider = FakeProvider()
+    provider.complete.return_value = llm(text="Résumé")
 
     mock_session = AsyncMock(spec=AsyncSession)
     mock_execute_result = MagicMock()
@@ -325,6 +317,7 @@ async def test_compaction_does_not_decrement_counters(tutor_service, sample_user
     mock_session_factory.return_value = mock_session
 
     with (
+        patch("app.domain.services.tutor_service.resolve_provider", return_value=provider),
         patch("app.domain.services.tutor_service.create_async_engine", return_value=mock_engine),
         patch(
             "app.domain.services.tutor_service.async_sessionmaker",
@@ -355,13 +348,8 @@ async def test_compaction_advances_position_by_actual_slice_length(tutor_service
     conv.compacted_through_position = start
     conversation_id = conv.id
 
-    class FakeTextBlock:
-        def __init__(self, text):
-            self.text = text
-
-    mock_compact_response = MagicMock()
-    mock_compact_response.content = [FakeTextBlock("Résumé partiel")]
-    tutor_service.anthropic.messages.create = AsyncMock(return_value=mock_compact_response)
+    provider = FakeProvider()
+    provider.complete.return_value = llm(text="Résumé partiel")
 
     mock_session = AsyncMock(spec=AsyncSession)
     mock_execute_result = MagicMock()
@@ -377,6 +365,7 @@ async def test_compaction_advances_position_by_actual_slice_length(tutor_service
     mock_session_factory.return_value = mock_session
 
     with (
+        patch("app.domain.services.tutor_service.resolve_provider", return_value=provider),
         patch("app.domain.services.tutor_service.create_async_engine", return_value=mock_engine),
         patch(
             "app.domain.services.tutor_service.async_sessionmaker",
@@ -397,13 +386,8 @@ async def test_message_count_updated_on_send(tutor_service, sample_user):
 
     conv = _make_conversation(sample_user.id, n_messages=4)
 
-    class FakeTextBlock:
-        def __init__(self, text):
-            self.text = text
-
-    mock_response = MagicMock()
-    mock_response.content = [FakeTextBlock("Test")]
-    tutor_service.anthropic.messages.create = AsyncMock(return_value=mock_response)
+    provider = FakeProvider()
+    provider.complete.return_value = llm(text="Test")
 
     mock_session = AsyncMock(spec=AsyncSession)
     mock_session.get = AsyncMock(return_value=sample_user)
@@ -412,6 +396,7 @@ async def test_message_count_updated_on_send(tutor_service, sample_user):
     mock_session.flush = AsyncMock()
 
     with (
+        patch("app.domain.services.tutor_service.resolve_provider", return_value=provider),
         patch.object(tutor_service, "_check_daily_limit", new_callable=AsyncMock, return_value=0),
         patch.object(
             tutor_service, "_get_or_create_conversation", new_callable=AsyncMock, return_value=conv

--- a/backend/tests/test_tutor_model_setting.py
+++ b/backend/tests/test_tutor_model_setting.py
@@ -1,0 +1,36 @@
+"""The tutor model settings expose a dropdown and validate the choice (#2483).
+
+``tutor-model`` and ``tutor-suggestions-model`` gained ``allowed_options`` so the
+admin UI renders a `<select>` and the backend rejects an out-of-list value,
+mirroring ``ai-model-content``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.domain.services.platform_settings_service import _validate_value
+from app.infrastructure.config.platform_defaults import DEFAULTS_BY_KEY
+
+
+@pytest.mark.parametrize("key", ["tutor-model", "tutor-suggestions-model"])
+def test_tutor_model_settings_are_dropdowns(key):
+    defn = DEFAULTS_BY_KEY[key]
+    assert defn.allowed_options, f"{key} should expose allowed_options for a dropdown"
+    # Default must itself be a valid option.
+    assert defn.default in defn.allowed_options
+    # A Moonshot model is offered so the tutor can run non-Anthropic.
+    assert "moonshot-v1-128k" in defn.allowed_options
+
+
+@pytest.mark.parametrize("key", ["tutor-model", "tutor-suggestions-model"])
+def test_tutor_model_rejects_value_outside_allowed_options(key):
+    defn = DEFAULTS_BY_KEY[key]
+    with pytest.raises(ValueError, match="must be one of"):
+        _validate_value(defn, "gpt-4o-not-allowed")
+
+
+@pytest.mark.parametrize("key", ["tutor-model", "tutor-suggestions-model"])
+def test_tutor_model_accepts_allowed_value(key):
+    defn = DEFAULTS_BY_KEY[key]
+    assert _validate_value(defn, "moonshot-v1-128k") == "moonshot-v1-128k"

--- a/backend/tests/test_tutor_service.py
+++ b/backend/tests/test_tutor_service.py
@@ -14,6 +14,7 @@ from app.domain.models.user import User
 from app.domain.services.learner_memory_service import LearnerMemoryService
 from app.domain.services.subscription_service import SubscriptionService
 from app.domain.services.tutor_service import SessionContext, TutorService
+from tests._provider_fakes import FakeProvider, llm
 
 
 @pytest.fixture
@@ -122,15 +123,14 @@ async def test_send_message_yields_content_type_chunks(
     mock_session = AsyncMock(spec=AsyncSession)
     mock_session.get = AsyncMock(return_value=sample_user)
 
-    class FakeTextBlock:
-        def __init__(self, text):
-            self.text = text
-
-    mock_response = MagicMock()
-    mock_response.content = [FakeTextBlock("Bonjour! Comment puis-je vous aider?")]
-    tutor_service.anthropic.messages.create = AsyncMock(return_value=mock_response)
+    provider = FakeProvider()
+    provider.complete.return_value = llm(text="Bonjour! Comment puis-je vous aider?")
 
     with (
+        patch(
+            "app.domain.services.tutor_service.resolve_provider",
+            return_value=provider,
+        ),
         patch.object(
             SubscriptionService,
             "get_active_subscription",
@@ -189,15 +189,14 @@ async def test_send_message_yields_sources_cited_type(
     mock_session = AsyncMock(spec=AsyncSession)
     mock_session.get = AsyncMock(return_value=sample_user)
 
-    class FakeTextBlock:
-        def __init__(self, text):
-            self.text = text
-
-    mock_response = MagicMock()
-    mock_response.content = [FakeTextBlock("Test response")]
-    tutor_service.anthropic.messages.create = AsyncMock(return_value=mock_response)
+    provider = FakeProvider()
+    provider.complete.return_value = llm(text="Test response")
 
     with (
+        patch(
+            "app.domain.services.tutor_service.resolve_provider",
+            return_value=provider,
+        ),
         patch.object(
             SubscriptionService,
             "get_active_subscription",
@@ -326,15 +325,14 @@ async def test_send_message_never_yields_text_type(tutor_service, sample_user, s
     mock_session = AsyncMock(spec=AsyncSession)
     mock_session.get = AsyncMock(return_value=sample_user)
 
-    class FakeTextBlock:
-        def __init__(self, text):
-            self.text = text
-
-    mock_response = MagicMock()
-    mock_response.content = [FakeTextBlock("Test response")]
-    tutor_service.anthropic.messages.create = AsyncMock(return_value=mock_response)
+    provider = FakeProvider()
+    provider.complete.return_value = llm(text="Test response")
 
     with (
+        patch(
+            "app.domain.services.tutor_service.resolve_provider",
+            return_value=provider,
+        ),
         patch.object(
             SubscriptionService,
             "get_active_subscription",

--- a/backend/tests/test_tutor_tools.py
+++ b/backend/tests/test_tutor_tools.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.ai.providers.base import ToolCall
 from app.ai.rag.retriever import SemanticRetriever
 from app.domain.models.content import GeneratedContent
 from app.domain.models.conversation import TutorConversation
@@ -22,6 +23,8 @@ from app.domain.services.tutor_service import (
     _split_into_chunks,
 )
 from app.domain.services.tutor_tools import TOOL_DEFINITIONS, TutorToolExecutor
+from tests._provider_fakes import FakeProvider as _FakeProvider
+from tests._provider_fakes import llm as _llm
 
 
 @pytest.fixture(autouse=True)
@@ -288,28 +291,30 @@ async def test_generate_mini_quiz_returns_valid_json(tool_executor, mock_anthrop
         }
     )
 
-    mock_response = MagicMock()
-    mock_response.content = [MagicMock(text=quiz_json)]
-    mock_anthropic.messages.create = AsyncMock(return_value=mock_response)
+    provider = _FakeProvider()
+    provider.complete = AsyncMock(return_value=_llm(text=quiz_json))
 
-    result_str = await tool_executor._generate_mini_quiz(
-        {"topic": "surveillance", "num_questions": 1, "difficulty": "medium"}
-    )
+    with patch("app.domain.services.tutor_tools.resolve_provider", return_value=provider):
+        result_str = await tool_executor._generate_mini_quiz(
+            {"topic": "surveillance", "num_questions": 1, "difficulty": "medium"}
+        )
     result = json.loads(result_str)
 
     assert result["topic"] == "surveillance"
     assert "questions" in result
     assert len(result["questions"]) == 1
+    # json_object must be requested so OpenAI-compatible backends return clean JSON.
+    assert provider.complete.call_args.kwargs["json_object"] is True
 
 
 async def test_generate_mini_quiz_handles_parse_error(tool_executor, mock_anthropic):
-    mock_response = MagicMock()
-    mock_response.content = [MagicMock(text="Not valid JSON here")]
-    mock_anthropic.messages.create = AsyncMock(return_value=mock_response)
+    provider = _FakeProvider()
+    provider.complete = AsyncMock(return_value=_llm(text="Not valid JSON here"))
 
-    result_str = await tool_executor._generate_mini_quiz(
-        {"topic": "test", "num_questions": 2, "difficulty": "easy"}
-    )
+    with patch("app.domain.services.tutor_tools.resolve_provider", return_value=provider):
+        result_str = await tool_executor._generate_mini_quiz(
+            {"topic": "test", "num_questions": 2, "difficulty": "easy"}
+        )
     result = json.loads(result_str)
 
     assert result["topic"] == "test"
@@ -432,40 +437,25 @@ async def test_tool_use_loop_executes_tool_and_gets_final_response(
     mock_session = AsyncMock(spec=AsyncSession)
     mock_session.get = AsyncMock(return_value=sample_user)
 
-    tool_use_block = MagicMock()
-    tool_use_block.__class__ = __import__("anthropic.types", fromlist=["ToolUseBlock"]).ToolUseBlock
-    tool_use_block.name = "search_knowledge_base"
-    tool_use_block.id = "tool_123"
-    tool_use_block.input = {"query": "surveillance épidémiologique"}
-
-    text_block = MagicMock()
-    text_block.text = "Excellente réflexion! Que penses-tu..."
-    del tool_use_block.__class__
-
-    from anthropic.types import ToolUseBlock
-
-    real_tool_use_block = MagicMock(spec=ToolUseBlock)
-    real_tool_use_block.name = "search_knowledge_base"
-    real_tool_use_block.id = "tool_123"
-    real_tool_use_block.input = {"query": "surveillance"}
-
-    first_response = MagicMock()
-    first_response.content = [real_tool_use_block]
-
-    second_response = MagicMock()
-    final_text = MagicMock()
-    final_text.text = "Excellente question!"
-    del final_text.__class__
-
-    class FakeTextBlock:
-        def __init__(self, text):
-            self.text = text
-
-    second_response.content = [FakeTextBlock("Excellente question! Penses-tu que...")]
-
-    mock_anthropic.messages.create = AsyncMock(side_effect=[first_response, second_response])
+    provider = _FakeProvider()
+    provider.complete.side_effect = [
+        _llm(
+            tool_calls=[
+                ToolCall(
+                    id="tool_123",
+                    name="search_knowledge_base",
+                    input={"query": "surveillance"},
+                )
+            ]
+        ),
+        _llm(text="Excellente question! Penses-tu que..."),
+    ]
 
     with (
+        patch(
+            "app.domain.services.tutor_service.resolve_provider",
+            return_value=provider,
+        ),
         patch.object(
             tutor_service,
             "_check_daily_limit",
@@ -513,6 +503,8 @@ async def test_tool_use_loop_executes_tool_and_gets_final_response(
     chunk_types = [c["type"] for c in chunks]
     assert "tool_call" in chunk_types, f"Expected tool_call chunk, got: {chunk_types}"
     assert "content" in chunk_types, f"Expected content chunk, got: {chunk_types}"
+    # Tool results must be re-encoded via the provider for the follow-up turn.
+    provider.build_tool_result_messages.assert_called_once()
 
 
 async def test_max_tool_calls_enforced(
@@ -522,21 +514,25 @@ async def test_max_tool_calls_enforced(
     mock_session = AsyncMock(spec=AsyncSession)
     mock_session.get = AsyncMock(return_value=sample_user)
 
-    from anthropic.types import ToolUseBlock
+    def make_tool_result():
+        return _llm(
+            tool_calls=[
+                ToolCall(
+                    id=f"tool_{uuid.uuid4().hex[:8]}",
+                    name="search_knowledge_base",
+                    input={"query": "test"},
+                )
+            ]
+        )
 
-    def make_tool_response():
-        tool_block = MagicMock(spec=ToolUseBlock)
-        tool_block.name = "search_knowledge_base"
-        tool_block.id = f"tool_{uuid.uuid4().hex[:8]}"
-        tool_block.input = {"query": "test"}
-        resp = MagicMock()
-        resp.content = [tool_block]
-        return resp
-
-    responses = [make_tool_response() for _ in range(MAX_TOOL_CALLS + 2)]
-    mock_anthropic.messages.create = AsyncMock(side_effect=responses)
+    provider = _FakeProvider()
+    provider.complete.side_effect = [make_tool_result() for _ in range(MAX_TOOL_CALLS + 2)]
 
     with (
+        patch(
+            "app.domain.services.tutor_service.resolve_provider",
+            return_value=provider,
+        ),
         patch.object(
             tutor_service,
             "_check_daily_limit",
@@ -585,7 +581,7 @@ async def test_max_tool_calls_enforced(
     assert len(tool_call_chunks) <= MAX_TOOL_CALLS, (
         f"Expected at most {MAX_TOOL_CALLS} tool calls, got {len(tool_call_chunks)}"
     )
-    assert mock_anthropic.messages.create.call_count <= MAX_TOOL_CALLS + 1
+    assert provider.complete.call_count <= MAX_TOOL_CALLS + 1
 
 
 async def test_no_tool_use_yields_content_chunks(
@@ -595,15 +591,16 @@ async def test_no_tool_use_yields_content_chunks(
     mock_session = AsyncMock(spec=AsyncSession)
     mock_session.get = AsyncMock(return_value=sample_user)
 
-    class FakeTextBlock:
-        def __init__(self, text):
-            self.text = text
-
-    response = MagicMock()
-    response.content = [FakeTextBlock("Excellente question! Penses-tu que la surveillance...")]
-    mock_anthropic.messages.create = AsyncMock(return_value=response)
+    provider = _FakeProvider()
+    provider.complete.return_value = _llm(
+        text="Excellente question! Penses-tu que la surveillance..."
+    )
 
     with (
+        patch(
+            "app.domain.services.tutor_service.resolve_provider",
+            return_value=provider,
+        ),
         patch.object(
             tutor_service,
             "_check_daily_limit",
@@ -657,15 +654,14 @@ async def test_finished_chunk_includes_tool_calls_made(
     mock_session = AsyncMock(spec=AsyncSession)
     mock_session.get = AsyncMock(return_value=sample_user)
 
-    class FakeTextBlock:
-        def __init__(self, text):
-            self.text = text
-
-    response = MagicMock()
-    response.content = [FakeTextBlock("Test response")]
-    mock_anthropic.messages.create = AsyncMock(return_value=response)
+    provider = _FakeProvider()
+    provider.complete.return_value = _llm(text="Test response")
 
     with (
+        patch(
+            "app.domain.services.tutor_service.resolve_provider",
+            return_value=provider,
+        ),
         patch.object(
             tutor_service,
             "_check_daily_limit",
@@ -707,6 +703,74 @@ async def test_finished_chunk_includes_tool_calls_made(
     assert len(finished_chunks) == 1
     assert "tool_calls_made" in finished_chunks[0]["data"]
     assert finished_chunks[0]["data"]["remaining_messages"] == 14
+
+
+async def test_multimodal_turn_falls_back_to_anthropic_on_non_anthropic_model(
+    tutor_service, sample_user, sample_conversation
+):
+    """When tutor-model is non-Anthropic and the turn carries file/image blocks,
+    the loop must transparently fall back to the default Claude model — the
+    OpenAI-compatible providers can't carry Anthropic content blocks (#2483).
+    """
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_session.get = AsyncMock(return_value=sample_user)
+
+    non_anthropic = _FakeProvider()
+    non_anthropic.is_anthropic = False
+    anthropic_fb = _FakeProvider()  # is_anthropic = True (class default)
+    anthropic_fb.complete.return_value = _llm(text="Voici l'analyse de l'image.")
+
+    # First resolve (configured tutor-model) → non-Anthropic; second resolve
+    # (fallback model) → Anthropic.
+    resolve_mock = MagicMock(side_effect=[non_anthropic, anthropic_fb])
+
+    image_block = {
+        "type": "image",
+        "source": {"type": "base64", "media_type": "image/png", "data": "x"},
+    }
+
+    with (
+        patch(
+            "app.domain.services.tutor_service.resolve_provider",
+            resolve_mock,
+        ),
+        patch.object(tutor_service, "_check_daily_limit", new_callable=AsyncMock, return_value=0),
+        patch.object(
+            tutor_service,
+            "_get_or_create_conversation",
+            new_callable=AsyncMock,
+            return_value=sample_conversation,
+        ),
+        patch.object(
+            tutor_service.session_manager,
+            "_get_previous_compact",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch.object(tutor_service, "_resolve_course", new_callable=AsyncMock, return_value=None),
+    ):
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.flush = AsyncMock()
+
+        chunks = await collect_chunks(
+            tutor_service.send_message(
+                user_id=sample_user.id,
+                message="Décris cette image",
+                session=mock_session,
+                file_content_blocks=[image_block],
+            )
+        )
+
+    # Resolved twice: once for the configured model, once for the fallback.
+    assert resolve_mock.call_count == 2
+    assert resolve_mock.call_args_list[1].args[0] == "claude-sonnet-4-6"
+    # The non-Anthropic provider must never be asked to complete a multimodal turn.
+    non_anthropic.complete.assert_not_called()
+    anthropic_fb.complete.assert_awaited()
+
+    content = "".join(c["data"]["text"] for c in chunks if c["type"] == "content")
+    assert "analyse de l'image" in content
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Promote #2483 (PR #2484, merged to dev) to `main` to deploy staging.

`main` already contains everything on dev up to #2480 (squash #2482), so the dev→main PR phantom-conflicted on prior squash SHAs. Per repo convention this cherry-picks the single new commit (`74c1ec41`) onto a fresh branch off `main`.

Wires the AI tutor's send loop, compaction, and mini-quiz through `resolve_provider().complete()`; exposes `tutor-model` / `tutor-suggestions-model` as admin dropdowns; multimodal turns fall back to Claude on non-Anthropic models. Tests migrated to a shared FakeProvider + new fallback/settings coverage.

Squash-merge per repo policy. Push to main triggers `deploy.yml` → staging.

Closes #2483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)