### PR TITLE
feat(ai): add kimi-k2.6 (Moonshot latest) as a selectable model

### DIFF
--- a/backend/app/ai/model_registry.py
+++ b/backend/app/ai/model_registry.py
@@ -32,6 +32,12 @@ _MODEL_CAPABILITIES: dict[str, dict] = {
         "max_output_tokens": 64_000,
         "chars_per_token": 3.5,
     },
+    # Moonshot kimi-k2.6 reasoning model — 256K context window.
+    "kimi-k2.6": {
+        "context_window_tokens": 256_000,
+        "max_output_tokens": 16_384,
+        "chars_per_token": 3.5,
+    },
     "_default": {
         "context_window_tokens": 200_000,
         "max_output_tokens": 8_000,

--- a/backend/app/ai/providers/openai_compat_provider.py
+++ b/backend/app/ai/providers/openai_compat_provider.py
@@ -56,6 +56,27 @@ def _to_openai_tool_choice(tool_choice: dict[str, Any]) -> Any:
     return "auto"
 
 
+# kimi-k2.6 (and the kimi-k2.x reasoning family) reject arbitrary sampling
+# params: temperature is *fixed* by the model (thinking mode → 1.0, non-thinking
+# → 0.6) and thinking is ON by default. We disable thinking — cheaper, lower
+# latency, and keeps the forced-tool/JSON-mode structured-output path reliable —
+# which pins the accepted temperature to 0.6. The standard chat family
+# (moonshot-v1-*) is unaffected and keeps arbitrary temperature + native JSON.
+_KIMI_NON_THINKING_TEMPERATURE = 0.6
+
+
+def _kimi_reasoning_overrides(model: str) -> tuple[float | None, dict[str, Any]]:
+    """Return ``(effective_temperature, extra_body)`` for a model.
+
+    For ``kimi-*`` reasoning models, force the non-thinking temperature and pass
+    ``thinking: disabled`` via ``extra_body``. Empty/``None`` for every other
+    model, leaving their call unchanged.
+    """
+    if (model or "").lower().startswith("kimi"):
+        return _KIMI_NON_THINKING_TEMPERATURE, {"thinking": {"type": "disabled"}}
+    return None, {}
+
+
 class OpenAICompatLLMProvider:
     """Any OpenAI Chat Completions backend (Moonshot / OpenRouter / OpenAI)."""
 
@@ -97,11 +118,14 @@ class OpenAICompatLLMProvider:
         )
         emulate_tool = bool(forced_name and tools and not self._supports_forced_tool_choice)
 
+        eff_temperature, extra_body = _kimi_reasoning_overrides(model)
         kwargs: dict[str, Any] = {
             "model": model,
             "max_tokens": max_tokens,
-            "temperature": temperature,
+            "temperature": eff_temperature if eff_temperature is not None else temperature,
         }
+        if extra_body:
+            kwargs["extra_body"] = extra_body
         if emulate_tool:
             forced_tool = next((t for t in tools if t.get("name") == forced_name), tools[0])
             schema = forced_tool.get("input_schema", {"type": "object", "properties": {}})
@@ -206,16 +230,20 @@ class OpenAICompatLLMProvider:
         temperature: float,
         model: str,
     ) -> AsyncGenerator[str, None]:
