### PR TITLE
fix(indexation): drop unreadable extracted images before linking to content

### DIFF
--- a/backend/app/ai/rag/image_extractor.py
+++ b/backend/app/ai/rag/image_extractor.py
@@ -19,6 +19,9 @@ from pathlib import Path
 import pymupdf
 import structlog
 
+from app.ai.rag.image_quality import assess_readability
+from app.infrastructure.config.settings import get_settings
+
 logger = structlog.get_logger(__name__)
 
 # Raised from 100/100/2KB to 200/200/4KB in #2073. PDFs frequently embed
@@ -271,6 +274,7 @@ class PDFImageExtractor:
         finally:
             doc.close()
 
+        results = self._filter_unreadable(results, source)
         results = self._deduplicate_images(results)
 
         logger.info(
@@ -830,6 +834,44 @@ class PDFImageExtractor:
             chapter=metadata.get("chapter"),
             section=metadata.get("section"),
         )
+
+    def _filter_unreadable(self, images: list[ExtractedImage], source: str) -> list[ExtractedImage]:
+        """Drop images with no legible content before they are linked to courses.
+
+        Covers every extraction path (xref, vector region, full-page raster)
+        because all of them funnel into the same ``results`` list. Gated by
+        ``enable_image_readability_filter`` so it can be turned off without a
+        code change if a real figure is ever wrongly rejected. See
+        ``image_quality.assess_readability`` for the per-signal calibration.
+        """
+        if not get_settings().enable_image_readability_filter:
+            return images
+
+        kept: list[ExtractedImage] = []
+        for img in images:
+            readable, reason = assess_readability(img.image_bytes)
+            if readable:
+                kept.append(img)
+            else:
+                logger.info(
+                    "Dropping unreadable extracted image",
+                    source=source,
+                    page=img.page_number,
+                    figure_number=img.figure_number,
+                    width=img.width,
+                    height=img.height,
+                    reason=reason,
+                )
+
+        dropped = len(images) - len(kept)
+        if dropped:
+            logger.info(
+                "Unreadable image filter complete",
+                source=source,
+                dropped=dropped,
+                kept=len(kept),
+            )
+        return kept
 
     def _deduplicate_images(self, images: list[ExtractedImage]) -> list[ExtractedImage]:
         """Remove near-duplicate images using average hash (8x8 grayscale, Hamming distance < 5).

--- a/backend/app/ai/rag/image_quality.py
+++ b/backend/app/ai/rag/image_quality.py
@@ -1,0 +1,118 @@
+"""Readability detection for images extracted from course PDFs.
+
+Drops images that carry no legible information *before* they are persisted as
+``source_images`` and linked to generated content. The dimension/byte-size
+floors in ``image_extractor`` only catch tiny images; an image can clear those
+and still be a solid fill, random-decode garbage, or a truncated stream.
+
+Three rejection signals, each tuned to be high-precision (a false positive here
+silently deletes a real figure, so the bar is "obviously unreadable"):
+
+* **decode-fail / truncated** — bytes that don't fully decode to pixels.
+* **blank / near-uniform** — near-zero luminance spread *and* a near-1.0
+  single-value fraction. Deliberately conservative so sparse line-diagrams and
+  flowcharts (mostly-white background, thin ink) are KEPT — those measure a
+  luminance stddev well above the blank floor.
+* **random-noise garbage** — a near-flat 256-bin histogram (high entropy)
+  *and* high difference between adjacent pixels (no smooth regions). Botched
+  CMYK/SMask decodes look like colour static; natural photos and diagrams fail
+  at least one of the two conditions, so both are required to reject.
+"""
+
+import io
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# --- Blank / near-uniform -------------------------------------------------
+# A solid fill has stddev ~0. A single thin diagonal line on a white page
+# measures a luminance stddev around 16 after downscale; we reject only well
+# below that. Both conditions must hold, so a low-stddev image with genuine
+# (if faint) structure — which spreads the histogram below the dominant
+# threshold — is kept.
+BLANK_STDDEV_MAX = 4.0
+# Fraction of pixels sharing the single most common luminance value. A solid
+# fill approaches 1.0; bilinear downscale of any real ink anti-aliases edges
+# and spreads the histogram below this, so even very sparse diagrams stay under.
+BLANK_DOMINANT_FRACTION_MIN = 0.999
+
+# --- Random-noise garbage -------------------------------------------------
+# Shannon entropy of the 8-bit luminance histogram (max 8.0). Uniform noise
+# approaches 8.0; detailed photos rarely exceed ~7.5 and, when they do, retain
+# smooth regions (low neighbour diff) that the second gate catches.
+NOISE_ENTROPY_MIN = 7.5
+# Mean absolute difference between horizontally-adjacent pixels (0-255). Pure
+# uniform noise sits near 85 (≈ 1/3 of the range); photos and diagrams stay
+# well below 55 thanks to smooth gradients and flat backgrounds.
+NOISE_NEIGHBOR_DIFF_MIN = 55.0
+
+# Downscale longest side to this before computing statistics — keeps the cost
+# roughly constant regardless of source resolution. Large enough to preserve
+# the signal each gate measures.
+ANALYSIS_MAX_DIM = 256
+
+
+def _load_gray(image_bytes: bytes):
+    """Decode ``image_bytes`` to a downscaled 8-bit grayscale PIL image.
+
+    ``img.load()`` forces a full decode so truncated/partial streams raise here
+    rather than later. Raises on any decode failure (caller treats as
+    unreadable).
+    """
+    from PIL import Image
+
+    img = Image.open(io.BytesIO(image_bytes))
+    img.load()  # force full decode; truncated streams fail here
+    img = img.convert("L")
+
+    longest = max(img.size)
+    if longest > ANALYSIS_MAX_DIM:
+        ratio = ANALYSIS_MAX_DIM / longest
+        img = img.resize(
+            (max(1, int(img.width * ratio)), max(1, int(img.height * ratio))),
+            Image.BILINEAR,
+        )
+    return img
+
+
+def assess_readability(image_bytes: bytes) -> tuple[bool, str | None]:
+    """Return ``(is_readable, reason)`` for a candidate image.
+
+    ``reason`` is ``None`` when readable, otherwise a short diagnostic string
+    (with the measured metrics) for logging. The check never raises — a decode
+    failure is itself an "unreadable" verdict.
+    """
+    from PIL import ImageChops, ImageStat
+
+    try:
+        img = _load_gray(image_bytes)
+    except Exception as exc:
+        return False, f"decode_failed: {type(exc).__name__}: {exc}"
+
+    if img.width < 2 or img.height < 2:
+        return False, f"degenerate_dimensions: {img.width}x{img.height}"
+
+    stat = ImageStat.Stat(img)
+    stddev = stat.stddev[0]
+
+    hist = img.histogram()
+    total = sum(hist) or 1
+    dominant = max(hist) / total
+
+    # Blank / near-uniform: flat luminance AND one value dominating.
+    if stddev <= BLANK_STDDEV_MAX and dominant >= BLANK_DOMINANT_FRACTION_MIN:
+        return False, f"blank(stddev={stddev:.2f},dominant={dominant:.4f})"
+
+    # Random-noise garbage: flat histogram AND no smooth regions. Both gates
+    # required, so a busy-but-real photo (high entropy, smooth gradients) and a
+    # high-contrast diagram (low entropy) both survive.
+    entropy = img.entropy()
+    if entropy >= NOISE_ENTROPY_MIN:
+        left = img.crop((0, 0, img.width - 1, img.height))
+        right = img.crop((1, 0, img.width, img.height))
+        neighbor_diff = ImageStat.Stat(ImageChops.difference(left, right)).mean[0]
+        if neighbor_diff >= NOISE_NEIGHBOR_DIFF_MIN:
+            return False, f"noise(entropy={entropy:.2f},neighbor={neighbor_diff:.1f})"
+
+    return True, None

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -69,6 +69,13 @@ class Settings(BaseSettings):
     # Issue #1928 — staging burned ~$30 in 4 hours of repeated backfills.
     enable_figure_vision: bool = True
 
+    # Drop unreadable extracted images (blank/near-uniform fills, random-noise
+    # garbage from botched colorspace/mask decodes, decode-failures) before they
+    # are persisted as source_images and linked to content (#2540). Calibrated
+    # to keep sparse line-diagrams/flowcharts. Set False to disable the filter
+    # if a real figure is ever wrongly dropped.
+    enable_image_readability_filter: bool = True
+
     # Figure-vision provider selection (#2435). The classifier + caption reader
     # call whichever provider is configured here. Gemini 2.5 Flash-Lite is the
     # cheapest accurate VLM (~$0.10/$0.40 per 1M; a figure image bills ~258

--- a/backend/app/tasks/image_indexation.py
+++ b/backend/app/tasks/image_indexation.py
@@ -549,3 +549,181 @@ async def _run_body_text_purge_with_factory(
             "deleted": deleted,
             "storage_failed": storage_failed,
         }
+
+
+# ---------------------------------------------------------------------------
+# Cleanup for unreadable extracted images (#2540)
+# ---------------------------------------------------------------------------
+#
+# ``image_quality.assess_readability`` now drops blank/near-uniform fills,
+# random-noise garbage, and undecodable/truncated streams at extraction time.
+# Courses indexed before that gate still hold such rows. This purge re-runs the
+# exact same check against the *stored* binary (downloaded from MinIO), so the
+# verdict matches new ingests, then deletes the unreadable rows. Junction rows
+# cascade; any baked-in {{source_image:UUID}} lesson marker becomes a no-op
+# orphan, dropped client-side (#2428).
+#
+# Only the primary raster (``storage_key``) is assessed — the FR variant may be
+# an SVG (flowchart/overlay re-derivation), which isn't a decodable raster.
+# Unlike the sibling purges this can't be a pure SQL predicate: readability is a
+# property of the pixels, so each candidate is downloaded and assessed. ``limit``
+# therefore caps the number of rows *scanned* (download + assess), letting the
+# job be staged across large libraries within the time limit.
+
+
+class PurgeUnreadableFiguresTask(Task):
+    """Celery base for the unreadable-image purge."""
+
+    def on_success(self, retval, task_id, args, kwargs):
+        logger.info("Unreadable-figure purge completed", task_id=task_id, result=retval)
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        logger.error("Unreadable-figure purge failed", task_id=task_id, exception=str(exc))
+
+
+@celery_app.task(
+    bind=True,
+    base=PurgeUnreadableFiguresTask,
+    time_limit=1800,
+    soft_time_limit=1500,
+    ignore_result=True,
+    acks_late=False,
+)
+def purge_unreadable_figures(
+    self,
+    rag_collection_id: str | None = None,
+    limit: int | None = None,
+    dry_run: bool = True,
+) -> dict:
+    """Delete ``source_images`` whose stored binary is unreadable (#2540).
+
+    Re-runs ``assess_readability`` against the stored raster, matching the
+    extraction-time gate. Args mirror :func:`purge_orphan_full_page_figures`,
+    except ``limit`` caps the rows *scanned* (each is downloaded + assessed).
+    """
+    return asyncio.run(
+        _run_unreadable_purge(
+            rag_collection_id=rag_collection_id,
+            limit=limit,
+            dry_run=dry_run,
+        )
+    )
+
+
+async def _run_unreadable_purge(
+    rag_collection_id: str | None,
+    limit: int | None,
+    dry_run: bool,
+) -> dict:
+    from app.infrastructure.config.settings import settings
+    from app.infrastructure.storage.s3 import S3StorageService
+
+    engine = create_async_engine(settings.database_url, pool_pre_ping=True)
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        return await _run_unreadable_purge_with_factory(
+            rag_collection_id=rag_collection_id,
+            limit=limit,
+            dry_run=dry_run,
+            session_factory=session_factory,
+            storage=S3StorageService(),
+        )
+    finally:
+        await engine.dispose()
+
+
+async def _run_unreadable_purge_with_factory(
+    rag_collection_id: str | None,
+    limit: int | None,
+    dry_run: bool,
+    session_factory: async_sessionmaker[AsyncSession],
+    storage,
+) -> dict:
+    from app.ai.rag.image_quality import assess_readability
+    from app.domain.models.source_image import SourceImage
+
+    async with session_factory() as session:
+        stmt = select(SourceImage).where(SourceImage.storage_key.is_not(None))
+        if rag_collection_id is not None:
+            stmt = stmt.where(SourceImage.rag_collection_id == rag_collection_id)
+        if limit is not None:
+            stmt = stmt.limit(limit)
+
+        candidates = (await session.execute(stmt)).scalars().all()
+        scanned = len(candidates)
+
+        unreadable: list[tuple] = []
+        download_failed = 0
+        for img in candidates:
+            try:
+                data = await storage.download_bytes(img.storage_key)
+            except Exception as exc:  # noqa: BLE001
+                # A transient/missing object isn't proof of unreadable content —
+                # skip rather than risk deleting a recoverable row.
+                download_failed += 1
+                logger.warning(
+                    "Unreadable purge: download failed, skipping",
+                    source_image_id=str(img.id),
+                    key=img.storage_key,
+                    error=str(exc),
+                )
+                continue
+            readable, reason = assess_readability(data)
+            if not readable:
+                unreadable.append((img, reason))
+
+        total = len(unreadable)
+        logger.info(
+            "Unreadable-figure purge: assessed",
+            scanned=scanned,
+            unreadable=total,
+            download_failed=download_failed,
+            rag_collection_id=rag_collection_id,
+            dry_run=dry_run,
+        )
+
+        if dry_run:
+            return {
+                "status": "dry_run",
+                "scanned": scanned,
+                "unreadable": total,
+                "download_failed": download_failed,
+                "preview": _unreadable_preview(unreadable),
+            }
+
+        rows = [img for img, _ in unreadable]
+        deleted, storage_failed = await _delete_image_rows(session, rows, storage)
+
+        logger.info(
+            "Unreadable-figure purge complete",
+            scanned=scanned,
+            deleted=deleted,
+            storage_failed=storage_failed,
+            download_failed=download_failed,
+            rag_collection_id=rag_collection_id,
+        )
+        return {
+            "status": "complete",
+            "scanned": scanned,
+            "unreadable": total,
+            "deleted": deleted,
+            "storage_failed": storage_failed,
+            "download_failed": download_failed,
+        }
+
+
+def _unreadable_preview(pairs: list[tuple]) -> list[dict]:
+    """First 20 unreadable rows (with the rejection reason) for a dry-run."""
+    return [
+        {
+            "id": str(img.id),
+            "rag_collection_id": img.rag_collection_id,
+            "page_number": img.page_number,
+            "figure_number": img.figure_number,
+            "width": img.width,
+            "height": img.height,
+            "storage_key": img.storage_key,
+            "reason": reason,
+        }
+        for img, reason in pairs[:20]
+    ]

--- a/backend/tests/test_image_extractor.py
+++ b/backend/tests/test_image_extractor.py
@@ -18,11 +18,14 @@ from app.ai.rag.image_extractor import (
 )
 
 
-def _make_minimal_png(width: int = 200, height: int = 200) -> bytes:
+def _make_minimal_png(width: int = 200, height: int = 200, block: int = 2) -> bytes:
     """Create a minimal valid PNG for testing.
 
-    Uses seeded pseudo-random pixel data so the compressed size stays above
-    MIN_SIZE_BYTES (2 KB) while remaining deterministic across test runs.
+    Uses seeded random-coloured 2x2 blocks (not per-pixel noise): incompressible
+    enough to keep the encoded size above MIN_SIZE_BYTES while keeping
+    adjacent-pixel differences low, so it reads as a real image rather than the
+    uniform-noise garbage that the readability filter drops (#2540). Deterministic
+    across runs.
     """
     import random as _random
 
@@ -35,10 +38,15 @@ def _make_minimal_png(width: int = 200, height: int = 200) -> bytes:
     signature = b"\x89PNG\r\n\x1a\n"
     ihdr_data = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
     ihdr = chunk(b"IHDR", ihdr_data)
-    rows = []
-    for _ in range(height):
-        row_pixels = bytes([rng.randint(0, 255) for _ in range(width * 3)])
-        rows.append(b"\x00" + row_pixels)
+    n_blocks_x = (width + block - 1) // block
+    rows: list[bytes] = []
+    y = 0
+    while y < height:
+        colors = [bytes(rng.randint(0, 255) for _ in range(3)) for _ in range(n_blocks_x)]
+        line = b"".join(colors[x // block] for x in range(width))
+        for _ in range(min(block, height - y)):
+            rows.append(b"\x00" + line)
+        y += block
     raw_data = b"".join(rows)
     idat = chunk(b"IDAT", zlib.compress(raw_data))
     iend = chunk(b"IEND", b"")

--- a/backend/tests/test_image_quality.py
+++ b/backend/tests/test_image_quality.py
@@ -1,0 +1,143 @@
+"""Tests for unreadable-image detection (#2540).
+
+Each signal in ``assess_readability`` is high-precision by design: a false
+positive silently deletes a real figure. These tests pin both the rejects
+(blank, solid, random noise, undecodable bytes) and — just as importantly —
+the keeps (sparse line-diagram, high-entropy smooth gradient).
+"""
+
+import io
+import random
+
+from PIL import Image, ImageDraw
+
+from app.ai.rag.image_extractor import ExtractedImage, PDFImageExtractor
+from app.ai.rag.image_quality import assess_readability
+
+
+def _png(img: Image.Image) -> bytes:
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _blank_white() -> bytes:
+    return _png(Image.new("L", (256, 256), 255))
+
+
+def _solid_color() -> bytes:
+    return _png(Image.new("RGB", (300, 300), (123, 200, 50)))
+
+
+def _random_noise() -> bytes:
+    data = random.Random(0).randbytes(256 * 256)
+    return _png(Image.frombytes("L", (256, 256), data))
+
+
+def _sparse_diagram() -> bytes:
+    """Mostly-white page with a few thin black lines — a legitimate figure."""
+    img = Image.new("L", (256, 256), 255)
+    draw = ImageDraw.Draw(img)
+    draw.rectangle((40, 40, 120, 90), outline=0, width=2)
+    draw.line((120, 65, 180, 65), fill=0, width=2)
+    draw.rectangle((180, 40, 220, 90), outline=0, width=2)
+    return _png(img)
+
+
+def _smooth_gradient() -> bytes:
+    """Left-to-right ramp: flat histogram (high entropy) but tiny neighbour diff."""
+    row = bytes(range(256))
+    data = row * 256
+    return _png(Image.frombytes("L", (256, 256), data))
+
+
+class TestAssessReadabilityRejects:
+    def test_blank_white_rejected(self):
+        readable, reason = assess_readability(_blank_white())
+        assert readable is False
+        assert reason and reason.startswith("blank")
+
+    def test_solid_color_rejected(self):
+        readable, reason = assess_readability(_solid_color())
+        assert readable is False
+        assert reason and reason.startswith("blank")
+
+    def test_random_noise_rejected(self):
+        readable, reason = assess_readability(_random_noise())
+        assert readable is False
+        assert reason and reason.startswith("noise")
+
+    def test_undecodable_bytes_rejected(self):
+        readable, reason = assess_readability(b"this is not an image")
+        assert readable is False
+        assert reason and reason.startswith("decode_failed")
+
+    def test_truncated_png_rejected(self):
+        truncated = _sparse_diagram()[:120]
+        readable, reason = assess_readability(truncated)
+        assert readable is False
+        assert reason and reason.startswith("decode_failed")
+
+
+class TestAssessReadabilityKeeps:
+    def test_sparse_line_diagram_kept(self):
+        # The critical non-regression: sparse diagrams look "almost blank" but
+        # carry real information and must survive.
+        readable, reason = assess_readability(_sparse_diagram())
+        assert readable is True
+        assert reason is None
+
+    def test_high_entropy_smooth_gradient_kept(self):
+        # Flat histogram trips the entropy gate, but the low neighbour-diff gate
+        # (both required for "noise") keeps this readable.
+        readable, reason = assess_readability(_smooth_gradient())
+        assert readable is True
+        assert reason is None
+
+
+class TestFilterUnreadableIntegration:
+    def _extracted(self, image_bytes: bytes, **kw) -> ExtractedImage:
+        defaults = dict(
+            image_bytes=image_bytes,
+            width=256,
+            height=256,
+            original_format="png",
+            file_size_bytes=len(image_bytes),
+            page_number=1,
+            figure_number=None,
+            caption=None,
+            attribution=None,
+            image_type="unknown",
+            surrounding_text="",
+            chapter=None,
+            section=None,
+        )
+        defaults.update(kw)
+        return ExtractedImage(**defaults)
+
+    def _extractor(self, tmp_path) -> PDFImageExtractor:
+        return PDFImageExtractor(tmp_path)
+
+    def test_filter_drops_unreadable_keeps_real(self, tmp_path):
+        ext = self._extractor(tmp_path)
+        images = [
+            self._extracted(_blank_white(), page_number=1),
+            self._extracted(_sparse_diagram(), page_number=2),
+            self._extracted(_random_noise(), page_number=3),
+        ]
+        kept = ext._filter_unreadable(images, "generic")
+        assert [img.page_number for img in kept] == [2]
+
+    def test_filter_disabled_keeps_everything(self, tmp_path, monkeypatch):
+        ext = self._extractor(tmp_path)
+
+        class _S:
+            enable_image_readability_filter = False
+
+        monkeypatch.setattr("app.ai.rag.image_extractor.get_settings", lambda: _S())
+        images = [
+            self._extracted(_blank_white(), page_number=1),
+            self._extracted(_sparse_diagram(), page_number=2),
+        ]
+        kept = ext._filter_unreadable(images, "generic")
+        assert len(kept) == 2

--- a/backend/tests/test_purge_unreadable_figures.py
+++ b/backend/tests/test_purge_unreadable_figures.py
@@ -1,0 +1,146 @@
+"""Unit tests for the unreadable-image purge (#2540).
+
+Covers ``_run_unreadable_purge_with_factory`` directly so no engine/DB is
+needed. Unlike the sibling purges the verdict is content-based, so a fake
+storage returns real image bytes per key and the task runs the same
+``assess_readability`` check used at extraction time.
+"""
+
+from __future__ import annotations
+
+import io
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from PIL import Image, ImageDraw
+
+from app.domain.models.source_image import SourceImage
+from app.tasks.image_indexation import _run_unreadable_purge_with_factory
+
+
+def _blank_png() -> bytes:
+    buf = io.BytesIO()
+    Image.new("L", (256, 256), 255).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _readable_png() -> bytes:
+    img = Image.new("L", (256, 256), 255)
+    draw = ImageDraw.Draw(img)
+    draw.rectangle((40, 40, 120, 90), outline=0, width=2)
+    draw.line((120, 65, 180, 65), fill=0, width=2)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_row(**overrides) -> MagicMock:
+    img = MagicMock(spec=SourceImage)
+    img.id = overrides.get("id", uuid.uuid4())
+    img.rag_collection_id = overrides.get("rag_collection_id", "col-1")
+    img.page_number = overrides.get("page_number", 12)
+    img.figure_number = overrides.get("figure_number", "Figure 1.1")
+    img.width = overrides.get("width", 256)
+    img.height = overrides.get("height", 256)
+    img.storage_key = overrides["storage_key"]
+    img.storage_key_fr = overrides.get("storage_key_fr")
+    return img
+
+
+def _factory_returning(rows: list):
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    session.delete = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = rows
+    session.execute = AsyncMock(return_value=result)
+
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=session)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=cm), session
+
+
+def _storage_for(content: dict[str, bytes]) -> AsyncMock:
+    storage = AsyncMock()
+    storage.download_bytes = AsyncMock(side_effect=lambda key: content[key])
+    storage.delete_object = AsyncMock()
+    return storage
+
+
+@pytest.mark.asyncio
+async def test_dry_run_flags_only_unreadable():
+    rows = [
+        _make_row(storage_key="blank.webp"),
+        _make_row(storage_key="ok.webp"),
+    ]
+    factory, session = _factory_returning(rows)
+    storage = _storage_for({"blank.webp": _blank_png(), "ok.webp": _readable_png()})
+
+    result = await _run_unreadable_purge_with_factory(
+        rag_collection_id=None,
+        limit=None,
+        dry_run=True,
+        session_factory=factory,
+        storage=storage,
+    )
+
+    assert result["status"] == "dry_run"
+    assert result["scanned"] == 2
+    assert result["unreadable"] == 1
+    assert len(result["preview"]) == 1
+    assert result["preview"][0]["storage_key"] == "blank.webp"
+    assert result["preview"][0]["reason"].startswith("blank")
+    session.delete.assert_not_called()
+    storage.delete_object.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_real_run_deletes_only_unreadable():
+    rows = [
+        _make_row(storage_key="blank.webp", storage_key_fr="blank_fr.svg"),
+        _make_row(storage_key="ok.webp"),
+    ]
+    factory, session = _factory_returning(rows)
+    storage = _storage_for({"blank.webp": _blank_png(), "ok.webp": _readable_png()})
+
+    result = await _run_unreadable_purge_with_factory(
+        rag_collection_id="col-1",
+        limit=None,
+        dry_run=False,
+        session_factory=factory,
+        storage=storage,
+    )
+
+    assert result["status"] == "complete"
+    assert result["scanned"] == 2
+    assert result["unreadable"] == 1
+    assert result["deleted"] == 1
+    # Only the blank row's objects are removed: blank.webp + blank_fr.svg.
+    assert storage.delete_object.await_count == 2
+    session.delete.assert_awaited_once()
+    session.commit.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_download_failure_is_skipped_not_deleted():
+    rows = [_make_row(storage_key="gone.webp")]
+    factory, session = _factory_returning(rows)
+    storage = AsyncMock()
+    storage.download_bytes = AsyncMock(side_effect=ConnectionError("MinIO down"))
+    storage.delete_object = AsyncMock()
+
+    result = await _run_unreadable_purge_with_factory(
+        rag_collection_id=None,
+        limit=None,
+        dry_run=False,
+        session_factory=factory,
+        storage=storage,
+    )
+
+    assert result["download_failed"] == 1
+    assert result["unreadable"] == 0
+    assert result["deleted"] == 0
+    session.delete.assert_not_called()


### PR DESCRIPTION
## Summary
Adds content-readability detection to the image-extraction pipeline so unreadable images never become `source_images` rows or get linked to course content, **plus** a backfill purge for images already indexed before this gate existed. Closes #2540.

The existing extractor only gates on **dimensions and byte size** — an image can clear those and still be a solid fill, random-decode garbage, or a truncated stream. This adds a content check.

## What's detected (and dropped)
- **Decode-fail / truncated** — bytes that don't fully decode to pixels.
- **Blank / near-uniform** — near-zero luminance stddev **and** a near-1.0 single-value fraction. Both required, so sparse line-diagrams/flowcharts (mostly-white + thin ink) are **kept** (verified by test).
- **Random-noise garbage** — near-flat histogram (high entropy) **and** high adjacent-pixel difference (no smooth regions). Both required, so busy real photos survive.

The **illegible full-page text-raster** case is already covered by the #2435 text-density gate, so it isn't duplicated here.

## Implementation
- New `app/ai/rag/image_quality.py` → `assess_readability(bytes) -> (is_readable, reason)`, thresholds documented inline.
- `image_extractor._filter_unreadable()` runs one filter pass over the collected results (covers xref, vector-region, and full-page paths) before dedup, logging each drop with its reason.
- New `enable_image_readability_filter` setting (default `True`), mirroring `enable_figure_vision` — flip to `False` if a real figure is ever wrongly dropped.

## Backfill (existing rows)
- New operator-triggered Celery task `purge_unreadable_figures(rag_collection_id=None, limit=None, dry_run=True)` in `app/tasks/image_indexation.py`.
- Re-runs `assess_readability` against the **stored** binary (downloaded from MinIO) so the verdict matches new ingests, then deletes unreadable rows via the shared `_delete_image_rows` (junction rows cascade; baked-in `{{source_image:UUID}}` markers no-op orphan, #2428).
- Mirrors the sibling `purge_orphan_full_page_figures` / `purge_body_text_figures` tasks: `dry_run` default, optional course scope, `limit` (here caps rows *scanned*, since each is downloaded + assessed). Only the primary raster is assessed (FR variants may be SVG). Download failures are skipped, never deleted.

## Tests
- `tests/test_image_quality.py` — pins each reject (blank, solid, noise, undecodable, truncated) and each keep (sparse diagram, high-entropy smooth gradient), plus filter integration + the disable flag.
- `tests/test_purge_unreadable_figures.py` — dry-run flags only unreadable, real run deletes only unreadable rows + their objects, download failures skipped.
- Updated the shared `_make_minimal_png` fixture (was per-pixel uniform noise — exactly what the filter rejects) to seeded 2x2 colour blocks: incompressible enough to clear `MIN_SIZE_BYTES`, but readable.
- Full extractor/pipeline/purge suites green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)