### PR TITLE
fix(indexation): make re-index idempotent — replace a resource's chunks instead of appending

### DIFF
--- a/backend/app/ai/rag/pipeline.py
+++ b/backend/app/ai/rag/pipeline.py
@@ -76,6 +76,15 @@ class RAGPipeline:
         if not pdf_path.exists():
             raise FileNotFoundError(f"PDF file not found: {pdf_path}")
 
+        # Idempotent re-index: drop this resource's existing chunks first so a
+        # re-run replaces rather than appends. _store_chunks' (source, chunk_index,
+        # content) guard isn't stable across runs (chunk_index resets per page) and
+        # the clone path has no guard at all, so without this a re-index doubles the
+        # chunk count. Scoped strictly by course_resource_id — siblings untouched. #2534
+        if course_resource_id:
+            async with async_session_factory() as _clear_session:
+                await self.clear_resource_chunks(source, course_resource_id, _clear_session)
+
         # Content-hash dedup: clone from a donor course instead of re-embedding.
         if content_hash and course_resource_id:
             async with async_session_factory() as _dedup_session:
@@ -802,6 +811,45 @@ class RAGPipeline:
 
         logger.info("Cleared existing chunks", source=source, count=existing_count)
         return existing_count
+
+    async def clear_resource_chunks(
+        self,
+        source: str,
+        course_resource_id: UUID,
+        session: AsyncSession | None = None,
+    ) -> int:
+        """Delete one resource's chunks, scoped by (source, course_resource_id).
+
+        Makes (re)indexing idempotent: callers clear a resource's existing chunks
+        before storing/cloning fresh ones, so a re-run replaces rather than
+        appends. Scoped strictly by ``course_resource_id`` so sibling resources in
+        the same RAG collection are untouched. See #2534.
+        """
+        session_provided = session is not None
+        if not session_provided:
+            async with async_session_factory() as session:
+                return await self._clear_resource_chunks(source, course_resource_id, session)
+        return await self._clear_resource_chunks(source, course_resource_id, session)
+
+    async def _clear_resource_chunks(
+        self, source: str, course_resource_id: UUID, session: AsyncSession
+    ) -> int:
+        result = await session.execute(
+            delete(DocumentChunk).where(
+                DocumentChunk.source == source,
+                DocumentChunk.course_resource_id == course_resource_id,
+            )
+        )
+        await session.commit()
+        deleted = result.rowcount or 0
+        if deleted:
+            logger.info(
+                "Cleared resource chunks before re-index",
+                source=source,
+                course_resource_id=str(course_resource_id),
+                count=deleted,
+            )
+        return deleted
 
     async def get_pipeline_stats(self, session: AsyncSession | None = None) -> dict[str, Any]:
         """Get statistics about the current state of the pipeline."""

--- a/backend/app/tasks/rag_indexation.py
+++ b/backend/app/tasks/rag_indexation.py
@@ -288,6 +288,12 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
                         "estimated_seconds_remaining": _remaining(extract_progress),
                     },
                 )
+                # Idempotent re-index: drop this resource's existing chunks first
+                # so a re-run replaces rather than appends (clone + embed paths
+                # below have no dedup of their own). Scoped by course_resource_id. #2534
+                async with async_session_factory() as _clear_session:
+                    await pipeline.clear_resource_chunks(rag_collection_id, res.id, _clear_session)
+
                 # Content-hash dedup: clone from donor course if same text already indexed.
                 if res.content_hash:
                     async with async_session_factory() as _dedup_session:

--- a/backend/tests/test_rag_pipeline_images.py
+++ b/backend/tests/test_rag_pipeline_images.py
@@ -836,3 +836,48 @@ class TestRAGPipelineVisionCaption:
         added = mock_session.add.call_args[0][0]
         assert added.figure_kind == "body_text"
         mock_classify.assert_not_called()
+
+
+class TestClearResourceChunks:
+    """Idempotent re-index: clear_resource_chunks must scope deletion by both
+    source and course_resource_id so a re-run replaces (not appends) and sibling
+    resources in the same collection are untouched. See #2534.
+    """
+
+    def setup_method(self):
+        self.pipeline = RAGPipeline(AsyncMock())
+
+    @pytest.mark.asyncio
+    async def test_delete_is_scoped_by_source_and_resource_and_returns_rowcount(self):
+        import uuid
+
+        rid = uuid.uuid4()
+        captured = {}
+
+        async def _execute(stmt):
+            captured["stmt"] = stmt
+            return MagicMock(rowcount=7)
+
+        session = MagicMock()
+        session.execute = AsyncMock(side_effect=_execute)
+        session.commit = AsyncMock()
+
+        deleted = await self.pipeline._clear_resource_chunks("collection-x", rid, session)
+
+        assert deleted == 7
+        session.commit.assert_awaited_once()
+        sql = str(captured["stmt"].compile(compile_kwargs={"literal_binds": False}))
+        assert "DELETE FROM document_chunks" in sql
+        # Both predicates present — not a collection-wide wipe.
+        assert "source" in sql and "course_resource_id" in sql
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_nothing_deleted(self):
+        import uuid
+
+        session = MagicMock()
+        session.execute = AsyncMock(return_value=MagicMock(rowcount=0))
+        session.commit = AsyncMock()
+
+        deleted = await self.pipeline._clear_resource_chunks("c", uuid.uuid4(), session)
+        assert deleted == 0


### PR DESCRIPTION
Fixes #2534

## Problem

Re-running indexation on an already-indexed course **doubles** a PDF's chunks. Seen on staging while verifying #2525: `donaldson.pdf` correctly cloned to 1658, but `…Douglas.pdf` went **1095 → 2190** (exact 2×). Total RAG = 3848 instead of 2753.

## Root cause

Neither index path is idempotent:
- **Disk path** — `_store_chunks` dedups on `(source, chunk_index, content)`, but `chunk_index` resets per page (`chunker.chunk_document` called per-page), so the key isn't stable across runs/code-versions → pre-existing rows don't match → a full second copy is inserted.
- **Clone path** — `_clone_chunks` has no dedup at all.

#2525 makes re-index the recommended recovery, so this now bites.

## Fix

Add `RAGPipeline.clear_resource_chunks(source, course_resource_id)` and call it before storing/cloning in **both** `process_pdf_document` and the DB-only clone/embed loop, so a re-index **replaces** rather than appends. Deletion is scoped strictly by `course_resource_id` — sibling resources in the same RAG collection are untouched.

## Tests

- 2 new unit tests: delete is scoped by `source` **and** `course_resource_id` (not a collection-wide wipe) and returns the rowcount; zero-delete case.
- `test_rag_pipeline_images.py` + `test_indexation_lifecycle.py`: 39 passed. `ruff` clean.

## Follow-up (not in this PR)

Courses re-indexed before this lands carry duplicate chunk sets (e.g. the Douglas 1095 extra) that need a one-off DB purge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)