### PR TITLE
feat(images): pluggable image provider, default Gemini (#2517)

### DIFF
--- a/backend/app/ai/providers/__init__.py
+++ b/backend/app/ai/providers/__init__.py
@@ -1,6 +1,11 @@
 """Pluggable LLM provider layer for content generation (#2443)."""
 
 from app.ai.providers.base import LLMProvider, LLMResult, ToolCall
+from app.ai.providers.image_provider import (
+    DEFAULT_IMAGE_MODEL,
+    ImageProvider,
+    resolve_image_provider,
+)
 from app.ai.providers.pricing import calculate_cost_cents, get_pricing
 from app.ai.providers.registry import resolve_provider
 
@@ -9,6 +14,9 @@ __all__ = [
     "LLMResult",
     "ToolCall",
     "resolve_provider",
+    "ImageProvider",
+    "resolve_image_provider",
+    "DEFAULT_IMAGE_MODEL",
     "calculate_cost_cents",
     "get_pricing",
 ]

--- a/backend/app/ai/providers/image_provider.py
+++ b/backend/app/ai/providers/image_provider.py
@@ -1,0 +1,109 @@
+"""Provider-agnostic image generation for lesson illustrations (#2517).
+
+Which backend generates the text-free illustration is config-selectable via the
+``ai-model-image`` platform setting and resolved by prefix. Both OpenAI
+(``gpt-image-1``) and Google's Gemini image models are reached through the OpenAI
+Images API — Gemini via its OpenAI-compatible endpoint, reusing the same
+``AsyncOpenAI`` client the vision and embeddings services already depend on (no
+extra package), exactly like ``translation.vision_provider``.
+
+Illustrations stay **text-free**; the title and labels are rendered as a DOM
+overlay (#2512), so the choice of backend is purely about base-image quality.
+
+A missing ``GOOGLE_API_KEY`` transparently falls back to ``gpt-image-1`` so a
+Gemini default never hard-fails image generation.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Protocol, runtime_checkable
+
+import structlog
+from openai import AsyncOpenAI
+
+from app.infrastructure.config.settings import Settings, get_settings
+
+logger = structlog.get_logger(__name__)
+
+_TIMEOUT_SECONDS = 120.0
+
+# Default backend. Gemini ("Nano Banana") gives stronger prompt adherence and
+# base-image quality than gpt-image-1.
+DEFAULT_IMAGE_MODEL = "gemini-2.5-flash-image"
+_FALLBACK_IMAGE_MODEL = "gpt-image-1"
+
+
+@runtime_checkable
+class ImageProvider(Protocol):
+    """Generates one image from a text prompt and returns the raw bytes."""
+
+    model: str
+
+    async def generate(self, prompt: str, *, size: str = "1536x1024") -> bytes: ...
+
+
+class OpenAIImageProvider:
+    """gpt-image-1 via the OpenAI Images API."""
+
+    def __init__(self, *, api_key: str, model: str = _FALLBACK_IMAGE_MODEL) -> None:
+        self._client = AsyncOpenAI(api_key=api_key, timeout=_TIMEOUT_SECONDS)
+        self.model = model
+
+    async def generate(self, prompt: str, *, size: str = "1536x1024") -> bytes:
+        response = await self._client.images.generate(
+            model=self.model,
+            prompt=prompt,
+            size=size,
+            quality="medium",
+        )
+        return base64.b64decode(response.data[0].b64_json)
+
+
+class GeminiImageProvider:
+    """Gemini image models via Google's OpenAI-compatible Images endpoint."""
+
+    def __init__(self, *, api_key: str, model: str, base_url: str) -> None:
+        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url, timeout=_TIMEOUT_SECONDS)
+        self.model = model
+
+    async def generate(self, prompt: str, *, size: str = "1536x1024") -> bytes:
+        # Gemini's compat endpoint controls aspect via the prompt, not a size arg;
+        # request base64 so we get bytes back (not a URL) and resize downstream.
+        response = await self._client.images.generate(
+            model=self.model,
+            prompt=prompt,
+            response_format="b64_json",
+        )
+        return base64.b64decode(response.data[0].b64_json)
+
+
+def resolve_image_provider(model: str | None = None) -> ImageProvider:
+    """Build the provider that serves ``model`` (prefix dispatch).
+
+    * ``gemini-*`` / ``imagen-*`` → Google (OpenAI-compatible endpoint), or a
+      graceful fallback to ``gpt-image-1`` when ``GOOGLE_API_KEY`` is unset.
+    * everything else (``gpt-image-*`` / ``dall-e-*``) → OpenAI Images.
+    """
+    settings = get_settings()
+    requested = model or _FALLBACK_IMAGE_MODEL
+    m = requested.lower()
+
+    if m.startswith("gemini") or m.startswith("imagen"):
+        if settings.google_api_key:
+            return GeminiImageProvider(
+                api_key=settings.google_api_key,
+                model=requested,
+                base_url=settings.gemini_openai_base_url,
+            )
+        logger.warning(
+            "GOOGLE_API_KEY unset — falling back to gpt-image-1 for image generation",
+            requested_model=requested,
+        )
+        return _openai_provider(settings, _FALLBACK_IMAGE_MODEL)
+
+    return _openai_provider(settings, requested)
+
+
+def _openai_provider(settings: Settings, model: str) -> OpenAIImageProvider:
+    return OpenAIImageProvider(api_key=settings.openai_api_key, model=model)

