### PR TITLE
fix(images): generate Black West African people, not white/European (#2526)

### DIFF
--- a/backend/app/domain/services/image_service.py
+++ b/backend/app/domain/services/image_service.py
@@ -23,6 +23,16 @@ SEMANTIC_REUSE_THRESHOLD = 0.85
 # the reuse cache from serving an old garbled-text image for a new lesson.
 STYLE_TAG = "style:illustration"
 
+# Sira serves West African learners. The Claude-authored prompt is asked to depict
+# Black West African people, but image models drift toward their (white/European)
+# training bias, so we also append this literal constraint to every prompt we send
+# to the image backend — belt-and-suspenders, since the model follows literal text.
+PEOPLE_CONSTRAINT = (
+    " Important: any human figures must be Black African people from West Africa, "
+    "with West African skin tones, hair textures and facial features. Never depict "
+    "white, Caucasian, European, Asian or other non-African people."
+)
+
 
 def _jaccard_similarity(tags_a: list[str], tags_b: list[str]) -> float:
     """Compute Jaccard coefficient between two tag lists (case-insensitive)."""
@@ -231,8 +241,8 @@ class ImageGenerationService:
             style_block = (
                 "STYLE for a children's audience: bright friendly cartoon-style flat "
                 "illustration, primary colors, rounded shapes, simple icons, optional "
-                "friendly mascot character. Keep visual complexity low. Show diverse "
-                "children where people appear."
+                "friendly mascot character. Keep visual complexity low. Where children "
+                "appear, they MUST be Black African children from West Africa."
             )
         else:
             style_block = (
@@ -255,10 +265,14 @@ class ImageGenerationService:
             "through imagery alone.\n"
             f"   - {style_block}\n"
             "   - Human figures (learners, professionals, customers, kids, etc.) ARE allowed and "
-            "even encouraged when they help convey the concept; depict diverse people and avoid "
-            "stereotypes. They are not required if the concept is purely structural.\n"
-            "   - Stay subject-agnostic: derive the visual setting from the lesson content itself "
-            "(do not assume any specific country, region, profession, or industry unless the lesson states it).\n"
+            "even encouraged when they help convey the concept. Whenever people appear they MUST "
+            "be Black African people from West Africa (West African skin tones, hair textures and "
+            "facial features); NEVER depict white, Caucasian, European, Asian or other non-African "
+            "people. Avoid stereotypes. People are not required if the concept is purely structural.\n"
+            "   - Stay subject-agnostic about the topic: derive the visual setting from the lesson "
+            "content itself (do not assume any specific profession or industry unless the lesson "
+            "states it). This does NOT override the rule above — any people shown are always Black "
+            "West Africans regardless of subject.\n"
             "   - 250-450 characters.\n"
             "   - GOOD example: 'Clean conceptual illustration: cross-section of a leaf showing a "
             "chloroplast, stomata and veins; arrows for CO2 entering, O2 leaving, water rising and "
@@ -392,7 +406,9 @@ class ImageGenerationService:
         from app.domain.services.platform_settings_service import SettingsCache
 
         model = SettingsCache.instance().get("ai-model-image", DEFAULT_IMAGE_MODEL)
-        image_bytes, used_model = await generate_image(prompt, model=model, size="1536x1024")
+        image_bytes, used_model = await generate_image(
+            prompt + PEOPLE_CONSTRAINT, model=model, size="1536x1024"
+        )
         return image_bytes, f"{used_model}://generated"
 
     # Backwards-compatible alias: the backfill task still calls ``_call_dalle``.

--- a/backend/tests/test_image_generation.py
+++ b/backend/tests/test_image_generation.py
@@ -546,6 +546,59 @@ class TestImageGenerationService:
             assert "no people" not in system_prompt.lower()
             assert "no human" not in system_prompt.lower()
 
+    async def test_extract_concept_requires_west_african_people(
+        self, service, mock_claude_response
+    ):
+        """#2526: when people appear they must be Black West Africans, never European."""
+        from app.ai.prompts.audience import AudienceContext
+
+        prov_patch, complete_mock = _provider_patch(responses=mock_claude_response)
+        with prov_patch:
+            await service._extract_concept_and_tags(
+                "Some lesson.",
+                language="en",
+                audience=AudienceContext(is_kids=False),
+            )
+
+            system_prompt = complete_mock.call_args.kwargs["system"]
+            assert "West Africa" in system_prompt
+            assert "Black African" in system_prompt
+            # The model must be told NOT to default to white/European people.
+            assert "European" in system_prompt
+            # The old region-neutral "diverse people" wording must be gone.
+            assert "depict diverse people" not in system_prompt
+
+    async def test_kids_style_requires_west_african_children(self, service, mock_claude_response):
+        """#2526: the kids style branch must also require Black West African children."""
+        from app.ai.prompts.audience import AudienceContext
+
+        prov_patch, complete_mock = _provider_patch(responses=mock_claude_response)
+        with prov_patch:
+            await service._extract_concept_and_tags(
+                "Counting from 1 to 10.",
+                language="en",
+                audience=AudienceContext(is_kids=True, age_min=6, age_max=10),
+            )
+
+            system_prompt = complete_mock.call_args.kwargs["system"]
+            assert "Black African children from West Africa" in system_prompt
+
+    async def test_generate_image_appends_west_african_constraint(self, service):
+        """#2526: the literal prompt sent to the image backend must carry the constraint."""
+        from app.domain.services.image_service import PEOPLE_CONSTRAINT
+
+        gen_mock = AsyncMock(return_value=(b"img-bytes", "gpt-image-1"))
+        with patch("app.ai.providers.image_provider.generate_image", gen_mock):
+            await service._generate_image("A clean conceptual illustration.")
+
+        sent_prompt = (
+            gen_mock.call_args.args[0]
+            if gen_mock.call_args.args
+            else (gen_mock.call_args.kwargs["prompt"])
+        )
+        assert sent_prompt.endswith(PEOPLE_CONSTRAINT)
+        assert "Black African people from West Africa" in sent_prompt
+
     async def test_extract_concept_injects_style_and_audience_tags(
         self, service, mock_claude_response
     ):


### PR DESCRIPTION
## Summary

Sira serves West African learners, but generated lesson illustrations were drifting toward the image model's white/European training bias. The prompt-building logic was deliberately region-neutral (`"depict diverse people"`, `"do not assume any specific country, region"`), so nothing steered the model toward West African people.

This hardcodes the constraint in **two layers** for reliability:

1. **Claude system prompt** (`_extract_concept_and_tags`) — when human figures appear they must be **Black African people from West Africa** (West African skin tones, hair, features); never white/Caucasian/European/Asian. Applied to both the adult and kids `style_block`. People remain optional for purely structural/diagram concepts.
2. **Final prompt to the image backend** (`_generate_image`) — appends a literal `PEOPLE_CONSTRAINT` string before sending to gpt-image-1/Gemini, since the image model follows literal prompt text regardless of what Claude returned. This covers both the lesson-generation path and the backfill task (via the `_call_dalle` alias).

The `subject-agnostic` rule is preserved for the *topic/setting*, with an explicit carve-out so it never overrides the people constraint.

## Scope

- `backend/app/domain/services/image_service.py` — prompt wording + `PEOPLE_CONSTRAINT`.
- `backend/tests/test_image_generation.py` — 3 new tests; existing 38 unaffected.

No change to caching/dedup (semantic tags untouched).

## Test

`pytest tests/test_image_generation.py` → 41 passed.

Fixes #2526

🤖 Generated with [Claude Code](https://claude.com/claude-code)