### PR TITLE
Promote dev → main: respect syllabus target hours (#2504)

### DIFF
--- a/backend/app/ai/prompts/syllabus_agent.py
+++ b/backend/app/ai/prompts/syllabus_agent.py
@@ -108,7 +108,9 @@ Chaque module doit contenir EXACTEMENT ces champs :
    - flashcard_count : nombre de flashcards recommandées (15-30)
    - case_study_scenario : scénario d'étude de cas ancré en AOF
 7. **source_references** : Références aux 3 livres de référence (Donaldson, Gordis, Triola)
-8. **estimated_hours** : Durée estimée (entre 15h et 25h par module)
+8. **estimated_hours** : Durée estimée par module — proportionnée à la durée
+   totale visée du cours, de sorte que la somme des modules ≈ la durée cible
+   (ne pas imposer un plancher fixe par module)
 9. **bloom_level** : Niveau Bloom cible (remember/understand/apply/analyze/evaluate/create)
 
 ### Livres de référence disponibles

--- a/backend/app/domain/services/course_agent_service.py
+++ b/backend/app/domain/services/course_agent_service.py
@@ -8,6 +8,20 @@ import structlog
 from app.ai.model_registry import get_model_caps
 from app.ai.providers import resolve_provider
 
+
+def _module_count_hint(estimated_hours: int) -> tuple[int, int]:
+    """Suggest a module-count range so per-module hours stay realistic (~2-5h each).
+
+    A short course should get fewer/shorter modules rather than being padded to a
+    fixed per-module size — the old "10-25h per module" floor made a 10h course
+    structurally impossible to honour. See #2504.
+    """
+    target = max(1, int(estimated_hours or 0))
+    lo = min(max(round(target / 5), 2), 10)
+    hi = min(max(round(target / 2.5), lo + 1), 15)
+    return lo, hi
+
+
 # ── Tool-use schema for structured syllabus output ──────────────────
 # Claude is forced to call this tool, ensuring every unit has an
 # explicit "type" enum value.  Adults get lesson/quiz/case-study;
@@ -267,6 +281,8 @@ class CourseAgentService:
                 audience_guidance=audience_guidance,
             )
 
+        hint_lo, hint_hi = _module_count_hint(estimated_hours)
+
         return (
             "You are an expert instructional designer specializing in "
             "bilingual (FR/EN) adaptive e-learning. You design curricula "
@@ -279,9 +295,9 @@ class CourseAgentService:
             f"- Domain(s): {domains_str}\n"
             f"- Level(s): {levels_str}\n"
             f"- Target audience: {audience_str}\n"
-            f"- Target total hours (advisory; the displayed course duration is the "
-            f"sum of per-module estimated_hours, so module estimates must add up to "
-            f"approximately this target ±20%): {estimated_hours}\n\n"
+            f"- Target total hours: {estimated_hours}h. CRITICAL: the displayed "
+            f"course duration is the SUM of every module's estimated_hours, so they "
+            f"MUST add up to ~{estimated_hours}h (not more).\n\n"
             f"{objectives_block}\n"
             f"{resource_block}\n\n"
             "## Design principles (mandatory)\n"
@@ -289,8 +305,10 @@ class CourseAgentService:
             "(remember/understand), build to applied skills "
             "(apply/analyze), end with expert synthesis "
             "(evaluate/create)\n"
-            "- Each module must be self-contained (10-25h) with clear "
-            "learning objectives\n"
+            f"- Size the course to the target: about {hint_lo}-{hint_hi} modules, "
+            f"each roughly 2-5h, so the module estimated_hours sum to "
+            f"~{estimated_hours}h. Do NOT pad modules to a fixed size — a short "
+            "course gets fewer/shorter modules\n"
             "- Units are micro-learning (10-15 min each), 3-6 lessons "
             "per module\n"
             "- Every module includes: lessons, a formative quiz per "
@@ -350,6 +368,7 @@ class CourseAgentService:
         audience_guidance: str,
     ) -> str:
         """Build kids-adapted syllabus prompt with child-centered pedagogy."""