-        stream = await self._client.chat.completions.create(
-            model=model,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            messages=[
+        eff_temperature, extra_body = _kimi_reasoning_overrides(model)
+        create_kwargs: dict[str, Any] = {
+            "model": model,
+            "max_tokens": max_tokens,
+            "temperature": eff_temperature if eff_temperature is not None else temperature,
+            "messages": [
                 {"role": "system", "content": flatten_system(system)},
                 {"role": "user", "content": user_message},
             ],
-            stream=True,
-        )
+            "stream": True,
+        }
+        if extra_body:
+            create_kwargs["extra_body"] = extra_body
+        stream = await self._client.chat.completions.create(**create_kwargs)
         async for chunk in stream:
             if not chunk.choices:
                 continue

--- a/backend/app/ai/providers/pricing.py
+++ b/backend/app/ai/providers/pricing.py
@@ -21,6 +21,10 @@ _PRICING: dict[str, dict[str, int]] = {
     # billed lower (cache_read ~$0.20/M, re-verify). Standard chat model: honors
     # arbitrary temperature + json_object (unlike the kimi-k2.6 reasoning model).
     "moonshot-v1-128k": {"input": 200, "output": 500, "cache_write": 0, "cache_read": 20},
+    # Moonshot kimi-k2.6 reasoning model (256K context). Placeholder rates mirror
+    # moonshot-v1-128k until confirmed.
+    # TODO(pricing): replace with confirmed kimi-k2.6 rates from the Kimi console.
+    "kimi-k2.6": {"input": 200, "output": 500, "cache_write": 0, "cache_read": 20},
 }
 
 _DEFAULT = {"input": 300, "output": 1500, "cache_write": 375, "cache_read": 30}

--- a/backend/app/infrastructure/config/platform_defaults.py
+++ b/backend/app/infrastructure/config/platform_defaults.py
@@ -375,10 +375,16 @@ SETTING_DEFINITIONS: list[SettingDef] = [
         "Model — content generation",
         "Model for lessons, quizzes, flashcards, case studies, pre-assessments, "
         "course syllabi and video scripts. Resolved to a provider by prefix "
-        "(claude-* → Anthropic; moonshot-* → Moonshot). NOTE: moonshot-v1-128k "
-        "runs on China-based servers — data-residency compliance was cleared "
-        "2026-06-08; default stays Claude.",
-        allowed_options=["claude-sonnet-4-6", "claude-haiku-4-5", "moonshot-v1-128k"],
+        "(claude-* → Anthropic; moonshot-*/kimi-* → Moonshot). NOTE: Moonshot "
+        "models run on China-based servers — data-residency compliance was "
+        "cleared 2026-06-08. kimi-k2.6 is the latest (256K context); thinking is "
+        "disabled by default (temperature pinned to 0.6). Default stays Claude.",
+        allowed_options=[
+            "claude-sonnet-4-6",
+            "claude-haiku-4-5",
+            "moonshot-v1-128k",
+            "kimi-k2.6",
+        ],
     ),
     SettingDef(
         "ai-model-quality",
@@ -443,11 +449,17 @@ SETTING_DEFINITIONS: list[SettingDef] = [
         "string",
         "Model — tutor response",
         "Model for the main tutor conversation loop. Resolved to a provider by "
-        "prefix (claude-* → Anthropic; moonshot-* → Moonshot). NOTE: "
+        "prefix (claude-* → Anthropic; moonshot-*/kimi-* → Moonshot). NOTE: "
         "non-Anthropic models lose Anthropic prompt caching (higher cost / "
         "latency), and turns with image/PDF uploads transparently fall back to "
-        "Claude — multimodal is Anthropic-only.",
-        allowed_options=["claude-sonnet-4-6", "claude-haiku-4-5", "moonshot-v1-128k"],
+        "Claude — multimodal input is Anthropic-only here. kimi-k2.6 runs with "
+        "thinking disabled (temperature pinned to 0.6).",
+        allowed_options=[
+            "claude-sonnet-4-6",
+            "claude-haiku-4-5",
+            "moonshot-v1-128k",
+            "kimi-k2.6",
+        ],
     ),
     SettingDef(
         "tutor-suggestions-model",
@@ -456,9 +468,15 @@ SETTING_DEFINITIONS: list[SettingDef] = [
         "string",
         "Model — tutor suggestions / mini-quiz",
         "Model for the tutor mini-quiz tool (bounded structured output). "
-        "Resolved to a provider by prefix (claude-* → Anthropic; moonshot-* → "
-        "Moonshot). Override to a larger model if quality regresses.",
-        allowed_options=["claude-haiku-4-5", "claude-sonnet-4-6", "moonshot-v1-128k"],
+        "Resolved to a provider by prefix (claude-* → Anthropic; moonshot-*/"
+        "kimi-* → Moonshot). kimi-k2.6 runs with thinking disabled (temperature "
+        "pinned to 0.6). Override to a larger model if quality regresses.",
+        allowed_options=[
+            "claude-haiku-4-5",
+            "claude-sonnet-4-6",
+            "moonshot-v1-128k",
+            "kimi-k2.6",
+        ],
     ),
     SettingDef(
         "tutor-response-max-tokens",

--- a/backend/tests/test_llm_providers.py
+++ b/backend/tests/test_llm_providers.py
@@ -273,6 +273,90 @@ async def test_openai_compat_json_object_without_tools():
     assert provider._client.chat.completions.kwargs["response_format"] == {"type": "json_object"}
 
 
+async def test_openai_compat_kimi_k26_disables_thinking_and_pins_temperature():
+    # kimi-k2.6 is a reasoning model: thinking on by default and temperature is
+    # fixed by the model. The provider must disable thinking and pin temperature
+    # to the non-thinking value (0.6), regardless of the requested temperature.
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content='{"ok": true}', tool_calls=None))],
+        usage=SimpleNamespace(prompt_tokens=5, completion_tokens=3, prompt_tokens_details=None),
+    )
+    provider = OpenAICompatLLMProvider(api_key="sk-test", supports_forced_tool_choice=False)
+    provider._client = _FakeOpenAI(response)
+
+    await provider.complete(
+        system="sys",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=50,
+        temperature=0.7,  # requested value must be overridden
+        model="kimi-k2.6",
+        json_object=True,
+    )
+
+    sent = provider._client.chat.completions.kwargs
+    assert sent["temperature"] == 0.6
+    assert sent["extra_body"] == {"thinking": {"type": "disabled"}}
+
+
+async def test_openai_compat_moonshot_v1_keeps_temperature_and_no_thinking():
+    # Regression guard: the standard chat family (moonshot-v1-*) is unaffected —
+    # arbitrary temperature forwarded, no thinking/extra_body injected.
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content='{"ok": true}', tool_calls=None))],
+        usage=SimpleNamespace(prompt_tokens=5, completion_tokens=3, prompt_tokens_details=None),
+    )
+    provider = OpenAICompatLLMProvider(api_key="sk-test")
+    provider._client = _FakeOpenAI(response)
+
+    await provider.complete(
+        system="sys",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=50,
+        temperature=0.7,
+        model="moonshot-v1-128k",
+        json_object=True,
+    )
+
+    sent = provider._client.chat.completions.kwargs
+    assert sent["temperature"] == 0.7
+    assert "extra_body" not in sent
+
+
+async def test_openai_compat_stream_kimi_k26_overrides_apply():
+    # The tutor streams through stream(); the same override must apply there or
+    # kimi-k2.6 rejects the requested temperature.
+    class _EmptyStream:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    class _CapturingCompletions:
+        async def create(self, **kwargs):
+            self.kwargs = kwargs
+            return _EmptyStream()
+
+    provider = OpenAICompatLLMProvider(api_key="sk-test")
+    completions = _CapturingCompletions()
+    provider._client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+
+    chunks = [
+        c
+        async for c in provider.stream(
+            system="sys",
+            user_message="hi",
+            max_tokens=50,
+            temperature=0.7,
+            model="kimi-k2.6",
+        )
+    ]
+    assert chunks == []
+    assert completions.kwargs["temperature"] == 0.6
+    assert completions.kwargs["extra_body"] == {"thinking": {"type": "disabled"}}
+    assert completions.kwargs["stream"] is True
+
+
 def test_openai_tool_result_messages_shape():
     provider = OpenAICompatLLMProvider(api_key="sk-test")
     msgs = provider.build_tool_result_messages([{"tool_call_id": "call_1", "content": "out"}])
