### PR TITLE
Promote dev → main: scope flashcard RAG retrieval (#2491)

### DIFF
--- a/backend/app/api/v1/flashcards.py
+++ b/backend/app/api/v1/flashcards.py
@@ -29,6 +29,7 @@ from app.domain.models.flashcard import FlashcardReview
 from app.domain.models.module import Module
 from app.domain.models.user import User
 from app.domain.services.analytics_service import AnalyticsService
+from app.domain.services.exceptions import CourseNotIndexedError
 from app.domain.services.flashcard_service import FlashcardGenerationService
 from app.domain.services.platform_settings_service import SettingsCache
 from app.domain.services.subscription_service import SubscriptionService
@@ -732,6 +733,22 @@ async def get_module_flashcards(
         )
 
         return flashcard_response
+
+    except CourseNotIndexedError as e:
+        # Must precede the ValueError handler below — CourseNotIndexedError
+        # subclasses ValueError. Flashcards are served synchronously, so this
+        # surfaces directly to the client (no polling sentinel). Emit both
+        # `error` (backend convention) and `code` (read by frontend apiFetch
+        # into ApiError.code) so the UI can show a "being prepared" state.
+        logger.warning("Course not indexed for flashcard generation", error=str(e))
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "course_not_indexed",
+                "code": "course_not_indexed",
+                "message": str(e),
+            },
+        )
 
     except ValueError as e:
         logger.warning("Invalid module flashcards request", error=str(e))

--- a/backend/app/domain/services/flashcard_service.py
+++ b/backend/app/domain/services/flashcard_service.py
@@ -15,6 +15,7 @@ from app.api.v1.schemas.content import FlashcardContent, FlashcardSetResponse
 from app.domain.models.content import GeneratedContent
 from app.domain.models.course import Course
 from app.domain.models.module import Module
+from app.domain.services.lesson_service import retrieve_with_fallback
 from app.domain.services.platform_settings_service import SettingsCache
 
 logger = structlog.get_logger()
@@ -137,6 +138,25 @@ class FlashcardGenerationService:
         result = await session.execute(query)
         return result.scalar_one_or_none()
 
