### PR TITLE
Promote dev → main: 'Go to module' button on course syllabus (#2496)

### DIFF
--- a/frontend/app/[locale]/(app)/courses/[courseSlug]/page.tsx
+++ b/frontend/app/[locale]/(app)/courses/[courseSlug]/page.tsx
@@ -18,6 +18,7 @@ import {
   ClipboardList,
   AlertTriangle,
   KeyRound,
+  Play,
 } from "lucide-react";
 import { apiFetch, enrollInCourse } from "@/lib/api";
 import { authClient } from "@/lib/auth";
@@ -202,6 +203,10 @@ export default function CourseDetailPage() {
 
   const title = locale === "fr" ? course.title_fr : course.title_en;
   const description = locale === "fr" ? course.description_fr : course.description_en;
+  const preassessmentBlocked =
+    course.preassessment_enabled &&
+    preassessmentStatus?.mandatory === true &&
+    preassessmentStatus?.completed === false;
 
   return (
     <div className="container mx-auto max-w-3xl px-4 py-6 space-y-6 pb-24 md:pb-6">
@@ -377,6 +382,22 @@ export default function CourseDetailPage() {
                           })}
                         </ul>
                       )}
+                      {enrolled && (
+                        <Button
+                          size="sm"
+                          className="mt-3 ml-10 min-h-11 bg-teal-600 hover:bg-teal-700"
+                          onClick={() => router.push(`/modules/${mod.id}`)}
+                          disabled={preassessmentBlocked}
+                          title={
+                            preassessmentBlocked
+                              ? tDetail("preassessmentRequiredTooltip")
+                              : undefined
+                          }
+                        >
+                          <Play className="mr-2 h-4 w-4" />
+                          {tDetail("goToModule")}
+                        </Button>
+                      )}
                     </CardContent>
                   )}
                 </Card>
@@ -393,15 +414,9 @@ export default function CourseDetailPage() {
             <Button
               className="w-full min-h-11 bg-teal-600 hover:bg-teal-700"
               onClick={() => router.push(`/modules?course_id=${course.id}`)}
-              disabled={
-                course.preassessment_enabled &&
-                preassessmentStatus?.mandatory === true &&
-                preassessmentStatus?.completed === false
-              }
+              disabled={preassessmentBlocked}
               title={
-                course.preassessment_enabled &&
-                preassessmentStatus?.mandatory === true &&
-                preassessmentStatus?.completed === false
+                preassessmentBlocked
                   ? tDetail("preassessmentRequiredTooltip")
                   : undefined
               }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -973,6 +973,7 @@
   },
   "CourseDetail": {
     "syllabus": "Syllabus",
+    "goToModule": "Go to module",
     "units": "units",
     "backToCatalog": "Back to catalog",
     "notFound": "Course not found.",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -973,6 +973,7 @@
   },
   "CourseDetail": {
     "syllabus": "Programme",
+    "goToModule": "Aller au module",
     "units": "unités",
     "backToCatalog": "Retour au catalogue",
     "notFound": "Cours non trouvé.",


### PR DESCRIPTION
Promotes the course-page **Go to module** button (#2496, dev PR #2498) to `main` → staging deploy.

A direct dev→main PR phantom-conflicted on prior squash SHAs, so this is a clean sync branch cut from `main` with the new dev commit cherry-picked. #2491 (flashcard RAG scope) cherry-picked empty — its content is already on `main` via an earlier promotion — so this carries **only** #2496.

Diff = the per-module "Aller au module / Go to module" button on the course detail page (enrolled-only, reuses `/modules/{id}` route + existing pre-assessment gate) plus the two `CourseDetail.goToModule` i18n keys.

Fixes #2496

🤖 Generated with [Claude Code](https://claude.com/claude-code)