@@ -308,6 +392,8 @@ def test_resolve_provider_moonshot_disables_forced_tool_choice(_fake_settings):
     # Moonshot can't force a single tool — the provider must emulate it.
     moonshot = resolve_provider("moonshot-v1-128k")
     assert moonshot._supports_forced_tool_choice is False
+    # kimi-k2.6 routes to Moonshot and likewise emulates forced tool_choice.
+    assert resolve_provider("kimi-k2.6")._supports_forced_tool_choice is False
     # Other OpenAI-compatible backends keep native forced tool_choice.
     assert resolve_provider("gpt-4o-mini")._supports_forced_tool_choice is True
 
@@ -332,5 +418,7 @@ def test_pricing_per_model():
     assert calculate_cost_cents("claude-sonnet-4-6", usage) == 1800
     # moonshot-v1-128k: $2.00 in + $5.00 out = 700 cents.
     assert calculate_cost_cents("moonshot-v1-128k", usage) == 700
+    # kimi-k2.6 has its own row (placeholder rates), not the default fallback.
+    assert calculate_cost_cents("kimi-k2.6", usage) == 700
     # Unknown model falls back to the default (Sonnet) table.
     assert calculate_cost_cents("mystery", usage) == 1800

--- a/backend/tests/test_tutor_model_setting.py
+++ b/backend/tests/test_tutor_model_setting.py
@@ -34,3 +34,11 @@ def test_tutor_model_rejects_value_outside_allowed_options(key):
 def test_tutor_model_accepts_allowed_value(key):
     defn = DEFAULTS_BY_KEY[key]
     assert _validate_value(defn, "moonshot-v1-128k") == "moonshot-v1-128k"