+    @staticmethod
+    def _resolve_books_sources(module: Module) -> dict | None:
+        """Return books_sources for the semantic retriever.
+
+        Admin-created courses index chunks with source=rag_collection_id,
+        so always prefer that over books_sources (which may contain PDF
+        filenames that don't match the stored chunk source).
+        Legacy courses (no rag_collection_id) use books_sources as-is.
+
+        Mirrors the staticmethod on the lesson/case-study generators; the
+        services share no base class, so the resolver is duplicated (#2491).
+        """
+        course = module.course
+        if course and course.rag_collection_id:
+            return {course.rag_collection_id: []}
+        if module.books_sources:
+            return module.books_sources
+        return None
+
     async def _generate_flashcard_set(
         self,
         module_id: uuid.UUID,
@@ -182,16 +202,22 @@ class FlashcardGenerationService:
 
         logger.info("Retrieving relevant content chunks", query=query)
 
-        # Retrieve relevant chunks using RAG
-        search_results = await self.semantic_retriever.search(
-            query=query,
+        # Retrieve relevant chunks using RAG, scoped to this module's course
+        # (#2491). Reuses the lesson/case-study fallback helper so an un-indexed
+        # course raises CourseNotIndexedError instead of silently borrowing
+        # off-topic chunks from other courses. Flashcards are module-level
+        # (no unit), so "flashcards" is passed as the unit_id log label.
+        search_results = await retrieve_with_fallback(
+            self.semantic_retriever,
+            module,
+            self._resolve_books_sources(module),
+            query,
+            "flashcards",
+            level,
+            language,
+            session,
             top_k=SettingsCache.instance().get("ai-rag-flashcard-top-k", 12),
-            filters={"level": {"$lte": level}},  # Only content appropriate for user's level
-            session=session,
         )
-
-        if not search_results:
-            raise ValueError(f"No relevant content found for module {module_id}")
 
         logger.info(f"Retrieved {len(search_results)} content chunks")
 

--- a/backend/app/domain/services/lesson_service.py
+++ b/backend/app/domain/services/lesson_service.py
@@ -56,11 +56,13 @@ async def retrieve_with_fallback(
     level: int,
     language: str,
     session: AsyncSession,
+    top_k: int = 8,
 ) -> list[SearchResult]:
     """Retrieve RAG chunks for a unit, degrading gracefully before failing.
 
-    Shared by the lesson and case-study generators (each resolves its own
-    ``books_sources`` and passes it in).
+    Shared by the lesson, case-study and flashcard generators (each resolves its
+    own ``books_sources`` and passes it in). ``top_k`` defaults to the lesson/
+    case-study value of 8; the flashcard generator overrides it (#2491).
 
     1. Primary pass: source-scoped search at the default 0.3 threshold.
     2. Fallback pass: same source-scoped query at a relaxed threshold
@@ -75,7 +77,7 @@ async def retrieve_with_fallback(
         user_level=level,
         user_language=language,
         books_sources=books_sources,
-        top_k=8,
+        top_k=top_k,
         session=session,
     )
     if chunks:
@@ -83,7 +85,7 @@ async def retrieve_with_fallback(
 
     chunks = await retriever.search(
         query=query,
-        top_k=8,
+        top_k=top_k,
         min_similarity=RAG_FALLBACK_MIN_SIMILARITY,
         filters=retriever._build_module_filters(level, books_sources),
         session=session,

--- a/backend/tests/test_flashcard_course_not_indexed_endpoint.py
+++ b/backend/tests/test_flashcard_course_not_indexed_endpoint.py
@@ -1,0 +1,64 @@
+"""The flashcard endpoint maps CourseNotIndexedError to HTTP 409 (#2491).
+
+Flashcards are served synchronously, so a course with zero indexed chunks must
+surface a distinct ``course_not_indexed`` response (409) the frontend can detect
+via ``ApiError.code`` — separate from the 404 (module not found) and 400
+(no relevant content) cases. The 409 branch must precede the ValueError handler
+because CourseNotIndexedError subclasses ValueError.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.v1 import flashcards as flashcards_module
+from app.domain.services.exceptions import CourseNotIndexedError
+
+
+async def _invoke(side_effect):
+    service = MagicMock()
+    service.get_or_generate_flashcard_set = AsyncMock(side_effect=side_effect)
+    # A UUID string resolves without a DB lookup in _resolve_module_id.
+    await flashcards_module.get_module_flashcards(
+        module_id=str(uuid.uuid4()),
+        language="fr",
+        country="CI",
+        level=1,
+        current_user=MagicMock(),
+        flashcard_service=service,
+        session=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_course_not_indexed_maps_to_409():
+    with pytest.raises(HTTPException) as exc:
+        await _invoke(CourseNotIndexedError())
+
+    assert exc.value.status_code == 409
+    assert exc.value.detail["error"] == "course_not_indexed"
+    # `code` is what the frontend apiFetch reads into ApiError.code.
+    assert exc.value.detail["code"] == "course_not_indexed"
+
+
+@pytest.mark.asyncio
+async def test_module_not_found_still_maps_to_404():
+    with pytest.raises(HTTPException) as exc:
+        await _invoke(ValueError("Module abc not found"))
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail["error"] == "module_not_found"
+
+
+@pytest.mark.asyncio
+async def test_plain_no_content_valueerror_still_maps_to_400():
+    # A unit/content miss (course IS indexed) must NOT be swallowed by the 409.
+    with pytest.raises(HTTPException) as exc:
+        await _invoke(ValueError("No relevant content found for module x"))
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail["error"] == "invalid_request"

--- a/backend/tests/test_flashcard_generation.py
+++ b/backend/tests/test_flashcard_generation.py
@@ -124,7 +124,7 @@ class TestFlashcardGenerationService:
 
         session.refresh = AsyncMock(side_effect=mock_refresh)
 
-        mock_semantic_retriever.search.return_value = sample_search_results
+        mock_semantic_retriever.search_for_module.return_value = sample_search_results
         mock_claude_service.generate_structured_content.return_value = {
             "flashcards": sample_flashcard_data,
             "__complete": True,
@@ -152,7 +152,7 @@ class TestFlashcardGenerationService:
         assert result.flashcards[1].formula is not None
         assert "Incidence Rate" in result.flashcards[1].formula
 
-        mock_semantic_retriever.search.assert_called_once()
+        mock_semantic_retriever.search_for_module.assert_called_once()
         mock_claude_service.generate_structured_content.assert_called_once()
         session.add.assert_called_once()
         session.commit.assert_called_once()
@@ -206,7 +206,7 @@ class TestFlashcardGenerationService:
         assert len(result.flashcards) == 2
 
         # Verify no generation calls were made
-        mock_semantic_retriever.search.assert_not_called()
+        mock_semantic_retriever.search_for_module.assert_not_called()
         mock_claude_service.generate_structured_content.assert_not_called()
 
     @pytest.mark.asyncio
@@ -236,7 +236,12 @@ class TestFlashcardGenerationService:
         module_result.scalar_one_or_none.return_value = mock_module
         session.execute = AsyncMock(side_effect=[cache_miss_result, module_result])
 
+        # Course IS indexed (count > 0) but neither the scoped pass nor the
+        # relaxed fallback matched — retrieve_with_fallback raises a plain
+        # ValueError (not CourseNotIndexedError).
+        mock_semantic_retriever.search_for_module.return_value = []
         mock_semantic_retriever.search.return_value = []
+        mock_semantic_retriever.count_source_chunks.return_value = 5
 
         with pytest.raises(ValueError, match="No relevant content found"):
             await flashcard_service.get_or_generate_flashcard_set(
@@ -282,7 +287,7 @@ class TestFlashcardGenerationService:
 
         session.refresh = AsyncMock(side_effect=mock_refresh)
 
-        mock_semantic_retriever.search.return_value = sample_search_results
+        mock_semantic_retriever.search_for_module.return_value = sample_search_results
         mock_claude_service.generate_structured_content.side_effect = Exception("API Error")
 
         with pytest.raises(ValueError, match="Content generation failed"):
@@ -329,7 +334,7 @@ class TestFlashcardGenerationService:
 
         session.refresh = AsyncMock(side_effect=mock_refresh)
 
-        mock_semantic_retriever.search.return_value = sample_search_results
+        mock_semantic_retriever.search_for_module.return_value = sample_search_results
         mock_claude_service.generate_structured_content.return_value = "Invalid JSON"
 
         with pytest.raises(ValueError, match="Unexpected response type"):
@@ -399,7 +404,7 @@ class TestFlashcardGenerationService:
                 obj.generated_at = datetime.now(UTC)
 
         session.refresh = AsyncMock(side_effect=mock_refresh)
-        mock_semantic_retriever.search.return_value = sample_search_results
+        mock_semantic_retriever.search_for_module.return_value = sample_search_results
         mock_claude_service.generate_structured_content.return_value = {
             "flashcards": sample_flashcard_data,
             "__complete": True,
@@ -413,7 +418,7 @@ class TestFlashcardGenerationService:
             session=session,
         )
 
-        call_args = mock_semantic_retriever.search.call_args
+        call_args = mock_semantic_retriever.search_for_module.call_args
         assert "Fondements de la Santé Publique" in call_args[1]["query"]
 
     def test_extract_sources_from_flashcards(

--- a/backend/tests/test_flashcard_retrieval_scoped.py
+++ b/backend/tests/test_flashcard_retrieval_scoped.py
@@ -1,0 +1,91 @@
+"""Flashcard RAG retrieval is scoped to the module's course (#2491).
+
+Before #2491 the flashcard generator called ``semantic_retriever.search()`` with
+only a level filter, so it could pull chunks from *any* course's documents. It
+now routes through ``retrieve_with_fallback`` with the course-scoped
+``books_sources`` (so an un-indexed course raises ``CourseNotIndexedError``
+instead of silently borrowing off-topic chunks).
+
+The retriever and Claude are mocked — no DB, no embeddings, no network.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.domain.services import flashcard_service as fc_module
+from app.domain.services.exceptions import CourseNotIndexedError
+from app.domain.services.flashcard_service import FlashcardGenerationService
+
+
+def _module(rag_collection_id=None, books_sources=None) -> MagicMock:
+    module = MagicMock()
+    module.id = uuid.uuid4()
+    module.title_fr = "Titre"
+    module.title_en = "Title"
+    module.books_sources = books_sources
+    course = MagicMock()
+    course.rag_collection_id = rag_collection_id
+    module.course = course
+    return module
+
+
+def test_resolve_books_sources_prefers_rag_collection_id():
+    rag_id = str(uuid.uuid4())
+    module = _module(rag_collection_id=rag_id, books_sources={"old.pdf": []})
+    assert FlashcardGenerationService._resolve_books_sources(module) == {rag_id: []}
+
+
+def test_resolve_books_sources_falls_back_to_books_sources():
+    module = _module(rag_collection_id=None, books_sources={"donaldson": []})
+    assert FlashcardGenerationService._resolve_books_sources(module) == {"donaldson": []}
+
+
+def test_resolve_books_sources_none_when_unindexed_legacy():
+    module = _module(rag_collection_id=None, books_sources=None)
+    assert FlashcardGenerationService._resolve_books_sources(module) is None
+
+
+@pytest.mark.asyncio
+async def test_generate_uses_scoped_retrieval_and_propagates_not_indexed(monkeypatch):
+    rag_id = str(uuid.uuid4())
+    module = _module(rag_collection_id=rag_id)
+
+    # session.execute(...).scalar_one_or_none() -> the module
+    exec_result = MagicMock()
+    exec_result.scalar_one_or_none.return_value = module
+    session = AsyncMock()
+    session.execute.return_value = exec_result
+
+    captured: dict = {}
+
+    async def fake_retrieve(
+        retriever, mod, books_sources, query, unit_id, level, language, sess, top_k
+    ):
+        captured["books_sources"] = books_sources
+        captured["unit_id"] = unit_id
+        captured["top_k"] = top_k
+        # Simulate a course with zero indexed chunks.
+        raise CourseNotIndexedError()
+
+    monkeypatch.setattr(fc_module, "retrieve_with_fallback", fake_retrieve)
+
+    service = FlashcardGenerationService(claude_service=MagicMock(), semantic_retriever=MagicMock())
+
+    with pytest.raises(CourseNotIndexedError):
+        await service._generate_flashcard_set(
+            module_id=module.id,
+            language="fr",
+            country="CI",
+            level=1,
+            session=session,
+        )
+
+    # The fix: retrieval is scoped to the course's rag_collection_id, module-level
+    # (no unit), and the flashcard top_k setting is forwarded.
+    assert captured["books_sources"] == {rag_id: []}
+    assert captured["unit_id"] == "flashcards"
+    assert isinstance(captured["top_k"], int)

--- a/frontend/app/[locale]/(app)/flashcards/flashcards-container.tsx
+++ b/frontend/app/[locale]/(app)/flashcards/flashcards-container.tsx
@@ -9,7 +9,7 @@ import { FlashcardSessionSummary } from '@/components/learning/flashcard-session
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { authClient, AuthError } from '@/lib/auth';
-import { generateModuleFlashcards, getAllModuleProgress } from '@/lib/api';
+import { ApiError, generateModuleFlashcards, getAllModuleProgress } from '@/lib/api';
 
 interface FlashcardData {
   id: string;
@@ -165,11 +165,29 @@ export function FlashcardsContainer() {
         .filter((m) => m.status === 'in_progress' || m.status === 'completed')
         .map((m) => m.module_id);
       const modulesToGenerate = activeModules.length > 0 ? activeModules : ['M01'];
-      await Promise.allSettled(
+      const results = await Promise.allSettled(
         modulesToGenerate.map((moduleId) =>
           generateModuleFlashcards({ moduleId, language: locale, level: 1 })
         )
       );
+      // If every module failed because its course isn't indexed yet (#2491),
+      // surface a "being prepared" message instead of a generic empty state.
+      // Don't block when at least one module succeeded.
+      const anyFulfilled = results.some((r) => r.status === 'fulfilled');
+      const allNotIndexed =
+        !anyFulfilled &&
+        results.length > 0 &&
+        results.every(
+          (r) =>
+            r.status === 'rejected' &&
+            r.reason instanceof ApiError &&
+            r.reason.code === 'course_not_indexed'
+        );
+      if (allNotIndexed) {
+        setGenerationError(t('contentBeingPrepared'));
+        setSessionState('empty');
+        return;
+      }
       await refetch();
     } catch (err) {
       setGenerationError(err instanceof Error ? err.message : String(err));
@@ -279,7 +297,9 @@ export function FlashcardsContainer() {
           <CardContent className="text-center space-y-4 py-12">
             <div className="text-6xl">📚</div>
             <h1 className="text-2xl font-bold">{t('noFlashcardsYet')}</h1>
-            <p className="text-muted-foreground">{t('noFlashcardsDescription')}</p>
+            <p className="text-muted-foreground">
+              {generationError ?? t('noFlashcardsDescription')}
+            </p>
             <Button
               onClick={() => router.push('/modules')}
               className="w-full min-h-11"

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -565,6 +565,7 @@
     "redirectingToLogin": "Redirecting to login...",
     "noFlashcardsYet": "No flashcards yet",
     "noFlashcardsDescription": "Complete modules to generate flashcards, or try again.",
+    "contentBeingPrepared": "This course's materials are still being prepared. Please try again soon.",
     "goToModules": "Go to Modules"
   },
   "Onboarding": {

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -565,6 +565,7 @@
     "redirectingToLogin": "Redirection vers la connexion...",
     "noFlashcardsYet": "Aucune flashcard pour l'instant",
     "noFlashcardsDescription": "Terminez des modules pour générer des flashcards, ou réessayez.",
+    "contentBeingPrepared": "Les supports de ce cours sont en cours de préparation. Réessayez bientôt.",
     "goToModules": "Aller aux modules"
   },
   "Onboarding": {


### PR DESCRIPTION
Promotes the flashcard RAG-scoping fix from `dev` to `main` (staging deploy).

Cherry-picked onto a fresh branch off `main` to avoid phantom conflicts with prior squash-promotions (#2495).

## What ships
- Flashcard retrieval is now scoped to the module's course via `retrieve_with_fallback` (no more cross-course chunk bleed).
- Un-indexed courses surface `409 course_not_indexed`; the flashcards UI shows a "content being prepared" message.
- `retrieve_with_fallback` gains an optional `top_k` (default 8) so flashcards keep `ai-rag-flashcard-top-k`=12; lessons/case studies unchanged.

Merged to `dev` in #2497.

Fixes #2491

🤖 Generated with [Claude Code](https://claude.com/claude-code)