### PR TITLE
fix(pwa): bust SW cache so new /subscribe provider page shows (#2506)

### DIFF
--- a/frontend/lib/offline/download-manager.ts
+++ b/frontend/lib/offline/download-manager.ts
@@ -460,7 +460,7 @@ async function downloadUnitQuiz(
 
 // Cache name MUST stay aligned with `pages-${CACHE_VERSION}` in frontend/sw.ts.
 // Bump both together when changing.
-const PAGES_CACHE_NAME = "pages-v7-status-no-cache";
+const PAGES_CACHE_NAME = "pages-v8-subscribe-provider-ui";
 
 /**
  * Pre-fetch a same-origin page and stash it in the SW page cache so an offline

--- a/frontend/lib/offline/sync-manager.ts
+++ b/frontend/lib/offline/sync-manager.ts
@@ -19,6 +19,7 @@ import { prewarmPage } from './download-manager';
 
 const PREWARM_V6_DONE_KEY = 'offline_prewarm_v6_done';
 const PREWARM_V7_DONE_KEY = 'offline_prewarm_v7_done';
+const PREWARM_V8_DONE_KEY = 'offline_prewarm_v8_done';
 
 export type SyncStatus =
   | { state: 'idle' }
@@ -55,6 +56,7 @@ class SyncManager {
       this.syncNow();
       this.runV6PrewarmMigration();
       this.runV7PrewarmMigration();
+      this.runV8PrewarmMigration();
     };
     window.addEventListener('online', this.onlineHandler);
 
@@ -64,6 +66,7 @@ class SyncManager {
     if (typeof navigator !== 'undefined' && navigator.onLine) {
       this.runV6PrewarmMigration();
       this.runV7PrewarmMigration();
+      this.runV8PrewarmMigration();
     }
   }
 
@@ -201,6 +204,45 @@ class SyncManager {
         }
       }
       localStorage.setItem(PREWARM_V7_DONE_KEY, '1');
+    } catch {
+      // best-effort; failure must not break sync
+    }
+  }
+
+  /**
+   * One-shot migration for the v8 cache-version bump (drop stale bundles so
+   * the new provider-selector /subscribe page replaces the cached old shell,
+   * #2355). Renaming the pages cache from `pages-v7-status-no-cache` to
+   * `pages-v8-subscribe-provider-ui` orphans previously-prewarmed module
+   * pages; re-warm them so offline navigation keeps hitting cache instead of
+   * /offline.html.
+   */
+  async runV8PrewarmMigration(): Promise<void> {
+    if (typeof window === 'undefined') return;
+    try {
+      if (localStorage.getItem(PREWARM_V8_DONE_KEY)) return;
+      if (typeof navigator !== 'undefined' && !navigator.onLine) return;
+
+      const modules = await getOfflineModulesByStatus('downloaded');
+      for (const mod of modules) {
+        const entries = await getOfflineContentByModule(mod.moduleId);
+        const flashcardKey = `__module_${mod.moduleId}__`;
+        const seen = new Set<string>();
+        for (const entry of entries) {
+          if (entry.unitId === flashcardKey) continue;
+          const key = `${entry.locale}|${entry.unitId}`;
+          if (seen.has(key)) continue;
+          seen.add(key);
+          await prewarmPage(
+            `/${entry.locale}/modules/${mod.moduleId}/units/${entry.unitId}`,
+          );
+        }
+        const locales = new Set(entries.map((e) => e.locale));
+        for (const loc of locales) {
+          await prewarmPage(`/${loc}/modules/${mod.moduleId}`);
+        }
+      }
+      localStorage.setItem(PREWARM_V8_DONE_KEY, '1');
     } catch {
       // best-effort; failure must not break sync
     }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2065,12 +2065,6 @@
   "Subscribe": {
     "title": "Subscription",
     "subtitle": "Access all courses and AI tutor",
-    "instructions": "Send your payment via Orange Money to the number below. Your subscription will be activated within 24h.",
-    "step1": "Add your phone number below",
-    "step2": "Send 1,000 XOF via Orange Money to the number shown",
-    "step3": "Your access is activated within 24h",
-    "orangeMoneyLabel": "Orange Money payment number",
-    "orangeMoneyNumber": "+221 77 000 0000",
     "amount": "1,000 XOF / 4 weeks",
     "active": "Active subscription",
     "expired": "Subscription expired",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -2065,12 +2065,6 @@
   "Subscribe": {
     "title": "Abonnement",
     "subtitle": "Accédez à tous les cours et au tuteur IA",
-    "instructions": "Envoyez votre paiement par Orange Money au numéro ci-dessous. Votre abonnement sera activé sous 24h.",
-    "step1": "Ajoutez votre numéro de téléphone ci-dessous",
-    "step2": "Envoyez 1 000 FCFA par Orange Money au numéro indiqué",
-    "step3": "Votre accès est activé sous 24h",
-    "orangeMoneyLabel": "Numéro Orange Money de paiement",
-    "orangeMoneyNumber": "+221 77 000 0000",
     "amount": "1 000 FCFA / 4 semaines",
     "active": "Abonnement actif",
     "expired": "Abonnement expiré",

--- a/frontend/sw.ts
+++ b/frontend/sw.ts
@@ -23,7 +23,10 @@ const DAY_IN_SECONDS = 24 * 60 * 60;
 // match `pages-${CACHE_VERSION}`) so downloaded modules render offline.
 // v7 excludes /api/v1/content/status/ from the API SWR cache so a stale
 // "generating" body can't keep the quiz spinner alive forever offline.
-const CACHE_VERSION = "v7-status-no-cache";
+// v8 drops stale bundles so clients pick up the new provider-selector
+// /subscribe page (#2355) instead of serving the cached old Orange-Money
+// manual-payment shell.
+const CACHE_VERSION = "v8-subscribe-provider-ui";
 
 const OFFLINE_FALLBACK_URL = "/offline.html";
 


### PR DESCRIPTION
## Context
Users still saw the **old subscription page** (static Orange Money number + 3 manual steps) on staging, even though the new provider-selector page (Orange Money / Wave / Paystack hosted checkout) shipped in #2355 and is already deployed.

**Root cause:** #2355 changed the `/subscribe` route but never bumped the service-worker `CACHE_VERSION` in `frontend/sw.ts` (still `v7-status-no-cache`), so returning PWA clients keep serving the cached old app shell. Same class as the prior fix `78d28cd8` ("bump SW CACHE_VERSION to drop stale pre-fix bundles"). Verified: the deployed staging bundle already contains the new `fetchEnabledPaymentProviders`/`initializePayment` code — this is a cache problem, not a deploy gap.

## Changes
- `frontend/sw.ts`: bump `CACHE_VERSION` `v7-status-no-cache` → `v8-subscribe-provider-ui`.
- `frontend/lib/offline/download-manager.ts`: keep `PAGES_CACHE_NAME` aligned (`pages-v8-subscribe-provider-ui`).
- `frontend/lib/offline/sync-manager.ts`: add `runV8PrewarmMigration` (mirrors v6/v7) so offline-downloaded module pages are re-warmed into the renamed pages cache instead of falling through to `/offline.html`.
- `frontend/messages/{en,fr}.json`: remove dead old Orange-Money manual-flow keys (`instructions`, `step1/2/3`, `orangeMoneyLabel`, `orangeMoneyNumber`) — unused by the current page. Key parity preserved.

## Verification
- After deploy: hard-reload / unregister SW on staging `/subscribe` → provider-selector card ("Choose a payment method") renders, not the old Orange-Money number/steps.
- JSON validity + en/fr key parity confirmed locally.

## Note (separate, ops — not in this PR)
The new page shows "No payment method available" until an admin enables a provider in **Admin → Settings** (`payments-*-enabled` default false). That's per-environment config.

Fixes #2506

🤖 Generated with [Claude Code](https://claude.com/claude-code)