+
+
+@pytest.mark.parametrize("key", ["tutor-model", "tutor-suggestions-model", "ai-model-content"])
+def test_kimi_k26_is_an_allowed_model(key):
+    # The latest Moonshot model is selectable for content generation and tutor.
+    defn = DEFAULTS_BY_KEY[key]
+    assert "kimi-k2.6" in defn.allowed_options
+    assert _validate_value(defn, "kimi-k2.6") == "kimi-k2.6"


### PR DESCRIPTION
## Summary

Adds Moonshot's latest model **`kimi-k2.6`** (256K context, multimodal, JSON Mode + ToolCalls) to the selectable LLM models. The pluggable provider system (#2443) already routes the `kimi-*` prefix to Moonshot, but the dropdowns only offered the older `moonshot-v1-128k`.

`kimi-k2.6` is a **reasoning model** with hard parameter constraints the generic provider violated:
- Temperature is **fixed by the model** (thinking → 1.0, non-thinking → 0.6); any other value (the platform sends 0.7/0.3) is rejected.
- Thinking is **ON by default** (`thinking:{type:enabled}` via `extra_body`).

## Changes

- **`openai_compat_provider.py`** — make the provider reasoning-aware: for `kimi-*`, disable thinking and pin temperature to `0.6` in both `complete()` and `stream()`. Centralized in one place, so content generation, the tutor, and compaction are all covered. `moonshot-v1-*` / OpenRouter / OpenAI paths are unchanged (regression-tested).
- **`pricing.py`** — add a `kimi-k2.6` row (placeholder rates mirroring `moonshot-v1-128k`, with a `TODO(pricing)` to confirm from the Kimi console).
- **`model_registry.py`** — `kimi-k2.6` capabilities (256K context window) so token budgeting doesn't fall back to the 200K default.
- **`platform_defaults.py`** — add `kimi-k2.6` to `ai-model-content`, `tutor-model`, `tutor-suggestions-model` `allowed_options` (kept alongside `moonshot-v1-128k`); updated NOTE text.
- **Tests** — provider override (thinking-disabled + temp 0.6) and `moonshot-v1` regression guard, stream-path override, pricing row, and settings allowlist.

**Decisions:** thinking disabled by default (cheaper/deterministic/reliable JSON). Default model stays Claude.

## Out of scope

- Multimodal (image/PDF) input on the OpenAI-compat path — tutor still falls back to Claude.
- Enabling thinking mode / an admin toggle.
- Confirming exact `kimi-k2.6` pricing numbers (placeholder until provided).

## Test plan

- [x] `uv run pytest tests/test_llm_providers.py tests/test_tutor_model_setting.py -q` — 26 passed
- [x] `ruff check` + `ruff format --check` clean
- [ ] Live smoke with `MOONSHOT_API_KEY`: select `kimi-k2.6`, generate one lesson, confirm no param error + cost row written

Fixes #2488

🤖 Generated with [Claude Code](https://claude.com/claude-code)