### PR TITLE
sync: route content-pipeline LLM calls through resolve_provider to main (#2523)

### DIFF
--- a/backend/app/ai/claude_service.py
+++ b/backend/app/ai/claude_service.py
@@ -6,7 +6,6 @@ from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from typing import Any
 
-import anthropic
 import structlog
 
 from app.ai.providers import resolve_provider
@@ -50,12 +49,6 @@ class ClaudeService:
         self.settings = get_settings()
         if not self.settings.anthropic_api_key:
             raise ValueError("ANTHROPIC_API_KEY is required")
-
-        # Retained for callers that still reach the raw Anthropic client directly.
-        self.client = anthropic.AsyncAnthropic(
-            api_key=self.settings.anthropic_api_key,
-            timeout=600.0,
-        )
 
         _cache = SettingsCache.instance()
         self._max_tokens = _cache.get("ai-max-tokens-content", 64000)

--- a/backend/app/ai/pdf_summarizer.py
+++ b/backend/app/ai/pdf_summarizer.py
@@ -279,11 +279,21 @@ def split_pdf_by_chapters(text: str, toc: list, max_chars: int) -> list[tuple[st
 
 
 def _get_summarizer_client(model: str):
-    """Return the appropriate API client based on model name."""
+    """Return the appropriate API client based on model name.
+
+    Moonshot/Kimi models go through the pluggable provider (#2523) so the
+    summarizer honors a ``moonshot-*`` ``syllabus-summarizer-model`` setting
+    instead of falling into the Anthropic branch and 404ing. The gpt-* and
+    claude-* paths keep their proven direct clients.
+    """
     if model.startswith("gpt-"):
         from openai import AsyncOpenAI
 
         return AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY", ""))
+    if model.startswith(("moonshot-", "kimi-")):
+        from app.ai.providers import resolve_provider
+
+        return resolve_provider(model)
     import anthropic
 
     return anthropic.AsyncAnthropic(
@@ -310,6 +320,16 @@ async def _call_model(
             ],
         )
         return response.choices[0].message.content.strip()
+    if model.startswith(("moonshot-", "kimi-")):
+        # client is an LLMProvider here (see _get_summarizer_client).
+        result = await client.complete(
+            system=system,
+            messages=[{"role": "user", "content": user_content}],
+            max_tokens=max_tokens,
+            temperature=1.0,
+            model=model,
+        )
+        return result.text.strip()
     async with client.messages.stream(
         model=model,
         max_tokens=max_tokens,
@@ -575,6 +595,9 @@ async def summarize_pdf_for_syllabus(
     if model.startswith("gpt-"):
         api_key = os.getenv("OPENAI_API_KEY", "")
         key_var = "OPENAI_API_KEY"
+    elif model.startswith(("moonshot-", "kimi-")):
+        api_key = os.getenv("MOONSHOT_API_KEY", "")
+        key_var = "MOONSHOT_API_KEY"
     else:
         api_key = os.getenv("ANTHROPIC_API_KEY", "")
         key_var = "ANTHROPIC_API_KEY"

--- a/backend/app/ai/translation/complex_overlay.py
+++ b/backend/app/ai/translation/complex_overlay.py
@@ -161,7 +161,11 @@ async def extract_label_positions(
     image_media_type: str = "image/webp",
     client: anthropic.AsyncAnthropic | None = None,
 ) -> DiagramLabels:
-    """Claude Vision call: return every visible label + its approximate position."""
+    """Claude Vision call: return every visible label + its approximate position.
+
+    Vision-only and intentionally NOT settings-driven: the OpenAI-compatible path
+    used for Moonshot/Kimi has no image input, so this stays on Anthropic (#2523).
+    """
     if not image_bytes:
         raise ValueError("image_bytes must be non-empty")
     settings = get_settings()
@@ -216,34 +220,39 @@ async def translate_labels(
     """Translate every label's text into ``target_lang``, preserving ids and positions."""
     if target_lang not in {"fr", "en"}:
         raise ValueError(f"unsupported target_lang: {target_lang!r}")
-    if client is None:
-        settings = get_settings()
-        if not settings.anthropic_api_key:
-            raise ValueError("ANTHROPIC_API_KEY is required to translate labels")
-        client = anthropic.AsyncAnthropic(
-            api_key=settings.anthropic_api_key,
-            timeout=60.0,
-        )
 
     target_full = {"fr": "French", "en": "English"}[target_lang]
     payload = labels.model_dump_json()
-    response = await client.messages.create(
-        model=_TRANSLATE_MODEL,
-        max_tokens=_MAX_TOKENS,
-        system=_TRANSLATE_SYSTEM,
-        messages=[
-            {
-                "role": "user",
-                "content": _TRANSLATE_USER_TEMPLATE.format(
-                    target_lang_full=target_full, payload=payload
-                ),
-            }
-        ],
-        temperature=0.0,
-    )
-    text = "".join(
-        getattr(block, "text", "") for block in response.content if hasattr(block, "text")
-    )
+    user_content = _TRANSLATE_USER_TEMPLATE.format(target_lang_full=target_full, payload=payload)
+
+    if client is not None:
+        # Test/override path: use the injected Anthropic client directly.
+        response = await client.messages.create(
+            model=_TRANSLATE_MODEL,
+            max_tokens=_MAX_TOKENS,
+            system=_TRANSLATE_SYSTEM,
+            messages=[{"role": "user", "content": user_content}],
+            temperature=0.0,
+        )
+        text = "".join(
+            getattr(block, "text", "") for block in response.content if hasattr(block, "text")
+        )
+    else:
+        # Production: text-only translation routes through the configured content
+        # provider (Anthropic or Moonshot) so it honors ai-model-image-metadata
+        # instead of always billing Anthropic (#2523).
+        from app.ai.providers import resolve_provider
+        from app.domain.services.platform_settings_service import SettingsCache
+
+        model = SettingsCache.instance().get("ai-model-image-metadata", _TRANSLATE_MODEL)
+        result = await resolve_provider(model).complete(
+            system=_TRANSLATE_SYSTEM,
+            messages=[{"role": "user", "content": user_content}],
+            max_tokens=_MAX_TOKENS,
+            temperature=0.0,
+            model=model,
+        )
+        text = result.text
     if not text.strip():
         raise ValueError("empty label-translation response")
     translated = _parse_labels(text)

--- a/backend/app/ai/translation/figure_translator.py
+++ b/backend/app/ai/translation/figure_translator.py
@@ -22,8 +22,6 @@ import anthropic
 import structlog
 from pydantic import BaseModel, Field, ValidationError
 
-from app.infrastructure.config.settings import get_settings
-
 logger = structlog.get_logger(__name__)
 
 
@@ -129,28 +127,37 @@ async def translate_figure_caption(
     if not caption or not caption.strip():
         raise ValueError("caption must be non-empty")
 
-    if client is None:
-        settings = get_settings()
-        if not settings.anthropic_api_key:
-            raise ValueError("ANTHROPIC_API_KEY is required to translate figures")
-        client = anthropic.AsyncAnthropic(
-            api_key=settings.anthropic_api_key,
-            timeout=60.0,
-        )
-
     user_prompt = _build_user_prompt(caption, image_type, figure_number)
-    response = await client.messages.create(
-        model=_TRANSLATOR_MODEL,
-        max_tokens=_MAX_TOKENS,
-        system=_SYSTEM_PROMPT,
-        messages=[{"role": "user", "content": user_prompt}],
-        temperature=0.0,
-    )
 
-    text = ""
-    for block in response.content:
-        if hasattr(block, "text"):
-            text += block.text
+    if client is not None:
+        # Test/override path: use the injected Anthropic client directly.
+        response = await client.messages.create(
+            model=_TRANSLATOR_MODEL,
+            max_tokens=_MAX_TOKENS,
+            system=_SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": user_prompt}],
+            temperature=0.0,
+        )
+        text = "".join(
+            getattr(block, "text", "") for block in response.content if hasattr(block, "text")
+        )
+    else:
+        # Production: text-only translation routes through the configured content
+        # provider (Anthropic or Moonshot) so it honors ai-model-image-metadata
+        # instead of always billing Anthropic (#2523).
+        from app.ai.providers import resolve_provider
+        from app.domain.services.platform_settings_service import SettingsCache
+
+        model = SettingsCache.instance().get("ai-model-image-metadata", _TRANSLATOR_MODEL)
+        result = await resolve_provider(model).complete(
+            system=_SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": user_prompt}],
+            max_tokens=_MAX_TOKENS,
+            temperature=0.0,
+            model=model,
+        )
+        text = result.text
+
     if not text.strip():
         raise ValueError("empty translator response")
 

--- a/backend/app/ai/translation/svg_rederiver.py
+++ b/backend/app/ai/translation/svg_rederiver.py
@@ -135,7 +135,11 @@ async def extract_flowchart_structure(
     image_media_type: str = "image/webp",
     client: anthropic.AsyncAnthropic | None = None,
 ) -> FlowchartStructure:
-    """Run Claude Vision to extract the logical graph of a flowchart."""
+    """Run Claude Vision to extract the logical graph of a flowchart.
+
+    Vision-only and intentionally NOT settings-driven: the OpenAI-compatible path
+    used for Moonshot/Kimi has no image input, so this stays on Anthropic (#2523).
+    """
     if not image_bytes:
         raise ValueError("image_bytes must be non-empty")
 
@@ -193,34 +197,38 @@ async def translate_structure(
     if target_lang not in {"fr", "en"}:
         raise ValueError(f"unsupported target_lang: {target_lang!r}")
 
-    if client is None:
-        settings = get_settings()
-        if not settings.anthropic_api_key:
-            raise ValueError("ANTHROPIC_API_KEY is required to translate flowcharts")
-        client = anthropic.AsyncAnthropic(
-            api_key=settings.anthropic_api_key,
-            timeout=60.0,
-        )
-
     target_full = {"fr": "French", "en": "English"}[target_lang]
     payload = structure.model_dump_json()
-    response = await client.messages.create(
-        model=_TRANSLATE_MODEL,
-        max_tokens=_MAX_TOKENS,
-        system=_TRANSLATE_SYSTEM,
-        messages=[
-            {
-                "role": "user",
-                "content": _TRANSLATE_USER_TEMPLATE.format(
-                    target_lang_full=target_full, payload=payload
-                ),
-            }
-        ],
-        temperature=0.0,
-    )
-    text = "".join(
-        getattr(block, "text", "") for block in response.content if hasattr(block, "text")
-    )
+    user_content = _TRANSLATE_USER_TEMPLATE.format(target_lang_full=target_full, payload=payload)
+
+    if client is not None:
+        # Test/override path: use the injected Anthropic client directly.
+        response = await client.messages.create(
+            model=_TRANSLATE_MODEL,
+            max_tokens=_MAX_TOKENS,
+            system=_TRANSLATE_SYSTEM,
+            messages=[{"role": "user", "content": user_content}],
+            temperature=0.0,
+        )
+        text = "".join(
+            getattr(block, "text", "") for block in response.content if hasattr(block, "text")
+        )
+    else:
+        # Production: text-only translation routes through the configured content
+        # provider (Anthropic or Moonshot) so it honors ai-model-image-metadata
+        # instead of always billing Anthropic (#2523).
+        from app.ai.providers import resolve_provider
+        from app.domain.services.platform_settings_service import SettingsCache
+
+        model = SettingsCache.instance().get("ai-model-image-metadata", _TRANSLATE_MODEL)
+        result = await resolve_provider(model).complete(
+            system=_TRANSLATE_SYSTEM,
+            messages=[{"role": "user", "content": user_content}],
+            max_tokens=_MAX_TOKENS,
+            temperature=0.0,
+            model=model,
+        )
+        text = result.text
     if not text.strip():
         raise ValueError("empty translate-structure response")
     translated = _parse_structure(text)

--- a/backend/app/api/v1/admin/syllabus.py
+++ b/backend/app/api/v1/admin/syllabus.py
@@ -6,7 +6,6 @@ import json
 import uuid
 
 import structlog
-from anthropic import AsyncAnthropic
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import StreamingResponse
 from sqlalchemy import select, text
@@ -41,11 +40,9 @@ _require_admin = require_role(UserRole.admin, UserRole.sub_admin)
 async def get_syllabus_agent_service() -> SyllabusAgentService:
     """Dependency factory for the syllabus agent service."""
     settings = get_settings()
-    anthropic_client = AsyncAnthropic(api_key=settings.anthropic_api_key)
     embedding_service = EmbeddingService(api_key=settings.openai_api_key)
     semantic_retriever = SemanticRetriever(embedding_service)
     return SyllabusAgentService(
-        anthropic_client=anthropic_client,
         semantic_retriever=semantic_retriever,
         embedding_service=embedding_service,
     )

--- a/backend/app/domain/services/image_service.py
+++ b/backend/app/domain/services/image_service.py
@@ -14,7 +14,6 @@ from sqlalchemy.orm import selectinload
 from app.ai.prompts.audience import AudienceContext, detect_audience
 from app.domain.models.generated_image import GeneratedImage
 from app.domain.models.source_image import SourceImage, SourceImageChunk
-from app.infrastructure.config.settings import settings
 
 logger = structlog.get_logger(__name__)
 
@@ -222,12 +221,11 @@ class ImageGenerationService:
         Returns ``(concept, prompt, tags, title_fr, title_en, labels)`` where ``labels``
         is a list of ``{"fr": ..., "en": ...}`` dicts.
         """
-        import anthropic
-
+        from app.ai.providers import resolve_provider
         from app.domain.services.platform_settings_service import SettingsCache
 
-        client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key, timeout=600.0)
         model = SettingsCache.instance().get("ai-model-image-metadata", "claude-haiku-4-5")
+        provider = resolve_provider(model)
 
         if audience.is_kids:
             style_block = (
@@ -285,19 +283,20 @@ class ImageGenerationService:
             "TAGS: <json_array>"
         )
 
-        message = await client.messages.create(
-            model=model,
-            max_tokens=700,
+        result = await provider.complete(
+            system=system,
             messages=[
                 {
                     "role": "user",
                     "content": f"Lesson content:\n{lesson_content[:2000]}",
                 }
             ],
-            system=system,
+            max_tokens=700,
+            temperature=1.0,
+            model=model,
         )
 
-        text = message.content[0].text if message.content else ""
+        text = result.text
         concept, prompt, tags, title_fr, title_en, labels = _parse_concept_response(text)
 
         # Inject server-side discriminator tags so the cache key always matches the
@@ -401,16 +400,14 @@ class ImageGenerationService:
 
     async def _generate_alt_text(self, concept: str) -> tuple[str, str]:
         """Generate bilingual alt-text for the image."""
-        import anthropic
-
+        from app.ai.providers import resolve_provider
         from app.domain.services.platform_settings_service import SettingsCache
 
-        client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key, timeout=600.0)
         model = SettingsCache.instance().get("ai-model-image-metadata", "claude-haiku-4-5")
+        provider = resolve_provider(model)
 
-        message = await client.messages.create(
-            model=model,
-            max_tokens=100,
+        result = await provider.complete(
+            system="",
             messages=[
                 {
                     "role": "user",
@@ -424,9 +421,12 @@ class ImageGenerationService:
                     ),
                 }
             ],
+            max_tokens=100,
+            temperature=1.0,
+            model=model,
         )
 
-        text = message.content[0].text if message.content else ""
+        text = result.text
         return _parse_alt_text(text, concept)
 
 

--- a/backend/app/domain/services/syllabus_agent_service.py
+++ b/backend/app/domain/services/syllabus_agent_service.py
@@ -17,7 +17,6 @@ from datetime import UTC, datetime
 from typing import Any
 
 import structlog
-from anthropic import AsyncAnthropic
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -75,11 +74,9 @@ class SyllabusAgentService:
 
     def __init__(
         self,
-        anthropic_client: AsyncAnthropic,
         semantic_retriever: SemanticRetriever,
         embedding_service: EmbeddingService,
     ) -> None:
-        self._client = anthropic_client
         self._retriever = semantic_retriever
         self._embedding_service = embedding_service
         self._system_prompt = get_syllabus_agent_system_prompt()

--- a/backend/app/infrastructure/config/platform_defaults.py
+++ b/backend/app/infrastructure/config/platform_defaults.py
@@ -392,8 +392,15 @@ SETTING_DEFINITIONS: list[SettingDef] = [
         "claude-sonnet-4-6",
         "string",
         "Model — quality auditor",
-        "Claude model for the course-quality auditor. Haiku is a cheaper "
+        "Model for the course-quality auditor. Resolved to a provider by prefix "
+        "(claude-* → Anthropic; moonshot-*/kimi-* → Moonshot). Haiku is a cheaper "
         "option once detection accuracy has been benchmarked.",
+        allowed_options=[
+            "claude-sonnet-4-6",
+            "claude-haiku-4-5",
+            "moonshot-v1-128k",
+            "kimi-k2.6",
+        ],
     ),
     SettingDef(
         "ai-model-image-metadata",
@@ -401,9 +408,17 @@ SETTING_DEFINITIONS: list[SettingDef] = [
         "claude-haiku-4-5",
         "string",
         "Model — image metadata",
-        "Claude model for image concept/tag extraction and alt-text "
-        "(low-stakes structured calls). Override to a larger model if "
-        "quality regresses.",
+        "Model for image concept/tag extraction, alt-text, and figure/diagram "
+        "label translation (low-stakes structured text calls). Resolved to a "
+        "provider by prefix (claude-* → Anthropic; moonshot-*/kimi-* → Moonshot). "
+        "Vision-based figure extraction stays on Anthropic regardless of this "
+        "setting. Override to a larger model if quality regresses.",
+        allowed_options=[
+            "claude-haiku-4-5",
+            "claude-sonnet-4-6",
+            "moonshot-v1-128k",
+            "kimi-k2.6",
+        ],
     ),
     SettingDef(
         "ai-model-image",
@@ -1771,7 +1786,15 @@ SETTING_DEFINITIONS: list[SettingDef] = [
         "gpt-5.4-nano",
         "string",
         "Summarizer model",
-        "Model for PDF summarization. Supports claude-* and gpt-* models.",
+        "Model for PDF summarization. Resolved by prefix: gpt-* → OpenAI, "
+        "moonshot-*/kimi-* → Moonshot, claude-* → Anthropic.",
+        allowed_options=[
+            "gpt-5.4-nano",
+            "claude-haiku-4-5",
+            "claude-sonnet-4-6",
+            "moonshot-v1-128k",
+            "kimi-k2.6",
+        ],
     ),
     SettingDef(
         "syllabus-chunk-max-tokens",

--- a/backend/tests/test_claude_service.py
+++ b/backend/tests/test_claude_service.py
@@ -35,31 +35,30 @@ def claude_service():
             cache_inst.get.return_value = 64000
             mock_cache.instance.return_value = cache_inst
 
-            with patch("app.ai.claude_service.anthropic"):
-                from app.ai.claude_service import ClaudeService
+            from app.ai.claude_service import ClaudeService
 
-                service = ClaudeService()
-                service.client = AsyncMock()
+            service = ClaudeService()
+            service.client = AsyncMock()
 
-                # ClaudeService now routes through a provider (#2443). Keep the
-                # existing tests' `client.messages.create` mocking intact by
-                # making the fake provider's complete() call it and adapt the
-                # Anthropic-style mock response into an LLMResult.
-                async def _fake_complete(**kwargs):
-                    resp = await service.client.messages.create(**kwargs)
-                    text = "".join(
-                        b.text for b in resp.content if getattr(b, "type", None) == "text"
-                    )
-                    return LLMResult(
-                        text=text,
-                        stop_reason=resp.stop_reason,
-                        usage={"output_tokens": getattr(resp.usage, "output_tokens", None)},
-                    )
+            # ClaudeService now routes through a provider (#2443). Keep the
+            # existing tests' `client.messages.create` mocking intact by
+            # making the fake provider's complete() call it and adapt the
+            # Anthropic-style mock response into an LLMResult.
+            async def _fake_complete(**kwargs):
+                resp = await service.client.messages.create(**kwargs)
+                text = "".join(
+                    b.text for b in resp.content if getattr(b, "type", None) == "text"
+                )
+                return LLMResult(
+                    text=text,
+                    stop_reason=resp.stop_reason,
+                    usage={"output_tokens": getattr(resp.usage, "output_tokens", None)},
+                )
 
-                fake_provider = MagicMock()
-                fake_provider.complete = AsyncMock(side_effect=_fake_complete)
-                service._provider = lambda: fake_provider
-                return service
+            fake_provider = MagicMock()
+            fake_provider.complete = AsyncMock(side_effect=_fake_complete)
+            service._provider = lambda: fake_provider
+            return service
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_claude_service.py
+++ b/backend/tests/test_claude_service.py
@@ -46,9 +46,7 @@ def claude_service():
             # Anthropic-style mock response into an LLMResult.
             async def _fake_complete(**kwargs):
                 resp = await service.client.messages.create(**kwargs)
-                text = "".join(
-                    b.text for b in resp.content if getattr(b, "type", None) == "text"
-                )
+                text = "".join(b.text for b in resp.content if getattr(b, "type", None) == "text")
                 return LLMResult(
                     text=text,
                     stop_reason=resp.stop_reason,

--- a/backend/tests/test_image_generation.py
+++ b/backend/tests/test_image_generation.py
@@ -18,6 +18,33 @@ from app.domain.services.image_service import (
 )
 
 
+def _provider_patch(*, responses=None, side_effect=None):
+    """Patch image_service's resolve_provider with a fake provider (#2523).
+
+    Image metadata/alt-text now route through the pluggable provider's
+    ``complete()`` instead of a direct ``anthropic.AsyncAnthropic`` call. This
+    adapts the existing Anthropic-style mock messages (each with
+    ``.content[0].text``) into ``LLMResult`` objects. Pass ``responses`` (one
+    message or a list, consumed in order) or ``side_effect`` (e.g. an exception).
+    Returns ``(patch_cm, complete_mock)`` — assert on ``complete_mock.call_args``.
+    """
+    from app.ai.providers.base import LLMResult
+
+    complete_mock = AsyncMock()
+    if side_effect is not None:
+        complete_mock.side_effect = side_effect
+    elif isinstance(responses, (list, tuple)):
+        complete_mock.side_effect = [LLMResult(text=r.content[0].text) for r in responses]
+    else:
+        complete_mock.return_value = LLMResult(text=responses.content[0].text)
+    provider = MagicMock()
+    provider.complete = complete_mock
+    return (
+        patch("app.ai.providers.resolve_provider", return_value=provider),
+        complete_mock,
+    )
+
+
 class TestJaccardSimilarity:
     def test_identical_tags_returns_one(self):
         tags = ["malaria", "épidémiologie", "aof"]
@@ -250,21 +277,20 @@ class TestImageGenerationService:
             side_effect=[dedup_result, _empty_lesson_context_result(), reuse_result]
         )
 
-        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
-            mock_client = AsyncMock()
-            mock_anthropic_cls.return_value = mock_client
-            mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
+        prov_patch, _ = _provider_patch(responses=mock_claude_response)
+        with (
+            prov_patch,
+            patch("app.ai.providers.image_provider.AsyncOpenAI") as mock_openai_cls,
+        ):
+            result = await service.generate_for_lesson(
+                lesson_id=uuid.uuid4(),
+                module_id=uuid.uuid4(),
+                unit_id="u01",
+                lesson_content="Lesson about malaria in West Africa.",
+                session=mock_session,
+            )
 
-            with patch("app.ai.providers.image_provider.AsyncOpenAI") as mock_openai_cls:
-                result = await service.generate_for_lesson(
-                    lesson_id=uuid.uuid4(),
-                    module_id=uuid.uuid4(),
-                    unit_id="u01",
-                    lesson_content="Lesson about malaria in West Africa.",
-                    session=mock_session,
-                )
-
-                mock_openai_cls.assert_not_called()
+            mock_openai_cls.assert_not_called()
 
         assert result.status == "ready"
         assert result.image_url == f"/api/v1/images/{result.id}/data"
@@ -287,13 +313,10 @@ class TestImageGenerationService:
         image_api_response = MagicMock()
         image_api_response.data = [MagicMock(b64_json=fake_b64)]
 
-        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
-            mock_client = AsyncMock()
-            mock_anthropic_cls.return_value = mock_client
-            mock_client.messages.create = AsyncMock(
-                side_effect=[mock_claude_response, mock_alt_text_response]
-            )
-
+        prov_patch, complete_mock = _provider_patch(
+            responses=[mock_claude_response, mock_alt_text_response]
+        )
+        with prov_patch:
             with patch("app.ai.providers.image_provider.AsyncOpenAI") as mock_openai_cls:
                 mock_openai = AsyncMock()
                 mock_openai_cls.return_value = mock_openai
@@ -333,11 +356,8 @@ class TestImageGenerationService:
         dedup_result = _no_existing_image_result()
         mock_session.execute = AsyncMock(return_value=dedup_result)
 
-        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
-            mock_client = AsyncMock()
-            mock_anthropic_cls.return_value = mock_client
-            mock_client.messages.create = AsyncMock(side_effect=RuntimeError("Claude API error"))
-
+        prov_patch, complete_mock = _provider_patch(side_effect=RuntimeError("Claude API error"))
+        with prov_patch:
             result = await service.generate_for_lesson(
                 lesson_id=uuid.uuid4(),
                 module_id=uuid.uuid4(),
@@ -365,25 +385,22 @@ class TestImageGenerationService:
         image_api_response = MagicMock()
         image_api_response.data = [MagicMock(b64_json=fake_b64)]
 
-        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
-            mock_client = AsyncMock()
-            mock_anthropic_cls.return_value = mock_client
-            mock_client.messages.create = AsyncMock(
-                side_effect=[mock_claude_response, mock_alt_text_response]
+        prov_patch, _ = _provider_patch(responses=[mock_claude_response, mock_alt_text_response])
+        with (
+            prov_patch,
+            patch("app.ai.providers.image_provider.AsyncOpenAI") as mock_openai_cls,
+        ):
+            mock_openai = AsyncMock()
+            mock_openai_cls.return_value = mock_openai
+            mock_openai.images.generate = AsyncMock(return_value=image_api_response)
+
+            result = await service.generate_for_lesson(
+                lesson_id=uuid.uuid4(),
+                module_id=uuid.uuid4(),
+                unit_id="u01",
+                lesson_content="Lesson content.",
+                session=mock_session,
             )
-
-            with patch("app.ai.providers.image_provider.AsyncOpenAI") as mock_openai_cls:
-                mock_openai = AsyncMock()
-                mock_openai_cls.return_value = mock_openai
-                mock_openai.images.generate = AsyncMock(return_value=image_api_response)
-
-                result = await service.generate_for_lesson(
-                    lesson_id=uuid.uuid4(),
-                    module_id=uuid.uuid4(),
-                    unit_id="u01",
-                    lesson_content="Lesson content.",
-                    session=mock_session,
-                )
 
         assert result.alt_text_fr is not None and len(result.alt_text_fr) > 0
         assert result.alt_text_en is not None and len(result.alt_text_en) > 0
@@ -402,11 +419,8 @@ class TestImageGenerationService:
             side_effect=[dedup_result, _empty_lesson_context_result(), reuse_result]
         )
 
-        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
-            mock_client = AsyncMock()
-            mock_anthropic_cls.return_value = mock_client
-            mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
-
+        prov_patch, complete_mock = _provider_patch(responses=mock_claude_response)
+        with prov_patch:
             await service.generate_for_lesson(
                 lesson_id=uuid.uuid4(),
                 module_id=uuid.uuid4(),
@@ -464,18 +478,15 @@ class TestImageGenerationService:
         """When language='fr', the system prompt sent to Claude must request French labels."""
         from app.ai.prompts.audience import AudienceContext
 
-        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
-            mock_client = AsyncMock()
-            mock_anthropic_cls.return_value = mock_client
-            mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
-
+        prov_patch, complete_mock = _provider_patch(responses=mock_claude_response)
+        with prov_patch:
             await service._extract_concept_and_tags(
                 "Lesson about photosynthesis.",
                 language="fr",
                 audience=AudienceContext(is_kids=False),
             )
 
-            system_prompt = mock_client.messages.create.call_args.kwargs["system"]
+            system_prompt = complete_mock.call_args.kwargs["system"]
             assert "French" in system_prompt
             assert "language-agnostic" in system_prompt.lower()
 
@@ -483,18 +494,15 @@ class TestImageGenerationService:
         """Default language='en' must request English labels in the system prompt."""
         from app.ai.prompts.audience import AudienceContext
 
-        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
-            mock_client = AsyncMock()
-            mock_anthropic_cls.return_value = mock_client
-            mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
-
+        prov_patch, complete_mock = _provider_patch(responses=mock_claude_response)
+        with prov_patch:
             await service._extract_concept_and_tags(
                 "Lesson about photosynthesis.",
                 language="en",
                 audience=AudienceContext(is_kids=False),
             )
 
-            system_prompt = mock_client.messages.create.call_args.kwargs["system"]
+            system_prompt = complete_mock.call_args.kwargs["system"]
             assert "English" in system_prompt
 
     async def test_extract_concept_kids_audience_branches_style(
@@ -503,18 +511,15 @@ class TestImageGenerationService:
         """When audience.is_kids=True, the prompt must request kid-friendly cartoon style."""
         from app.ai.prompts.audience import AudienceContext
 
-        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
-            mock_client = AsyncMock()
-            mock_anthropic_cls.return_value = mock_client
-            mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
-
+        prov_patch, complete_mock = _provider_patch(responses=mock_claude_response)
+        with prov_patch:
             await service._extract_concept_and_tags(
                 "Counting from 1 to 10.",
                 language="en",
                 audience=AudienceContext(is_kids=True, age_min=6, age_max=10),
             )
 
-            system_prompt = mock_client.messages.create.call_args.kwargs["system"]
+            system_prompt = complete_mock.call_args.kwargs["system"]
             # Kids style markers (cartoon, primary colors, mascot) must appear.
             assert "cartoon" in system_prompt.lower()
             assert "children" in system_prompt.lower() or "child" in system_prompt.lower()
@@ -525,18 +530,15 @@ class TestImageGenerationService:
         """The system prompt must explicitly allow human figures in the infographic."""
         from app.ai.prompts.audience import AudienceContext
 
-        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
-            mock_client = AsyncMock()
-            mock_anthropic_cls.return_value = mock_client
-            mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
-
+        prov_patch, complete_mock = _provider_patch(responses=mock_claude_response)
+        with prov_patch:
             await service._extract_concept_and_tags(
                 "Some lesson.",
                 language="en",
                 audience=AudienceContext(is_kids=False),
             )
 
-            system_prompt = mock_client.messages.create.call_args.kwargs["system"]
+            system_prompt = complete_mock.call_args.kwargs["system"]
             # Humans must be explicitly allowed (not forbidden).
             assert "Human figures" in system_prompt or "human figures" in system_prompt
             assert "allowed" in system_prompt.lower()
@@ -554,11 +556,8 @@ class TestImageGenerationService:
         """
         from app.ai.prompts.audience import AudienceContext
 
-        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
-            mock_client = AsyncMock()
-            mock_anthropic_cls.return_value = mock_client
-            mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
-
+        prov_patch, complete_mock = _provider_patch(responses=mock_claude_response)
+        with prov_patch:
             _, _, tags, _, _, _ = await service._extract_concept_and_tags(
                 "Counting lesson.",
                 language="fr",
@@ -663,25 +662,22 @@ class TestImageGenerationService:
         image_api_response = MagicMock()
         image_api_response.data = [MagicMock(b64_json=fake_b64)]
 
-        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
-            mock_client = AsyncMock()
-            mock_anthropic_cls.return_value = mock_client
-            mock_client.messages.create = AsyncMock(
-                side_effect=[mock_claude_response, mock_alt_text_response]
+        prov_patch, _ = _provider_patch(responses=[mock_claude_response, mock_alt_text_response])
+        with (
+            prov_patch,
+            patch("app.ai.providers.image_provider.AsyncOpenAI") as mock_openai_cls,
+        ):
+            mock_openai = AsyncMock()
+            mock_openai_cls.return_value = mock_openai
+            mock_openai.images.generate = AsyncMock(return_value=image_api_response)
+
+            result = await service.generate_for_lesson(
+                lesson_id=uuid.uuid4(),
+                module_id=uuid.uuid4(),
+                unit_id="u01",
+                lesson_content="Lesson about tuberculosis surveillance in Senegal.",
+                session=mock_session,
             )
-
-            with patch("app.ai.providers.image_provider.AsyncOpenAI") as mock_openai_cls:
-                mock_openai = AsyncMock()
-                mock_openai_cls.return_value = mock_openai
-                mock_openai.images.generate = AsyncMock(return_value=image_api_response)
-
-                result = await service.generate_for_lesson(
-                    lesson_id=uuid.uuid4(),
-                    module_id=uuid.uuid4(),
-                    unit_id="u01",
-                    lesson_content="Lesson about tuberculosis surveillance in Senegal.",
-                    session=mock_session,
-                )
 
         assert result.image_data is not None, "image_data must not be NULL after generation"
         assert len(result.image_data) > 0

--- a/backend/tests/test_pdf_summarizer.py
+++ b/backend/tests/test_pdf_summarizer.py
@@ -485,6 +485,35 @@ class TestSummarizeSinglePdf:
         assert result == "GPT summary"
         mock_client.chat.completions.create.assert_called_once()
 
+    def test_moonshot_model_uses_provider_complete(self):
+        """A moonshot-* summarizer model must route through the pluggable
+        provider's complete() — not the Anthropic messages.stream path (#2523)."""
+        from types import SimpleNamespace
+
+        from app.ai.pdf_summarizer import summarize_single_pdf
+
+        provider = MagicMock()
+        provider.complete = AsyncMock(return_value=SimpleNamespace(text="  Kimi summary  "))
+
+        result = asyncio.run(
+            summarize_single_pdf(provider, "Book", "text", model="moonshot-v1-128k")
+        )
+
+        assert result == "Kimi summary"
+        provider.complete.assert_awaited_once()
+        assert provider.complete.await_args.kwargs["model"] == "moonshot-v1-128k"
+
+    def test_get_summarizer_client_resolves_moonshot_provider(self):
+        """_get_summarizer_client must delegate moonshot-* to resolve_provider."""
+        from app.ai import pdf_summarizer
+
+        sentinel = object()
+        with patch("app.ai.providers.resolve_provider", return_value=sentinel) as resolve:
+            client = pdf_summarizer._get_summarizer_client("kimi-k2.6")
+
+        assert client is sentinel
+        resolve.assert_called_once_with("kimi-k2.6")
+
 
 class TestSummarizePdfsSync:
     def test_returns_one_summary_per_pdf(self):

--- a/backend/tests/test_syllabus_agent.py
+++ b/backend/tests/test_syllabus_agent.py
@@ -18,11 +18,6 @@ from app.main import app
 
 
 @pytest.fixture
-def mock_anthropic_client():
-    return MagicMock()
-
-
-@pytest.fixture
 def mock_semantic_retriever():
     retriever = AsyncMock(spec=SemanticRetriever)
     retriever.retrieve = AsyncMock(return_value=[])
@@ -35,9 +30,8 @@ def mock_embedding_service():
 
 
 @pytest.fixture
-def syllabus_service(mock_anthropic_client, mock_semantic_retriever, mock_embedding_service):
+def syllabus_service(mock_semantic_retriever, mock_embedding_service):
     return SyllabusAgentService(
-        anthropic_client=mock_anthropic_client,
         semantic_retriever=mock_semantic_retriever,
         embedding_service=mock_embedding_service,
     )

--- a/backend/tests/test_tutor_source_image.py
+++ b/backend/tests/test_tutor_source_image.py
@@ -20,6 +20,24 @@ from app.domain.services.tutor_tools import TOOL_DEFINITIONS, TutorToolExecutor
 # ---------------------------------------------------------------------------
 
 
+def _provider_patch(*responses):
+    """Patch image_service's resolve_provider with a fake provider (#2523).
+
+    Image metadata/alt-text route through the pluggable provider's ``complete()``
+    now, not a direct ``anthropic.AsyncAnthropic`` call. Adapts Anthropic-style
+    mock messages (each ``.content[0].text``) into ``LLMResult`` objects,
+    consumed in order.
+    """
+    from unittest.mock import patch
+
+    from app.ai.providers.base import LLMResult
+
+    complete_mock = AsyncMock(side_effect=[LLMResult(text=r.content[0].text) for r in responses])
+    provider = MagicMock()
+    provider.complete = complete_mock
+    return patch("app.ai.providers.resolve_provider", return_value=provider)
+
+
 def _make_source_image(
     image_type: str = "diagram",
     figure_number: str = "3.2",
@@ -506,25 +524,21 @@ class TestDallEFallbackOptimization:
             ]
         )
 
-        with __import__("unittest.mock", fromlist=["patch"]).patch(
-            "anthropic.AsyncAnthropic"
-        ) as mock_anthropic_cls:
-            mock_client = AsyncMock()
-            mock_anthropic_cls.return_value = mock_client
-            mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
-
-            with __import__("unittest.mock", fromlist=["patch"]).patch(
+        with (
+            _provider_patch(mock_claude_response),
+            __import__("unittest.mock", fromlist=["patch"]).patch(
                 "openai.AsyncOpenAI"
-            ) as mock_openai_cls:
-                result = await service.generate_for_lesson(
-                    lesson_id=uuid.uuid4(),
-                    module_id=uuid.uuid4(),
-                    unit_id="u01",
-                    lesson_content="Lesson about disease surveillance in West Africa.",
-                    session=mock_session,
-                )
+            ) as mock_openai_cls,
+        ):
+            result = await service.generate_for_lesson(
+                lesson_id=uuid.uuid4(),
+                module_id=uuid.uuid4(),
+                unit_id="u01",
+                lesson_content="Lesson about disease surveillance in West Africa.",
+                session=mock_session,
+            )
 
-                mock_openai_cls.assert_not_called()
+            mock_openai_cls.assert_not_called()
 
         assert result.status == "ready"
         assert source_img.storage_url in (result.image_url or "")
@@ -551,13 +565,7 @@ class TestDallEFallbackOptimization:
             side_effect=[dedup_result, _lesson_context_result(None), reuse_result]
         )
 
-        with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
-            mock_client = AsyncMock()
-            mock_anthropic_cls.return_value = mock_client
-            mock_client.messages.create = AsyncMock(
-                side_effect=[mock_claude_response, alt_text_msg]
-            )
-
+        with _provider_patch(mock_claude_response, alt_text_msg):
             with patch("app.ai.providers.image_provider.AsyncOpenAI") as mock_openai_cls:
                 mock_openai = AsyncMock()
                 mock_openai_cls.return_value = mock_openai
@@ -607,23 +615,19 @@ class TestDallEFallbackOptimization:
             ]
         )
 
-        with __import__("unittest.mock", fromlist=["patch"]).patch(
-            "anthropic.AsyncAnthropic"
-        ) as mock_anthropic_cls:
-            mock_client = AsyncMock()
-            mock_anthropic_cls.return_value = mock_client
-            mock_client.messages.create = AsyncMock(return_value=mock_claude_response)
-
-            with __import__("unittest.mock", fromlist=["patch"]).patch(
+        with (
+            _provider_patch(mock_claude_response),
+            __import__("unittest.mock", fromlist=["patch"]).patch(
                 "app.ai.providers.image_provider.AsyncOpenAI"
-            ):
-                result = await service.generate_for_lesson(
-                    lesson_id=uuid.uuid4(),
-                    module_id=uuid.uuid4(),
-                    unit_id="u01",
-                    lesson_content="Statistics lesson with charts.",
-                    session=mock_session,
-                )
+            ),
+        ):
+            result = await service.generate_for_lesson(
+                lesson_id=uuid.uuid4(),
+                module_id=uuid.uuid4(),
+                unit_id="u01",
+                lesson_content="Statistics lesson with charts.",
+                session=mock_session,
+            )
 
         assert result.image_url == "https://cdn.example.com/figures/fig1.webp"
         assert result.format == "webp"


### PR DESCRIPTION
Promotes #2523 (merged to `dev` in #2524) to `main`.

Cherry-picked onto a fresh sync branch off `main` to avoid the usual dev↔main squash-SHA phantom conflicts. Content is identical to #2524 — 14 files, no other changes (the recent image-provider backlog #2517/#2520/#2512 is already on main via its own sync PRs).

## What it does
Routes the hardcoded / mis-defaulted content-pipeline LLM calls through `resolve_provider` so they honor a model setting instead of always billing Anthropic:
- `image_service` concept/tags + alt-text, figure/diagram label translation, `pdf_summarizer` moonshot branch
- Adds `moonshot-v1-128k`/`kimi-k2.6` to `allowed_options` for `ai-model-quality`, `ai-model-image-metadata`, `syllabus-summarizer-model`
- Removes dead Anthropic clients (`ClaudeService.client`, injected `SyllabusAgentService` client)

Vision figure-extraction + tutor multimodal intentionally stay on Anthropic.

Fixes #2523

🤖 Generated with [Claude Code](https://claude.com/claude-code)