### PR TITLE
fix(images): crop figures, geometric body_text guard, FR captions in prompt (#2502)

### DIFF
--- a/backend/app/ai/prompts/lesson.py
+++ b/backend/app/ai/prompts/lesson.py
@@ -297,7 +297,20 @@ REFERENCE DOCUMENTS:
                 if total_image_annotations >= max_image_annotations:
                     break
                 fig_num = img.get("figure_number") or ""
-                caption = img.get("caption") or ""
+                # Use the lesson-language caption so Claude reasons over (and
+                # may echo) the translated figure text, not the raw English the
+                # PyMuPDF extractor pulled from the PDF (#2502). The translated
+                # variants are produced at indexation time and carried through
+                # SourceImage.to_meta_dict(); fall back across locales then the
+                # raw caption.
+                if language == "fr":
+                    caption = (
+                        img.get("caption_fr") or img.get("caption") or img.get("caption_en") or ""
+                    )
+                else:
+                    caption = (
+                        img.get("caption_en") or img.get("caption") or img.get("caption_fr") or ""
+                    )
                 img_type = img.get("image_type") or "unknown"
                 img_id = img.get("id", "")
                 label_parts = []

--- a/backend/app/ai/rag/image_extractor.py
+++ b/backend/app/ai/rag/image_extractor.py
@@ -85,6 +85,11 @@ class ExtractedImage:
     chapter: str | None
     section: str | None
     image_hash: str | None = None
+    # Geometric body-text signal (#2502): the crop is mostly prose with a
+    # negligible drawing area. Set when vision is disabled and the page/region
+    # heuristics flag a non-figure. The pipeline maps this to
+    # figure_kind="body_text" so the retriever excludes it.
+    is_text_dominant: bool = False
 
 
 # Multi-part numbering pattern: matches "1", "1.5", "2-8", "12.3.4", "1-2-3".
@@ -673,6 +678,12 @@ class PDFImageExtractor:
                     page, region, SURROUNDING_CHAR_LIMIT
                 )
                 image_type = self._classify_image_type(metadata.get("caption"), final_w, final_h)
+                # A vector cluster that is mostly prose with negligible drawing
+                # area is a text excerpt, not a figure (#2502). Flag it so the
+                # pipeline tags figure_kind="body_text" and the retriever excludes it.
+                text_dominant = self._is_region_text_dominant(
+                    page, region=region, drawings=drawings
+                )
 
                 results.append(
                     ExtractedImage(
@@ -689,6 +700,7 @@ class PDFImageExtractor:
                         surrounding_text=surrounding_text,
                         chapter=metadata.get("chapter"),
                         section=metadata.get("section"),
+                        is_text_dominant=text_dominant,
                     )
                 )
             return results
@@ -697,58 +709,211 @@ class PDFImageExtractor:
         if has_visual_content:
             caption_bbox = self._find_leading_caption_block(page, figure_patterns)
             if caption_bbox is not None:
-                extracted = self._rasterize_full_page_as_figure(
+                # Crop to the figure region (caption + adjacent visual content)
+                # instead of rasterizing the whole page (#2502). Rendering the
+                # full page is what turned text pages with a stray rule + a
+                # "Figure X.Y" caption into whole-page "figures". When no visual
+                # content sits near the caption there is nothing to crop, so we
+                # emit nothing rather than a page of prose.
+                extracted = self._rasterize_caption_anchored_figure(
                     page,
                     page_number,
                     figure_patterns,
                     caption_bbox=caption_bbox,
+                    drawings=drawings,
+                    already_extracted_bboxes=already_extracted_bboxes,
                 )
                 if extracted:
                     results.append(extracted)
 
         return results
 
-    def _text_coverage_fraction(self, page: pymupdf.Page) -> float:
-        """Fraction of the page area covered by text blocks (#2435).
+    def _build_caption_figure_region(
+        self,
+        page: pymupdf.Page,
+        caption_bbox: pymupdf.Rect,
+        drawings: list[dict],
+        already_extracted_bboxes: list[pymupdf.Rect],
+    ) -> pymupdf.Rect | None:
+        """Build the crop rect for a caption-anchored figure (#2502).
+
+        Unions the page's vector drawings and embedded-raster bboxes with the
+        caption block, so the figure and its caption stay together while the
+        rest of the page's prose is cropped out. Returns ``None`` when there is
+        no visual content to anchor to — a prose page that merely opens with a
+        "Figure X.Y" line, which must not become an image.
+        """
+        visual_rects: list[pymupdf.Rect] = []
+        for drawing in drawings:
+            rect = drawing.get("rect")
+            if rect is not None:
+                visual_rects.append(pymupdf.Rect(rect))
+        visual_rects.extend(already_extracted_bboxes)
+        if not visual_rects:
+            return None
+
+        region: pymupdf.Rect | None = None
+        for rect in visual_rects:
+            region = pymupdf.Rect(rect) if region is None else (region | rect)
+        region = region | caption_bbox
+        region &= page.rect
+        if (
+            region.is_empty
+            or region.width < VECTOR_MIN_REGION_PX
+            or region.height < VECTOR_MIN_REGION_PX
+        ):
+            return None
+        return region
+
+    def _rasterize_caption_anchored_figure(
+        self,
+        page: pymupdf.Page,
+        page_number: int,
+        figure_patterns: list[re.Pattern],
+        caption_bbox: pymupdf.Rect,
+        drawings: list[dict],
+        already_extracted_bboxes: list[pymupdf.Rect],
+    ) -> "ExtractedImage | None":
+        """Rasterize a cropped figure region anchored to a block-leading caption (#2502).
+
+        Replaces the legacy full-page rasterize for the few-drawings fallback.
+        Metadata is anchored to ``caption_bbox`` (the real caption, not a stray
+        mid-page "Figure X.Y"), and the crop is flagged ``is_text_dominant`` when
+        it is still mostly prose so the pipeline stores it as body_text.
+        """
+        region = self._build_caption_figure_region(
+            page, caption_bbox, drawings, already_extracted_bboxes
+        )
+        if region is None:
+            return None
+
+        try:
+            png_bytes, w, h = self._rasterize_region(page, region)
+        except Exception as exc:
+            logger.warning(
+                "Caption-anchored region rasterization failed",
+                page=page_number,
+                error=str(exc),
+            )
+            return None
+
+        if len(png_bytes) < MIN_SIZE_BYTES or w < MIN_WIDTH_PX or h < MIN_HEIGHT_PX:
+            return None
+
+        try:
+            webp_bytes, final_w, final_h = self._convert_to_webp(
+                png_bytes, "png", max_width=WEBP_MAX_WIDTH
+            )
+        except Exception:
+            webp_bytes = png_bytes
+            final_w = w
+            final_h = h
+
+        metadata = self._extract_figure_metadata(page, caption_bbox, figure_patterns)
+        surrounding_text = self._extract_surrounding_text(
+            page, caption_bbox, SURROUNDING_CHAR_LIMIT
+        )
+        image_type = self._classify_image_type(metadata.get("caption"), final_w, final_h)
+        text_dominant = self._is_region_text_dominant(page, region=region, drawings=drawings)
+
+        return ExtractedImage(
+            image_bytes=webp_bytes,
+            width=final_w,
+            height=final_h,
+            original_format="png",
+            file_size_bytes=len(webp_bytes),
+            page_number=page_number,
+            figure_number=metadata.get("figure_number"),
+            caption=metadata.get("caption"),
+            attribution=metadata.get("attribution"),
+            image_type=image_type,
+            surrounding_text=surrounding_text,
+            chapter=metadata.get("chapter"),
+            section=metadata.get("section"),
+            is_text_dominant=text_dominant,
+        )
+
+    def _text_coverage_fraction(
+        self, page: pymupdf.Page, region: pymupdf.Rect | None = None
+    ) -> float:
+        """Fraction of ``region`` (or the whole page) area covered by text blocks (#2435).
 
         Text blocks don't overlap, so the summed block area is a good proxy.
-        High values mean a prose page; genuine figures sit well below.
+        High values mean a prose region; genuine figures sit well below. When a
+        ``region`` is given, each block is intersected with it so the ratio
+        reflects only the crop that would be rasterized (#2502).
         """
         try:
             page_dict = page.get_text("dict")
         except Exception:
             return 0.0
-        page_area = abs(page.rect.get_area()) or 1.0
+        bounds = region if region is not None else page.rect
+        bounds_area = abs(bounds.get_area()) or 1.0
         text_area = 0.0
         for block in page_dict.get("blocks", []):
             if block.get("type") != 0:
                 continue
             bbox = block.get("bbox")
-            if bbox:
-                text_area += abs(pymupdf.Rect(bbox).get_area())
-        return min(text_area / page_area, 1.0)
+            if not bbox:
+                continue
+            r = pymupdf.Rect(bbox)
+            if region is not None:
+                r = r & region
+                if r.is_empty:
+                    continue
+            text_area += abs(r.get_area())
+        return min(text_area / bounds_area, 1.0)
 
-    def _drawings_coverage_fraction(self, page: pymupdf.Page) -> float:
-        """Fraction of the page covered by the bounding box of all vector drawings (#2435).
+    def _drawings_coverage_fraction(
+        self,
+        page: pymupdf.Page,
+        region: pymupdf.Rect | None = None,
+        drawings: list[dict] | None = None,
+    ) -> float:
+        """Fraction of ``region`` (or the page) covered by the union of vector drawings (#2435).
 
         A real chart/diagram clusters drawings into a substantial region; a prose
-        page's drawings are thin rules with negligible area.
+        page's drawings are thin rules with negligible area. When a ``region`` is
+        given, drawing rects are intersected with it so the ratio reflects the
+        crop (#2502).
         """
-        try:
-            drawings = page.get_drawings()
-        except Exception:
-            return 0.0
-        page_area = abs(page.rect.get_area()) or 1.0
+        if drawings is None:
+            try:
+                drawings = page.get_drawings()
+            except Exception:
+                return 0.0
+        bounds = region if region is not None else page.rect
+        bounds_area = abs(bounds.get_area()) or 1.0
         union: pymupdf.Rect | None = None
         for drawing in drawings:
             rect = drawing.get("rect")
             if rect is None:
                 continue
             r = pymupdf.Rect(rect)
+            if region is not None:
+                r = r & region
+                if r.is_empty:
+                    continue
             union = r if union is None else (union | r)
         if union is None:
             return 0.0
-        return min(abs(union.get_area()) / page_area, 1.0)
+        return min(abs(union.get_area()) / bounds_area, 1.0)
+
+    def _is_region_text_dominant(
+        self,
+        page: pymupdf.Page,
+        region: pymupdf.Rect | None = None,
+        drawings: list[dict] | None = None,
+    ) -> bool:
+        """True when a region is prose with negligible drawings — a non-figure (#2502).
+
+        Shared gate for the page-level full-page fallback and the per-region
+        crops. A genuine figure has low text coverage and/or a substantial
+        drawing area, so it clears this gate.
+        """
+        text_cov = self._text_coverage_fraction(page, region=region)
+        draw_cov = self._drawings_coverage_fraction(page, region=region, drawings=drawings)
+        return text_cov >= TEXT_DENSITY_REJECT_FRACTION and draw_cov < MIN_DRAWING_COVERAGE_FRACTION
 
     def _rasterize_full_page_as_figure(
         self,
@@ -770,20 +935,12 @@ class PDFImageExtractor:
         # leak in (#2435/#2272). Reject a page dominated by prose with negligible
         # visual area before rasterizing it as a figure. The high-drawing path
         # (caption_bbox is None) keeps its legacy behaviour.
-        if caption_bbox is not None:
-            text_cov = self._text_coverage_fraction(page)
-            draw_cov = self._drawings_coverage_fraction(page)
-            if (
-                text_cov >= TEXT_DENSITY_REJECT_FRACTION
-                and draw_cov < MIN_DRAWING_COVERAGE_FRACTION
-            ):
-                logger.info(
-                    "Skipping full-page raster — body-text page, not a figure",
-                    page=page_number,
-                    text_coverage=round(text_cov, 2),
-                    drawing_coverage=round(draw_cov, 2),
-                )
-                return None
+        if caption_bbox is not None and self._is_region_text_dominant(page):
+            logger.info(
+                "Skipping full-page raster — body-text page, not a figure",
+                page=page_number,
+            )
+            return None
 
         try:
             pixmap = page.get_pixmap(dpi=RASTERIZE_DPI)

--- a/backend/app/ai/rag/pipeline.py
+++ b/backend/app/ai/rag/pipeline.py
@@ -517,11 +517,13 @@ class RAGPipeline:
             )
 
             figure_kind: str | None = None
-            if vision_body_text:
-                # The caption reader already determined this crop is page text,
-                # not a figure (#2435). Tag it so the retriever excludes it and
-                # purge_body_text_figures (#2431) can remove it; skip the extra
-                # classification call.
+            if vision_body_text or img.is_text_dominant:
+                # This crop is page text, not a figure — either the vision
+                # caption reader said so (#2435) or the geometric extractor
+                # heuristic flagged it (#2502, the vision-free path that works
+                # when ENABLE_FIGURE_VISION is off). Tag it so the retriever
+                # excludes it and purge_body_text_figures (#2431) can remove it;
+                # skip the extra classification call.
                 figure_kind = "body_text"
             else:
                 try:

--- a/backend/app/api/v1/schemas/source_images.py
+++ b/backend/app/api/v1/schemas/source_images.py
@@ -11,6 +11,8 @@ class SourceImageMetadataResponse(BaseModel):
     rag_collection_id: str | None = None
     figure_number: str | None = None
     caption: str | None = None
+    caption_fr: str | None = None
+    caption_en: str | None = None
     attribution: str | None = None
     image_type: str
     page_number: int

--- a/backend/tests/test_image_extractor.py
+++ b/backend/tests/test_image_extractor.py
@@ -12,6 +12,8 @@ import pytest
 
 from app.ai.rag.image_extractor import (
     BOOKS,
+    MIN_HEIGHT_PX,
+    MIN_WIDTH_PX,
     ExtractedImage,
     PDFImageExtractor,
     _build_figure_patterns,
@@ -773,8 +775,13 @@ class TestExtractNonXrefFigures:
         results = self.extractor._extract_non_xref_figures(page, 1, patterns, [])
         assert results == []
 
-    def test_drawings_with_block_leading_caption_triggers_full_page(self):
-        """One drawing + a 'Figure X.Y …' block-leading caption rasterizes."""
+    def test_drawings_with_block_leading_caption_crops_to_figure_region(self):
+        """One drawing + a 'Figure X.Y …' block-leading caption crops to the figure (#2502).
+
+        Previously this rasterized the whole page, baking the body text into the
+        "figure". Now it crops to the drawing + caption region, so the clip
+        passed to get_pixmap is strictly smaller than the page.
+        """
         page = MagicMock()
         page.get_drawings.return_value = [{"rect": pymupdf.Rect(100, 100, 300, 300)}]
         caption_text = "Figure 1.3 Types of Competitive Advantage"
@@ -785,7 +792,7 @@ class TestExtractNonXrefFigures:
                 "blocks": [
                     {
                         "type": 0,
-                        "bbox": (50, 600, 562, 650),
+                        "bbox": (50, 320, 562, 360),
                         "lines": [{"spans": [{"text": caption_text}]}],
                     }
                 ]
@@ -793,9 +800,9 @@ class TestExtractNonXrefFigures:
         )
         page.rect = pymupdf.Rect(0, 0, 612, 792)
         mock_pixmap = MagicMock()
-        mock_pixmap.tobytes.return_value = _make_minimal_png(612, 792)
-        mock_pixmap.width = 612
-        mock_pixmap.height = 792
+        mock_pixmap.tobytes.return_value = _make_minimal_png(400, 300)
+        mock_pixmap.width = 400
+        mock_pixmap.height = 300
         page.get_pixmap.return_value = mock_pixmap
 
         patterns = self._make_figure_patterns()
@@ -804,6 +811,10 @@ class TestExtractNonXrefFigures:
         assert len(results) == 1
         assert results[0].figure_number is not None
         assert "1.3" in results[0].figure_number
+        # The page was cropped, not rendered whole: the clip is smaller than the page.
+        clip = page.get_pixmap.call_args.kwargs["clip"]
+        assert clip.width < page.rect.width
+        assert clip.height < page.rect.height
 
     def test_drawings_with_only_inline_reference_does_not_trigger(self):
         """Drawings present but no block-leading caption (only mid-block reference) → no rasterize."""
@@ -844,6 +855,156 @@ class TestExtractNonXrefFigures:
 
         results = self.extractor._extract_non_xref_figures(page, 1, patterns, [])
         assert results == []
+
+
+class TestTextDominanceGuard:
+    """Tests for the geometric body-text guard and caption-anchored cropping (#2502)."""
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.extractor = PDFImageExtractor(Path(self.temp_dir))
+
+    def teardown_method(self):
+        import shutil
+
+        shutil.rmtree(self.temp_dir)
+
+    def _page_with_blocks(self, blocks, drawings=None):
+        page = MagicMock()
+        page.rect = pymupdf.Rect(0, 0, 612, 792)
+        page.get_text.side_effect = lambda mode=None: "" if mode != "dict" else {"blocks": blocks}
+        page.get_drawings.return_value = drawings or []
+        return page
+
+    def test_is_region_text_dominant_true_for_prose(self):
+        # A block covering most of the page + a negligible drawing → prose.
+        blocks = [{"type": 0, "bbox": (0, 0, 612, 520), "lines": []}]
+        page = self._page_with_blocks(blocks)
+        drawings = [{"rect": pymupdf.Rect(0, 0, 10, 10)}]
+        assert self.extractor._is_region_text_dominant(page, drawings=drawings) is True
+
+    def test_is_region_text_dominant_false_for_figure(self):
+        # Small text + a large drawing → genuine figure.
+        blocks = [{"type": 0, "bbox": (0, 0, 100, 50), "lines": []}]
+        page = self._page_with_blocks(blocks)
+        drawings = [{"rect": pymupdf.Rect(50, 50, 520, 520)}]
+        assert self.extractor._is_region_text_dominant(page, drawings=drawings) is False
+
+    def test_text_coverage_fraction_respects_region(self):
+        # The block sits in the top half; measuring only the bottom half → ~0.
+        blocks = [{"type": 0, "bbox": (0, 0, 612, 396), "lines": []}]
+        page = self._page_with_blocks(blocks)
+        bottom = pymupdf.Rect(0, 400, 612, 792)
+        assert self.extractor._text_coverage_fraction(page, region=bottom) < 0.05
+
+    def test_build_caption_figure_region_none_without_visual(self):
+        page = MagicMock()
+        page.rect = pymupdf.Rect(0, 0, 612, 792)
+        caption = pymupdf.Rect(50, 600, 562, 650)
+        assert self.extractor._build_caption_figure_region(page, caption, [], []) is None
+
+    def test_build_caption_figure_region_crops_smaller_than_page(self):
+        page = MagicMock()
+        page.rect = pymupdf.Rect(0, 0, 612, 792)
+        caption = pymupdf.Rect(50, 500, 562, 540)
+        drawings = [{"rect": pymupdf.Rect(100, 150, 400, 480)}]
+        region = self.extractor._build_caption_figure_region(page, caption, drawings, [])
+        assert region is not None
+        assert region.width < page.rect.width
+        assert region.height < page.rect.height
+
+    def test_caption_crop_flags_text_dominant_when_rule_spans_prose(self):
+        """A thin full-width rule + prose between it and the caption → body_text crop."""
+        caption_text = "Figure 2.1 Trends in incidence over time"
+        blocks = [
+            {"type": 0, "bbox": (50, 310, 562, 480), "lines": [{"spans": [{"text": "x " * 200}]}]},
+            {
+                "type": 0,
+                "bbox": (50, 500, 562, 540),
+                "lines": [{"spans": [{"text": caption_text}]}],
+            },
+        ]
+        page = MagicMock()
+        page.rect = pymupdf.Rect(0, 0, 612, 792)
+        page.get_text.side_effect = lambda mode=None: (
+            caption_text if mode != "dict" else {"blocks": blocks}
+        )
+        # One thin full-width rule near the top of the region.
+        drawings = [{"rect": pymupdf.Rect(40, 305, 572, 308)}]
+        page.get_drawings.return_value = drawings
+        mock_pixmap = MagicMock()
+        mock_pixmap.tobytes.return_value = _make_minimal_png(520, 230)
+        mock_pixmap.width = 520
+        mock_pixmap.height = 230
+        page.get_pixmap.return_value = mock_pixmap
+
+        patterns = _build_figure_patterns(BOOKS["generic"])
+        results = self.extractor._extract_non_xref_figures(page, 1, patterns, [])
+        # It may be emitted, but never as a clean figure — it's flagged body_text.
+        assert all(r.is_text_dominant for r in results)
+
+
+class TestRealPDFExtraction:
+    """End-to-end extraction over real (in-memory) PDFs (#2502)."""
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.resources_path = Path(self.temp_dir)
+        self.extractor = PDFImageExtractor(self.resources_path)
+
+    def teardown_method(self):
+        import shutil
+
+        shutil.rmtree(self.temp_dir)
+
+    def _write_pdf(self, doc, name: str) -> Path:
+        path = self.resources_path / name
+        doc.save(str(path))
+        doc.close()
+        return path
+
+    def test_text_page_with_caption_and_rule_not_surfaced_as_figure(self):
+        """A prose page that opens a 'Figure X.Y' caption + a stray rule must not
+        yield a clean figure — the core #2502 defect."""
+        doc = pymupdf.open()
+        page = doc.new_page(width=612, height=792)
+        body = "Public health surveillance relies on timely data collection. " * 40
+        page.insert_textbox(pymupdf.Rect(50, 50, 562, 560), body, fontsize=11)
+        page.insert_textbox(
+            pymupdf.Rect(50, 600, 562, 640),
+            "Figure 1.3 Distribution of reported cases by district",
+            fontsize=11,
+        )
+        page.draw_line(pymupdf.Point(50, 580), pymupdf.Point(562, 580))
+        pdf_path = self._write_pdf(doc, "Guide_sante.pdf")
+
+        results = self.extractor.extract_images_from_pdf(pdf_path, "generic")
+        # Either nothing is extracted, or anything extracted is flagged body_text.
+        assert all(r.is_text_dominant for r in results)
+
+    def test_diagram_page_with_caption_is_extracted_as_clean_figure(self):
+        """A page with a real filled diagram + caption yields one non-text figure."""
+        doc = pymupdf.open()
+        page = doc.new_page(width=612, height=792)
+        shape = page.new_shape()
+        shape.draw_rect(pymupdf.Rect(120, 120, 500, 470))
+        shape.finish(fill=(0.2, 0.45, 0.8))
+        shape.commit()
+        page.insert_textbox(
+            pymupdf.Rect(120, 485, 500, 525),
+            "Figure 2.1 Reference model of the health system",
+            fontsize=11,
+        )
+        pdf_path = self._write_pdf(doc, "Rapport_OMS.pdf")
+
+        results = self.extractor.extract_images_from_pdf(pdf_path, "generic")
+        clean = [r for r in results if not r.is_text_dominant]
+        assert len(clean) >= 1
+        fig = clean[0]
+        assert fig.width >= MIN_WIDTH_PX and fig.height >= MIN_HEIGHT_PX
+        # Cropped to the (near-square) diagram region, not the whole portrait
+        # page: a full-page render keeps the page's ~1.29 height:width ratio.
+        assert fig.height < fig.width * 1.25
 
 
 class TestHighDrawingCountPage:

--- a/backend/tests/test_rag_pipeline_images.py
+++ b/backend/tests/test_rag_pipeline_images.py
@@ -836,3 +836,45 @@ class TestRAGPipelineVisionCaption:
         added = mock_session.add.call_args[0][0]
         assert added.figure_kind == "body_text"
         mock_classify.assert_not_called()
+
+    async def test_geometric_text_dominant_tagged_body_text_with_vision_off(self):
+        """Vision-free path (#2502): the extractor's is_text_dominant flag tags
+        the row body_text even when the caption reader is disabled."""
+        pdf_path = Path(self.temp_dir) / "test.pdf"
+        pdf_path.touch()
+        fake_image = _make_extracted_image(figure_number="Figure 4.1", is_text_dominant=True)
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=MagicMock())
+
+        with (
+            patch(
+                "app.ai.rag.pipeline.PDFImageExtractor.extract_images_from_pdf",
+                return_value=[fake_image],
+            ),
+            patch(
+                "app.ai.rag.pipeline.S3StorageService.upload_bytes",
+                new_callable=AsyncMock,
+                return_value="http://minio/k.webp",
+            ),
+            # Vision disabled — read_figure_caption raises the kill-switch error.
+            patch(
+                "app.ai.rag.pipeline.read_figure_caption",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("vision disabled"),
+            ),
+            patch("app.ai.rag.pipeline.translate_figure_caption", new_callable=AsyncMock),
+            patch("app.ai.rag.pipeline.classify_figure", new_callable=AsyncMock) as mock_classify,
+            patch.object(
+                ImageLinker, "link_images_to_chunks", new_callable=AsyncMock, return_value=0
+            ),
+        ):
+            count = await self.pipeline.process_pdf_images(
+                pdf_path=str(pdf_path), source="donaldson", session=mock_session
+            )
+
+        assert count == 1
+        added = mock_session.add.call_args[0][0]
+        assert added.figure_kind == "body_text"
+        mock_classify.assert_not_called()

--- a/backend/tests/test_source_image_injection.py
+++ b/backend/tests/test_source_image_injection.py
@@ -114,6 +114,47 @@ class TestFormatRagContextForLesson:
         result = format_rag_context_for_lesson(chunks, "q", "M01", "1.1", "fr", linked_images=None)
         assert "FIGURE DISPONIBLE" not in result
 
+    def test_fr_lesson_injects_french_caption_not_english(self):
+        """FR lessons must put the translated caption in the prompt, not the raw
+        English the extractor pulled from the PDF (#2502)."""
+        chunk_id = uuid.uuid4()
+        img = _make_image_meta(
+            caption="Steps in the Marketing Process",
+            caption_fr="Étapes du processus de marketing",
+            caption_en="Steps in the Marketing Process",
+        )
+        chunks = [_make_search_result(chunk_id=chunk_id)]
+        result = format_rag_context_for_lesson(
+            chunks, "q", "M01", "1.1", "fr", linked_images={chunk_id: [img]}
+        )
+        assert "Étapes du processus de marketing" in result
+        assert "Steps in the Marketing Process" not in result
+
+    def test_en_lesson_injects_english_caption(self):
+        chunk_id = uuid.uuid4()
+        img = _make_image_meta(
+            caption="Steps in the Marketing Process",
+            caption_fr="Étapes du processus de marketing",
+            caption_en="Steps in the Marketing Process",
+        )
+        chunks = [_make_search_result(chunk_id=chunk_id)]
+        result = format_rag_context_for_lesson(
+            chunks, "q", "M01", "1.1", "en", linked_images={chunk_id: [img]}
+        )
+        assert "Steps in the Marketing Process" in result
+        assert "Étapes du processus de marketing" not in result
+
+    def test_fr_lesson_falls_back_to_raw_caption_when_no_translation(self):
+        """When caption_fr is missing, fall back to the raw caption rather than
+        dropping the annotation entirely."""
+        chunk_id = uuid.uuid4()
+        img = _make_image_meta(caption="Raw extracted caption", caption_fr=None, caption_en=None)
+        chunks = [_make_search_result(chunk_id=chunk_id)]
+        result = format_rag_context_for_lesson(
+            chunks, "q", "M01", "1.1", "fr", linked_images={chunk_id: [img]}
+        )
+        assert "Raw extracted caption" in result
+
     def test_annotation_includes_figure_number_and_caption(self):
         chunk_id = uuid.uuid4()
         img = _make_image_meta(figure_number="2.5", caption="Epidemiology cycle")


### PR DESCRIPTION
Fixes #2502

## Problem

Some course "extracted images" were whole text pages with no actual figure — the cropping wasn't working. A trace also found two adjacent defects in linking and French captions.

**Root cause (cropping):** the embedded-image (xref) path is fine. The non-xref fallback in `_extract_non_xref_figures` rasterized the **entire page** whenever a page had ≥1 vector "drawing" (PyMuPDF counts header rules, table borders, underlines as drawings) **and** a text block merely *started* with "Figure X.Y". #2435 added a page-level prose guard but still rendered the full page, so a real figure on a text-heavy page baked in all the body text.

## What changed

### A — Cropping (core)
- The caption-triggered path now builds a **figure region** from the visual content near the caption (drawings + embedded rasters ∪ caption block) and rasterizes that crop via the existing `_rasterize_region`, instead of `page.rect`.
- When no visual content sits near the caption there's nothing to crop → it emits **nothing** rather than a page of prose.
- Coverage helpers (`_text_coverage_fraction`, `_drawings_coverage_fraction`) are generalized to measure a **region**; a shared `_is_region_text_dominant` gate flags crops still dominated by prose.

### B — Linking (vision-free body_text)
- `body_text` detection previously required vision (`ENABLE_FIGURE_VISION`, off in prod) — which is why ~1,911 body-text rows were never excluded (#2431).
- The extractor now sets a geometric `is_text_dominant` flag; the pipeline maps it to `figure_kind="body_text"`, so the retriever's existing `_EXCLUDED_KINDS` drops them and `purge_body_text_figures` can remove them — **without vision**.

### C — French captions
- `format_rag_context_for_lesson()` injected the **raw English** caption into the prompt for French lessons. It now prefers `caption_fr`/`caption_en` by lesson language (carried through `SourceImage.to_meta_dict()`), with fallback to the raw caption.
- `SourceImageMetadataResponse` now exposes `caption_fr`/`caption_en`.

## Tests
- `test_image_extractor.py`: text page with caption+rule yields no clean figure; real in-memory PDF diagram crops to a near-square region (not the portrait page); region/text-dominance helpers; caption-anchored crop uses a clip smaller than the page.
- `test_source_image_injection.py`: FR lesson injects French caption (not English); EN injects English; FR falls back to raw caption when untranslated.
- `test_rag_pipeline_images.py`: geometric `is_text_dominant` tags `body_text` with vision off.

All image-related suites green (224 passed locally); ruff clean.

## Follow-up (not in this PR)
Per plan decision **prevent + re-index**: after deploy, re-index affected courses on staging and clear cached `generated_content` so corrected images + French captions take effect. Relates to #2431, #2066.

🤖 Generated with [Claude Code](https://claude.com/claude-code)