--- a/backend/app/domain/services/image_service.py
+++ b/backend/app/domain/services/image_service.py
@@ -147,8 +147,8 @@ class ImageGenerationService:
             image_record.status = "generating"
             await session.flush()
 
-            image_bytes, image_url = await self._call_dalle(prompt)
-            # Keep gpt-image-1's native width (1536) — downscaling blurs fine detail.
+            image_bytes, image_url = await self._generate_image(prompt)
+            # Keep the provider's native width (~1536) — downscaling blurs fine detail.
             webp_bytes, width = _resize_to_webp(image_bytes, max_width=1536)
 
             alt_fr, alt_en = await self._generate_alt_text(concept)
@@ -379,25 +379,28 @@ class ImageGenerationService:
                 return candidate
         return None
 
-    async def _call_dalle(self, prompt: str) -> tuple[bytes, str]:
-        """Call OpenAI gpt-image-1 API and return (image_bytes, image_url)."""
-        import base64
+    async def _generate_image(self, prompt: str) -> tuple[bytes, str]:
+        """Generate the illustration via the configured image provider.
 
-        from openai import AsyncOpenAI
-
-        client = AsyncOpenAI(api_key=settings.openai_api_key)
-
-        response = await client.images.generate(
-            model="gpt-image-1",
-            prompt=prompt,
-            size="1536x1024",
-            quality="medium",
+        The backend (``gpt-image-1`` or a Gemini image model) is selected by the
+        ``ai-model-image`` platform setting and resolved by prefix; a missing
+        GOOGLE_API_KEY transparently falls back to gpt-image-1. Returns
+        ``(image_bytes, image_url)`` where the URL is a backend tag (the public
+        URL is set by the caller from the stored data endpoint).
+        """
+        from app.ai.providers.image_provider import (
+            DEFAULT_IMAGE_MODEL,
+            resolve_image_provider,
         )
+        from app.domain.services.platform_settings_service import SettingsCache
 
-        image_bytes = base64.b64decode(response.data[0].b64_json)
-        image_url = f"gpt-image-1://{id(response)}"
+        model = SettingsCache.instance().get("ai-model-image", DEFAULT_IMAGE_MODEL)
+        provider = resolve_image_provider(model)
+        image_bytes = await provider.generate(prompt, size="1536x1024")
+        return image_bytes, f"{provider.model}://generated"
 
-        return image_bytes, image_url
+    # Backwards-compatible alias: the backfill task still calls ``_call_dalle``.
+    _call_dalle = _generate_image
 
     async def _generate_alt_text(self, concept: str) -> tuple[str, str]:
         """Generate bilingual alt-text for the image."""

--- a/backend/app/infrastructure/config/platform_defaults.py
+++ b/backend/app/infrastructure/config/platform_defaults.py
@@ -406,6 +406,20 @@ SETTING_DEFINITIONS: list[SettingDef] = [
         "quality regresses.",
     ),
     SettingDef(
+        "ai-model-image",
+        "ai",
+        "gemini-2.5-flash-image",
+        "string",
+        "Model — image generation",
+        "Backend that generates the text-free lesson illustration. Resolved by "
+        "prefix (gemini-*/imagen-* → Google via its OpenAI-compatible endpoint; "
+        "gpt-image-1/dall-e-* → OpenAI). NOTE: Gemini runs on Google US servers "
+        "and stamps a SynthID watermark on every image; a missing GOOGLE_API_KEY "
+        "transparently falls back to gpt-image-1. Illustrations stay text-free — "
+        "the title and labels are rendered as a DOM overlay.",
+        allowed_options=["gemini-2.5-flash-image", "gpt-image-1"],
+    ),
+    SettingDef(
         "ai-rag-default-top-k",
         "ai",
         8,

--- a/backend/tests/test_image_generation.py
+++ b/backend/tests/test_image_generation.py
@@ -255,7 +255,7 @@ class TestImageGenerationService:
             mock_anthropic_cls.return_value = mock_client
             mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
 
-            with patch("openai.AsyncOpenAI") as mock_openai_cls:
+            with patch("app.ai.providers.image_provider.AsyncOpenAI") as mock_openai_cls:
                 result = await service.generate_for_lesson(
                     lesson_id=uuid.uuid4(),
                     module_id=uuid.uuid4(),
@@ -294,7 +294,7 @@ class TestImageGenerationService:
                 side_effect=[mock_claude_response, mock_alt_text_response]
             )
 
-            with patch("openai.AsyncOpenAI") as mock_openai_cls:
+            with patch("app.ai.providers.image_provider.AsyncOpenAI") as mock_openai_cls:
                 mock_openai = AsyncMock()
                 mock_openai_cls.return_value = mock_openai
                 mock_openai.images.generate = AsyncMock(return_value=image_api_response)
@@ -372,7 +372,7 @@ class TestImageGenerationService:
                 side_effect=[mock_claude_response, mock_alt_text_response]
             )
 
