### PR TITLE
Promote dev → main: AI wizard uses admin-set hours (#2509)

### DIFF
--- a/frontend/components/admin/ai-course-wizard.tsx
+++ b/frontend/components/admin/ai-course-wizard.tsx
@@ -486,7 +486,10 @@ export function AICourseWizard({
 
     const hydrate = async () => {
       try {
-        await getAdminCourse(resumeCourseId);
+        const course = await getAdminCourse(resumeCourseId);
+        // Restore the admin-set duration so a resumed draft generates against
+        // the intended target rather than the default (#2509).
+        if (course?.estimated_hours) setEstimatedHours(course.estimated_hours);
 
         if (resumeCreationStep === "generating") {
           // Task might still be running — go to generate step, polling will pick it up
@@ -674,13 +677,13 @@ export function AICourseWizard({
     setShouldForceGenerate(false);
 
     try {
-      const result = await triggerSyllabusGeneration(courseId, 20, useForce);
+      const result = await triggerSyllabusGeneration(courseId, estimatedHours, useForce);
       setGenerateTaskId(result.task_id);
     } catch {
       setGenerateError(t("generate.error"));
       setIsGenerating(false);
     }
-  }, [courseId, isGenerating, shouldForceGenerate, t]);
+  }, [courseId, isGenerating, shouldForceGenerate, estimatedHours, t]);
 
   const regenerateSyllabus = useCallback(async (mode: "reuse" | "fresh") => {
     if (!courseId || isGenerating || isRegenerating) return;


### PR DESCRIPTION
Promotes the #2509 fix from dev to main (staging deploy). Fixes #2509.

Cherry-pick of the squashed feature commit onto a fresh sync branch off `main` (avoids the phantom-conflict on prior squash SHAs).

The AI course wizard now passes the admin-set "Heures estimées" to syllabus generation (and rehydrates it on resume) instead of a hardcoded 20. See PR #2510 (feature → dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)