### PR TITLE
fix(wizard): use admin-set estimated hours in AI syllabus generation (#2509)

### DIFF
--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -486,7 +486,10 @@ export function AICourseWizard({
 
     const hydrate = async () => {
       try {
-        await getAdminCourse(resumeCourseId);
+        const course = await getAdminCourse(resumeCourseId);
+        // Restore the admin-set duration so a resumed draft generates against
+        // the intended target rather than the default (#2509).
+        if (course?.estimated_hours) setEstimatedHours(course.estimated_hours);
 
         if (resumeCreationStep === "generating") {
           // Task might still be running — go to generate step, polling will pick it up
@@ -674,13 +677,13 @@ export function AICourseWizard({
     setShouldForceGenerate(false);
 
     try {
-      const result = await triggerSyllabusGeneration(courseId, 20, useForce);
+      const result = await triggerSyllabusGeneration(courseId, estimatedHours, useForce);
       setGenerateTaskId(result.task_id);
     } catch {
       setGenerateError(t("generate.error"));
       setIsGenerating(false);
     }
-  }, [courseId, isGenerating, shouldForceGenerate, t]);
+  }, [courseId, isGenerating, shouldForceGenerate, estimatedHours, t]);
 
   const regenerateSyllabus = useCallback(async (mode: "reuse" | "fresh") => {
     if (!courseId || isGenerating || isRegenerating) return;


### PR DESCRIPTION
Fixes #2509.

## Problem
The AI course-creation wizard ignored the admin-set **Heures estimées** and always generated the syllabus against a hardcoded `20`. Verified on staging: a 5h target produced a 20h course (6 modules summing to 20h). The value *was* collected and saved to the course, but the generate call discarded it.

## Fix (`frontend/components/admin/ai-course-wizard.tsx`)
- `generateSyllabus` now passes `estimatedHours` instead of the literal `20` to `triggerSyllabusGeneration` (and adds it to the `useCallback` deps).
- The resume `hydrate()` effect now restores `estimatedHours` from the fetched course (`getAdminCourse`), so a reopened draft generates against its intended target instead of the default.

The other two generate entry points were already correct and are untouched (`course-wizard-client.tsx`, `courses-client.tsx`).

## Relation to #2504
The backend syllabus normalization shipped in #2504 was already working — it produced right-sized modules summing exactly to the target it received. It just received the wrong target because of this frontend hardcode. With this change, a 5h course generates ~5h of modules.

## Verification
- `tsc --noEmit` clean; `eslint` on the file reports only pre-existing unused-var warnings (none from this change).
- Logic: the generate request body now carries the user-entered hours; resumed drafts rehydrate the duration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)