-            with patch("openai.AsyncOpenAI") as mock_openai_cls:
+            with patch("app.ai.providers.image_provider.AsyncOpenAI") as mock_openai_cls:
                 mock_openai = AsyncMock()
                 mock_openai_cls.return_value = mock_openai
                 mock_openai.images.generate = AsyncMock(return_value=image_api_response)
@@ -445,15 +445,18 @@ class TestImageGenerationService:
         source = inspect.getsource(image_service)
         assert "NO text, letters, numbers, or written words" not in source
 
-    def test_dalle_call_uses_medium_quality_landscape(self):
-        """gpt-image-1 must be invoked at medium quality, 1536x1024."""
+    def test_openai_image_provider_uses_medium_quality_landscape(self):
+        """gpt-image-1 must be invoked at medium quality; image_service requests 1536x1024."""
         import inspect
 
+        from app.ai.providers import image_provider
         from app.domain.services import image_service
 
-        source = inspect.getsource(image_service)
-        assert '"1536x1024"' in source
-        assert '"medium"' in source
+        provider_source = inspect.getsource(image_provider)
+        assert '"gpt-image-1"' in provider_source or "gpt-image-1" in provider_source
+        assert '"medium"' in provider_source
+        # image_service requests the landscape size from whichever provider runs.
+        assert '"1536x1024"' in inspect.getsource(image_service)
 
     async def test_extract_concept_localizes_to_lesson_language(
         self, service, mock_claude_response
@@ -667,7 +670,7 @@ class TestImageGenerationService:
                 side_effect=[mock_claude_response, mock_alt_text_response]
             )
 
-            with patch("openai.AsyncOpenAI") as mock_openai_cls:
+            with patch("app.ai.providers.image_provider.AsyncOpenAI") as mock_openai_cls:
                 mock_openai = AsyncMock()
                 mock_openai_cls.return_value = mock_openai
                 mock_openai.images.generate = AsyncMock(return_value=image_api_response)

