### PR TITLE
fix(images): text-free lesson illustrations + DOM overlay (#2512)

### DIFF
--- a/backend/app/api/v1/images.py
+++ b/backend/app/api/v1/images.py
@@ -66,6 +66,28 @@ def _get_alt_text(image: GeneratedImage, lang: str) -> str:
     return _ALT_TEXT[lang_key]
 
 
+def _get_overlay_title(image: GeneratedImage, lang: str) -> str | None:
+    """Return the overlay title in the requested language, falling back to the other."""
+    if lang == "en":
+        return image.title_en or image.title_fr
+    return image.title_fr or image.title_en
+
+
+def _get_overlay_labels(image: GeneratedImage, lang: str) -> list[str]:
+    """Flatten the bilingual overlay_labels into localized strings for the legend."""
+    if not image.overlay_labels:
+        return []
+    other = "fr" if lang == "en" else "en"
+    labels: list[str] = []
+    for item in image.overlay_labels:
+        if not isinstance(item, dict):
+            continue
+        text = (item.get(lang) or item.get(other) or "").strip()
+        if text:
+            labels.append(text)
+    return labels
+
+
 def _resolve_image_url(img: GeneratedImage) -> str | None:
     """Return a public URL for a ready image.
 
@@ -123,6 +145,8 @@ async def get_lesson_images(
                 status=img_status,
                 image_url=_resolve_image_url(img),
                 alt_text=_get_alt_text(img, lang),
+                title=_get_overlay_title(img, lang),
+                labels=_get_overlay_labels(img, lang),
                 format=img.format,
                 width=img.width,
             )

--- a/backend/app/api/v1/schemas/images.py
+++ b/backend/app/api/v1/schemas/images.py
@@ -19,6 +19,14 @@ class LessonImageResponse(BaseModel):
         description="Public image URL — present only when status='ready', null otherwise",
     )
     alt_text: str = Field(..., description="Localized alt text for accessibility")
+    title: str | None = Field(
+        None,
+        description="Localized overlay title rendered as DOM text above the image",
+    )
+    labels: list[str] = Field(
+        default_factory=list,
+        description="Localized component labels rendered as a legend below the image",
+    )
     format: str = Field(default="webp", description="Image format (webp, png, jpeg)")
     width: int = Field(default=800, description="Image width in pixels")
 
@@ -30,6 +38,8 @@ class LessonImageResponse(BaseModel):
                 "status": "ready",
                 "image_url": "https://cdn.example.com/images/550e8400.webp",
                 "alt_text": "Diagramme illustrant la surveillance épidémiologique",
+                "title": "Surveillance épidémiologique",
+                "labels": ["Collecte", "Analyse", "Riposte"],
                 "format": "webp",
                 "width": 800,
             }

--- a/backend/app/domain/models/generated_image.py
+++ b/backend/app/domain/models/generated_image.py
@@ -42,6 +42,11 @@ class GeneratedImage(Base):
     width: Mapped[int] = mapped_column(Integer, server_default="512")
     alt_text_fr: Mapped[str | None] = mapped_column(Text, nullable=True)
     alt_text_en: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Overlay text rendered as real DOM text on top of the text-free illustration.
+    title_fr: Mapped[str | None] = mapped_column(Text, nullable=True)
+    title_en: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # List of {"fr": ..., "en": ...} component labels for the legend.
+    overlay_labels: Mapped[list | None] = mapped_column(JSONB, nullable=True)
     semantic_tags: Mapped[list | None] = mapped_column(JSONB, nullable=True)
     reuse_count: Mapped[int] = mapped_column(Integer, server_default="0")
     status: Mapped[str] = mapped_column(

--- a/backend/app/domain/services/image_service.py
+++ b/backend/app/domain/services/image_service.py
@@ -19,7 +19,10 @@ from app.infrastructure.config.settings import settings
 logger = structlog.get_logger(__name__)
 
 SEMANTIC_REUSE_THRESHOLD = 0.85
-STYLE_TAG_INFOGRAPHIC = "style:infographic"
+# Text-free illustrations are a distinct style from the legacy baked-in-text
+# "infographic" images, so they carry their own style discriminator. This keeps
+# the reuse cache from serving an old garbled-text image for a new lesson.
+STYLE_TAG = "style:illustration"
 
 
 def _jaccard_similarity(tags_a: list[str], tags_b: list[str]) -> float:
@@ -79,12 +82,22 @@ class ImageGenerationService:
 
         try:
             lesson_row, language, audience = await self._load_lesson_context(lesson_id, session)
-            concept, prompt, tags = await self._extract_concept_and_tags(
-                lesson_content, language, audience
-            )
+            (
+                concept,
+                prompt,
+                tags,
+                title_fr,
+                title_en,
+                labels,
+            ) = await self._extract_concept_and_tags(lesson_content, language, audience)
             image_record.concept = concept
             image_record.prompt = prompt
             image_record.semantic_tags = tags
+            # Title/labels are this lesson's overlay text; they stay on this record
+            # even when the underlying illustration is reused from another lesson.
+            image_record.title_fr = title_fr
+            image_record.title_en = title_en
+            image_record.overlay_labels = labels
 
             reusable = await self._find_reusable_image(tags, session)
             if reusable is not None:
@@ -135,7 +148,8 @@ class ImageGenerationService:
             await session.flush()
 
             image_bytes, image_url = await self._call_dalle(prompt)
-            webp_bytes, width = _resize_to_webp(image_bytes, max_width=1024)
+            # Keep gpt-image-1's native width (1536) — downscaling blurs fine detail.
+            webp_bytes, width = _resize_to_webp(image_bytes, max_width=1536)
 
             alt_fr, alt_en = await self._generate_alt_text(concept)
 
@@ -201,8 +215,13 @@ class ImageGenerationService:
 
     async def _extract_concept_and_tags(
         self, lesson_content: str, language: str, audience: AudienceContext
-    ) -> tuple[str, str, list[str]]:
-        """Use Claude API to extract key concept, DALL-E prompt, and semantic tags."""
+    ) -> tuple[str, str, list[str], str, str, list[dict[str, str]]]:
+        """Use Claude to extract the concept, a text-free image prompt, semantic tags,
+        a bilingual title, and bilingual component labels for the DOM overlay.
+
+        Returns ``(concept, prompt, tags, title_fr, title_en, labels)`` where ``labels``
+        is a list of ``{"fr": ..., "en": ...}`` dicts.
+        """
         import anthropic
 
         from app.domain.services.platform_settings_service import SettingsCache
@@ -210,63 +229,65 @@ class ImageGenerationService:
         client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key, timeout=600.0)
         model = SettingsCache.instance().get("ai-model-image-metadata", "claude-haiku-4-5")
 
-        language_name = "French" if language == "fr" else "English"
-
         if audience.is_kids:
             style_block = (
                 "STYLE for a children's audience: bright friendly cartoon-style flat "
-                "illustration, primary colors, rounded shapes, big readable text, simple "
-                "icons, optional friendly mascot character. Keep visual complexity low; "
-                "callout labels MUST be 1 to 3 words. Show diverse children where people "
-                "appear."
+                "illustration, primary colors, rounded shapes, simple icons, optional "
+                "friendly mascot character. Keep visual complexity low. Show diverse "
+                "children where people appear."
             )
         else:
             style_block = (
                 "STYLE: flat editorial illustration, hand-drawn educational poster feel, "
-                "muted palette with one or two accent colors, lots of whitespace, sans-serif labels."
+                "muted palette with one or two accent colors, lots of whitespace."
             )
 
         system = (
-            "You design explanatory infographics for an adaptive multi-subject learning platform. "
-            "Given lesson content, extract:\n"
+            "You design clean conceptual illustrations for an adaptive multi-subject learning "
+            "platform. The app renders the title and labels as real text OUTSIDE the image, so "
+            "the image itself MUST be completely text-free. Given lesson content, extract:\n"
             "1) A short key concept (5 words max, in English).\n"
-            "2) A detailed image-generation prompt for an editorial-poster-style INFOGRAPHIC "
-            "that explains the concept at a glance. The prompt MUST request:\n"
-            "   - A clear short title across the top.\n"
-            "   - 3 to 6 named components, objects, or steps drawn as a labeled diagram, "
-            "each with a short callout label.\n"
-            "   - Connector arrows or lines that show how the components relate "
-            "(flow, hierarchy, before/after, cause/effect).\n"
-            "   - Optional split panels when the concept has natural contrasts.\n"
-            "   - An optional small legend or maturity/timeline strip at the bottom only if it fits.\n"
+            "2) A detailed image-generation prompt for a single clear conceptual illustration "
+            "that depicts the concept at a glance. The prompt MUST:\n"
+            "   - Show 3 to 5 components, objects, or steps arranged so their relationship is "
+            "visually obvious (flow, hierarchy, before/after, cause/effect) through arrows, "
+            "positioning, or grouping — but with NO written labels on them.\n"
+            "   - Contain ABSOLUTELY NO text: no title, no caption, no labels, no letters, no "
+            "words, no numbers, no writing, no signage, no UI text of any kind. Convey meaning "
+            "through imagery alone.\n"
             f"   - {style_block}\n"
             "   - Human figures (learners, professionals, customers, kids, etc.) ARE allowed and "
             "even encouraged when they help convey the concept; depict diverse people and avoid "
             "stereotypes. They are not required if the concept is purely structural.\n"
             "   - Stay subject-agnostic: derive the visual setting from the lesson content itself "
             "(do not assume any specific country, region, profession, or industry unless the lesson states it).\n"
-            f"   - LANGUAGE: write the in-image title and ALL callout labels in {language_name} "
-            "(natural, idiomatic). The CONCEPT and TAGS fields below MUST stay in English so the "
-            "cache key is language-agnostic.\n"
             "   - 250-450 characters.\n"
-            '   - GOOD example (en): \'Educational poster titled "Photosynthesis". Cross-section of '
-            "a leaf with labeled callouts in English: chloroplast, stomata, xylem, phloem. Arrows "
-            "show CO2 in, O2 out, water up, sugar down. Flat illustration, muted greens, hand-drawn feel.'\n"
-            "   - GOOD example (fr): 'Affiche éducative titrée « Photosynthèse ». Coupe d'une "
-            "feuille avec des étiquettes en français : chloroplaste, stomate, xylème, phloème. "
-            "Flèches montrant CO2 entrant, O2 sortant, eau qui monte, sucre qui descend.'\n"
-            "   - BAD example: 'A green leaf in nature, vibrant colors' (no labels, no structure).\n"
-            "3) A JSON array of 5-8 lowercase English semantic tags describing the lesson concept. "
-            f'Always include the literal tag "{STYLE_TAG_INFOGRAPHIC}" as one of the tags.\n'
+            "   - GOOD example: 'Clean conceptual illustration: cross-section of a leaf showing a "
+            "chloroplast, stomata and veins; arrows for CO2 entering, O2 leaving, water rising and "
+            "sugar descending; flat illustration, muted greens, hand-drawn feel, absolutely no text "
+            "or labels.'\n"
+            "   - BAD example: 'A poster titled \"Photosynthesis\" with labeled callouts' "
+            "(contains text).\n"
+            "3) A short title for the illustration in BOTH French and English (natural, idiomatic, "
+            "6 words max each).\n"
+            "4) 3 to 4 key component labels — the things a learner should notice in the image — "
+            "each in BOTH French and English (1 to 4 words each), as a JSON array of "
+            '{"fr": "...", "en": "..."} objects.\n'
+            "5) A JSON array of 5-8 lowercase English semantic tags describing the lesson concept. "
+            f'Always include the literal tag "{STYLE_TAG}" as one of the tags. The CONCEPT, LABELS '
+            "en-field and TAGS must stay in English so the cache key is language-agnostic.\n"
             "Reply ONLY in this exact format:\n"
             "CONCEPT: <concept>\n"
             "PROMPT: <image_prompt>\n"
+            "TITLE_FR: <french title>\n"
+            "TITLE_EN: <english title>\n"
+            "LABELS: <json_array>\n"
             "TAGS: <json_array>"
         )
 
         message = await client.messages.create(
             model=model,
-            max_tokens=400,
+            max_tokens=700,
             messages=[
                 {
                     "role": "user",
@@ -277,20 +298,19 @@ class ImageGenerationService:
         )
 
         text = message.content[0].text if message.content else ""
-        concept, prompt, tags = _parse_concept_response(text)
+        concept, prompt, tags, title_fr, title_en, labels = _parse_concept_response(text)
 
         # Inject server-side discriminator tags so the cache key always matches the
-        # actual generated style/language/audience, regardless of what Claude returned.
+        # actual generated style/audience, regardless of what Claude returned. Note
+        # there is deliberately NO lang: tag — text-free illustrations are language
+        # agnostic, so one image is reused across FR and EN lessons.
         tag_set = {t.lower() for t in tags}
-        if STYLE_TAG_INFOGRAPHIC not in tag_set:
-            tags.append(STYLE_TAG_INFOGRAPHIC)
-        lang_tag = f"lang:{language}"
-        if lang_tag not in tag_set:
-            tags.append(lang_tag)
+        if STYLE_TAG not in tag_set:
+            tags.append(STYLE_TAG)
         if audience.is_kids and "audience:kids" not in tag_set:
             tags.append("audience:kids")
 
-        return concept, prompt, tags
+        return concept, prompt, tags, title_fr, title_en, labels
 
     async def _find_source_image(
         self, lesson: object | None, session: AsyncSession
@@ -327,15 +347,14 @@ class ImageGenerationService:
         """Search generated_images for an existing ready image with ≥85% tag overlap.
 
         A candidate must share **every** discriminator-prefixed tag from the new
-        generation — currently ``style:``, ``lang:``, and ``audience:``. This
-        prevents cross-language reuse (an EN infographic for an FR lesson) and
-        cross-audience reuse (an adult infographic for a kids lesson). Old rows
-        that pre-date a discriminator simply lack it and are skipped.
+        generation — currently ``style:`` and ``audience:``. This keeps the new
+        text-free ``style:illustration`` images separate from the legacy baked-in
+        text images, and prevents cross-audience reuse (an adult illustration for a
+        kids lesson). There is deliberately no ``lang:`` discriminator: text-free
+        illustrations are language agnostic and are reused across FR and EN.
         """
         new_discriminators = {
-            t.lower()
-            for t in tags
-            if any(t.lower().startswith(p) for p in ("style:", "lang:", "audience:"))
+            t.lower() for t in tags if any(t.lower().startswith(p) for p in ("style:", "audience:"))
         }
         if not new_discriminators:
             return None
@@ -351,7 +370,7 @@ class ImageGenerationService:
             candidate_discriminators = {
                 t.lower()
                 for t in candidate.semantic_tags
-                if any(t.lower().startswith(p) for p in ("style:", "lang:", "audience:"))
+                if any(t.lower().startswith(p) for p in ("style:", "audience:"))
             }
             if not new_discriminators.issubset(candidate_discriminators):
                 continue
@@ -411,14 +430,23 @@ class ImageGenerationService:
         return _parse_alt_text(text, concept)
 
 
-def _parse_concept_response(text: str) -> tuple[str, str, list[str]]:
-    """Parse Claude's structured response into (concept, prompt, tags)."""
+def _parse_concept_response(
+    text: str,
+) -> tuple[str, str, list[str], str, str, list[dict[str, str]]]:
+    """Parse Claude's structured response.
+
+    Returns ``(concept, prompt, tags, title_fr, title_en, labels)`` where ``labels``
+    is a list of ``{"fr": ..., "en": ...}`` dicts.
+    """
     import json
     import re
 
     concept = ""
     prompt = ""
     tags: list[str] = []
+    title_fr = ""
+    title_en = ""
+    labels: list[dict[str, str]] = []
 
     for line in text.splitlines():
         line = line.strip()
@@ -426,6 +454,13 @@ def _parse_concept_response(text: str) -> tuple[str, str, list[str]]:
             concept = line[len("CONCEPT:") :].strip()
         elif line.startswith("PROMPT:"):
             prompt = line[len("PROMPT:") :].strip()
+        elif line.startswith("TITLE_FR:"):
+            title_fr = line[len("TITLE_FR:") :].strip()
+        elif line.startswith("TITLE_EN:"):
+            title_en = line[len("TITLE_EN:") :].strip()
+        elif line.startswith("LABELS:"):
+            raw = line[len("LABELS:") :].strip()
+            labels = _parse_labels(raw)
         elif line.startswith("TAGS:"):
             raw = line[len("TAGS:") :].strip()
             try:
@@ -439,16 +474,50 @@ def _parse_concept_response(text: str) -> tuple[str, str, list[str]]:
         concept = "lesson concept"
     if not prompt:
         prompt = (
-            f'Editorial-poster-style infographic titled "{concept}" with 3-5 labeled '
-            "components, callouts, and connector arrows. Flat illustration, hand-drawn feel, "
-            "muted palette, sans-serif labels."
+            f"Clean conceptual illustration of {concept}: 3-5 related components arranged to "
+            "show their relationship through arrows, positioning and grouping. Flat "
+            "illustration, hand-drawn feel, muted palette, absolutely no text or labels."
         )
     if not tags:
         tags = [concept.lower()]
-    if "style:infographic" not in {t.lower() for t in tags}:
-        tags.append("style:infographic")
+    if STYLE_TAG not in {t.lower() for t in tags}:
+        tags.append(STYLE_TAG)
+    # Title falls back to the concept; the overlay always needs something to show.
+    if not title_en:
+        title_en = concept
+    if not title_fr:
+        title_fr = title_en
 
-    return concept, prompt, tags
+    return concept, prompt, tags, title_fr, title_en, labels
+
+
+def _parse_labels(raw: str) -> list[dict[str, str]]:
+    """Parse the LABELS JSON array into a list of ``{"fr", "en"}`` dicts.
+
+    Tolerates Claude returning plain strings instead of objects (uses the string
+    for both languages) and silently drops malformed entries.
+    """
+    import json
+
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return []
+    if not isinstance(parsed, list):
+        return []
+
+    labels: list[dict[str, str]] = []
+    for item in parsed:
+        if isinstance(item, dict):
+            fr = str(item.get("fr") or item.get("en") or "").strip()
+            en = str(item.get("en") or item.get("fr") or "").strip()
+        elif isinstance(item, str):
+            fr = en = item.strip()
+        else:
+            continue
+        if fr or en:
+            labels.append({"fr": fr, "en": en})
+    return labels
 
 
 def _parse_alt_text(text: str, concept: str) -> tuple[str, str]:
@@ -466,8 +535,14 @@ def _parse_alt_text(text: str, concept: str) -> tuple[str, str]:
     return alt_fr, alt_en
 
 
-def _resize_to_webp(image_bytes: bytes, max_width: int = 512) -> tuple[bytes, int]:
-    """Convert image bytes to WebP format, skipping resize if already at target width."""
+def _resize_to_webp(
+    image_bytes: bytes, max_width: int = 1536, quality: int = 92
+) -> tuple[bytes, int]:
+    """Convert image bytes to WebP, downscaling only if wider than ``max_width``.
+
+    Quality defaults to 92: text-free illustrations have soft gradients that compress
+    well, and the higher quality keeps edges crisp without a large size penalty.
+    """
     try:
         from PIL import Image
 
@@ -477,7 +552,7 @@ def _resize_to_webp(image_bytes: bytes, max_width: int = 512) -> tuple[bytes, in
             new_height = int(img.height * ratio)
             img = img.resize((max_width, new_height), Image.LANCZOS)
         buf = io.BytesIO()
-        img.save(buf, format="WEBP", quality=85)
+        img.save(buf, format="WEBP", quality=quality)
         return buf.getvalue(), img.width
     except (ImportError, Exception):
         return image_bytes, max_width

--- a/backend/app/tasks/content_generation.py
+++ b/backend/app/tasks/content_generation.py
@@ -1499,7 +1499,8 @@ def backfill_missing_image_data(self) -> dict:
                             "for West African public health"
                         )
                         image_bytes, _ = await service._call_dalle(prompt)
-                        webp_bytes, width = _resize_to_webp(image_bytes, max_width=512)
+                        # Keep native width — 512 was far too small and blurred detail.
+                        webp_bytes, width = _resize_to_webp(image_bytes)
 
                         img.image_data = webp_bytes
                         img.image_url = f"/api/v1/images/{img.id}/data"

--- a/backend/migrations/versions/101_add_image_overlay_text.py
+++ b/backend/migrations/versions/101_add_image_overlay_text.py
@@ -1,0 +1,33 @@
+"""Add overlay text columns to generated_images
+
+Text-free illustrations (#2512) render their title and component labels as real
+DOM text on top of the image instead of baking garbled text into the pixels.
+These columns carry that bilingual overlay text per image.
+
+Revision ID: 101_add_image_overlay_text
+Revises: 100_merge_099_heads
+Create Date: 2026-06-15
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "101_add_image_overlay_text"
+down_revision: str | None = "100_merge_099_heads"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("generated_images", sa.Column("title_fr", sa.Text(), nullable=True))
+    op.add_column("generated_images", sa.Column("title_en", sa.Text(), nullable=True))
+    op.add_column("generated_images", sa.Column("overlay_labels", JSONB(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("generated_images", "overlay_labels")
+    op.drop_column("generated_images", "title_en")
+    op.drop_column("generated_images", "title_fr")

--- a/backend/tests/test_image_generation.py
+++ b/backend/tests/test_image_generation.py
@@ -13,6 +13,7 @@ from app.domain.services.image_service import (
     _jaccard_similarity,
     _parse_alt_text,
     _parse_concept_response,
+    _parse_labels,
     _resize_to_webp,
 )
 
@@ -43,22 +44,66 @@ class TestJaccardSimilarity:
 
 class TestParseConceptResponse:
     def test_parses_valid_response(self):
-        text = 'CONCEPT: paludisme\nPROMPT: Malaria parasite cycle illustration\nTAGS: ["paludisme", "aof"]'
-        concept, prompt, tags = _parse_concept_response(text)
+        text = (
+            "CONCEPT: paludisme\n"
+            "PROMPT: Malaria parasite cycle illustration, no text\n"
+            "TITLE_FR: Cycle du paludisme\n"
+            "TITLE_EN: Malaria cycle\n"
+            'LABELS: [{"fr": "Moustique", "en": "Mosquito"}, {"fr": "Foie", "en": "Liver"}]\n'
+            'TAGS: ["paludisme", "aof"]'
+        )
+        concept, prompt, tags, title_fr, title_en, labels = _parse_concept_response(text)
         assert concept == "paludisme"
         assert "Malaria" in prompt
         assert "paludisme" in tags
+        assert title_fr == "Cycle du paludisme"
+        assert title_en == "Malaria cycle"
+        assert labels == [
+            {"fr": "Moustique", "en": "Mosquito"},
+            {"fr": "Foie", "en": "Liver"},
+        ]
 
     def test_defaults_when_empty(self):
-        concept, prompt, tags = _parse_concept_response("")
+        concept, prompt, tags, title_fr, title_en, labels = _parse_concept_response("")
         assert concept == "lesson concept"
         assert len(tags) > 0
-        assert "style:infographic" in tags
+        assert "style:illustration" in tags
+        # Title falls back to the concept so the overlay always has something.
+        assert title_en == "lesson concept"
+        assert title_fr == "lesson concept"
+        assert labels == []
 
     def test_tags_lowercased(self):
         text = 'CONCEPT: Malaria\nPROMPT: Illustration\nTAGS: ["MALARIA", "AOF"]'
-        _, _, tags = _parse_concept_response(text)
+        _, _, tags, _, _, _ = _parse_concept_response(text)
         assert all(t == t.lower() for t in tags)
+
+    def test_title_fr_falls_back_to_en(self):
+        text = "CONCEPT: water\nPROMPT: x\nTITLE_EN: Water cycle\nTAGS: []"
+        _, _, _, title_fr, title_en, _ = _parse_concept_response(text)
+        assert title_en == "Water cycle"
+        assert title_fr == "Water cycle"
+
+
+class TestParseLabels:
+    def test_parses_objects(self):
+        labels = _parse_labels('[{"fr": "Eau", "en": "Water"}]')
+        assert labels == [{"fr": "Eau", "en": "Water"}]
+
+    def test_string_items_used_for_both_languages(self):
+        labels = _parse_labels('["Water", "Sun"]')
+        assert labels == [
+            {"fr": "Water", "en": "Water"},
+            {"fr": "Sun", "en": "Sun"},
+        ]
+
+    def test_malformed_returns_empty(self):
+        assert _parse_labels("not json") == []
+        assert _parse_labels('{"fr": "x"}') == []
+
+    def test_missing_one_language_backfills_from_other(self):
+        labels = _parse_labels('[{"en": "Water"}]')
+        assert labels == [{"fr": "Water", "en": "Water"}]
 
 
 class TestParseAltText:
@@ -172,8 +217,11 @@ class TestImageGenerationService:
         content_block = MagicMock()
         content_block.text = (
             "CONCEPT: paludisme\n"
-            "PROMPT: Educational poster titled Paludisme with labeled life-cycle stages and arrows\n"
-            'TAGS: ["paludisme", "malaria", "aof", "épidémiologie", "style:infographic", "lang:en"]'
+            "PROMPT: Clean conceptual illustration of the malaria life cycle, no text or labels\n"
+            "TITLE_FR: Cycle du paludisme\n"
+            "TITLE_EN: Malaria life cycle\n"
+            'LABELS: [{"fr": "Moustique", "en": "Mosquito"}, {"fr": "Sang", "en": "Blood"}]\n'
+            'TAGS: ["paludisme", "malaria", "aof", "épidémiologie", "style:illustration"]'
         )
         msg.content = [content_block]
         return msg
@@ -191,7 +239,7 @@ class TestImageGenerationService:
     async def test_semantic_reuse_skips_dalle(self, service, mock_session, mock_claude_response):
         """When a matching image exists (≥85% Jaccard), DALL-E must NOT be called."""
         existing = _make_db_image(
-            ["paludisme", "malaria", "aof", "épidémiologie", "style:infographic", "lang:en"]
+            ["paludisme", "malaria", "aof", "épidémiologie", "style:illustration"]
         )
         existing.reuse_count = 0
 
@@ -264,14 +312,21 @@ class TestImageGenerationService:
             assert call_kwargs.get("model") == "gpt-image-1"
             assert call_kwargs.get("size") == "1536x1024"
             assert call_kwargs.get("quality") == "medium"
+            # The prompt passed to gpt-image-1 is the text-free prompt Claude returned.
             prompt_sent = call_kwargs.get("prompt", "")
-            assert "NO text" not in prompt_sent
-            assert "no text, letters, numbers" not in prompt_sent.lower()
+            assert "no text" in prompt_sent.lower()
 
         assert result.status == "ready"
         assert result.image_url == f"/api/v1/images/{result.id}/data"
         assert result.image_data is not None
         assert len(result.image_data) > 0
+        # Overlay text extracted by Claude must be persisted on the record.
+        assert result.title_fr == "Cycle du paludisme"
+        assert result.title_en == "Malaria life cycle"
+        assert result.overlay_labels == [
+            {"fr": "Moustique", "en": "Mosquito"},
+            {"fr": "Sang", "en": "Blood"},
+        ]
 
     async def test_failure_handling_sets_failed_status(self, service, mock_session):
         """When DALL-E raises an exception, status must be 'failed' and lesson unaffected."""
@@ -336,7 +391,7 @@ class TestImageGenerationService:
     async def test_reuse_increments_reuse_count(self, service, mock_session, mock_claude_response):
         """Reusing an existing image must increment its reuse_count."""
         existing = _make_db_image(
-            ["paludisme", "malaria", "aof", "épidémiologie", "style:infographic", "lang:en"]
+            ["paludisme", "malaria", "aof", "épidémiologie", "style:illustration"]
         )
         existing.reuse_count = 2
 
@@ -362,16 +417,21 @@ class TestImageGenerationService:
 
         assert existing.reuse_count == 3
 
-    def test_system_prompt_requests_infographic_style(self):
-        """System prompt for concept extraction must ask for an infographic with labels."""
+    def test_system_prompt_requests_text_free_illustration(self):
+        """System prompt must request a text-free illustration, not baked-in labels."""
         import inspect
 
         from app.domain.services import image_service
 
         source = inspect.getsource(image_service)
-        assert "INFOGRAPHIC" in source
-        assert "callout" in source.lower()
+        # Must demand a text-free image and provide structured overlay text instead.
+        assert "ABSOLUTELY NO text" in source
+        assert "TITLE_FR" in source and "TITLE_EN" in source
+        assert "LABELS" in source
         assert "subject-agnostic" in source.lower()
+        # Legacy baked-in-text infographic framing must be gone.
+        assert "labeled diagram" not in source.lower()
+        assert "callout label" not in source.lower()
         # West-Africa / public-health framing must be gone.
         assert "West African setting" not in source
         assert "public health education for West Africa" not in source
@@ -481,10 +541,14 @@ class TestImageGenerationService:
             assert "no people" not in system_prompt.lower()
             assert "no human" not in system_prompt.lower()
 
-    async def test_extract_concept_injects_lang_and_audience_tags(
+    async def test_extract_concept_injects_style_and_audience_tags(
         self, service, mock_claude_response
     ):
-        """Server-side discriminator tags (lang:, audience:) must be injected into the tag list."""
+        """style: and audience: discriminators are injected; lang: deliberately is NOT.
+
+        Text-free illustrations are language agnostic, so one image is reused across
+        FR and EN — no lang discriminator is added.
+        """
         from app.ai.prompts.audience import AudienceContext
 
         with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
@@ -492,65 +556,66 @@ class TestImageGenerationService:
             mock_anthropic_cls.return_value = mock_client
             mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
 
-            _, _, tags = await service._extract_concept_and_tags(
+            _, _, tags, _, _, _ = await service._extract_concept_and_tags(
                 "Counting lesson.",
                 language="fr",
                 audience=AudienceContext(is_kids=True, age_min=6, age_max=10),
             )
 
             tags_lower = {t.lower() for t in tags}
-            assert "lang:fr" in tags_lower
             assert "audience:kids" in tags_lower
-            assert "style:infographic" in tags_lower
+            assert "style:illustration" in tags_lower
+            assert not any(t.startswith("lang:") for t in tags_lower)
 
-    async def test_find_reusable_image_blocks_cross_language_reuse(self, service, mock_session):
-        """An EN-tagged existing image must NOT be reused for a new FR generation."""
-        en_existing = _make_db_image(
-            ["paludisme", "malaria", "aof", "épidémiologie", "style:infographic", "lang:en"]
-        )
-
-        reuse_result = MagicMock()
-        reuse_result.scalars.return_value.all.return_value = [en_existing]
-        mock_session.execute = AsyncMock(return_value=reuse_result)
-
-        new_tags = [
-            "paludisme",
-            "malaria",
-            "aof",
-            "épidémiologie",
-            "style:infographic",
-            "lang:fr",
-        ]
-        result = await service._find_reusable_image(new_tags, mock_session)
-        assert result is None
-
-    async def test_find_reusable_image_allows_same_language_reuse(self, service, mock_session):
-        """Same-language same-style same-audience candidate with ≥85% Jaccard reuses fine."""
+    async def test_find_reusable_image_reuses_across_languages(self, service, mock_session):
+        """A text-free illustration (no lang tag) is reused regardless of lesson language."""
         existing = _make_db_image(
-            [
-                "paludisme",
-                "malaria",
-                "aof",
-                "épidémiologie",
-                "style:infographic",
-                "lang:fr",
-            ]
+            ["paludisme", "malaria", "aof", "épidémiologie", "style:illustration"]
         )
 
         reuse_result = MagicMock()
         reuse_result.scalars.return_value.all.return_value = [existing]
         mock_session.execute = AsyncMock(return_value=reuse_result)
 
+        new_tags = ["paludisme", "malaria", "aof", "épidémiologie", "style:illustration"]
+        result = await service._find_reusable_image(new_tags, mock_session)
+        assert result is existing
+
+    async def test_find_reusable_image_blocks_cross_style_reuse(self, service, mock_session):
+        """A legacy baked-text infographic must NOT be reused for a new text-free illustration."""
+        legacy = _make_db_image(
+            ["paludisme", "malaria", "aof", "épidémiologie", "style:infographic"]
+        )
+
+        reuse_result = MagicMock()
+        reuse_result.scalars.return_value.all.return_value = [legacy]
+        mock_session.execute = AsyncMock(return_value=reuse_result)
+
+        new_tags = ["paludisme", "malaria", "aof", "épidémiologie", "style:illustration"]
+        result = await service._find_reusable_image(new_tags, mock_session)
+        assert result is None
+
+    async def test_find_reusable_image_blocks_cross_audience_reuse(self, service, mock_session):
+        """An adult illustration must NOT be reused for a kids lesson."""
+        adult = _make_db_image(
+            ["paludisme", "malaria", "aof", "épidémiologie", "style:illustration"]
+        )
+
+        reuse_result = MagicMock()
+        reuse_result.scalars.return_value.all.return_value = [adult]
+        mock_session.execute = AsyncMock(return_value=reuse_result)
+
+        # New (kids) generation carries the audience:kids discriminator the adult lacks.
         new_tags = [
             "paludisme",
             "malaria",
             "aof",
             "épidémiologie",
-            "style:infographic",
-            "lang:fr",
+            "style:illustration",
+            "audience:kids",
         ]
         result = await service._find_reusable_image(new_tags, mock_session)
-        assert result is existing
+        assert result is None
 
     def test_openai_api_key_not_in_frontend_accessible_code(self):
         """Verify OPENAI_API_KEY is loaded from settings (server-side), not hardcoded."""

--- a/backend/tests/test_images.py
+++ b/backend/tests/test_images.py
@@ -23,6 +23,9 @@ def _make_image(
     alt_text_fr=None,
     alt_text_en=None,
     image_data=None,
+    title_fr=None,
+    title_en=None,
+    overlay_labels=None,
 ):
     img = MagicMock()
     img.id = image_id
@@ -32,6 +35,9 @@ def _make_image(
     img.image_data = image_data
     img.alt_text_fr = alt_text_fr
     img.alt_text_en = alt_text_en
+    img.title_fr = title_fr
+    img.title_en = title_en
+    img.overlay_labels = overlay_labels
     img.format = "webp"
     img.width = 800
     return img
@@ -44,6 +50,12 @@ _READY_IMAGE = _make_image(
     image_url=f"/api/v1/images/{IMAGE_READY_ID}/data",
     alt_text_fr="Illustration de la leçon",
     alt_text_en="Lesson illustration",
+    title_fr="Cycle de l'eau",
+    title_en="Water cycle",
+    overlay_labels=[
+        {"fr": "Évaporation", "en": "Evaporation"},
+        {"fr": "Pluie", "en": "Rain"},
+    ],
 )
 _PENDING_IMAGE = _make_image(
     IMAGE_PENDING_ID,
@@ -291,6 +303,50 @@ class TestGetLessonImages:
             images = response.json()["images"]
             en_image = next(img for img in images if img["image_id"] == str(IMAGE_GENERATING_ID))
             assert en_image["alt_text"] == "Lesson illustration"
+        finally:
+            app.dependency_overrides.pop(get_db_session, None)
+
+    async def test_overlay_title_and_labels_localized_fr(
+        self, client: AsyncClient, allow_rate_limit
+    ) -> None:
+        db_mock = AsyncMock()
+        db_mock.execute.return_value = _make_db_scalars(_ALL_LESSON_IMAGES)
+        from app.api.deps import get_db_session
+        from app.main import app
+
+        async def override():
+            yield db_mock
+
+        app.dependency_overrides[get_db_session] = override
+        try:
+            response = await client.get(f"/api/v1/images/lesson/{LESSON_ID}?lang=fr")
+            assert response.status_code == 200
+            images = response.json()["images"]
+            ready = next(img for img in images if img["image_id"] == str(IMAGE_READY_ID))
+            assert ready["title"] == "Cycle de l'eau"
+            assert ready["labels"] == ["Évaporation", "Pluie"]
+        finally:
+            app.dependency_overrides.pop(get_db_session, None)
+
+    async def test_overlay_title_and_labels_localized_en(
+        self, client: AsyncClient, allow_rate_limit
+    ) -> None:
+        db_mock = AsyncMock()
+        db_mock.execute.return_value = _make_db_scalars(_ALL_LESSON_IMAGES)
+        from app.api.deps import get_db_session
+        from app.main import app
+
+        async def override():
+            yield db_mock
+
+        app.dependency_overrides[get_db_session] = override
+        try:
+            response = await client.get(f"/api/v1/images/lesson/{LESSON_ID}?lang=en")
+            assert response.status_code == 200
+            images = response.json()["images"]
+            ready = next(img for img in images if img["image_id"] == str(IMAGE_READY_ID))
+            assert ready["title"] == "Water cycle"
+            assert ready["labels"] == ["Evaporation", "Rain"]
         finally:
             app.dependency_overrides.pop(get_db_session, None)
 

--- a/frontend/components/learning/lesson-image.tsx
+++ b/frontend/components/learning/lesson-image.tsx
@@ -20,6 +20,8 @@ export function LessonImage({ lessonId, language }: LessonImageProps) {
   const [status, setStatus] = useState<LessonImageStatus>('pending');
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [altText, setAltText] = useState<string>('');
+  const [title, setTitle] = useState<string>('');
+  const [labels, setLabels] = useState<string[]>([]);
   const [isVisible, setIsVisible] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
 
@@ -43,6 +45,8 @@ export function LessonImage({ lessonId, language }: LessonImageProps) {
               ? (data.alt_text_fr ?? data.alt_text ?? '')
               : (data.alt_text_en ?? data.alt_text ?? '');
           setAltText(alt);
+          setTitle(data.title ?? '');
+          setLabels(data.labels ?? []);
           const resolvedUrl = data.url.startsWith('/')
             ? `${API_BASE}${data.url}`
             : data.url;
@@ -88,27 +92,47 @@ export function LessonImage({ lessonId, language }: LessonImageProps) {
 
   return (
     <>
-      <div className="w-full my-6">
+      <figure className="w-full my-6">
         <button
           type="button"
-          className="w-full rounded-lg overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 min-h-11"
+          className="relative block w-full rounded-lg overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 min-h-11"
           aria-label={t('imageViewFullscreen')}
           onClick={() => setIsFullscreen(true)}
         >
           <Image
             src={imageUrl}
             alt={altText}
-            width={512}
-            height={512}
+            width={1536}
+            height={1024}
             loading="lazy"
             sizes="(max-width: 768px) 100vw, (max-width: 1024px) 90vw, 832px"
             unoptimized
-            className={`w-full h-auto object-cover rounded-lg transition-opacity duration-300 ${
+            className={`w-full h-auto rounded-lg transition-opacity duration-300 ${
               isVisible ? 'opacity-100' : 'opacity-0'
             }`}
           />
+          {title && (
+            <span className="absolute inset-x-0 top-0 bg-gradient-to-b from-black/70 to-transparent px-4 pt-3 pb-8 text-left">
+              <span className="block text-white font-semibold text-base sm:text-lg leading-snug drop-shadow">
+                {title}
+              </span>
+            </span>
+          )}
         </button>
-      </div>
+
+        {labels.length > 0 && (
+          <figcaption className="mt-2 flex flex-wrap gap-1.5">
+            {labels.map((label, i) => (
+              <span
+                key={`${label}-${i}`}
+                className="inline-block rounded-full bg-teal-50 text-teal-800 px-2.5 py-0.5 text-xs font-medium"
+              >
+                {label}
+              </span>
+            ))}
+          </figcaption>
+        )}
+      </figure>
 
       {isFullscreen && (
         <div
@@ -129,16 +153,25 @@ export function LessonImage({ lessonId, language }: LessonImageProps) {
           >
             <X className="w-5 h-5" aria-hidden="true" />
           </button>
-          <Image
-            src={imageUrl}
-            alt={altText}
-            width={512}
-            height={512}
-            sizes="(max-width: 640px) 100vw, 512px"
-            unoptimized
-            className="max-w-full max-h-full object-contain rounded-lg"
+          <figure
+            className="relative max-w-full max-h-full"
             onClick={(e) => e.stopPropagation()}
-          />
+          >
+            <Image
+              src={imageUrl}
+              alt={altText}
+              width={1536}
+              height={1024}
+              sizes="(max-width: 640px) 100vw, 1024px"
+              unoptimized
+              className="max-w-full max-h-[85vh] w-auto h-auto object-contain rounded-lg"
+            />
+            {title && (
+              <figcaption className="absolute inset-x-0 top-0 bg-gradient-to-b from-black/70 to-transparent px-4 pt-3 pb-8 text-white font-semibold text-lg leading-snug rounded-t-lg">
+                {title}
+              </figcaption>
+            )}
+          </figure>
         </div>
       )}
     </>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -385,6 +385,8 @@ export interface LessonImageResponse {
   alt_text?: string;
   alt_text_fr?: string;
   alt_text_en?: string;
+  title?: string;
+  labels?: string[];
 }
 
 interface _ApiLessonImage {
@@ -393,6 +395,8 @@ interface _ApiLessonImage {
   status: LessonImageStatus;
   image_url: string | null;
   alt_text: string;
+  title?: string | null;
+  labels?: string[];
   format: string;
   width: number;
 }
@@ -420,6 +424,8 @@ export async function getLessonImageStatus(
     alt_text: first.alt_text,
     alt_text_fr: first.alt_text,
     alt_text_en: first.alt_text,
+    title: first.title ?? undefined,
+    labels: first.labels ?? [],
   };
 }
 


### PR DESCRIPTION
Promotes the text-free lesson image change to `main` (staging rollout).

Fixes #2512. Cherry-pick of the dev commit (PR #2514, already merged to `dev`) onto a fresh branch off `main` to avoid the phantom conflict from prior squash SHAs. Diff is exactly the 10 image-pipeline files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)