### PR TITLE
fix(images): fall back to gpt-image-1 on provider runtime errors (#2520)

### DIFF
--- a/backend/app/ai/providers/__init__.py
+++ b/backend/app/ai/providers/__init__.py
@@ -4,6 +4,7 @@ from app.ai.providers.base import LLMProvider, LLMResult, ToolCall
 from app.ai.providers.image_provider import (
     DEFAULT_IMAGE_MODEL,
     ImageProvider,
+    generate_image,
     resolve_image_provider,
 )
 from app.ai.providers.pricing import calculate_cost_cents, get_pricing
@@ -16,6 +17,7 @@ __all__ = [
     "resolve_provider",
     "ImageProvider",
     "resolve_image_provider",
+    "generate_image",
     "DEFAULT_IMAGE_MODEL",
     "calculate_cost_cents",
     "get_pricing",

--- a/backend/app/ai/providers/image_provider.py
+++ b/backend/app/ai/providers/image_provider.py
@@ -107,3 +107,26 @@ def resolve_image_provider(model: str | None = None) -> ImageProvider:
 
 def _openai_provider(settings: Settings, model: str) -> OpenAIImageProvider:
     return OpenAIImageProvider(api_key=settings.openai_api_key, model=model)
+
+
+async def generate_image(prompt: str, *, model: str, size: str = "1536x1024") -> tuple[bytes, str]:
+    """Generate an image for ``model``, falling back to gpt-image-1 on any error.
+
+    The resolve-time fallback only covers a *missing* key. A present-but-unprivileged
+    key (e.g. a free-tier Gemini key with image quota 0) raises at call time
+    (429 RESOURCE_EXHAUSTED). Catch any provider error and retry once on gpt-image-1
+    so image generation never hard-fails. Returns ``(image_bytes, model_used)``.
+    """
+    provider = resolve_image_provider(model)
+    try:
+        return await provider.generate(prompt, size=size), provider.model
+    except Exception as exc:
+        if isinstance(provider, OpenAIImageProvider):
+            raise  # already on the fallback backend — nothing left to try
+        logger.warning(
+            "image provider failed — falling back to gpt-image-1",
+            provider_model=provider.model,
+            error=str(exc),
+        )
+        fallback = _openai_provider(get_settings(), _FALLBACK_IMAGE_MODEL)
+        return await fallback.generate(prompt, size=size), fallback.model

--- a/backend/app/domain/services/image_service.py
+++ b/backend/app/domain/services/image_service.py
@@ -383,21 +383,18 @@ class ImageGenerationService:
         """Generate the illustration via the configured image provider.
 
         The backend (``gpt-image-1`` or a Gemini image model) is selected by the
-        ``ai-model-image`` platform setting and resolved by prefix; a missing
-        GOOGLE_API_KEY transparently falls back to gpt-image-1. Returns
-        ``(image_bytes, image_url)`` where the URL is a backend tag (the public
-        URL is set by the caller from the stored data endpoint).
+        ``ai-model-image`` platform setting and resolved by prefix. A missing
+        GOOGLE_API_KEY *or* any provider runtime error (e.g. Gemini quota 429)
+        transparently falls back to gpt-image-1. Returns ``(image_bytes, image_url)``
+        where the URL is a backend tag (the public URL is set by the caller from the
+        stored data endpoint).
         """
-        from app.ai.providers.image_provider import (
-            DEFAULT_IMAGE_MODEL,
-            resolve_image_provider,
-        )
+        from app.ai.providers.image_provider import DEFAULT_IMAGE_MODEL, generate_image
         from app.domain.services.platform_settings_service import SettingsCache
 
         model = SettingsCache.instance().get("ai-model-image", DEFAULT_IMAGE_MODEL)
-        provider = resolve_image_provider(model)
-        image_bytes = await provider.generate(prompt, size="1536x1024")
-        return image_bytes, f"{provider.model}://generated"
+        image_bytes, used_model = await generate_image(prompt, model=model, size="1536x1024")
+        return image_bytes, f"{used_model}://generated"
 
     # Backwards-compatible alias: the backfill task still calls ``_call_dalle``.
     _call_dalle = _generate_image

--- a/backend/tests/test_image_providers.py
+++ b/backend/tests/test_image_providers.py
@@ -11,6 +11,7 @@ import pytest
 from app.ai.providers.image_provider import (
     GeminiImageProvider,
     OpenAIImageProvider,
+    generate_image,
     resolve_image_provider,
 )
 
@@ -124,3 +125,59 @@ def test_default_setting_options_resolve(model):
         return_value=_settings(google="gk", openai="ok"),
     ):
         assert resolve_image_provider(model) is not None
+
+
+class TestGenerateImageFallback:
+    async def test_success_returns_model_used(self):
+        with (
+            patch(
+                "app.ai.providers.image_provider.get_settings",
+                return_value=_settings(openai="ok"),
+            ),
+            patch("app.ai.providers.image_provider.AsyncOpenAI") as mock_cls,
+        ):
+            client = MagicMock()
+            client.images.generate = AsyncMock(return_value=_fake_image_response(b"OK"))
+            mock_cls.return_value = client
+
+            data, used = await generate_image("p", model="gpt-image-1")
+            assert data == b"OK"
+            assert used == "gpt-image-1"
+
+    async def test_falls_back_to_openai_when_gemini_errors(self):
+        """A runtime Gemini error (e.g. 429 quota) must fall back to gpt-image-1."""
+        with (
+            patch(
+                "app.ai.providers.image_provider.get_settings",
+                return_value=_settings(google="gk", openai="ok"),
+            ),
+            patch("app.ai.providers.image_provider.AsyncOpenAI") as mock_cls,
+        ):
+            client = MagicMock()
+            # First call (Gemini) raises; second call (gpt-image-1 fallback) succeeds.
+            client.images.generate = AsyncMock(
+                side_effect=[RuntimeError("429 RESOURCE_EXHAUSTED"), _fake_image_response(b"FB")]
+            )
+            mock_cls.return_value = client
+
+            data, used = await generate_image("p", model="gemini-2.5-flash-image")
+            assert data == b"FB"
+            assert used == "gpt-image-1"
+            assert client.images.generate.await_count == 2
+
+    async def test_no_double_fallback_when_openai_itself_errors(self):
+        """If the backend is already gpt-image-1, an error must propagate (no loop)."""
+        with (
+            patch(
+                "app.ai.providers.image_provider.get_settings",
+                return_value=_settings(openai="ok"),
+            ),
+            patch("app.ai.providers.image_provider.AsyncOpenAI") as mock_cls,
+        ):
+            client = MagicMock()
+            client.images.generate = AsyncMock(side_effect=RuntimeError("openai down"))
+            mock_cls.return_value = client
+
+            with pytest.raises(RuntimeError):
+                await generate_image("p", model="gpt-image-1")
+            assert client.images.generate.await_count == 1


### PR DESCRIPTION
Promotes the image-provider runtime fallback to `main` (staging rollout).

Fixes #2520. Cherry-pick of the dev commit (PR #2521, already merged to `dev`) onto a fresh branch off `main` to avoid the phantom conflict from prior squash SHAs. Diff is exactly the 4 fallback files.

After this deploys, the Gemini default is safe: any provider runtime error (e.g. the staging key's 429 quota) auto-falls back to gpt-image-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)