### PR TITLE
sync: make re-index idempotent to main (#2534) (#2535)

### DIFF
--- a/backend/app/ai/rag/pipeline.py
+++ b/backend/app/ai/rag/pipeline.py
@@ -76,6 +76,15 @@ class RAGPipeline:
         if not pdf_path.exists():
             raise FileNotFoundError(f"PDF file not found: {pdf_path}")
 
+        # Idempotent re-index: drop this resource's existing chunks first so a
+        # re-run replaces rather than appends. _store_chunks' (source, chunk_index,
+        # content) guard isn't stable across runs (chunk_index resets per page) and
+        # the clone path has no guard at all, so without this a re-index doubles the
+        # chunk count. Scoped strictly by course_resource_id — siblings untouched. #2534
+        if course_resource_id:
+            async with async_session_factory() as _clear_session:
+                await self.clear_resource_chunks(source, course_resource_id, _clear_session)
+
         # Content-hash dedup: clone from a donor course instead of re-embedding.
         if content_hash and course_resource_id:
             async with async_session_factory() as _dedup_session:
@@ -802,6 +811,45 @@ class RAGPipeline:
 
         logger.info("Cleared existing chunks", source=source, count=existing_count)
         return existing_count
+
+    async def clear_resource_chunks(
+        self,
+        source: str,
+        course_resource_id: UUID,
+        session: AsyncSession | None = None,
+    ) -> int:
+        """Delete one resource's chunks, scoped by (source, course_resource_id).
+
+        Makes (re)indexing idempotent: callers clear a resource's existing chunks
+        before storing/cloning fresh ones, so a re-run replaces rather than
+        appends. Scoped strictly by ``course_resource_id`` so sibling resources in
+        the same RAG collection are untouched. See #2534.
+        """
+        session_provided = session is not None
+        if not session_provided:
+            async with async_session_factory() as session:
+                return await self._clear_resource_chunks(source, course_resource_id, session)
+        return await self._clear_resource_chunks(source, course_resource_id, session)
+
+    async def _clear_resource_chunks(
+        self, source: str, course_resource_id: UUID, session: AsyncSession
+    ) -> int:
+        result = await session.execute(
+            delete(DocumentChunk).where(
+                DocumentChunk.source == source,
+                DocumentChunk.course_resource_id == course_resource_id,
+            )
+        )
+        await session.commit()
+        deleted = result.rowcount or 0
+        if deleted:
+            logger.info(
+                "Cleared resource chunks before re-index",
+                source=source,
+                course_resource_id=str(course_resource_id),
+                count=deleted,
+            )
+        return deleted
 
     async def get_pipeline_stats(self, session: AsyncSession | None = None) -> dict[str, Any]:
         """Get statistics about the current state of the pipeline."""

--- a/backend/app/tasks/rag_indexation.py
+++ b/backend/app/tasks/rag_indexation.py
@@ -288,6 +288,12 @@ def index_course_resources(self, course_id: str, rag_collection_id: str) -> dict
                         "estimated_seconds_remaining": _remaining(extract_progress),
                     },
                 )
+                # Idempotent re-index: drop this resource's existing chunks first
+                # so a re-run replaces rather than appends (clone + embed paths
+                # below have no dedup of their own). Scoped by course_resource_id. #2534
+                async with async_session_factory() as _clear_session:
+                    await pipeline.clear_resource_chunks(rag_collection_id, res.id, _clear_session)
+
                 # Content-hash dedup: clone from donor course if same text already indexed.
                 if res.content_hash:
                     async with async_session_factory() as _dedup_session:

--- a/backend/tests/test_rag_pipeline_images.py
+++ b/backend/tests/test_rag_pipeline_images.py
@@ -836,3 +836,48 @@ class TestRAGPipelineVisionCaption:
         added = mock_session.add.call_args[0][0]
         assert added.figure_kind == "body_text"
         mock_classify.assert_not_called()
+
+
+class TestClearResourceChunks:
+    """Idempotent re-index: clear_resource_chunks must scope deletion by both
+    source and course_resource_id so a re-run replaces (not appends) and sibling
+    resources in the same collection are untouched. See #2534.
+    """
+
+    def setup_method(self):
+        self.pipeline = RAGPipeline(AsyncMock())
+
+    @pytest.mark.asyncio
+    async def test_delete_is_scoped_by_source_and_resource_and_returns_rowcount(self):
+        import uuid
+
+        rid = uuid.uuid4()
+        captured = {}
+
+        async def _execute(stmt):
+            captured["stmt"] = stmt
+            return MagicMock(rowcount=7)
+
+        session = MagicMock()
+        session.execute = AsyncMock(side_effect=_execute)
+        session.commit = AsyncMock()
+
+        deleted = await self.pipeline._clear_resource_chunks("collection-x", rid, session)
+
+        assert deleted == 7
+        session.commit.assert_awaited_once()
+        sql = str(captured["stmt"].compile(compile_kwargs={"literal_binds": False}))
+        assert "DELETE FROM document_chunks" in sql
+        # Both predicates present — not a collection-wide wipe.
+        assert "source" in sql and "course_resource_id" in sql
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_nothing_deleted(self):
+        import uuid
+
+        session = MagicMock()
+        session.execute = AsyncMock(return_value=MagicMock(rowcount=0))
+        session.commit = AsyncMock()
+
+        deleted = await self.pipeline._clear_resource_chunks("c", uuid.uuid4(), session)
+        assert deleted == 0


### PR DESCRIPTION
Fixes #2534

Per-feature promotion of the #2534 idempotency fix to `main` (deploys staging). Cherry-pick of the change already merged to `dev` (PR #2535) onto a fresh sync branch off `main`, avoiding the bulk dev→main phantom-conflict.

## Change
`RAGPipeline.clear_resource_chunks(source, course_resource_id)` is now called before storing/cloning in both `process_pdf_document` and the DB-only clone/embed loop, so re-indexing **replaces** a resource's chunks instead of appending a duplicate set. Scoped strictly by `course_resource_id`.

## Tests
18 passed on the `main` base (2 new `TestClearResourceChunks` + indexation lifecycle), ruff clean.

## Note
After deploy, one re-index of an affected course self-heals existing duplicates (clear-before-store wipes the doubled set first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)