--- a/backend/tests/test_image_providers.py
+++ b/backend/tests/test_image_providers.py
@@ -1,0 +1,126 @@
+"""Tests for the pluggable image-generation providers (#2517)."""
+
+from __future__ import annotations
+
+import base64
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.ai.providers.image_provider import (
+    GeminiImageProvider,
+    OpenAIImageProvider,
+    resolve_image_provider,
+)
+
+_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
+
+
+def _settings(*, google: str = "", openai: str = "") -> SimpleNamespace:
+    return SimpleNamespace(
+        google_api_key=google,
+        openai_api_key=openai,
+        gemini_openai_base_url=_GEMINI_BASE_URL,
+    )
+
+
+def _fake_image_response(payload: bytes = b"IMG") -> MagicMock:
+    response = MagicMock()
+    response.data = [MagicMock(b64_json=base64.b64encode(payload).decode())]
+    return response
+
+
+class TestResolveImageProvider:
+    def test_gemini_model_resolves_to_gemini_when_google_key_present(self):
+        with patch(
+            "app.ai.providers.image_provider.get_settings",
+            return_value=_settings(google="gk", openai="ok"),
+        ):
+            provider = resolve_image_provider("gemini-2.5-flash-image")
+        assert isinstance(provider, GeminiImageProvider)
+        assert provider.model == "gemini-2.5-flash-image"
+
+    def test_imagen_model_resolves_to_gemini(self):
+        with patch(
+            "app.ai.providers.image_provider.get_settings",
+            return_value=_settings(google="gk", openai="ok"),
+        ):
+            provider = resolve_image_provider("imagen-4.0-generate-001")
+        assert isinstance(provider, GeminiImageProvider)
+
+    def test_gemini_falls_back_to_openai_when_google_key_missing(self):
+        with patch(
+            "app.ai.providers.image_provider.get_settings",
+            return_value=_settings(google="", openai="ok"),
+        ):
+            provider = resolve_image_provider("gemini-2.5-flash-image")
+        assert isinstance(provider, OpenAIImageProvider)
+        assert provider.model == "gpt-image-1"
+
+    def test_gpt_image_resolves_to_openai(self):
+        with patch(
+            "app.ai.providers.image_provider.get_settings",
+            return_value=_settings(openai="ok"),
+        ):
+            provider = resolve_image_provider("gpt-image-1")
+        assert isinstance(provider, OpenAIImageProvider)
+        assert provider.model == "gpt-image-1"
+
+    def test_none_defaults_to_openai_backend(self):
+        with patch(
+            "app.ai.providers.image_provider.get_settings",
+            return_value=_settings(openai="ok"),
+        ):
+            provider = resolve_image_provider(None)
+        assert isinstance(provider, OpenAIImageProvider)
+
+
+class TestOpenAIImageProvider:
+    async def test_generate_calls_images_api_with_quality_and_size(self):
+        with patch("app.ai.providers.image_provider.AsyncOpenAI") as mock_cls:
+            client = MagicMock()
+            client.images.generate = AsyncMock(return_value=_fake_image_response(b"PNG"))
+            mock_cls.return_value = client
+
+            provider = OpenAIImageProvider(api_key="ok")
+            out = await provider.generate("a prompt", size="1536x1024")
+
+            kwargs = client.images.generate.call_args.kwargs
+            assert kwargs["model"] == "gpt-image-1"
+            assert kwargs["size"] == "1536x1024"
+            assert kwargs["quality"] == "medium"
+            assert out == b"PNG"
+
+
+class TestGeminiImageProvider:
+    async def test_generate_uses_base_url_and_b64_response_format(self):
+        with patch("app.ai.providers.image_provider.AsyncOpenAI") as mock_cls:
+            client = MagicMock()
+            client.images.generate = AsyncMock(return_value=_fake_image_response(b"GEM"))
+            mock_cls.return_value = client
+
+            provider = GeminiImageProvider(
+                api_key="gk",
+                model="gemini-2.5-flash-image",
+                base_url=_GEMINI_BASE_URL,
+            )
+            out = await provider.generate("a prompt")
+
+            # Client built against Google's OpenAI-compatible endpoint.
+            assert mock_cls.call_args.kwargs["base_url"] == _GEMINI_BASE_URL
+            assert mock_cls.call_args.kwargs["api_key"] == "gk"
+            kwargs = client.images.generate.call_args.kwargs
+            assert kwargs["model"] == "gemini-2.5-flash-image"
+            assert kwargs["response_format"] == "b64_json"
+            assert out == b"GEM"
+
+
+@pytest.mark.parametrize("model", ["gemini-2.5-flash-image", "gpt-image-1"])
+def test_default_setting_options_resolve(model):
+    """Both allowed_options for ai-model-image must resolve to a provider."""
+    with patch(
+        "app.ai.providers.image_provider.get_settings",
+        return_value=_settings(google="gk", openai="ok"),
+    ):
+        assert resolve_image_provider(model) is not None

--- a/backend/tests/test_tutor_source_image.py
+++ b/backend/tests/test_tutor_source_image.py
@@ -558,7 +558,7 @@ class TestDallEFallbackOptimization:
                 side_effect=[mock_claude_response, alt_text_msg]
             )
 
-            with patch("openai.AsyncOpenAI") as mock_openai_cls:
+            with patch("app.ai.providers.image_provider.AsyncOpenAI") as mock_openai_cls:
                 mock_openai = AsyncMock()
                 mock_openai_cls.return_value = mock_openai
                 mock_openai.images.generate = AsyncMock(return_value=image_api_response)
@@ -614,7 +614,9 @@ class TestDallEFallbackOptimization:
             mock_anthropic_cls.return_value = mock_client
             mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
 
-            with __import__("unittest.mock", fromlist=["patch"]).patch("openai.AsyncOpenAI"):
+            with __import__("unittest.mock", fromlist=["patch"]).patch(
+                "app.ai.providers.image_provider.AsyncOpenAI"
+            ):
                 result = await service.generate_for_lesson(
                     lesson_id=uuid.uuid4(),
                     module_id=uuid.uuid4(),


### PR DESCRIPTION
Promotes the Gemini image-provider change to `main` (staging rollout).

Fixes #2517. Cherry-pick of the dev commit (PR #2518, already merged to `dev`) onto a fresh branch off `main` to avoid the phantom conflict from prior squash SHAs. Diff is exactly the 7 image-provider files.

⚠️ Default = gemini-2.5-flash-image; GOOGLE_API_KEY is set on staging (verified). Falls back to gpt-image-1 if the key is ever missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)