### PR TITLE
fix(quiz): scope subscription-gate unit lookup by module_id (#2537)

### DIFF
--- a/backend/app/api/v1/quiz.py
+++ b/backend/app/api/v1/quiz.py
@@ -42,13 +42,18 @@ logger = structlog.get_logger()
 router = APIRouter(prefix="/quiz", tags=["quiz"])
 
 
-async def _check_subscription_or_first_unit(user: AuthenticatedUser, unit_id: str) -> None:
+async def _check_subscription_or_first_unit(
+    user: AuthenticatedUser, unit_id: str, module_id: UUID | None = None
+) -> None:
     """Allow free units of a module; require subscription for others.
 
     The number of free units is controlled by the 'subscription-free-units-count' platform
     setting (default: 2). Admin users always bypass this check.
     Falls back to DB ModuleUnit.order_index check when unit_id format is unrecognised.
     Raises 403 with code 'subscription_required' if no subscription.
+
+    ``unit_number`` is unique only per module, so the DB fallback is scoped by
+    ``module_id`` to avoid MultipleResultsFound (#2537).
     """
     import uuid as _uuid
 
@@ -72,10 +77,14 @@ async def _check_subscription_or_first_unit(user: AuthenticatedUser, unit_id: st
             return
 
         if unit_id:
-            result = await session.execute(
-                select(ModuleUnit.order_index).where(ModuleUnit.unit_number == unit_id)
-            )
-            order = result.scalar_one_or_none()
+            order_query = select(ModuleUnit.order_index).where(ModuleUnit.unit_number == unit_id)
+            if module_id is not None:
+                order_query = order_query.where(ModuleUnit.module_id == module_id)
+            # unit_number is unique per module, not globally — take the first row
+            # so a duplicated unit_number across modules can't raise
+            # MultipleResultsFound (#2537).
+            result = await session.execute(order_query.limit(1))
+            order = result.scalars().first()
             if order is not None and order < free_count:
                 return
         break
@@ -176,9 +185,9 @@ async def generate_quiz(
     - Country-contextualized examples
     """
     try:
-        await _check_subscription_or_first_unit(current_user, request.unit_id)
-
         module_uuid = await _resolve_module_uuid(request.module_id, session)
+
+        await _check_subscription_or_first_unit(current_user, request.unit_id, module_uuid)
 
         logger.info(
             "Quiz generation requested",

--- a/backend/tests/test_quiz_subscription_gate_unit_lookup.py
+++ b/backend/tests/test_quiz_subscription_gate_unit_lookup.py
@@ -1,0 +1,106 @@
+"""Regression tests for the quiz free-unit subscription gate (#2537).
+
+`_check_subscription_or_first_unit` (the quiz endpoint's gate) used to run an
+unscoped `select(ModuleUnit.order_index).where(unit_number == unit_id)` and call
+`scalar_one_or_none()`. Because a unit number like "1.5" exists in many modules,
+that matched multiple rows and raised MultipleResultsFound, which escaped the
+route as a generic 500 ("La génération du quiz a échoué") — but only for
+learners (admins/sub_admins bypass the gate). This is the same bug class fixed
+for the lesson gate in #2459; these tests lock in the module-scoped, crash-proof
+lookup for the quiz gate.
+"""
+
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.exc import MultipleResultsFound
+
+from app.api.deps_local_auth import AuthenticatedUser
+from app.api.v1.quiz import _check_subscription_or_first_unit
+
+
+def _learner(role: str = "user") -> AuthenticatedUser:
+    return AuthenticatedUser({"sub": str(uuid.uuid4()), "email": "n@sira.app", "role": role})
+
+
+@asynccontextmanager
+async def _patched(session, *, sub):
+    """Patch the gate's lazily-imported collaborators around one call."""
+
+    async def _fake_get_db_session():
+        yield session
+
+    sub_service = MagicMock()
+    sub_service.get_active_subscription = AsyncMock(return_value=sub)
+
+    settings_cache = MagicMock()
+    settings_cache.get.return_value = 2  # free-units-count
+
+    with (
+        patch(
+            "app.infrastructure.persistence.database.get_db_session",
+            _fake_get_db_session,
+        ),
+        patch(
+            "app.domain.services.subscription_service.SubscriptionService",
+            return_value=sub_service,
+        ),
+        # SettingsCache is bound at module import time in app.api.v1.quiz.
+        patch("app.api.v1.quiz.SettingsCache") as cache_cls,
+    ):
+        cache_cls.instance.return_value = settings_cache
+        yield
+
+
+async def test_admin_bypasses_without_db():
+    # Admins never touch the DB lookup at all.
+    await _check_subscription_or_first_unit(_learner(role="admin"), "1.5")
+
+
+async def test_paid_unit_no_sub_returns_403_not_500():
+    # Unit "1.5" is paid (5 > free_count 2). A learner without a subscription must
+    # get a clean 403 — never MultipleResultsFound, even though the lookup would
+    # match a shared unit number. We make scalar_one_or_none() blow up to prove the
+    # gate doesn't rely on it.
+    result_obj = MagicMock()
+    result_obj.scalars.return_value.first.return_value = 2  # order_index >= free_count
+    result_obj.scalar_one_or_none.side_effect = MultipleResultsFound("must not be called")
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=result_obj)
+
+    async with _patched(session, sub=None):
+        with pytest.raises(HTTPException) as exc:
+            await _check_subscription_or_first_unit(_learner(), "1.5", uuid.uuid4())
+
+    assert exc.value.status_code == 403
+    result_obj.scalar_one_or_none.assert_not_called()
+
+
+async def test_active_subscription_grants_access():
+    # An active subscription short-circuits before the unit lookup.
+    session = MagicMock()
+    session.execute = AsyncMock()
+
+    async with _patched(session, sub=MagicMock()):
+        await _check_subscription_or_first_unit(_learner(), "1.5", uuid.uuid4())
+
+    session.execute.assert_not_called()
+
+
+async def test_free_unit_short_circuits_before_db():
+    # Unit "1.2" is within the free window — granted without any subscription check.
+    await _check_subscription_or_first_unit(_learner(), "1.2")
+
+
+async def test_low_order_index_grants_access():
+    # A unit whose number doesn't parse but resolves to an early order_index is free.
+    result_obj = MagicMock()
+    result_obj.scalars.return_value.first.return_value = 0  # order_index < free_count
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=result_obj)
+
+    async with _patched(session, sub=None):
+        await _check_subscription_or_first_unit(_learner(), "intro", uuid.uuid4())


### PR DESCRIPTION
## Summary

Fixes the quiz **"La génération du quiz a échoué. Veuillez réessayer."** error learners hit on paid units (e.g. Unité 1.5).

The quiz endpoint's free-unit gate `_check_subscription_or_first_unit` ran an **unscoped** lookup:

```python
select(ModuleUnit.order_index).where(ModuleUnit.unit_number == unit_id)  # no module_id
order = result.scalar_one_or_none()
```

`ModuleUnit.unit_number` is unique only *per module* (`UniqueConstraint("module_id", "unit_number")`), so a value like `"1.5"` matches many rows and `scalar_one_or_none()` raises `MultipleResultsFound`. That escapes as a generic 500 (`generation_failed`) — but only for **non-subscribers on a paid unit** (unit index ≥ free-units-count; admins/subscribers short-circuit earlier), which is exactly the reported case.

This is the same bug class fixed for the **lesson** gate in #2459; that fix missed the quiz gate.

## Changes
- `generate_quiz` now resolves the module UUID **before** the gate and passes it in.
- The gate scopes the lookup by `module_id` and uses `.limit(1)` / `.scalars().first()`, so a duplicated `unit_number` can never crash the request. Mirrors the existing `require_subscription_or_first_unit` pattern.
- New regression test `tests/test_quiz_subscription_gate_unit_lookup.py` (parallels `test_subscription_gate_unit_lookup.py`): proves the gate returns a clean 403 instead of `MultipleResultsFound`, and that `scalar_one_or_none` is never called.

## Testing
- `pytest tests/test_quiz_subscription_gate_unit_lookup.py tests/test_subscription_gate_unit_lookup.py` → 9 passed
- `pytest tests/test_quiz_country_fallback.py tests/test_quiz_service.py` → 48 passed (callers unaffected by signature/reorder)
- `ruff check` + `ruff format` clean

## Note
The `deps_local_auth.py` lesson gate was already scoped on `dev` (#2459) — no change needed there. Only the quiz gate was unfixed.

Fixes #2537

🤖 Generated with [Claude Code](https://claude.com/claude-code)