### PR TITLE
fix(indexation): index file_hash-deduped DB-only sources alongside disk PDFs

### DIFF
--- a/backend/app/tasks/rag_indexation.py
+++ b/backend/app/tasks/rag_indexation.py
@@ -27,6 +27,32 @@ def _estimate_seconds(pdf_files: list[Path]) -> int:
     return max(30, int(extraction_s + embedding_s))
 
 
+def _db_only_resources(pdf_files: list[Path], db_resources: list) -> list:
+    """Return DB resources that have extracted text but no file on disk.
+
+    ``file_hash``-deduped uploads (``upload_course_resource``) create a thin
+    ``CourseResource`` that copies the donor's ``content_hash`` and writes **no**
+    file to disk. The disk-glob indexing path would skip them entirely, dropping
+    the source from the course's RAG even though its chunks already exist on a
+    donor and only need cloning. We index those "DB-only" resources via the
+    clone-or-embed DB path alongside any on-disk PDFs.
+
+    A resource counts as "on disk" when a PDF's stem equals its ``filename`` or
+    its ``parent_filename`` (split parts share the parent's single file). See #2525.
+    """
+    disk_stems = {p.stem for p in pdf_files}
+    out = []
+    for r in db_resources:
+        if not r.raw_text:
+            continue
+        if r.filename in disk_stems:
+            continue
+        if r.parent_filename and r.parent_filename in disk_stems:
+            continue
+        out.append(r)
+    return out
+
+
 def finalize_indexation_state(
     course_id: str | None,
     *,
@@ -152,31 +178,32 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
     course_dir = UPLOAD_DIR / course_id
     pdf_files = list(course_dir.glob("*.pdf")) if course_dir.exists() else []
 
-    db_resources: list = []
-    if not pdf_files:
-        from sqlalchemy import create_engine, select
-        from sqlalchemy.orm import Session
+    # Always load DB resources. file_hash-deduped uploads carry raw_text + a
+    # donor content_hash but write no file to disk, so the disk-glob path would
+    # skip them. We index those "DB-only" resources alongside the on-disk PDFs
+    # instead of only when no PDF exists on disk (the old mutual exclusion). #2525
+    from sqlalchemy import create_engine, select
+    from sqlalchemy.orm import Session
 
-        from app.domain.models.course_resource import CourseResource
-        from app.infrastructure.config.settings import settings
+    from app.domain.models.course_resource import CourseResource
+    from app.infrastructure.config.settings import settings
 
-        _eng = create_engine(settings.database_url_sync, pool_pre_ping=True)
-        try:
-            with Session(_eng) as _sess:
-                db_resources = (
-                    _sess.execute(
-                        select(CourseResource).where(
-                            CourseResource.course_id == uuid.UUID(course_id)
-                        )
-                    )
-                    .scalars()
-                    .all()
+    _eng = create_engine(settings.database_url_sync, pool_pre_ping=True)
+    try:
+        with Session(_eng) as _sess:
+            all_db_resources = list(
+                _sess.execute(
+                    select(CourseResource).where(CourseResource.course_id == uuid.UUID(course_id))
                 )
-                db_resources = [r for r in db_resources if r.raw_text]
-        finally:
-            _eng.dispose()
+                .scalars()
+                .all()
+            )
+    finally:
+        _eng.dispose()
 
-    if not pdf_files and not db_resources:
+    db_only_resources = _db_only_resources(pdf_files, all_db_resources)
+
+    if not pdf_files and not db_only_resources:
         self.update_state(
             state="FAILURE",
             meta={
@@ -192,7 +219,7 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
         }
 
     estimated_seconds = (
-        _estimate_seconds(pdf_files) if pdf_files else max(30, len(db_resources) * 60)
+        _estimate_seconds(pdf_files) if pdf_files else max(30, len(db_only_resources) * 60)
     )
     start_time = time.monotonic()
 
@@ -231,26 +258,30 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
         total_chunks = 0
         total_images = 0
 
-        if not pdf_files and db_resources:
+        # Phase 1: DB-only resources (file_hash-deduped; no file on disk).
+        # Cloning from a donor is ~instant, so index these first — a soft time
+        # limit hit on a heavy disk PDF afterward can't starve them. #2525
+        if db_only_resources:
             logger.info(
-                "No PDFs on disk — indexing text chunks from DB course_resources",
+                "Indexing DB-only course_resources (no file on disk)",
                 course_id=course_id,
-                resource_count=len(db_resources),
+                resource_count=len(db_only_resources),
             )
             from app.infrastructure.persistence.database import async_session_factory
 
             chunker = TextChunker()
-            files_count = len(db_resources)
-            for i, res in enumerate(db_resources):
+            files_count = len(db_only_resources)
+            for i, res in enumerate(db_only_resources):
                 resource_name = res.filename
-                extract_progress = 5 + int((i / files_count) * 80)
+                # Cap DB-only progress at 30%; the disk loop owns 5→100 below.
+                extract_progress = 5 + int((i / files_count) * 25)
                 self.update_state(
                     state="EMBEDDING",
                     meta={
                         "step": "embedding",
                         "step_label": f"Indexation depuis DB: {resource_name}",
                         "progress": extract_progress,
-                        "files_total": files_count,
+                        "files_total": files_count + len(pdf_files),
                         "files_processed": i,
                         "current_file": resource_name,
                         "chunks_processed": total_chunks,
@@ -300,31 +331,9 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
                     course_id=course_id,
                 )
 
-            # Extract images from any PDFs on disk even in DB-resources path
-            if course_dir.exists():
-                img_pdfs = list(course_dir.glob("*.pdf"))
-                for pdf_path in img_pdfs:
-                    try:
-                        ic = await pipeline.process_pdf_images(
-                            pdf_path=str(pdf_path),
-                            source=rag_collection_id,
-                            rag_collection_id=rag_collection_id,
-                        )
-                        total_images += ic
-                        logger.info(
-                            "Extracted images from PDF (DB resources path)",
-                            file=pdf_path.name,
-                            images=ic,
-                            course_id=course_id,
-                        )
-                    except Exception as img_exc:
-                        logger.warning(
-                            "Image extraction failed (DB path, non-blocking)",
-                            file=pdf_path.name,
-                            course_id=course_id,
-                            error=str(img_exc),
-                        )
-
+        # Pure-deduped course (every source was file_hash-deduped): no disk PDFs
+        # to extract text/images from, so we're done.
+        if not pdf_files:
             return total_chunks, total_images
 
         # Build pdf_path → course_resource_id lookup so chunks land with

--- a/backend/tests/test_indexation_lifecycle.py
+++ b/backend/tests/test_indexation_lifecycle.py
@@ -196,7 +196,7 @@ class TestSoftTimeLimitHandling:
 
         course_path = MagicMock()
         course_path.exists.return_value = True
-        # One PDF on disk so we reach the asyncio.run try-block (skip DB path).
+        # One PDF on disk so we reach the asyncio.run try-block.
         course_path.glob.return_value = [Path("/tmp/nonexistent-for-test.pdf")]
 
         def _raise_soft_timeout(coro):
@@ -205,15 +205,25 @@ class TestSoftTimeLimitHandling:
             coro.close()
             raise SoftTimeLimitExceeded()
 
+        # The task now always loads CourseResource rows up front (to index
+        # file_hash-deduped DB-only sources alongside disk PDFs, #2525). Stub the
+        # query so it returns no DB-only resources for this disk-PDF scenario.
+        empty_session = MagicMock()
+        empty_session.execute.return_value.scalars.return_value.all.return_value = []
+        empty_session.__enter__ = lambda self: self
+        empty_session.__exit__ = lambda *a: None
+
         with (
             patch.object(mod, "UPLOAD_DIR") as mock_upload_dir,
+            patch("sqlalchemy.create_engine"),
+            patch("sqlalchemy.orm.Session", return_value=empty_session),
             patch("asyncio.run", side_effect=_raise_soft_timeout),
             patch.object(task, "update_state") as mock_update_state,
         ):
             mock_upload_dir.__truediv__.return_value = course_path
 
             # Must NOT raise — raising would trigger autoretry of a ~20-min run.
-            result = task.run("course-x", "collection-x")
+            result = task.run("11111111-1111-1111-1111-111111111111", "collection-x")
 
         assert result["status"] == "partial_timeout"
         assert result["rag_collection_id"] == "collection-x"
@@ -232,3 +242,66 @@ class TestSoftTimeLimitHandling:
         assert index_course_resources.ignore_result is False
         assert index_course_resources.soft_time_limit >= 3000
         assert index_course_resources.time_limit > index_course_resources.soft_time_limit
+
+
+class TestDbOnlyResources:
+    """Unit tests for ``_db_only_resources`` — the partition that keeps
+    file_hash-deduped uploads (no file on disk) from being silently dropped by
+    the disk-glob indexing path. See #2525.
+    """
+
+    @staticmethod
+    def _res(filename, *, raw_text="text", parent_filename=None):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            filename=filename, parent_filename=parent_filename, raw_text=raw_text
+        )
+
+    def test_deduped_db_only_resource_is_selected_when_disk_pdf_coexists(self) -> None:
+        from pathlib import Path
+
+        from app.tasks.rag_indexation import _db_only_resources
+
+        pdf_files = [Path("/u/course/Douglas.pdf")]
+        douglas = self._res("Douglas")  # on disk
+        donaldson = self._res("donaldson")  # file_hash-deduped, no file on disk
+
+        out = _db_only_resources(pdf_files, [douglas, donaldson])
+
+        # The regression: donaldson must be picked up even though a disk PDF
+        # exists — the old `if not pdf_files` gate dropped it entirely.
+        assert out == [donaldson]
+
+    def test_resource_matching_disk_stem_is_excluded(self) -> None:
+        from pathlib import Path
+
+        from app.tasks.rag_indexation import _db_only_resources
+
+        pdf_files = [Path("/u/course/Douglas.pdf")]
+        out = _db_only_resources(pdf_files, [self._res("Douglas")])
+        assert out == []
+
+    def test_split_part_excluded_when_parent_on_disk(self) -> None:
+        from pathlib import Path
+
+        from app.tasks.rag_indexation import _db_only_resources
+
+        pdf_files = [Path("/u/course/Douglas.pdf")]
+        part = self._res("Douglas_part2", parent_filename="Douglas")
+        out = _db_only_resources(pdf_files, [part])
+        assert out == []
+
+    def test_resource_without_raw_text_excluded(self) -> None:
+        from app.tasks.rag_indexation import _db_only_resources
+
+        out = _db_only_resources([], [self._res("pending", raw_text=None)])
+        assert out == []
+
+    def test_all_deduped_course_with_no_disk_files(self) -> None:
+        from app.tasks.rag_indexation import _db_only_resources
+
+        a = self._res("a")
+        b = self._res("b")
+        out = _db_only_resources([], [a, b])
+        assert out == [a, b]


### PR DESCRIPTION
Fixes #2525

## Problem

On the AI course wizard, a deduped source (e.g. `donaldson.pdf`, previously indexed in another course) showed **"Extrait, non indexé"** with **0 chunks** and was dropped from the course's RAG, while the freshly-uploaded source indexed fine. Re-running indexation never recovered it.

## Root cause

Two correct features interacted into a silent gap:

- **Upload-time `file_hash` dedup** (`upload_course_resource`): a binary-identical PDF creates a *thin* `CourseResource` that copies the donor's `content_hash`, writes **no file to disk**, and skips extraction.
- **Indexation** (`index_course_resources`): selected work via `course_dir.glob("*.pdf")` and only loaded/ran the DB path **`if not pdf_files`**.

⇒ Whenever any PDF was on disk, every `file_hash`-deduped **DB-only** resource was skipped entirely — the content-hash clone that would reuse its existing chunks lived in the DB path that never executed. Disk and DB paths were mutually exclusive when they should be additive.

## Fix

- Always load `CourseResource` rows; compute the **DB-only** set (has `raw_text`, no matching file on disk) via new `_db_only_resources()`.
- Index DB-only resources via the existing clone-or-embed DB path **in addition** to on-disk PDFs.
- Process the cheap clone-able DB-only resources **first**, so a soft time limit on a heavy disk PDF can't starve them.

## Tests

- 5 new unit tests for the disk-vs-DB-only partition (deduped source selected when a disk PDF coexists; disk-stem / split-part / no-raw_text exclusions; all-deduped course).
- Updated the soft-time-limit test for the now-unconditional DB load. Full file: 16 passed. `ruff check` + `ruff format` clean.

## Note

Affected courses on staging stay at 0 chunks for the deduped source until re-indexed; after this fix a re-index clones them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)