### PR TITLE
feat(courses): add 'Go to module' button on course syllabus (#2496)

### DIFF
--- a/frontend/app/[locale]/(app)/courses/[courseSlug]/page.tsx
+++ b/frontend/app/[locale]/(app)/courses/[courseSlug]/page.tsx
@@ -18,6 +18,7 @@ import {
   ClipboardList,
   AlertTriangle,
   KeyRound,
+  Play,
 } from "lucide-react";
 import { apiFetch, enrollInCourse } from "@/lib/api";
 import { authClient } from "@/lib/auth";
@@ -202,6 +203,10 @@ export default function CourseDetailPage() {
 
   const title = locale === "fr" ? course.title_fr : course.title_en;
   const description = locale === "fr" ? course.description_fr : course.description_en;
+  const preassessmentBlocked =
+    course.preassessment_enabled &&
+    preassessmentStatus?.mandatory === true &&
+    preassessmentStatus?.completed === false;
 
   return (
     <div className="container mx-auto max-w-3xl px-4 py-6 space-y-6 pb-24 md:pb-6">
@@ -377,6 +382,22 @@ export default function CourseDetailPage() {
                           })}
                         </ul>
                       )}
+                      {enrolled && (
+                        <Button
+                          size="sm"
+                          className="mt-3 ml-10 min-h-11 bg-teal-600 hover:bg-teal-700"
+                          onClick={() => router.push(`/modules/${mod.id}`)}
+                          disabled={preassessmentBlocked}
+                          title={
+                            preassessmentBlocked
+                              ? tDetail("preassessmentRequiredTooltip")
+                              : undefined
+                          }
+                        >
+                          <Play className="mr-2 h-4 w-4" />
+                          {tDetail("goToModule")}
+                        </Button>
+                      )}
                     </CardContent>
                   )}
                 </Card>
@@ -393,15 +414,9 @@ export default function CourseDetailPage() {
             <Button
               className="w-full min-h-11 bg-teal-600 hover:bg-teal-700"
               onClick={() => router.push(`/modules?course_id=${course.id}`)}
-              disabled={
-                course.preassessment_enabled &&
-                preassessmentStatus?.mandatory === true &&
-                preassessmentStatus?.completed === false
-              }
+              disabled={preassessmentBlocked}
               title={
-                course.preassessment_enabled &&
-                preassessmentStatus?.mandatory === true &&
-                preassessmentStatus?.completed === false
+                preassessmentBlocked
                   ? tDetail("preassessmentRequiredTooltip")
                   : undefined
               }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -972,6 +972,7 @@
   },
   "CourseDetail": {
     "syllabus": "Syllabus",
+    "goToModule": "Go to module",
     "units": "units",
     "backToCatalog": "Back to catalog",
     "notFound": "Course not found.",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -972,6 +972,7 @@
   },
   "CourseDetail": {
     "syllabus": "Programme",
+    "goToModule": "Aller au module",
     "units": "unités",
     "backToCatalog": "Retour au catalogue",
     "notFound": "Cours non trouvé.",


### PR DESCRIPTION
## Summary

Adds a direct **"Aller au module" / "Go to module"** button inside each expanded module on the course detail page (`/[locale]/courses/[courseSlug]`). Previously, to open a specific module a learner had to click the generic **"Voir les modules"** button at the bottom (→ `/modules?course_id=…` map) and then find and click the same module again — an unnecessary extra hop.

## Scope (as agreed)
- **Module-level button only** — units (1.1, 1.2…) stay as plain text.
- **Enrolled learners only** — non-enrolled users keep seeing just the Enroll CTA.
- Reuses the existing `/modules/{moduleId}` route (same target as the module map).
- Disabled with the existing `preassessmentRequiredTooltip` when a mandatory pre-assessment is incomplete, matching the sticky button. Factored the gate into a shared `preassessmentBlocked` const (removes prior duplication).

## Changes
- `frontend/app/[locale]/(app)/courses/[courseSlug]/page.tsx` — per-module button + `preassessmentBlocked` const + `Play` icon import.
- `frontend/messages/{fr,en}.json` — `CourseDetail.goToModule` ("Aller au module" / "Go to module").

## Verification
1. Enrolled learner → expand a module → "Aller au module" appears → click → lands on `/{locale}/modules/{moduleId}`.
2. `en` locale → reads "Go to module".
3. Non-enrolled user → no per-module button.
4. Mandatory pre-assessment incomplete → button disabled + tooltip.

Fixes #2496

🤖 Generated with [Claude Code](https://claude.com/claude-code)