+        hint_lo, hint_hi = _module_count_hint(estimated_hours)
         return (
             "You are a warm, encouraging instructional designer who creates "
             "bilingual (FR/EN) course syllabi for young learners aged "
@@ -363,17 +382,18 @@ class CourseAgentService:
             f"- Domain(s): {domains_str}\n"
             f"- Level(s): {levels_str}\n"
             f"- Target audience: {audience_str} (ages {age_range})\n"
-            f"- Target total hours (advisory; the displayed course duration is the "
-            f"sum of per-module estimated_hours, so module estimates must add up to "
-            f"approximately this target ±20%): {estimated_hours}\n\n"
+            f"- Target total hours: {estimated_hours}h. CRITICAL: the displayed "
+            f"course duration is the SUM of every module's estimated_hours, so they "
+            f"MUST add up to ~{estimated_hours}h (not more).\n\n"
             f"{resource_block}\n\n"
             "## Design principles (mandatory)\n"
             "- Progressive complexity: start with discovery (remember/understand), "
             "build to exploration (apply), and for older children (ages 13+) "
             "reach basic analysis (analyze/evaluate)\n"
             "- Bloom level cap: primary school → apply; secondary school → evaluate\n"
-            "- Each module must be self-contained (5-15h) with child-friendly "
-            "learning objectives\n"
+            f"- Size the course to the target: about {hint_lo}-{hint_hi} modules so "
+            f"the module estimated_hours sum to ~{estimated_hours}h. Do NOT pad "
+            "modules to a fixed size — a short course gets fewer/shorter modules\n"
             "- Units are short learning sessions (5-10 min for ages 5-8, "
             "10-15 min for ages 9-15), 3-6 units per module\n"
             "- Every module includes: lessons, a formative quiz per lesson "

--- a/backend/app/tasks/syllabus_generation.py
+++ b/backend/app/tasks/syllabus_generation.py
@@ -13,6 +13,57 @@ from app.tasks.celery_app import celery_app
 logger = structlog.get_logger(__name__)
 
 
+def _normalize_module_hours(module_dicts: list[dict], target_hours: int) -> None:
+    """Rescale each module's ``estimated_hours`` in place so they sum to ``target_hours``.
+
+    The displayed course duration is ``SUM(module.estimated_hours)`` (see
+    ``_compute_course_hours`` in ``app/api/v1/courses.py``), and ``target_hours`` is the
+    admin-set AI target. The LLM routinely ignores the target (every prompt path carries a
+    per-module floor that fights it), so a 10h course can render as 23h. This deterministic
+    pass is the guarantee that holds regardless of which prompt produced the modules.
+
+    Modules keep their relative weights (a module the LLM judged twice as long stays twice as
+    long). When the LLM omits hours everywhere, we fall back to an even split. No-ops when
+    ``target_hours`` <= 0 or there are no modules.
+    """
+    if not module_dicts or target_hours <= 0:
+        return
+
+    raw = [max(0, int(m.get("estimated_hours") or 0)) for m in module_dicts]
+    actual = sum(raw)
+    n = len(module_dicts)
+
+    if actual <= 0:
+        # No usable per-module signal — divide the target evenly.
+        base = max(1, target_hours // n)
+        scaled = [base] * n
+    else:
+        scale = target_hours / actual
+        scaled = [max(1, round(h * scale)) for h in raw]
+
+    # Fix integer-rounding drift so the displayed total matches the target exactly.
+    # Distribute the remainder onto the largest modules first; never trim below 1h
+    # (so a target smaller than the module count settles at one hour each).
+    order = sorted(range(n), key=lambda i: scaled[i], reverse=True)
+    drift = target_hours - sum(scaled)
+    while drift > 0:
+        for i in order:
+            scaled[i] += 1
+            drift -= 1
+            if drift == 0:
+                break
+    while drift < 0 and any(scaled[i] > 1 for i in range(n)):
+        for i in order:  # largest first
+            if scaled[i] > 1:
+                scaled[i] -= 1
+                drift += 1
+                if drift == 0:
+                    break
+
+    for m, h in zip(module_dicts, scaled, strict=False):
+        m["estimated_hours"] = h
+
+
 class SyllabusTask(Task):
     """Base task for syllabus generation with progress tracking."""
 
@@ -469,6 +520,11 @@ def generate_course_syllabus(
             " response was unparseable. Refusing to save. Check logs for root cause."
         )
 
+    # Reconcile the LLM's per-module hours with the admin's target so the displayed
+    # course duration (SUM of module hours) actually matches it. The prompt is only a
+    # soft nudge; this is the guarantee. See #2504.
+    _normalize_module_hours(module_dicts, estimated_hours or course_hours or 0)
+
     self.update_state(
         state="SAVING",
         meta={
@@ -515,16 +571,9 @@ def generate_course_syllabus(
             )
             session.execute(delete(Module).where(Module.course_id == uuid.UUID(course_id)))
 
-            # If Claude omits per-module hours, divide the target across modules
-            # rather than slapping a flat 20h per module (which inflated the
-            # displayed course total — see #2223).
-            target_total_hours = estimated_hours or course_hours or 0
-            fallback_per_module = (
-                max(1, target_total_hours // len(module_dicts))
-                if module_dicts and target_total_hours > 0
-                else 1
-            )
-
+            # Per-module hours were already reconciled with the target by
+            # _normalize_module_hours above (see #2504 / #2223), so each module now
+            # carries a positive estimated_hours that sums to the target.
             saved_modules = []
             for i, m in enumerate(module_dicts):
                 module_id = uuid.uuid4()
@@ -536,7 +585,7 @@ def generate_course_syllabus(
                     title_en=m["title_en"],
                     description_fr=m.get("description_fr"),
                     description_en=m.get("description_en"),
-                    estimated_hours=m.get("estimated_hours") or fallback_per_module,
+                    estimated_hours=m.get("estimated_hours") or 1,
                     bloom_level=m.get("bloom_level"),
                     course_id=uuid.UUID(course_id),
                     books_sources=books_sources,

--- a/backend/tests/test_syllabus_generation_task.py
+++ b/backend/tests/test_syllabus_generation_task.py
@@ -34,6 +34,85 @@ def sample_module_dicts():
     ]
 
 
+class TestNormalizeModuleHours:
+    """Unit tests for _normalize_module_hours — the deterministic reconciliation of
+    per-module hours with the admin's target so the displayed course duration
+    (SUM of module hours) matches it. See #2504.
+    """
+
+    @staticmethod
+    def _hours(mods):
+        return [m["estimated_hours"] for m in mods]
+
+    def test_overshoot_rescaled_down_to_target(self):
+        """8 modules summing to 23h are rescaled so they total exactly the 10h target."""
+        from app.tasks.syllabus_generation import _normalize_module_hours
+
+        mods = [{"estimated_hours": 3} for _ in range(7)] + [{"estimated_hours": 2}]
+        assert sum(self._hours(mods)) == 23
+
+        _normalize_module_hours(mods, 10)
+
+        assert sum(self._hours(mods)) == 10
+        assert all(h >= 1 for h in self._hours(mods))
+
+    def test_relative_weights_preserved(self):
+        """A module the LLM judged longer stays longer after rescaling."""
+        from app.tasks.syllabus_generation import _normalize_module_hours
+
+        mods = [{"estimated_hours": 30}, {"estimated_hours": 10}, {"estimated_hours": 10}]
+        _normalize_module_hours(mods, 20)
+
+        h = self._hours(mods)
+        assert sum(h) == 20
+        assert h[0] > h[1] and h[0] > h[2]
+
+    def test_missing_hours_even_split(self):
+        """When the LLM omits hours everywhere, the target is divided evenly."""
+        from app.tasks.syllabus_generation import _normalize_module_hours
+
+        mods = [{}, {}, {}, {}]
+        _normalize_module_hours(mods, 20)
+
+        assert self._hours(mods) == [5, 5, 5, 5]
+
+    def test_already_on_target_is_idempotent(self):
+        """Modules already summing to the target come out unchanged."""
+        from app.tasks.syllabus_generation import _normalize_module_hours
+
+        mods = [{"estimated_hours": 4}, {"estimated_hours": 3}, {"estimated_hours": 3}]
+        _normalize_module_hours(mods, 10)
+
+        assert sum(self._hours(mods)) == 10
+
+    def test_single_module_gets_full_target(self):
+        from app.tasks.syllabus_generation import _normalize_module_hours
+
+        mods = [{"estimated_hours": 25}]
+        _normalize_module_hours(mods, 8)
+
+        assert self._hours(mods) == [8]
+
+    def test_target_smaller_than_module_count_floors_at_one(self):
+        """A 3h target across 5 modules can't go below 1h each → settles at 5h total."""
+        from app.tasks.syllabus_generation import _normalize_module_hours
+
+        mods = [{"estimated_hours": 4} for _ in range(5)]
+        _normalize_module_hours(mods, 3)
+
+        h = self._hours(mods)
+        assert all(v == 1 for v in h)
+        assert sum(h) == 5  # cannot go below 1 per module
+
+    def test_no_target_is_noop(self):
+        from app.tasks.syllabus_generation import _normalize_module_hours
+
+        mods = [{"estimated_hours": 7}, {"estimated_hours": 9}]
+        _normalize_module_hours(mods, 0)
+
+        assert self._hours(mods) == [7, 9]
+
+
 class TestSyllabusGenerationTaskUnit:
     """Unit tests for generate_course_syllabus.
 


### PR DESCRIPTION
Promotes the #2504 fix from dev to main (staging deploy).

Fixes #2504. Cherry-pick of the squashed feature commit onto a fresh sync branch off `main` (avoids the phantom-conflict on prior squash SHAs).

Syllabus generation now respects the admin's target hours: a deterministic `_normalize_module_hours` pass rescales per-module hours to sum to the target, and the prompts lead with the target as a CRITICAL constraint with target-derived module-count guidance. 15 backend tests pass; reviewed clean.

See PR #2505 (feature → dev) for the full discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)